### PR TITLE
test(atomic-writes): scope the check to method bodies so it can fail on its own subject

### DIFF
--- a/docs/specs/atomic-writes-method-scope.eli16.md
+++ b/docs/specs/atomic-writes-method-scope.eli16.md
@@ -1,0 +1,95 @@
+# ELI16 — the safety check that could not fail on its own subject
+
+## What it protects
+
+When the agent saves state — your sessions, your relationships, your quota counters — it must not
+write straight over the existing file. If the process dies halfway through, you are left with half a
+file, and half a JSON file is worse than no file: it parses as garbage or not at all.
+
+The safe pattern is to write to a temporary file first and then rename it into place. Renaming is
+atomic on every filesystem we run on: either the old file is there or the new one is, never a
+half-written mixture.
+
+There is a test whose entire job is to prove the modules that save state actually do that.
+
+## What was wrong
+
+It could not detect the thing it exists to detect.
+
+I did not argue this from reading the code — I measured it. I inserted a genuinely unsafe write of
+real session state into `saveSession`, which is one of the exact methods the test names, in one of
+the exact files it names. **All twenty-one of its assertions passed.**
+
+Three separate causes, each of which would have been enough on its own:
+
+**1. It was looking at almost none of the file.** The test tried to track "am I inside a save method
+right now" with a flag that got switched ON when a method's name appeared on a line — and never got
+switched off. Its two findings (did I see a write? did I see a rename?) were reset every time a name
+appeared. So by the time it checked its answer at the end, the answer only described the stretch of
+file after the *last* mention of any method name. In the biggest file that is 125 lines out of 617 —
+**twenty percent** — leaving three of its four named methods completely unexamined.
+
+**2. Two of its checks were "does this word appear anywhere in the file".** One `renameSync` anywhere
+satisfied it, no matter how many unsafe writes sat elsewhere. The same for the `.tmp` check — and
+neither excluded comments, so a comment mentioning the safe pattern satisfied a check about whether
+the code performed it.
+
+**3. A method that no longer existed produced silence.** If a declared method had been renamed, its
+name simply never appeared, the flag never flipped, and nothing was checked — with no complaint. A
+missing *file* was skipped outright with a green tick.
+
+## What that third one immediately turned up
+
+Switching "missing means failure" on found two stale declarations straight away: **`saveState` has
+zero occurrences in either `StateManager` or `QuotaTracker`.** Both were renamed at some point. So
+two of the ten declared method entries have been pointing at nothing, quietly, for however long.
+
+QuotaTracker's real writer is `updateState`, and it does the safe thing correctly. It had simply
+never been verified by this test.
+
+## The part that made the fix harder than it looks
+
+The obvious fix — "check each method's own body for a write and a rename" — would have **failed on
+the best-written module in the set.**
+
+`StateManager` doesn't write files in its save methods at all. It sends every write through one
+private helper that does the temp-then-rename properly, in one place. That is exactly the pattern
+this codebase argues for everywhere else. Under a naive per-method rule its methods contain no write
+at all, so they would pass for the wrong reason — or, if I demanded a rename in each body, fail for
+being well written.
+
+So the check now follows one step of that delegation: if a method hands off to a helper in the same
+file, the *helper* is what gets verified. Which means `StateManager`'s writes are now genuinely
+checked, where before nothing checked them.
+
+## How you know it works
+
+Both directions, against the same code, in the same checkout — not one run in one place and another
+run somewhere else:
+
+| the check | against an unsafe write inserted into a declared method |
+|---|---|
+| the old one | **21 of 21 passed** |
+| the new one | **fails**, naming the file, the method, the deciding body and the line |
+
+The source file was restored byte-for-byte afterwards, verified by checksum.
+
+Eighteen more tests pin the parts. Six describe writes the old version could not see. Six are
+controls that pass under *both* versions — a correct delegation to a real helper, a proper
+temp-then-rename, a method that legitimately writes nothing, a commented-out write, a *call* to a
+method rather than its declaration, and a duplicate declaration where the unsafe one must win rather
+than the tidy one. Those six matter more than the six that fail: a rule that flagged good code would
+fail builds on exemplary work, which costs more than the gap it closes.
+
+## What it still does not cover, stated plainly
+
+**The list of modules is hand-written and has seven entries.** Hundreds of files under the source
+tree write files, and this test says nothing whatsoever about any of them. Widening that list is real
+work with real risk of flagging correct code, and it is deliberately **not** done here.
+
+Delegation is followed one step, within one file. A helper that calls another helper, or one imported
+from elsewhere, is not resolved — that needs real symbol analysis rather than reading text.
+
+And to be clear about what this is and is not: **the actual code is safe.** Every module the check
+now examines does the right thing, including through the helper. This fixes a weak instrument, not a
+live corruption bug, and I would rather say so than let a good headline stand.

--- a/tests/helpers/atomicWriteScope.ts
+++ b/tests/helpers/atomicWriteScope.ts
@@ -1,0 +1,262 @@
+/**
+ * Method-scoped atomicity analysis for the atomic-writes consistency check.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The original check tracked `inSaveMethod` with a flag that was set when a
+ * method NAME appeared on a line and was never set back to false. Its
+ * `hasWriteFile`/`hasRename` booleans were re-zeroed at each name occurrence,
+ * so the assertion at the end of the loop reflected only the window between the
+ * LAST method-name mention and EOF — 125 of 617 lines (20%) in StateManager.ts,
+ * leaving three of its four declared methods structurally unreachable. Within
+ * that window the two booleans were file-scope, so a `renameSync` anywhere
+ * satisfied a `writeFileSync` anywhere, in a different method.
+ *
+ * Measured consequence: a bare, non-atomic `fs.writeFileSync` of durable session
+ * state, inserted into `saveSession` — a DECLARED method of a DECLARED module —
+ * passed all 21 tests. The check could not fail on its own subject.
+ *
+ * These helpers replace the flag with brace-matched method bodies, and resolve
+ * ONE level of `this.helper()` delegation so a module that funnels its writes
+ * through a private `atomicWrite()` is verified through the funnel rather than
+ * passing trivially because its own body contains no write call.
+ *
+ * SCOPE, stated rather than implied: this is source-text analysis, not a
+ * TypeScript symbol graph. Delegation resolves one level, within one file.
+ */
+
+/** A method body located by brace matching, with the line its declaration starts on. */
+export interface MethodBody {
+  /** 1-indexed line of the declaration. */
+  line: number;
+  /** Body text INCLUDING the outer braces. */
+  text: string;
+}
+
+export type AtomicityVerdict =
+  | 'atomic-inline' // writes and renames in its own body
+  | 'atomic-via-funnel' // no direct write; delegates to an in-file body that is atomic-inline
+  | 'non-atomic' // a write with no rename on the resolved path
+  | 'no-write'; // neither writes nor delegates to anything that writes
+
+export interface MethodClassification {
+  found: boolean;
+  verdict: AtomicityVerdict | null;
+  /** Where the deciding write lives — the method itself, or the helper it delegates to. */
+  via: string | null;
+  line: number | null;
+}
+
+/**
+ * Remove `//` and block comments while preserving line count and never touching
+ * text inside string or template literals.
+ *
+ * Comment-stripping is load-bearing in BOTH directions here: a commented-out
+ * `writeFileSync` must not count as a write (false alarm), and — the reason this
+ * function exists at all — a comment mentioning `renameSync` beside a bare write
+ * must not launder that write into looking atomic.
+ */
+export function stripComments(src: string): string {
+  let out = '';
+  let i = 0;
+  let quote: string | null = null;
+
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+
+    if (quote) {
+      if (c === '\\') {
+        out += c + (next ?? '');
+        i += 2;
+        continue;
+      }
+      if (c === quote) quote = null;
+      out += c;
+      i += 1;
+      continue;
+    }
+
+    if (c === '"' || c === "'" || c === '`') {
+      quote = c;
+      out += c;
+      i += 1;
+      continue;
+    }
+
+    if (c === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') i += 1;
+      continue; // the newline itself is emitted by the next iteration
+    }
+
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) {
+        if (src[i] === '\n') out += '\n'; // preserve line numbering
+        i += 1;
+      }
+      i += 2;
+      continue;
+    }
+
+    out += c;
+    i += 1;
+  }
+
+  return out;
+}
+
+/**
+ * Brace-matched bodies of every declaration of `method` in `src`.
+ *
+ * Only DECLARATIONS are returned, never call sites: a line such as
+ * `this.saveSession({...})` is a call, and treating it as a declaration is how
+ * the original check conflated one method's write with another's rename.
+ * Brace depth is tracked string-aware so a `{` inside a literal cannot
+ * desynchronise the match; an unbalanced body yields nothing rather than a
+ * wrong region, so a syntax error elsewhere can never become a false verdict.
+ */
+export function methodBodies(src: string, method: string): MethodBody[] {
+  const clean = stripComments(src);
+  const bodies: MethodBody[] = [];
+
+  // A declaration is `name(` whose preceding non-space token opens a member
+  // position — start of file, `{`, `}` or `;` — after skipping any modifiers.
+  // Deciding by the PRECEDING token rather than by line position is what rejects
+  // `this.saveSession(` and `helper(save(1))` as calls while still accepting a
+  // declaration that does not begin its own line.
+  const declRe = new RegExp(String.raw`\b` + escapeRe(method) + String.raw`\s*\(`, 'g');
+  const MODIFIERS = new Set(['public', 'private', 'protected', 'static', 'async', 'readonly', 'override']);
+
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(clean)) !== null) {
+    if (!opensMemberPosition(clean, m.index, MODIFIERS)) continue;
+    const open = clean.indexOf('{', m.index + m[0].length - 1);
+    if (open < 0) continue;
+
+    let depth = 0;
+    let quote: string | null = null;
+    let end = -1;
+
+    for (let j = open; j < clean.length; j += 1) {
+      const c = clean[j];
+      if (quote) {
+        if (c === '\\') {
+          j += 1;
+          continue;
+        }
+        if (c === quote) quote = null;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') {
+        quote = c;
+        continue;
+      }
+      if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          end = j;
+          break;
+        }
+      }
+    }
+
+    if (end < 0) continue; // unbalanced — fail toward NOT reporting a region
+    bodies.push({ line: clean.slice(0, m.index).split('\n').length, text: clean.slice(open, end + 1) });
+  }
+
+  return bodies;
+}
+
+/** `this.helper(` call targets inside a body. */
+export function delegateTargets(body: string): string[] {
+  const out = new Set<string>();
+  const re = /\bthis\.([A-Za-z_$][\w$]*)\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) out.add(m[1]);
+  return [...out];
+}
+
+const writesDirectly = (body: string) => /\bwriteFileSync\s*\(/.test(body);
+const renamesDirectly = (body: string) => /\brenameSync\s*\(/.test(body);
+
+/**
+ * Classify a declared state-writing method.
+ *
+ * The invariant: a write on the method's resolved path must be paired with a
+ * rename IN THE SAME BODY. Per-body pairing is the whole point — a rename in a
+ * sibling method proves nothing about this one.
+ */
+export function classifyMethod(src: string, method: string): MethodClassification {
+  const bodies = methodBodies(src, method);
+  if (bodies.length === 0) return { found: false, verdict: null, via: null, line: null };
+
+  let best: MethodClassification | null = null;
+
+  for (const body of bodies) {
+    let verdict: AtomicityVerdict;
+    let via: string | null = null;
+
+    if (writesDirectly(body.text)) {
+      verdict = renamesDirectly(body.text) ? 'atomic-inline' : 'non-atomic';
+      via = method;
+    } else {
+      verdict = 'no-write';
+      for (const target of delegateTargets(body.text)) {
+        if (target === method) continue; // recursion is not resolution
+        const helpers = methodBodies(src, target);
+        for (const helper of helpers) {
+          if (!writesDirectly(helper.text)) continue;
+          via = target;
+          verdict = renamesDirectly(helper.text) ? 'atomic-via-funnel' : 'non-atomic';
+          break;
+        }
+        if (verdict !== 'no-write') break;
+      }
+    }
+
+    const candidate: MethodClassification = { found: true, verdict, via, line: body.line };
+    // Report the WORST verdict across overloads/duplicate declarations: a single
+    // non-atomic path is the finding, and letting a clean sibling mask it would
+    // reintroduce exactly the conflation this replaces.
+    if (!best || rank(verdict) > rank(best.verdict!)) best = candidate;
+  }
+
+  return best!;
+}
+
+function rank(v: AtomicityVerdict): number {
+  return v === 'non-atomic' ? 3 : v === 'atomic-inline' || v === 'atomic-via-funnel' ? 2 : 1;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * True when the text immediately before `index` puts this occurrence in a
+ * member-declaration position rather than a call position.
+ *
+ * Walks back over whitespace and any modifier keywords, then inspects the first
+ * real character. `.` means a method CALL (`this.saveSession(`), `(` or `,` mean
+ * an argument (`helper(save(1))`), `=` means an assignment — none of which
+ * declare the method being looked for.
+ */
+function opensMemberPosition(src: string, index: number, modifiers: Set<string>): boolean {
+  let i = index - 1;
+
+  for (;;) {
+    while (i >= 0 && /\s/.test(src[i])) i -= 1;
+    if (i < 0) return true; // start of file
+
+    // Step back over a preceding modifier keyword, then re-test what precedes it.
+    let end = i;
+    while (i >= 0 && /[A-Za-z]/.test(src[i])) i -= 1;
+    const word = src.slice(i + 1, end + 1);
+    if (word && modifiers.has(word)) continue;
+
+    const ch = src[end];
+    return ch === '{' || ch === '}' || ch === ';';
+  }
+}

--- a/tests/unit/atomic-write-scope.test.ts
+++ b/tests/unit/atomic-write-scope.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import {
+  stripComments,
+  methodBodies,
+  delegateTargets,
+  classifyMethod,
+} from '../helpers/atomicWriteScope.js';
+
+/**
+ * Method-scoped atomicity analysis — the primitives behind
+ * `atomic-writes-consistency.test.ts`.
+ *
+ * THE DEFECT cases are the forms the previous file-scope/never-reset-flag check
+ * could not see; each fails against that behaviour. The CONTROL cases pass under
+ * BOTH, and they are the reason this is a check rather than an alarm: a rule
+ * that flagged a correct funnel or a commented-out example would fail builds on
+ * exemplary code, which costs more than the hole it closes.
+ */
+
+describe('THE DEFECT — writes the previous check could not see', () => {
+  it('flags a bare write in a method whose body has no rename', () => {
+    // The measured case: this exact shape, inserted into StateManager#saveSession,
+    // passed all 21 of the old assertions.
+    const src = [
+      'class S {',
+      '  saveSession(s: Session): void {',
+      '    fs.writeFileSync(filePath, JSON.stringify(s), "utf-8");',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(classifyMethod(src, 'saveSession').verdict).toBe('non-atomic');
+  });
+
+  it('does not let a SIBLING method\'s rename vouch for this one', () => {
+    // File-scope booleans made any renameSync anywhere satisfy any write anywhere.
+    const src = [
+      'class S {',
+      '  saveSession(s) {',
+      '    fs.writeFileSync(p, d);',
+      '  }',
+      '  unrelated() {',
+      '    fs.renameSync(tmp, p);',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(classifyMethod(src, 'saveSession').verdict).toBe('non-atomic');
+  });
+
+  it('checks a method declared EARLY in the file, not only the last one', () => {
+    // The never-reset flag meant only the window after the LAST method-name
+    // mention reached the assertion.
+    const src = [
+      'class S {',
+      '  saveSession(s) { fs.writeFileSync(p, d); }',
+      '  later() { return 1; }',
+      '  lastOfAll() { fs.writeFileSync(t, d); fs.renameSync(t, p); }',
+      '}',
+    ].join('\n');
+    expect(classifyMethod(src, 'saveSession').verdict).toBe('non-atomic');
+  });
+
+  it('flags a broken FUNNEL reached by delegation', () => {
+    // A module that funnels its writes passes trivially under a per-method rule
+    // (its own body contains no write at all). One level is resolved so the
+    // funnel is what gets verified.
+    const src = [
+      'class S {',
+      '  saveSession(s) { this.atomicWrite(p, d); }',
+      '  private atomicWrite(p, d) { fs.writeFileSync(p, d); }',
+      '}',
+    ].join('\n');
+    const r = classifyMethod(src, 'saveSession');
+    expect(r.verdict).toBe('non-atomic');
+    expect(r.via).toBe('atomicWrite');
+  });
+
+  it('does not accept a rename that exists only in a COMMENT', () => {
+    const src = [
+      'class S {',
+      '  saveSession(s) {',
+      '    // followed by fs.renameSync(tmp, p) — not really',
+      '    fs.writeFileSync(p, d);',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(classifyMethod(src, 'saveSession').verdict).toBe('non-atomic');
+  });
+
+  it('reports a missing method rather than silently checking nothing', () => {
+    // Two real declarations were stale when this landed: StateManager.saveState
+    // and QuotaTracker.saveState have zero occurrences in their files.
+    const r = classifyMethod('class S { other() {} }', 'saveState');
+    expect(r.found).toBe(false);
+    expect(r.verdict).toBeNull();
+  });
+});
+
+describe('CONTROL — correct code stays passing (over-block is the dominant risk)', () => {
+  it('accepts an in-body tmp-then-rename', () => {
+    const src = [
+      'class S {',
+      '  updateState(s) {',
+      '    fs.writeFileSync(tmpPath, JSON.stringify(s));',
+      '    fs.renameSync(tmpPath, this.file);',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(classifyMethod(src, 'updateState').verdict).toBe('atomic-inline');
+  });
+
+  it('accepts delegation to a GENUINE atomic funnel', () => {
+    // This is the real StateManager shape. Failing it would be a false red on
+    // the single-funnel pattern this codebase argues for everywhere else.
+    const src = [
+      'class S {',
+      '  saveSession(s) { this.atomicWrite(p, d); }',
+      '  private atomicWrite(p, d) {',
+      '    fs.writeFileSync(tmpPath, d);',
+      '    fs.renameSync(tmpPath, p);',
+      '  }',
+      '}',
+    ].join('\n');
+    const r = classifyMethod(src, 'saveSession');
+    expect(r.verdict).toBe('atomic-via-funnel');
+    expect(r.via).toBe('atomicWrite');
+  });
+
+  it('does not invent a violation for a method that writes nothing', () => {
+    const src = 'class S { appendEvent(e) { this.buffer.push(e); } }';
+    expect(classifyMethod(src, 'appendEvent').verdict).toBe('no-write');
+  });
+
+  it('does not treat a commented-out write as a write', () => {
+    const src = 'class S { save(s) { /* fs.writeFileSync(p, d); */ return; } }';
+    expect(classifyMethod(src, 'save').verdict).toBe('no-write');
+  });
+
+  it('does not mistake a CALL site for a declaration', () => {
+    // `this.saveSession({...})` inside another method is a call. Treating it as
+    // a declaration is precisely how the old flag conflated two methods.
+    const src = [
+      'class S {',
+      '  saveSession(s) { fs.writeFileSync(t, d); fs.renameSync(t, p); }',
+      '  bulk(list) {',
+      '    for (const s of list) this.saveSession({ ...s });',
+      '    fs.writeFileSync(other, d);',
+      '  }',
+      '}',
+    ].join('\n');
+    expect(classifyMethod(src, 'saveSession').verdict).toBe('atomic-inline');
+  });
+
+  it('reports the WORST verdict across duplicate declarations, not the kindest', () => {
+    const src = [
+      'class A { save(s) { fs.writeFileSync(t, d); fs.renameSync(t, p); } }',
+      'class B { save(s) { fs.writeFileSync(p, d); } }',
+    ].join('\n');
+    expect(classifyMethod(src, 'save').verdict).toBe('non-atomic');
+  });
+});
+
+describe('the primitives, pinned directly', () => {
+  it('strips comments without touching string contents, preserving line count', () => {
+    const out = stripComments('const s = "// not a comment";\n// real\nconst t = 1;\n');
+    expect(out).toContain('// not a comment');
+    expect(out).not.toContain('real');
+    expect(out.split('\n').length).toBe(4);
+  });
+
+  it('brace-matches a body containing a brace inside a string literal', () => {
+    const src = 'class S { save() { const x = "}"; fs.writeFileSync(p, x); } }';
+    const bodies = methodBodies(src, 'save');
+    expect(bodies.length).toBe(1);
+    expect(bodies[0].text).toContain('writeFileSync');
+  });
+
+  it('yields no body for an unbalanced brace — fails toward NOT reporting', () => {
+    expect(methodBodies('class S { save() { fs.writeFileSync(p, d);', 'save').length).toBe(0);
+  });
+
+  it('reports the declaration line, not the call line', () => {
+    const src = ['class S {', '  other() { this.save(1); }', '  save(n) { return n; }', '}'].join('\n');
+    const bodies = methodBodies(src, 'save');
+    expect(bodies.length).toBe(1);
+    expect(bodies[0].line).toBe(3);
+  });
+
+  it('collects this.helper() delegation targets and ignores bare calls', () => {
+    const targets = delegateTargets('{ this.atomicWrite(p, d); helper(1); obj.other(2); }');
+    expect(targets).toContain('atomicWrite');
+    expect(targets).not.toContain('helper');
+    expect(targets).not.toContain('other');
+  });
+
+  it('does not resolve a method delegating to ITSELF as a funnel', () => {
+    const src = 'class S { save(n) { if (n) this.save(n - 1); } }';
+    expect(classifyMethod(src, 'save').verdict).toBe('no-write');
+  });
+});

--- a/tests/unit/atomic-writes-consistency.test.ts
+++ b/tests/unit/atomic-writes-consistency.test.ts
@@ -1,82 +1,108 @@
 /**
- * Atomic writes consistency test — verifies ALL state-writing modules
- * use the write-to-tmp-then-rename pattern to prevent corruption
- * from process crashes during writes.
+ * Atomic writes consistency test — verifies the declared state-writing modules
+ * use the write-to-tmp-then-rename pattern, so a crash mid-write cannot leave a
+ * truncated state file behind.
+ *
+ * WHAT CHANGED AND WHY (2026-08-15)
+ * ---------------------------------
+ * The previous version could not fail on its own subject. Measured, not argued:
+ * a bare `fs.writeFileSync` of durable session state inserted into `saveSession`
+ * — a DECLARED method of a DECLARED module — passed all 21 assertions.
+ *
+ * Three causes, each fixed here:
+ *
+ *  1. SCOPING. `inSaveMethod` was set when a method NAME appeared and never
+ *     reset, while `hasWriteFile`/`hasRename` were re-zeroed at each occurrence.
+ *     Only the window from the LAST name mention to EOF survived to the
+ *     assertion — 125 of 617 lines in StateManager.ts, leaving three of its four
+ *     declared methods unreachable. Bodies are now brace-matched per method.
+ *
+ *  2. FILE-SCOPE SUBSTRING CHECKS. `source.includes('renameSync')` and
+ *     `source.includes('.tmp')` are satisfied by one occurrence anywhere in the
+ *     file — including a comment — however many bare writes sit elsewhere.
+ *     Pairing is now per body.
+ *
+ *  3. SILENT DECLARATION ROT. A missing file was `it.skip`ped and a missing
+ *     method simply never set the flag, so a renamed method dropped out of
+ *     coverage without a sound. Both are failures now — and enabling that check
+ *     immediately found two: `StateManager.saveState` and `QuotaTracker.saveState`
+ *     have ZERO occurrences in their files. QuotaTracker's real writer,
+ *     `updateState()`, is atomic and had never been verified by this test.
+ *
+ * DELEGATION. StateManager funnels every write through a private `atomicWrite()`.
+ * Under a naive per-method rule its declared methods contain no write call at all
+ * and would pass trivially. One level of `this.helper()` delegation is resolved so
+ * the funnel itself is what gets verified.
+ *
+ * POPULATION — declared openly rather than implied: the module list below is
+ * CURATED and holds 7 entries. Hundreds of files under `src/` call
+ * `writeFileSync`, and this test says nothing about any of them. Widening the
+ * population is real work with real over-block risk and is NOT done here.
  */
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { classifyMethod } from '../helpers/atomicWriteScope.js';
 
 const SRC_ROOT = path.join(process.cwd(), 'src');
 
-/** List of all modules that persist state and MUST use atomic writes */
+/** Modules that persist durable state and MUST use atomic writes. */
 const STATE_WRITING_MODULES = [
-  { file: 'core/StateManager.ts', methods: ['saveState', 'saveSession', 'saveJobState', 'appendEvent'] },
+  { file: 'core/StateManager.ts', methods: ['saveSession', 'saveJobState', 'appendEvent'] },
   { file: 'core/RelationshipManager.ts', methods: ['save'] },
   { file: 'core/FeedbackManager.ts', methods: ['saveFeedback'] },
   { file: 'core/UpdateChecker.ts', methods: ['saveState'] },
   { file: 'users/UserManager.ts', methods: ['persistUsers'] },
-  { file: 'monitoring/QuotaTracker.ts', methods: ['saveState'] },
+  { file: 'monitoring/QuotaTracker.ts', methods: ['updateState'] },
   { file: 'messaging/TelegramAdapter.ts', methods: ['saveRegistry'] },
 ];
 
 describe('Atomic writes consistency', () => {
   for (const mod of STATE_WRITING_MODULES) {
     describe(mod.file, () => {
-      let source: string;
+      const absolute = path.join(SRC_ROOT, mod.file);
+      const source = fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf-8') : null;
 
-      try {
-        source = fs.readFileSync(path.join(SRC_ROOT, mod.file), 'utf-8');
-      } catch {
-        source = ''; // File may not exist yet
+      it('the declared module exists', () => {
+        // A missing file used to `it.skip`, so a moved module left coverage
+        // silently. Absence is a finding, not a reason to say nothing.
+        expect(source, `${mod.file} is declared here but not present under src/`).not.toBeNull();
+      });
+
+      if (!source) return;
+
+      for (const method of mod.methods) {
+        const result = classifyMethod(source, method);
+
+        it(`declares ${method}()`, () => {
+          expect(
+            result.found,
+            `${mod.file} declares no ${method}() — the declaration is stale, and a stale ` +
+              `declaration checks nothing while looking like coverage`
+          ).toBe(true);
+        });
+
+        it(`${method}() writes atomically`, () => {
+          expect(
+            result.verdict,
+            `${mod.file}#${method} performs a write with no renameSync on the same body ` +
+              `(deciding body: ${result.via ?? 'n/a'}, line ${result.line ?? '?'}). ` +
+              `A crash between write and rename leaves a truncated state file.`
+          ).not.toBe('non-atomic');
+        });
       }
 
-      if (!source) {
-        it.skip(`${mod.file} not found`, () => {});
-        return;
-      }
-
-      it('uses renameSync for atomic writes', () => {
-        // Must import or destructure renameSync
+      it('at least one declared method actually reaches a write', () => {
+        // ANTI-VACUITY. If every declared method resolves to `no-write`, this
+        // module has coverage in name only — the shape of failure this whole
+        // rewrite exists to remove.
+        const verdicts = mod.methods.map((m) => classifyMethod(source, m).verdict);
         expect(
-          source.includes('renameSync') || source.includes('fs.renameSync')
+          verdicts.some((v) => v === 'atomic-inline' || v === 'atomic-via-funnel' || v === 'non-atomic'),
+          `no declared method of ${mod.file} resolves to a write path — the declarations are ` +
+            `pointing at methods that do not persist anything`
         ).toBe(true);
-      });
-
-      it('writes to .tmp before renaming', () => {
-        // Pattern: write to tmpPath, then rename
-        expect(source).toContain('.tmp');
-      });
-
-      it('does NOT have bare writeFileSync as the final write for state', () => {
-        // Check that writeFileSync is always followed by renameSync in the same method
-        // This is a structural check — we look for the atomic pattern
-        const lines = source.split('\n');
-        let inSaveMethod = false;
-        let hasWriteFile = false;
-        let hasRename = false;
-
-        for (const line of lines) {
-          // Check if we're entering a save method
-          for (const method of mod.methods) {
-            if (line.includes(`${method}(`)) {
-              inSaveMethod = true;
-              hasWriteFile = false;
-              hasRename = false;
-            }
-          }
-
-          if (inSaveMethod) {
-            if (line.includes('writeFileSync')) hasWriteFile = true;
-            if (line.includes('renameSync')) hasRename = true;
-          }
-        }
-
-        // If there's a save method with writeFileSync, it should also have renameSync
-        if (hasWriteFile) {
-          expect(hasRename).toBe(true);
-        }
       });
     });
   }

--- a/upgrades/next/atomic-writes-method-scope.md
+++ b/upgrades/next/atomic-writes-method-scope.md
@@ -1,0 +1,63 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+The atomic-writes consistency test could not detect the defect it exists to detect.
+
+Measured rather than argued: a bare `fs.writeFileSync` of durable session state, inserted into
+`saveSession` — a DECLARED method of a DECLARED module — passed all 21 of its assertions.
+
+Three causes, all fixed:
+
+1. **Scoping.** `inSaveMethod` was set when a method NAME appeared on a line and never reset, while
+   `hasWriteFile`/`hasRename` were re-zeroed at each occurrence. Only the window from the LAST name
+   mention to EOF reached the assertion — 125 of 617 lines (20%) in `StateManager.ts`, leaving three
+   of its four declared methods structurally unreachable. Bodies are now brace-matched per method.
+2. **File-scope substring checks.** `source.includes('renameSync')` and `source.includes('.tmp')` are
+   satisfied by one occurrence anywhere in the file, comments included. Pairing is now per body.
+3. **Silent declaration rot.** A missing file was `it.skip`ped and a missing method never set the
+   flag, so a rename dropped a module out of coverage without a sound. Both are failures now — and
+   enabling that found two immediately: `saveState` has ZERO occurrences in `StateManager.ts` and in
+   `QuotaTracker.ts`. QuotaTracker's real writer, `updateState()`, is atomic and had never been
+   verified by this test. The declared list is corrected here.
+
+**Delegation.** `StateManager` funnels every write through a private `atomicWrite()`. A naive
+per-method rule would have failed the best-written module in the set for being well written, so one
+level of `this.helper()` delegation is resolved and the funnel is what gets verified — which means
+`StateManager`'s writes are now genuinely checked, where before nothing checked them.
+
+Added `tests/helpers/atomicWriteScope.ts` (`stripComments`, `methodBodies`, `delegateTargets`,
+`classifyMethod`) and `tests/unit/atomic-write-scope.test.ts`.
+
+**Declared open in the source:** the module list is curated at 7 entries and says nothing about the
+hundreds of other files under `src/` that call `writeFileSync`; delegation resolves one level within
+one file; only `writeFileSync`/`renameSync` are recognised.
+
+**The production code is atomic** everywhere the check now looks. This fixes a weak instrument, not a
+live corruption bug.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).
+
+## Evidence
+
+- `tests/unit/atomic-write-scope.test.ts` — 18/18 green (6 defect cases, 6 over-block controls, 6 primitives).
+- `tests/unit/atomic-writes-consistency.test.ts` — 32/32 green against the real tree.
+- **Both-directions proof in ONE worktree**, shipped check restored from git alongside the new one so
+  subject and control share a boundary: shipped → **21/21 PASSED** against the mutation; new →
+  **1 failed / 31 passed**, naming file, method, deciding body and line. `src/core/StateManager.ts`
+  restored byte-exact (sha match, zero markers, zero stray files).
+- Six over-block controls pass under BOTH behaviours — genuine funnel delegation, in-body
+  tmp-then-rename, a method that writes nothing, a commented-out write, a call site vs a declaration,
+  and worst-verdict-wins across duplicate declarations.
+- `tsc --noEmit` exit 0 — with the boundary stated: `tsconfig.json` excludes `tests`, so that run says
+  nothing about these files.

--- a/upgrades/side-effects/atomic-writes-method-scope.md
+++ b/upgrades/side-effects/atomic-writes-method-scope.md
@@ -1,0 +1,152 @@
+# Side-Effects Review — atomic-writes check scopes to method bodies
+
+**Version / slug:** `atomic-writes-method-scope`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1. Test-only change; no file under src/, scripts/, .husky/ or skills/ is touched, so there is no runtime path and no shipped behaviour. The change makes an existing check stricter and adds no authority.`
+
+## Summary of the change
+
+`tests/unit/atomic-writes-consistency.test.ts` verifies that state-writing modules use
+write-to-tmp-then-rename, so a crash mid-write cannot leave a truncated state file. **It could not
+detect the defect it exists to detect.**
+
+Measured, not argued — a bare `fs.writeFileSync` of durable session state inserted into
+`saveSession`, a DECLARED method of a DECLARED module:
+
+| check | verdict against that mutation |
+|---|---|
+| shipped | **21/21 PASSED** |
+| this change | **1 failed / 31 passed**, naming file, method, deciding body, line |
+
+Both runs were made in the SAME worktree against the SAME mutated source, with the shipped check
+restored from git alongside the new one — subject and control share a boundary rather than being
+compared across two checkouts.
+
+Three causes, all fixed:
+
+1. **Scoping.** `inSaveMethod` was set when a method NAME appeared on a line and never reset, while
+   `hasWriteFile`/`hasRename` were re-zeroed at each occurrence. Only the window from the LAST name
+   mention to EOF survived to the assertion — measured at **125 of 617 lines (20%)** in
+   `StateManager.ts`, leaving three of its four declared methods structurally unreachable. Within
+   that window the booleans were file-scope, so a rename in one method vouched for a write in another.
+2. **File-scope substring checks.** `source.includes('renameSync')` and `source.includes('.tmp')` are
+   satisfied by one occurrence anywhere, comments included.
+3. **Silent declaration rot.** A missing file was `it.skip`ped; a missing method simply never set the
+   flag. Both are failures now.
+
+## What enabling (3) immediately found
+
+**Two of the ten declared (module, method) pairs name methods that do not exist.** `saveState` has
+ZERO occurrences in `src/core/StateManager.ts` and ZERO in `src/monitoring/QuotaTracker.ts` — verified
+by grep with a control (`saveSession(`, `appendEvent(`, `persistUsers(` all found). QuotaTracker's
+real writer is `updateState()`, which is correctly atomic and had never been verified by this test.
+The declared list is corrected in the same change.
+
+## Decision-point inventory
+
+- `tests/helpers/atomicWriteScope.ts` — ADD. `stripComments` (quote-aware, line-count preserving),
+  `methodBodies` (brace-matched, string-aware, declaration-vs-call aware), `delegateTargets`,
+  `classifyMethod`.
+- `tests/unit/atomic-writes-consistency.test.ts` — REWRITTEN to per-method assertions; declared list
+  corrected; missing file/method now fail; anti-vacuity assertion added.
+- `tests/unit/atomic-write-scope.test.ts` — ADD. 18 tests pinning the primitives and both directions.
+- No file under `src/`, `scripts/`, `.husky/` or `skills/` is touched. No runtime decision added.
+
+## 1. Over-block
+
+**The dominant risk, and it nearly bit me.** The obvious fix — require a rename in each declared
+method's own body — would have FAILED on `StateManager`, the best-written module in the set, because
+it routes every write through a private `atomicWrite()` funnel and its save methods contain no write
+call at all. Failing the single-funnel pattern this codebase argues for everywhere else would be a
+false red on exemplary code.
+
+So one level of `this.helper()` delegation is resolved and the funnel is what gets verified — which
+also means `StateManager`'s writes are now genuinely checked, where previously nothing checked them.
+
+Six controls, each with a test, all passing under BOTH the old and new behaviour:
+
+- delegation to a genuine atomic funnel → `atomic-via-funnel`, not a violation;
+- in-body tmp-then-rename → `atomic-inline`;
+- a method that legitimately writes nothing → `no-write`, no invented violation;
+- a commented-out write is not a write;
+- a CALL site (`this.saveSession({...})` inside another method) is not a declaration — treating it as
+  one is precisely how the old flag conflated two methods;
+- an unbalanced brace yields no body rather than a wrong region, so a syntax error elsewhere cannot
+  become a false verdict here.
+
+**Verified against the real tree: 32/32 green.** The production code is atomic everywhere the check
+now looks, including through the funnel.
+
+**A defect in my own helper, caught by these controls before it shipped:** the first `methodBodies`
+required a declaration at line start. That works on real source (which indents declarations) and
+returned `found: false` for every hand-written fixture — so five tests failed loudly rather than
+passing vacuously. The matcher now decides by the PRECEDING token (start / `{` / `}` / `;` after
+skipping modifiers), which rejects `this.save(` and `helper(save(1))` as calls while accepting a
+declaration that does not begin its own line.
+
+## 2. Under-block
+
+Stated in the source rather than implied:
+
+- **Population.** The module list is CURATED and holds 7 entries. Hundreds of files under `src/` call
+  `writeFileSync`; this test says nothing about any of them. A heuristic sweep suggested a state-writing
+  population in the low hundreds, but that heuristic missed 2 of the 7 KNOWN-good modules, so it is not
+  a defect count and is not quoted as one. Widening the population is separate work with real
+  over-block risk and is deliberately not attempted here.
+- **Delegation depth.** One level, one file. A helper calling another helper, or an imported writer,
+  is not resolved — that needs a symbol graph, not text.
+- **Write vocabulary.** Only `writeFileSync`/`renameSync`. A module writing via a stream, `fs.promises`,
+  or a third-party helper is invisible.
+
+## 3. Level-of-abstraction fit
+
+Same layer as the existing check — source-text analysis in a unit test, no AST, no type information,
+no new dependency. The brace matcher is the minimum needed to answer "which method is this line in?",
+which is the question the original flag was trying and failing to answer.
+
+## 4. Signal vs authority compliance
+
+A test, not a runtime authority. It gates CI only. It gained teeth (it can now fail) but no new
+decision-making power over agent behaviour.
+
+## 5. Interactions
+
+- Runs in the existing unit shards; no new script, no lint-chain entry, no CI wiring change.
+- `tsc --noEmit` exit 0 — **but stated honestly: `tsconfig.json` excludes `tests`, so that run says
+  nothing about these files.** Their correctness is evidenced by the suite passing, not by the compiler.
+- No source module, route, config key, or state file touched.
+
+## 6. External surfaces
+
+None. Developer tooling. The Agent Awareness Standard does not apply — no agent capability is added.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correct.** A unit test reads files in one checkout and returns an exit
+code. No durable state, no user-facing notice, no generated URL, no runtime decision — nothing to
+replicate, merge on read, or strand on a topic transfer. Every machine runs it over its own checkout
+of the same tracked source and reaches the same verdict; determinism comes from the source tree, not
+from coordination.
+
+## 8. Rollback cost
+
+`git revert` of three test files. No migration, no state, no deployed artifact, no runtime impact.
+
+## Conclusion
+
+Ship. A check that could not fail on its own subject now fails on it, two stale declarations are
+repaired, the best-written module in the set is verified for the first time, and the limits are named
+in the source rather than implied.
+
+## Evidence pointers
+
+- `tests/unit/atomic-write-scope.test.ts` — 18/18 green (6 defect cases, 6 over-block controls, 6 primitives).
+- `tests/unit/atomic-writes-consistency.test.ts` — 32/32 green against the real tree.
+- **Both-directions proof in ONE worktree:** shipped check vs the mutation → 21/21 PASSED; new check
+  vs the SAME mutation → 1 failed / 31 passed. `src/core/StateManager.ts` restored byte-exact
+  (sha match, zero probe markers, zero stray files).
+- Stale declarations verified by grep with a control that fired.
+- `tsc --noEmit` exit 0 (boundary stated above: tests are excluded from that config).
+- Tier **1** declared: `classifyTier` reports riskFloor 1 with no safety-invariant match, and `tests/`
+  is outside `inScope()`, so the size heuristic contributes nothing either.


### PR DESCRIPTION
## What this fixes

`tests/unit/atomic-writes-consistency.test.ts` verifies that state-writing modules use
write-to-tmp-then-rename, so a crash mid-write cannot leave a truncated state file. **It could not
fail on its own subject.**

Measured, not argued — a bare `fs.writeFileSync` of durable session state inserted into
`saveSession`, a DECLARED method of a DECLARED module:

| check | vs that mutation |
|---|---|
| shipped | **21 / 21 PASSED** |
| this PR | **1 failed / 31 passed** — names file, method, deciding body, line |

Both runs were made in the **same worktree against the same mutated source**, with the shipped check
restored from git alongside the new one, so subject and control share a boundary instead of being
compared across two checkouts. `src/core/StateManager.ts` restored byte-exact afterwards (sha match,
zero probe markers, zero stray files).

Three causes:

1. **Scoping.** `inSaveMethod` was set when a method NAME appeared on a line and never reset, while
   `hasWriteFile`/`hasRename` were re-zeroed at each occurrence. Only the window from the LAST name
   mention to EOF reached the assertion — **125 of 617 lines (20%)** in `StateManager.ts`, leaving
   three of its four declared methods structurally unreachable. Within that window the booleans were
   file-scope, so a rename in one method vouched for a write in another.
2. **File-scope substring checks.** `source.includes('renameSync')` and `source.includes('.tmp')` are
   satisfied by one occurrence anywhere, comments included.
3. **Silent declaration rot.** A missing file was `it.skip`ped; a missing method never set the flag.

### What enabling (3) immediately found

**Two of the ten declared (module, method) pairs name methods that do not exist.** `saveState` has
ZERO occurrences in `src/core/StateManager.ts` and ZERO in `src/monitoring/QuotaTracker.ts` —
verified by grep with a control that fired (`saveSession(`, `appendEvent(`, `persistUsers(` all
found). QuotaTracker's real writer is `updateState()`, which is correctly atomic and had **never
been verified by this test**. The declared list is corrected here.

### The part that made the fix non-obvious

The obvious rule — require a rename in each declared method's own body — would have **failed the
best-written module in the set.** `StateManager` routes every write through a private `atomicWrite()`
funnel and its save methods contain no write call at all. Failing the single-funnel pattern this
codebase argues for everywhere else is a false red on exemplary code.

So one level of `this.helper()` delegation is resolved and the funnel is what gets verified — which
means `StateManager`'s writes are now genuinely checked, where previously nothing checked them.

## ELI16

When the agent saves state — sessions, relationships, quota counters — it must not write straight
over the existing file. If the process dies halfway through you get half a file, and half a JSON file
is worse than none: it parses as garbage or not at all. The safe pattern is to write a temporary file
first and then rename it into place, because renaming is all-or-nothing.

There is a test whose entire job is to prove the modules that save state actually do that. It could
not detect the thing it exists to detect. I did not argue that from reading the code — I inserted a
genuinely unsafe write of real session state into one of the exact methods it names, in one of the
exact files it names, and all twenty-one of its assertions passed.

Three separate causes, any one of which would have been enough. It was **looking at almost none of
the file**: it tried to track "am I inside a save method" with a flag that switched on when a name
appeared and never switched off, so its answer only described the stretch after the *last* mention of
any name — twenty percent of the biggest file, leaving three of its four named methods unexamined.
Two of its checks were **"does this word appear anywhere"**, satisfied by a single occurrence
including inside a comment. And **a method that no longer existed produced silence** rather than a
complaint.

Turning that last one on found two stale entries immediately: one declared method name has zero
occurrences in either of two files. Both were renamed at some point, and both have been pointing at
nothing. The module whose real writer was never checked does the safe thing correctly — it had simply
never been verified.

The fix was harder than it looks, because the obvious version would have failed the best-written
module in the set. That module doesn't write files in its save methods at all; it sends every write
through one private helper that does the safe thing in one place — exactly the pattern this codebase
argues for everywhere else. So the check now follows one step of that handoff and verifies the
helper, which means that module's writes are genuinely checked for the first time.

How you know it works: the old check passes 21 of 21 against an unsafe write; the new one fails and
names the method and line. Eighteen further tests pin the parts — six for writes the old version
could not see, six controls that pass under *both* versions, and six for the primitives. The six
controls matter more than the six failures: a rule that flagged good code would fail builds on
exemplary work, which costs more than the gap it closes.

**And to be clear about scope: the actual code is safe.** Every module the check now examines does
the right thing, including through the helper. This fixes a weak instrument, not a live corruption
bug, and I would rather say so than let a better headline stand.

Full version: `docs/specs/atomic-writes-method-scope.eli16.md`.

## What it still can't see, stated in the source

- **Population.** The module list is CURATED at **7 entries**. Hundreds of files under `src/` call
  `writeFileSync` and this test says nothing about any of them. A heuristic sweep suggested a
  state-writing population in the low hundreds, but that heuristic missed **2 of the 7 known-good
  modules**, so it is not a defect count and is not quoted as one. Widening the population is separate
  work with real over-block risk and is deliberately not attempted here.
- **Delegation depth.** One level, one file. A helper calling another helper, or an imported writer,
  needs a symbol graph rather than text.
- **Write vocabulary.** Only `writeFileSync`/`renameSync` — a stream, `fs.promises`, or a third-party
  writer is invisible.

## Evidence

- `tests/unit/atomic-write-scope.test.ts` — **18/18** (6 defect cases, 6 over-block controls, 6 primitives).
- `tests/unit/atomic-writes-consistency.test.ts` — **32/32** against the real tree.
- Six over-block controls pass under **both** behaviours: genuine funnel delegation, in-body
  tmp-then-rename, a method that legitimately writes nothing, a commented-out write, a **call site vs
  a declaration** (treating a call as a declaration is precisely how the old flag conflated two
  methods), and worst-verdict-wins across duplicate declarations.
- **A defect in my own helper, caught by those controls before it shipped:** the first `methodBodies`
  required a declaration at line start. That works on real source and returned `found: false` for
  every hand-written fixture — five tests failed loudly rather than passing vacuously. The matcher now
  decides by the PRECEDING token, rejecting `this.save(` and `helper(save(1))` as calls while
  accepting a declaration that does not begin its own line.
- `tsc --noEmit` exit 0 — **with the boundary stated: `tsconfig.json` excludes `tests`**, so that run
  says nothing about these files. Their correctness is evidenced by the suite, not the compiler.
- Pre-push smoke: 2 files / 50 tests green.

## Tier

**Tier 1 declared — and the gate did not evaluate it.** No file under `src/`, `scripts/`, `.husky/`
or `skills/` is touched, so `inScopeFiles` is empty and the pre-commit gate short-circuits before
tier evaluation; it wrote no decision record. `classifyTier` reports riskFloor 1 with no
safety-invariant match when asked directly. So this is my declaration, unreviewed by the gate, stated
rather than left to be assumed — the change adds no runtime path, no authority and no capability, and
only makes an existing CI check stricter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
