### PR TITLE
fix(lint): tmux send-keys guard matches the array, not the line

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T00-41-03-021Z-tmux-send-lint-array-scope.json
+++ b/.instar/instar-dev-decisions/2026-08-15T00-41-03-021Z-tmux-send-lint-array-scope.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T00:41:03.021Z",
+  "slug": "tmux-send-lint-array-scope",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 171,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unfunneled-tmux-literal-send.js"
+    ],
+    "addedLines": 159,
+    "deletedLines": 12
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tmux-send-lint-array-scope.eli16.md
+++ b/docs/specs/tmux-send-lint-array-scope.eli16.md
@@ -1,0 +1,97 @@
+# ELI16 — the guard that could be defeated by running a code formatter
+
+## What it protects
+
+Instar types into terminal sessions to talk to them. There is a command for sending literal text, and
+it passes the whole message as a single argument — which the operating system caps at about 16 KB.
+
+Below that cap everything works. Above it, the send fails with a bare "command too long" that says
+nothing about what went wrong.
+
+On 4 August that happened for real. A large prompt crossed the ceiling, the component watching for
+failures misread the meaningless error as "the AI provider is rate-limiting us", and it shut itself off
+— fourteen times in a row, fifteen minutes apart. Ten different parts of the system that depend on AI
+calls sat at between three-quarters and total failure while it did.
+
+The fix was to route every such send through one helper that splits the text into safe-sized pieces.
+This build check is what stops the problem coming back: it fails the build if anyone writes a raw send
+that skips the helper.
+
+## What was wrong
+
+The check read the code one line at a time, and only complained when it saw the command name and its
+flag **on the same line**.
+
+So it saw nothing here:
+
+```js
+const args = [
+  "send-keys",
+  "-l",
+  payload,
+];
+```
+
+That is the identical command. It is also just what any code formatter produces when a list gets too
+long for one line — which is the part worth pausing on. **You could defeat this guard by running
+prettier.** Nobody would be trying to get around anything; the list would simply grow, get reformatted,
+and the protection would quietly stop applying.
+
+Three more plain forms slipped through the same way: putting the flag in a named constant, putting the
+command name in a named constant, and — the worst one — *mentioning the helper's name in a comment*.
+The check treated "this line mentions the helper" as "this line uses the helper", so writing
+`// TODO: use buildLiteralSendArgs here` next to a raw send switched off the very guard the note was
+admitting you needed.
+
+I measured all four against the shipped check before changing anything, with the one-line form running
+in the same pass as a control — so I could prove the check was working and still missing these.
+
+## What changed
+
+The check now looks at the whole **list**, not one line — it matches the brackets to find where the
+list starts and ends, so a list spread over five lines is read as one thing. Before that, it removes
+comments (properly, without touching text inside quotes) and works out what named constants actually
+hold.
+
+## Why it won't start failing builds it shouldn't
+
+This check blocks commits, so wrongly flagging correct code costs more than missing a case — a noisy
+check gets switched off, and then it protects nothing. Six things are deliberate, each with a test:
+
+1. **A send without that flag is fine** — it is only the literal-text form that has the size ceiling.
+2. **A genuinely routed call is fine.**
+3. **Two separate lists are never joined.** An unrelated list containing `-l` somewhere else in the file
+   cannot complete a send command. This is the main reason the unit is the bracket-matched list rather
+   than "a few lines near each other".
+4. **A constant holding something else is fine.**
+5. **An example living entirely inside a comment is fine** — this is what makes it safe to *document*
+   the bad pattern, including in this file.
+6. **An ambiguous name is left alone.** If one name is set to two different things in the same file, it
+   is treated as unresolvable rather than guessed at — guessing wrong fails somebody's build.
+
+Unbalanced brackets also produce no result rather than a bad one, so a syntax error somewhere else can
+never turn into a false accusation here.
+
+## What it still can't see — and a correction to what it used to claim
+
+The old note said only that "a wrapper that builds the argv array dynamically could still evade it."
+That was true but it **understated the gap**, because the four forms above are not dynamic and not
+wrappers — they are the plainest possible way to write the command. The note has been corrected to say
+what was actually missing.
+
+What genuinely remains: a list assembled while the program runs — built up piece by piece, joined from
+another list, or returned by a helper. Catching that needs real analysis of how values flow through the
+program, not more pattern matching, and guessing would flag correct code.
+
+## One more thing this fixes quietly
+
+Loading this check used to run the entire scan, and it stops the whole process the moment it finds a
+real problem — so importing it to test its own logic would kill the test run. It now only scans when
+you run it directly. Four other checks hit exactly this trap this week.
+
+## How you know it works
+
+The tests were written first and run against the old behaviour: **six of the eighteen fail** without
+this change. The other twelve pass either way — those are the controls, and half of them exist purely
+to prove the check stays quiet where it should. Against the real codebase it scans 1,631 files and
+reports clean both before and after, so nothing that exists today is newly blocked.

--- a/scripts/lint-no-unfunneled-tmux-literal-send.js
+++ b/scripts/lint-no-unfunneled-tmux-literal-send.js
@@ -22,9 +22,33 @@
  * Structure > Willpower — a comment asking authors to remember is a wish; this
  * is the guarantee.
  *
- * Guardrail, not proof: a wrapper that builds the argv array dynamically could
- * still evade it. The declared duty stays "literal sends go through the
- * funnel"; this catches the direct pattern.
+ * SCOPE CORRECTED 2026-08-15. The previous header said only that "a wrapper that
+ * builds the argv array dynamically could still evade it". That understated the
+ * gap: the check was LINE-oriented and required `send-keys` and `'-l'` on the
+ * SAME line, so four PLAIN literal forms — none of them dynamic, none of them a
+ * wrapper — walked straight past it. Measured against the shipped check, with the
+ * one-line form as a positive control firing in the same run:
+ *
+ *   ["send-keys", "-l", p]                        CONTROL  exit 1 (caught)
+ *   [\n  "send-keys",\n  "-l",\n  p,\n]        exit 0 — EVADES
+ *   const F = "-l";      ["send-keys", F, p]      exit 0 — EVADES
+ *   const C = "send-keys"; [C, "-l", p]           exit 0 — EVADES
+ *   ["send-keys","-l",p]  // buildLiteralSendArgs exit 0 — EVADES
+ *
+ * The first is the one that matters: a multi-line argv array is simply how any
+ * formatter writes an array over the print width. The guard could be defeated by
+ * running prettier. The last is worse in kind — merely NAMING the funnel in a
+ * COMMENT on that line suppressed the check, so `// TODO: use buildLiteralSendArgs`
+ * beside a raw send silenced the guard that the TODO was admitting was needed.
+ *
+ * Now: comments are stripped quote-aware first, string constants are resolved
+ * per file, and the unit of matching is the ARRAY LITERAL (bracket-matched,
+ * bounded) rather than the line — which is what the original rule always meant.
+ *
+ * STILL not proof, and this is the honest remainder: an argv array assembled at
+ * RUNTIME (push(), concat(), spread of a computed list, a helper that returns the
+ * array) is invisible here. That is the gap the original header named, and it is
+ * the only one left. Closing it needs dataflow, not more patterns.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -46,20 +70,142 @@ function walk(dir, out = []) {
   return out;
 }
 
+/**
+ * Strip // and block comments WITHOUT touching string contents, replacing each
+ * removed character with a space so every byte offset — and therefore every
+ * reported line number — is preserved exactly.
+ */
+export function stripComments(src) {
+  let out = '';
+  let i = 0;
+  let quote = null;
+  while (i < src.length) {
+    const c = src[i];
+    const n = src[i + 1];
+    if (quote) {
+      out += c;
+      if (c === '\\') { out += n ?? ''; i += 2; continue; }
+      if (c === quote) quote = null;
+      i += 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') { quote = c; out += c; i += 1; continue; }
+    if (c === '/' && n === '/') {
+      while (i < src.length && src[i] !== '\n') { out += ' '; i += 1; }
+      continue;
+    }
+    if (c === '/' && n === '*') {
+      out += '  '; i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
+        out += src[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      out += '  '; i += 2;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Identifiers bound to a plain string literal in THIS file. An identifier bound
+ * more than once to DIFFERENT values is UNRESOLVABLE and dropped, so an ambiguous
+ * name can never be substituted into a match — ambiguity fails toward NOT flagging,
+ * because a guess that fails someone's build is the expensive direction.
+ */
+export function collectStringConsts(code) {
+  const seen = new Map();
+  const conflicting = new Set();
+  const DECL = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(['"`])([^'"`\n]*)\2/g;
+  let m;
+  while ((m = DECL.exec(code)) !== null) {
+    const [, name, , value] = m;
+    if (seen.has(name) && seen.get(name) !== value) conflicting.add(name);
+    else seen.set(name, value);
+  }
+  for (const name of conflicting) seen.delete(name);
+  return seen;
+}
+
+/**
+ * Every bracket-matched array literal in the source, as {text, line}. Bounded:
+ * an array longer than MAX_ARRAY_CHARS is truncated rather than scanned whole, so
+ * a pathological file cannot make this quadratic. Unbalanced brackets simply
+ * yield no region — the check fails toward NOT flagging.
+ */
+const MAX_ARRAY_CHARS = 4000;
+export function arrayRegions(code) {
+  const regions = [];
+  for (let i = 0; i < code.length; i++) {
+    if (code[i] !== '[') continue;
+    let depth = 0;
+    let quote = null;
+    let j = i;
+    for (; j < code.length && j - i < MAX_ARRAY_CHARS; j++) {
+      const c = code[j];
+      if (quote) {
+        if (c === '\\') { j += 1; continue; }
+        if (c === quote) quote = null;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') { quote = c; continue; }
+      if (c === '[') depth += 1;
+      else if (c === ']') { depth -= 1; if (depth === 0) break; }
+    }
+    if (depth !== 0) continue;
+    const text = code.slice(i, j + 1);
+    const line = code.slice(0, i).split('\n').length;
+    regions.push({ text, line });
+  }
+  return regions;
+}
+
+/** True when the resolved region is a raw literal `send-keys -l` argv. */
+export function regionViolates(regionText, consts) {
+  let t = regionText;
+  for (const [name, value] of consts) {
+    t = t.replace(new RegExp(`\\b${name}\\b`, 'g'), `'${value}'`);
+  }
+  if (!/['"`]send-keys['"`]/.test(t)) return false;
+  if (!/['"`]-l['"`]/.test(t)) return false;
+  // Already funnelled — checked on COMMENT-STRIPPED code, so merely naming the
+  // funnel in a comment can no longer silence the guard.
+  if (t.includes('buildLiteralSendArgs')) return false;
+  return true;
+}
+
+export function scanSource(code) {
+  const stripped = stripComments(code);
+  const consts = collectStringConsts(stripped);
+  const hits = [];
+  for (const region of arrayRegions(stripped)) {
+    if (regionViolates(region.text, consts)) {
+      hits.push({ line: region.line, text: region.text.replace(/\s+/g, ' ').trim() });
+    }
+  }
+  return hits;
+}
+
+// DIRECT-INVOCATION GUARD. Without it, importing this module to unit-test the
+// helpers above runs the whole src/ scan and calls process.exit(1) the moment the
+// repo has a real violation — killing the importing process. Four other lints hit
+// exactly that this week; the guard is the same fix.
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) runLint();
+
+function runLint() {
 const violations = [];
 
 for (const file of walk(SRC)) {
   const rel = path.relative(REPO, file);
   if (EXEMPT.has(rel)) continue;
-  const lines = fs.readFileSync(file, 'utf-8').split('\n');
-  lines.forEach((line, i) => {
-    // Match an argv array literal carrying both 'send-keys' and a '-l' flag.
-    if (!line.includes('send-keys')) return;
-    if (!/['"]-l['"]/.test(line)) return;
-    // Already funnelled.
-    if (line.includes('buildLiteralSendArgs')) return;
-    violations.push({ rel, line: i + 1, text: line.trim() });
-  });
+  for (const hit of scanSource(fs.readFileSync(file, 'utf-8'))) {
+    violations.push({ rel, line: hit.line, text: hit.text });
+  }
 }
 
 if (violations.length > 0) {
@@ -76,3 +222,4 @@ if (violations.length > 0) {
 }
 
 console.log(`✓ tmux literal sends funnelled (scanned ${walk(SRC).length} files, 0 unfunneled)`);
+}

--- a/tests/unit/tmux-send-lint-array-scope.test.ts
+++ b/tests/unit/tmux-send-lint-array-scope.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripComments,
+  collectStringConsts,
+  arrayRegions,
+  scanSource,
+} from '../../scripts/lint-no-unfunneled-tmux-literal-send.js';
+
+/**
+ * `lint-no-unfunneled-tmux-literal-send` guards the `send-keys -l` argv ceiling.
+ * On 2026-08-04 a ~40 KB prompt blew that ceiling and took down the whole
+ * internal-LLM substrate on one machine: the breaker misread the opaque send
+ * error as a rate limit and tripped 14 consecutive times while ten LLM-backed
+ * components sat at 76-100% error rate.
+ *
+ * The check required `send-keys` and `'-l'` on the SAME LINE, so four plain
+ * literal forms evaded it. THE DEFECT tests fail against that behaviour. The
+ * CONTROL tests pass against BOTH — this lint blocks commits, so a version that
+ * flags correct code would be worse than the hole it closes.
+ *
+ * These tests can import the module only because it now carries a
+ * direct-invocation guard; before, importing ran the whole src/ scan and could
+ * call process.exit(1), killing the test run.
+ */
+
+const flags = (src: string) => scanSource(src).length > 0;
+
+describe('THE DEFECT — plain literal sends that walked past a line-oriented check', () => {
+  it('catches a multi-line argv array — the form any formatter produces', () => {
+    // The one that matters: nobody has to try. Prettier writes this.
+    expect(flags('const a = [\n  "send-keys",\n  "-l",\n  payload,\n];\n')).toBe(true);
+  });
+
+  it('catches the -l flag lifted into a constant', () => {
+    expect(flags('const F = "-l";\nconst a = ["send-keys", F, payload];\n')).toBe(true);
+  });
+
+  it('catches the send-keys verb lifted into a constant', () => {
+    expect(flags('const C = "send-keys";\nconst a = [C, "-l", payload];\n')).toBe(true);
+  });
+
+  it('is not silenced by merely NAMING the funnel in a comment', () => {
+    // Worse in kind than the others: `// TODO: use buildLiteralSendArgs` beside a
+    // raw send silenced the very guard the TODO was admitting was needed.
+    expect(flags('const a = ["send-keys", "-l", p]; // TODO: buildLiteralSendArgs\n')).toBe(true);
+  });
+
+  it('catches both spellings together — multi-line AND a resolved constant', () => {
+    expect(flags('const F = "-l";\nconst a = [\n  "send-keys",\n  F,\n  payload,\n];\n')).toBe(true);
+  });
+});
+
+describe('CONTROL — the one-line form the shipped check already caught still fires', () => {
+  it('still catches the plain single-line argv', () => {
+    expect(flags('const a = ["send-keys", "-l", payload];\n')).toBe(true);
+  });
+});
+
+describe('CONTROL — correct code stays legal (over-block is the dominant risk)', () => {
+  it('does not flag send-keys without the -l flag', () => {
+    expect(flags('const a = ["send-keys", "Enter"];\n')).toBe(false);
+  });
+
+  it('does not flag a genuinely funnelled call', () => {
+    expect(flags('const a = buildLiteralSendArgs(target, payload);\n')).toBe(false);
+  });
+
+  it('does not join two SEPARATE arrays into one violation', () => {
+    // The whole reason the unit is the bracket-matched array and not a line
+    // window: an unrelated ["ls", "-l"] must not complete a send-keys array.
+    expect(flags('const a = ["send-keys", "Enter"];\nconst b = ["ls", "-l"];\n')).toBe(false);
+  });
+
+  it('does not flag a constant bound to a different flag', () => {
+    expect(flags('const F = "-x";\nconst a = ["send-keys", F, p];\n')).toBe(false);
+  });
+
+  it('does not flag an example that lives entirely inside a comment', () => {
+    expect(flags('// example: ["send-keys", "-l", payload]\nconst a = 1;\n')).toBe(false);
+  });
+
+  it('does not flag an identifier bound twice to DIFFERENT values — unresolvable', () => {
+    // Ambiguity must fail toward NOT flagging. Substituting either value is a
+    // guess, and a guess that fails a build is the expensive direction.
+    expect(flags('const F = "-l";\nlet F = "-x";\nconst a = ["send-keys", F, p];\n')).toBe(false);
+  });
+});
+
+describe('the primitives, pinned directly', () => {
+  it('strips comments without touching string contents, preserving line numbers', () => {
+    const out = stripComments('const s = "// not a comment";\n// real\nconst t = 1;\n');
+    expect(out).toContain('// not a comment');
+    expect(out).not.toContain('real');
+    expect(out.split('\n').length).toBe(4);
+  });
+
+  it('drops an identifier with conflicting bindings rather than picking one', () => {
+    expect(collectStringConsts('const M = "a";\nconst M = "b";\n').has('M')).toBe(false);
+  });
+
+  it('keeps an identifier bound twice to the SAME value', () => {
+    expect(collectStringConsts('const M = "a";\nconst M = "a";\n').get('M')).toBe('a');
+  });
+
+  it('matches nested arrays as one region and reports the opening line', () => {
+    const regions = arrayRegions('const a = 1;\nconst b = ["x", ["y"], "z"];\n');
+    expect(regions.length).toBeGreaterThan(0);
+    expect(regions[0].line).toBe(2);
+    expect(regions[0].text).toContain('"y"');
+  });
+
+  it('yields no region for an unbalanced bracket — fails toward NOT flagging', () => {
+    expect(arrayRegions('const a = ["send-keys", "-l"\n').length).toBe(0);
+  });
+
+  it('ignores a bracket that appears inside a string', () => {
+    const regions = arrayRegions('const a = "[not an array";\nconst b = ["x"];\n');
+    expect(regions.length).toBe(1);
+    expect(regions[0].line).toBe(2);
+  });
+});

--- a/upgrades/next/tmux-send-lint-array-scope.md
+++ b/upgrades/next/tmux-send-lint-array-scope.md
@@ -1,0 +1,54 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+`scripts/lint-no-unfunneled-tmux-literal-send.js` now matches the bracket-matched ARGV ARRAY rather
+than a single line.
+
+That lint guards the `send-keys -l` argv ceiling (~16.2 KB) — the class behind the 2026-08-04 incident
+where a ~40 KB prompt blew the ceiling, the circuit breaker misread the opaque send error as a provider
+rate-limit and tripped 14 consecutive times, and ten LLM-backed components sat at 76-100% error rate.
+
+It required `send-keys` and `'-l'` on the SAME line, so four PLAIN literal forms evaded it — measured
+against the shipped check with the one-line form as a positive control firing in the same run: a
+multi-line array (what any formatter produces), the flag lifted into a const, the verb lifted into a
+const, and — worst in kind — merely NAMING the funnel in a comment on that line, so
+`// TODO: use buildLiteralSendArgs` beside a raw send silenced the guard the TODO was admitting was
+needed.
+
+The first is the one that matters: **the guard could be defeated by running prettier.**
+
+Added: `stripComments` (quote-aware, line-number preserving), `collectStringConsts` (per-file;
+conflicting bindings dropped as unresolvable), `arrayRegions` (bracket-matched, string-aware, bounded),
+`regionViolates` and `scanSource`. The rule, the exemption and the message are unchanged. Also added a
+direct-invocation guard — importing the module previously ran the whole `src/` scan and could
+`process.exit(1)`, which is why its internals had never been unit-tested.
+
+## What to Tell Your User
+
+Nothing changes for you. A build-time check that stops a known way of breaking terminal sends could be
+walked past just by letting a code formatter split a list across lines — no intent required. It now
+reads the whole list instead of one line. Nothing you use behaves differently; a failure mode that once
+took down ten components for hours got harder to reintroduce by accident.
+
+## Summary of New Capabilities
+
+None. No new command, endpoint, setting, or runtime behaviour. A CI guard that a code formatter could
+defeat no longer can be.
+
+## Evidence
+
+- `tests/unit/tmux-send-lint-array-scope.test.ts` — 18/18 green.
+- **Negative control: 6 of 18 fail** against the shipped line-oriented behaviour; the other 12 pass both
+  ways and are the controls. Source restored byte-exact afterwards (sha match, zero markers left).
+- Six anti-over-block controls, because this lint blocks commits: send-keys without the flag; a genuinely
+  funnelled call; two SEPARATE arrays never joined; a const bound to a different flag; an example living
+  entirely inside a comment; and an identifier with conflicting bindings left unresolvable.
+- Real tree: `exit 0` before AND after, 1,631 files scanned.
+- Full `npm run lint` chain green; chain membership verified explicitly rather than inferred.
+- **Scope CORRECTED, not restated:** the old header claimed only that a dynamically-built argv could
+  evade it. None of the four measured evasions is dynamic. The header now names what was actually
+  missing, and the genuine remainder (a runtime-assembled array — push/concat/spread/helper).

--- a/upgrades/side-effects/tmux-send-lint-array-scope.md
+++ b/upgrades/side-effects/tmux-send-lint-array-scope.md
@@ -1,0 +1,122 @@
+# Side-Effects Review — tmux send-keys guard matches the array, not the line
+
+**Version / slug:** `tmux-send-lint-array-scope`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1 (CI-only lint script; no runtime path). The rule is unchanged; the check now reads the unit it always meant (the argv array) instead of a single line.`
+
+## Summary of the change
+
+`scripts/lint-no-unfunneled-tmux-literal-send.js` guards the `send-keys -l` argv ceiling (~16.2 KB).
+The 2026-08-04 incident it exists to prevent: a ~40 KB prompt blew the ceiling, `LlmCircuitBreaker`
+misclassified the opaque send error as a provider rate-limit and tripped 14 consecutive times while ten
+LLM-backed components sat at 76-100% error rate.
+
+The check required `send-keys` AND `'-l'` on the SAME LINE. Measured against the shipped check, with the
+one-line form as a positive control firing in the same run:
+
+| form | shipped |
+|---|---|
+| `["send-keys", "-l", p]` — POSITIVE CONTROL | exit 1 (caught) |
+| the same array across 5 lines | **exit 0 — EVADES** |
+| `const F = "-l"; ["send-keys", F, p]` | **exit 0 — EVADES** |
+| `const C = "send-keys"; [C, "-l", p]` | **exit 0 — EVADES** |
+| `["send-keys","-l",p] // buildLiteralSendArgs` | **exit 0 — EVADES** |
+
+The unit of matching is now the bracket-matched ARRAY LITERAL, over comment-stripped, const-resolved
+source. The rule, the exemption and the message are unchanged.
+
+## Decision-point inventory
+
+- `stripComments(src)` — ADD — quote-aware; replaces removed bytes with spaces so line numbers are exact.
+- `collectStringConsts(code)` — ADD — per-file identifier → literal; conflicting bindings dropped.
+- `arrayRegions(code)` — ADD — bracket-matched, string-aware, bounded at 4000 chars per region.
+- `regionViolates(text, consts)` — ADD — resolves then applies the EXISTING two patterns.
+- `scanSource(code)` — ADD — the composed scan, extracted so matching is testable.
+- Direct-invocation guard — ADD — the scan runs only when invoked directly.
+- The `EXEMPT` set, the two patterns, the violation message and exit codes — UNCHANGED.
+- No runtime block/allow decision added or modified. CI-time only.
+
+## 1. Over-block
+
+The failure that matters: this lint blocks commits, and a check that flags correct code gets switched
+off. Six controls, each with a test, all passing under BOTH old and new behaviour:
+
+- `send-keys` WITHOUT `-l` is not flagged (only the literal form has the ceiling).
+- A genuinely funnelled `buildLiteralSendArgs(...)` call is not flagged.
+- **Two separate arrays are never joined** — an unrelated `["ls", "-l"]` cannot complete a send-keys
+  array. This is the whole reason the unit is a bracket-matched region rather than a line window.
+- A const bound to a different flag is not flagged.
+- An example living entirely inside a comment is not flagged — which is what makes it safe to document
+  the bad pattern, including in this file and the ELI16.
+- An identifier bound twice to DIFFERENT values is unresolvable and never substituted.
+
+Unbalanced brackets yield no region, so a syntax error elsewhere cannot become a false accusation.
+
+**Verified against the real tree: exit 0 before AND after**, scanning 1,631 files. No new flags.
+
+## 2. Under-block
+
+Stated in the source, and it is a CORRECTION rather than a restatement. The old header claimed only
+that "a wrapper that builds the argv array dynamically could still evade it" — true, but it understated
+the gap, since none of the four measured evasions is dynamic or a wrapper. The header now names what was
+actually missing and what genuinely remains:
+
+- An argv array assembled at RUNTIME — `push()`, `concat()`, spread of a computed list, or a helper that
+  returns the array. That is the original declared gap and it is the only one left.
+- Closing it needs dataflow, not more patterns.
+
+## 3. Level-of-abstraction fit
+
+Same layer as the existing check — regex over source text, no AST, no type information, no new
+dependency. Bracket matching is the minimum needed to read an array literal as one unit; going further
+(a parser) would be a different check at a different layer.
+
+## 4. Signal vs authority compliance
+
+Unchanged. A CI guard, not a runtime authority. It pushes callers toward `buildLiteralSendArgs()`; the
+funnel itself stays exempt.
+
+## 5. Interactions
+
+- `npm run lint` chain — membership verified explicitly (in the `lint` chain CI runs, not merely
+  referenced by a standalone entry); full chain green.
+- The direct-invocation guard changes import behaviour from "runs the src/ scan and may exit(1)" to
+  "exports only". Nothing imported this module before, so no caller changes.
+- No source module, route, config key, or state file touched.
+
+## 6. External surfaces
+
+None. Developer tooling, not an agent capability; the Agent Awareness Standard does not apply.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN, and correctly so — not an unexamined assumption.** A CI-time source scan with
+no runtime surface: it reads files in one checkout and exits. No durable state, no user-facing notice, no
+generated URL, no runtime decision — so nothing to replicate, nothing to merge on read, nothing that can
+strand on a topic transfer. Every machine runs it over its own checkout of the same tracked source and
+reaches the same verdict; determinism comes from the source tree, not from coordination. Resolution is
+explicitly per-file, so it cannot depend on the rest of the checkout, let alone another machine.
+
+## 8. Rollback cost
+
+`git revert` of one script plus the added test file. No migration, no state, no deployed artifact.
+
+## Conclusion
+
+Ship. Four evasions closed on a guard with a real production incident behind it, six anti-over-block
+controls added, the stated scope corrected rather than restated, and the import hazard removed.
+
+## Evidence pointers
+
+- `tests/unit/tmux-send-lint-array-scope.test.ts` — **18/18 green**.
+- **Negative control: 6 of 18 fail** against the shipped line-oriented behaviour. The other 12 pass both
+  ways — which is what makes them controls. Source restored byte-exact after the mutation (sha match,
+  zero markers left).
+- Reproduced by hand FIRST with a positive control firing in the same run; the control is what makes the
+  four EVADES verdicts mean anything.
+- Real-tree verdict: exit 0, 1,631 files scanned, before and after.
+- Full `npm run lint` chain green.
+- Tier **1** declared: risk floor 1, verified with a directional control (`SessionReaper.ts` → floor 2
+  with its reason named). The size heuristic suggests 2 on added LOC alone; stated openly, since the tier
+  I choose is the one that lets my own change through.


### PR DESCRIPTION
## What this fixes

`lint-no-unfunneled-tmux-literal-send` guards the `send-keys -l` argv ceiling (~16.2 KB). The incident
it exists to prevent, from its own header: on **2026-08-04** a ~40 KB prompt blew the ceiling,
`LlmCircuitBreaker` misclassified the opaque `command too long` as a provider rate-limit and tripped
**14 consecutive times**, while **ten LLM-backed components sat at 76-100% error rate**.

The check required `send-keys` AND `'-l'` on the **same line**. Measured against the shipped check,
with the one-line form as a **positive control firing in the same run**:

```js
["send-keys", "-l", payload]                     // CONTROL   exit 1 (caught)
[\n  "send-keys",\n  "-l",\n  payload,\n]        //           exit 0 — EVADES
const F = "-l";        ["send-keys", F, payload] //           exit 0 — EVADES
const C = "send-keys"; [C, "-l", payload]        //           exit 0 — EVADES
["send-keys","-l",p];  // TODO: buildLiteralSendArgs          exit 0 — EVADES
```

**The first is the one that matters: this guard could be defeated by running prettier.** A multi-line
argv array is simply what any formatter produces once the list exceeds the print width — nobody has to
be trying to get around anything.

**The last is worse in kind.** `line.includes('buildLiteralSendArgs')` was the "already funnelled"
escape, so merely *naming* the funnel in a comment silenced the check — `// TODO: use
buildLiteralSendArgs` beside a raw send switched off the guard the TODO was admitting was needed.

The matching unit is now the bracket-matched **argv array**, over comment-stripped, const-resolved
source. `EXEMPT`, both patterns and the violation message are **unchanged** — only the unit changed,
and the array is what the original rule's own comment always said it meant.

## ELI16

Instar types into terminal sessions. The command for sending literal text passes the whole message as a
single argument, which the operating system caps at about 16 KB. Below the cap everything works; above
it the send fails with a bare "command too long" that says nothing useful. In August that happened for
real — the component watching for failures read the meaningless error as "the AI provider is rate
limiting us" and shut itself off fourteen times in a row, while ten parts of the system that need AI
calls sat at between three-quarters and total failure.

The fix routed every such send through one helper that splits the text into safe pieces. A build check
stops the problem coming back by failing the build on any raw send that skips the helper.

That check read one line at a time, and only complained when the command and its flag appeared on the
same line. So it saw nothing when the list was spread over several lines — the identical command, and
exactly what a code formatter produces when a list gets long. **You could defeat the guard by running
prettier**, with no intent at all. Three more plain forms slipped past the same way, the worst being
that *mentioning the helper's name in a comment* counted as using it.

It now looks at the whole list rather than one line: it matches brackets to find where the list starts
and ends, removes comments properly (without touching text inside quotes), and works out what named
constants actually hold.

Because this check blocks commits, wrongly flagging correct code would cost more than the hole it
closes — a noisy check gets switched off, and then it protects nothing. So: a send without that flag is
fine; a genuinely routed call is fine; two separate lists are never joined; a constant holding something
else is fine; an example living entirely inside a comment is fine (which is what makes it safe to
document the bad pattern); and a name set to two different things in one file is treated as unresolvable
rather than guessed at.

It still can't see a list assembled while the program runs — built up with `push`, joined from another
list, or returned by a helper. That needs real dataflow analysis, and guessing would flag correct code.

Full version: `docs/specs/tmux-send-lint-array-scope.eli16.md`.

## Scope CORRECTED, not restated

The old header said only that *"a wrapper that builds the argv array dynamically could still evade it."*
That was true and it **understated the gap** — none of the four measured evasions is dynamic, and none
is a wrapper. They are the plainest ways to write the command. The header now names what was actually
missing, and the genuine remainder: a **runtime-assembled** argv (`push()`, `concat()`, spread of a
computed list, a helper returning the array). Closing that needs dataflow, not more patterns.

## Evidence

- `tests/unit/tmux-send-lint-array-scope.test.ts` — **18/18 green**.
- **Negative control: 6 of 18 fail** against the shipped line-oriented behaviour. The other 12 pass
  **both ways**, which is what makes them controls rather than echoes. Source restored **byte-exact**
  after the mutation (sha match, zero markers left).
- **Six anti-over-block controls**, because this lint blocks commits: `send-keys` without the flag; a
  genuinely funnelled call; **two SEPARATE arrays never joined** (the reason the unit is a
  bracket-matched region and not a line window); a const bound to a different flag; an example entirely
  inside a comment; and an identifier with **conflicting bindings** left unresolvable — ambiguity fails
  toward NOT flagging, because a guess that fails someone's build is the expensive direction.
- Unbalanced brackets yield no region, so a syntax error elsewhere can never become a false accusation.
- **Real tree: `exit 0` before AND after**, 1,631 files scanned — no new flags on existing code.
- Full `npm run lint` chain green; chain membership verified **explicitly** rather than inferred from a
  `package.json` reference.
- Also adds a **direct-invocation guard** — importing this module used to run the whole `src/` scan and
  call `process.exit(1)`, which is why its internals had never been unit-tested. Four other lints hit
  the same hazard this week; a peer's sweep of 144 modules showed the guard is already the established
  convention here (40 export-bearing modules call `process.exit`, all guarded), so these were outliers.
- Tier **1** declared. Risk floor 1, verified with a directional control (`SessionReaper.ts` → floor 2
  with its reason named); the gate's own signal agreed (`riskFloor=1`). The size heuristic suggests 2 on
  added LOC alone — stated openly, since the tier I choose is the one that lets my own change through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
