### PR TITLE
fix(lint): destructive-op guard resolves local bindings, and refuses to report clean on a run that parsed nothing

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T01-24-56-753Z-destructive-lint-local-bindings.json
+++ b/.instar/instar-dev-decisions/2026-08-15T01-24-56-753Z-destructive-lint-local-bindings.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T01:24:56.753Z",
+  "slug": "destructive-lint-local-bindings",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 174,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-destructive.js"
+    ],
+    "addedLines": 167,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T01-45-26-159Z-destructive-lint-local-bindings.json
+++ b/.instar/instar-dev-decisions/2026-08-15T01-45-26-159Z-destructive-lint-local-bindings.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-15T01:45:26.159Z",
+  "slug": "destructive-lint-local-bindings",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 21,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-destructive.js",
+      "scripts/pre-push-gate.js"
+    ],
+    "addedLines": 18,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/destructive-lint-local-bindings.eli16.md
+++ b/docs/specs/destructive-lint-local-bindings.eli16.md
@@ -62,8 +62,17 @@ inspected at all, and "no problems found" is then a statement about a search tha
 never happened.
 
 So: if a run scans files and not one of them parses, it now refuses to report
-success and says why. This cannot fail a build in any working checkout, because
-in a working checkout files parse.
+success and says why.
+
+**And I got the first version of that wrong, which CI caught.** I made it report
+failure using the same signal as "I found a problem" — and three tests went red,
+because one of them copies the build machinery into a bare temporary folder with
+no dependencies installed and runs it there. My reasoning had been "no real
+checkout can hit this", and a test fixture is not a real checkout. The machinery
+already knew the difference between a check that *failed to run* and a check that
+*found something*; I was sending one down the other's channel. It now reports
+"could not look" distinctly, and the surrounding machinery treats that as a
+warning rather than a blocked push.
 
 ## Why it won't start failing builds it shouldn't
 

--- a/docs/specs/destructive-lint-local-bindings.eli16.md
+++ b/docs/specs/destructive-lint-local-bindings.eli16.md
@@ -1,0 +1,108 @@
+# ELI16 — the delete-guard you could switch off by shortening a name
+
+## What it protects
+
+Deleting files is the one thing the agent cannot undo. So every destructive
+filesystem or git operation has to go through a single pair of modules that
+record what was deleted and why. That record is the whole point: if something
+disappears, there is a trail.
+
+A build check enforces it. Call a delete directly instead of going through the
+funnel and the build fails.
+
+## What was wrong
+
+**One line of ordinary tidying switched it off for a whole file.**
+
+```ts
+const fsp = fs.promises;
+await fsp.rm(p, { recursive: true, force: true });   // build passed
+```
+
+Written out in full — `fs.promises.rm(p, …)` — that same delete is caught.
+Giving the thing a shorter name made it invisible. Nobody writing that is trying
+to get around anything; aliasing a namespace is one of the most ordinary things
+in JavaScript. That is exactly what makes it worth fixing: the gap does not need
+an attacker, only a tidy afternoon.
+
+Three more plain forms did the same: pulling the delete function itself into a
+name, destructuring it out with a rename, and reaching it through a type
+assertion — which is erased before the code ever runs, so it changes nothing
+except whether the check can see it.
+
+I measured all of these against the shipped check before changing anything, with
+a plain unaliased delete running in the same pass as a control. Without that
+control, "nothing was flagged" and "the check did not run" look identical — a
+distinction that mattered more than I expected, as the next section shows.
+
+## Why it was surprising
+
+This check is one of the better-built ones in the codebase. It parses the code
+properly rather than pattern-matching text, and that already buys it real
+resolution — it catches an import that has been renamed on the way in, which the
+text-matching checks cannot do.
+
+The gap was narrower than "it doesn't understand names". It understood names
+arriving from *imports* and nothing about names created *locally*. So the fix
+feeds the existing rules better information rather than adding new rules beside
+them.
+
+## The second thing, which I found by accident
+
+Halfway through, I ran the check in a fresh copy of the repo that had not had its
+dependencies installed. Every single file failed to parse — and the check
+reported **clean** and exited successfully, because a parse failure was treated
+as a soft warning. The only sign was some text on the error stream that a build
+log buries.
+
+That soft-warning behaviour is deliberate and mostly right: one file the parser
+dislikes should not fail everybody's build. But there is a difference between
+*one* file failing and *every* file failing. The second one means nothing was
+inspected at all, and "no problems found" is then a statement about a search that
+never happened.
+
+So: if a run scans files and not one of them parses, it now refuses to report
+success and says why. This cannot fail a build in any working checkout, because
+in a working checkout files parse.
+
+## Why it won't start failing builds it shouldn't
+
+This check blocks commits, so wrongly flagging good code costs more than the gap
+it closes — a noisy check gets switched off, and then it protects nothing. Five
+things are deliberate, each with a test that passes under *both* the old and new
+versions:
+
+1. **A non-destructive call is fine.** Reading a file is not deleting one.
+2. **A shortened name used for something harmless is fine** — the shortcut is not
+   the problem, the delete is.
+3. **Creating a directory through that same shortcut is fine.** Creating is not
+   deleting.
+4. **An unrelated object that happens to use the same words is fine.** Resolution
+   is anchored to the real filesystem module, never to a method name.
+5. **A name that is never actually called is fine.** Holding a reference is not
+   performing an operation.
+
+Against the real codebase the check reports clean both before and after this
+change, so nothing that exists today is newly blocked.
+
+## The bit I liked
+
+My own test needed to delete its temporary directory when it finished — which is
+exactly the thing this check forbids. Rather than adding the file to the
+exemption list, I routed that cleanup through the funnel like everything else.
+The test that argues for the rule now follows it, and costs one audit entry per
+run.
+
+## How you know it works
+
+The tests were written first and run against the old behaviour: **seven of the
+sixteen fail** without this change. The other nine pass either way — three
+confirming the forms it already caught still fire, five holding the line against
+flagging good code, and one proving the new refusal fires on "nothing parsed"
+rather than on "a file was scanned".
+
+## What it still can't see
+
+Names that cross a file boundary, or are assembled while the program runs, still
+need real whole-program analysis rather than reading one file at a time. Guessing
+at those would flag correct code, which is the expensive direction.

--- a/scripts/lint-no-direct-destructive.js
+++ b/scripts/lint-no-direct-destructive.js
@@ -23,6 +23,9 @@
  * Exit codes:
  *   0 — no violations.
  *   1 — at least one violation.
+ *   2 — could not inspect: files were scanned and NONE parsed (an environment
+ *       problem, e.g. a missing `typescript`). Distinct from 1 on purpose —
+ *       "I could not look" is not "I looked and found nothing".
  *
  * Usage:
  *   node scripts/lint-no-direct-destructive.js                # full repo
@@ -845,12 +848,18 @@ function main() {
   if (astAttempted > 0 && astParsed === 0) {
     process.stderr.write('\n');
     process.stderr.write(
-      `[lint-no-direct-destructive] REFUSING TO REPORT CLEAN — ${astAttempted} file(s) were scanned `
+      `[lint-no-direct-destructive] COULD NOT INSPECT — ${astAttempted} file(s) were scanned `
       + 'and NONE could be parsed, so nothing was actually inspected. This is an environment '
       + "problem (most often a missing `typescript` dependency — run `npm install`), not a clean "
       + 'tree. Reporting success here would silently disable the destructive-operation funnel.\n'
     );
-    return 1;
+    // Exit 2, NOT 1. "I could not inspect" and "I found violations" are
+    // different facts and callers act on them differently: pre-push-gate.js
+    // already treats a lint that FAILED TO RUN as a warning and a lint that
+    // found VIOLATIONS as a push-blocking error. Returning 1 here reported an
+    // uninstalled scratch tree as violations — which is how this was caught,
+    // by three pre-push-gate tests going red in CI.
+    return 2;
   }
 
   if (violations.length === 0) {

--- a/scripts/lint-no-direct-destructive.js
+++ b/scripts/lint-no-direct-destructive.js
@@ -39,6 +39,14 @@ import { fileURLToPath } from 'node:url';
 // only when a TS file actually needs parsing.
 let _ts = null;
 function ts() {
+  // Test hook for the parsed-nothing refusal below. It can ONLY force the
+  // fail-closed path (every file fails to parse → the run refuses to report
+  // clean); there is no flag here that can make this lint pass something it
+  // would otherwise flag. Without it the refusal would be untested, which is
+  // the failure mode this whole guard exists to prevent.
+  if (process.env.INSTAR_LINT_FORCE_PARSE_FAILURE === '1') {
+    throw new Error('forced parse failure (INSTAR_LINT_FORCE_PARSE_FAILURE=1)');
+  }
   if (_ts) return _ts;
   _ts = require('typescript');
   return _ts;
@@ -304,7 +312,15 @@ function lintTsFile(file, text) {
   const T = ts();
   const sf = T.createSourceFile(file, text, T.ScriptTarget.Latest, true);
   const ctx = { text };
-  const r = (f, l, c, m) => report(f, l, c, m, ctx);
+  // Declaration collection runs BEFORE reporting (see the collect/report loop at
+  // the foot of this function), so a binding declared after the function that
+  // uses it is still resolved. While collecting, findings are suppressed —
+  // otherwise every violation would be reported once per collection pass.
+  let collecting = true;
+  const r = (f, l, c, m) => {
+    if (collecting) return;
+    report(f, l, c, m, ctx);
+  };
 
   /** module name → local identifier (default + namespace + named) */
   const childProcessIdentifiers = new Set();
@@ -317,6 +333,34 @@ function lintTsFile(file, text) {
   function lineCol(node) {
     const lc = sf.getLineAndCharacterOfPosition(node.getStart(sf));
     return { line: lc.line + 1, col: lc.character + 1 };
+  }
+
+  /**
+   * Strip syntax that changes nothing at runtime but hides an identifier from a
+   * structural check — parentheses, `as` assertions, `<T>` assertions and `!`.
+   * `(fs as any)['rmSync'](p)` performs exactly the same delete as `fs.rmSync(p)`;
+   * without this it reached the computed-access branch as a ParenthesizedExpression
+   * and the `isIdentifier` test failed, so the call was invisible.
+   */
+  /**
+   * Idempotent: collection now runs more than once (see the collect/report loop
+   * below), and an array push is the one collector here that is not naturally
+   * idempotent — repeated passes would duplicate entries and keep the binding
+   * count growing, so the fixpoint would never be reached.
+   */
+  function addSimpleGitImport(localName) {
+    if (!simpleGitImports.some((s2) => s2.localName === localName)) {
+      simpleGitImports.push({ localName });
+    }
+  }
+
+  function unwrap(node) {
+    let n = node;
+    while (n && (T.isParenthesizedExpression(n) || T.isAsExpression(n)
+                 || T.isTypeAssertionExpression?.(n) || T.isNonNullExpression(n))) {
+      n = n.expression;
+    }
+    return n;
   }
 
   function visit(node) {
@@ -342,7 +386,7 @@ function lintTsFile(file, text) {
             } else if (FS_MODULE_NAMES.has(mod) && DESTRUCTIVE_FS_NAMES.has(importedName)) {
               fsNamedDestructiveImports.set(localName, importedName);
             } else if (mod === 'simple-git' && importedName === 'simpleGit') {
-              simpleGitImports.push({ localName });
+              addSimpleGitImport(localName);
             }
           }
         }
@@ -355,7 +399,7 @@ function lintTsFile(file, text) {
         } else if (FS_MODULE_NAMES.has(mod)) {
           fsNamespaceIdentifiers.add(localName);
         } else if (mod === 'simple-git') {
-          simpleGitImports.push({ localName });
+          addSimpleGitImport(localName);
         }
       }
     }
@@ -376,7 +420,7 @@ function lintTsFile(file, text) {
               fsNamespaceIdentifiers.add(localName);
               requireBindings.set(localName, mod);
             } else if (mod === 'simple-git') {
-              simpleGitImports.push({ localName });
+              addSimpleGitImport(localName);
             }
           }
           // Destructured: const { execFileSync } = require('child_process')
@@ -392,7 +436,7 @@ function lintTsFile(file, text) {
               } else if (FS_MODULE_NAMES.has(mod) && DESTRUCTIVE_FS_NAMES.has(importedName)) {
                 fsNamedDestructiveImports.set(localName, importedName);
               } else if (mod === 'simple-git' && importedName === 'simpleGit') {
-                simpleGitImports.push({ localName });
+                addSimpleGitImport(localName);
               }
             }
           }
@@ -441,6 +485,83 @@ function lintTsFile(file, text) {
       }
     }
 
+    // ── Local re-bindings of a banned namespace or function ────
+    // The sets above were populated ONLY from imports/requires, so one line of
+    // ordinary tidying disabled the funnel for a whole file:
+    //
+    //   const fsp = fs.promises;   await fsp.rm(p, { recursive: true });
+    //
+    // Aliasing `fs.promises` to a short name is idiomatic JavaScript, not an
+    // evasion — and `fs.promises.rm` written out IS caught, so the difference
+    // between flagged and invisible was a variable. Resolving the binding feeds
+    // the EXISTING checks below rather than adding a parallel rule.
+    if (T.isVariableDeclaration(node) && node.initializer) {
+      const init = unwrap(node.initializer);
+
+      // `const X = <expr>` where X is a plain identifier.
+      if (T.isIdentifier(node.name)) {
+        const local = node.name.text;
+
+        // Whole-namespace alias: `const f = fs` / `const fsp = fs.promises`.
+        if (T.isIdentifier(init) && fsNamespaceIdentifiers.has(init.text)) {
+          fsNamespaceIdentifiers.add(local);
+        } else if (T.isIdentifier(init) && childProcessIdentifiers.has(init.text)) {
+          childProcessIdentifiers.add(local);
+        } else if (T.isPropertyAccessExpression(init)) {
+          const base = unwrap(init.expression);
+          const member = init.name.text;
+
+          // `const fsp = fs.promises` — still the fs namespace, so the member
+          // checks below apply to it unchanged.
+          if (T.isIdentifier(base) && fsNamespaceIdentifiers.has(base.text) && member === 'promises') {
+            fsNamespaceIdentifiers.add(local);
+          } else if (T.isIdentifier(base) && fsNamespaceIdentifiers.has(base.text)
+                     && DESTRUCTIVE_FS_NAMES.has(member)) {
+            // `const del = fs.rmSync`
+            fsNamedDestructiveImports.set(local, member);
+          } else if (T.isIdentifier(base) && childProcessIdentifiers.has(base.text)
+                     && CHILD_PROCESS_FNS.has(member)) {
+            // `const ex = cp.execFileSync`
+            childProcessNamedImports.set(local, member);
+          } else if (T.isPropertyAccessExpression(base) && T.isIdentifier(unwrap(base.expression))
+                     && fsNamespaceIdentifiers.has(unwrap(base.expression).text)
+                     && base.name.text === 'promises'
+                     && DESTRUCTIVE_FS_NAMES.has(member)) {
+            // `const del = fs.promises.rm`
+            fsNamedDestructiveImports.set(local, member);
+          }
+        }
+      }
+
+      // `const { rmSync, unlink: del } = fs` / `... = fs.promises`
+      if (T.isObjectBindingPattern(node.name)) {
+        const init2 = unwrap(node.initializer);
+        let isFsSource = false;
+        let isCpSource = false;
+        if (T.isIdentifier(init2)) {
+          isFsSource = fsNamespaceIdentifiers.has(init2.text);
+          isCpSource = childProcessIdentifiers.has(init2.text);
+        } else if (T.isPropertyAccessExpression(init2) && init2.name.text === 'promises') {
+          const base = unwrap(init2.expression);
+          isFsSource = T.isIdentifier(base) && fsNamespaceIdentifiers.has(base.text);
+        }
+        if (isFsSource || isCpSource) {
+          for (const el of node.name.elements) {
+            if (!T.isBindingElement(el) || !T.isIdentifier(el.name)) continue;
+            const original = el.propertyName && T.isIdentifier(el.propertyName)
+              ? el.propertyName.text
+              : el.name.text;
+            const local = el.name.text;
+            if (isFsSource && DESTRUCTIVE_FS_NAMES.has(original)) {
+              fsNamedDestructiveImports.set(local, original);
+            } else if (isCpSource && CHILD_PROCESS_FNS.has(original)) {
+              childProcessNamedImports.set(local, original);
+            }
+          }
+        }
+      }
+    }
+
     // ── Member call on namespace identifier ────────────────────
     if (T.isCallExpression(node) && T.isPropertyAccessExpression(node.expression)) {
       const obj = node.expression.expression;
@@ -479,7 +600,7 @@ function lintTsFile(file, text) {
 
     // ── Dynamic / computed access: fs['rm' + 'Sync'](...) ──────
     if (T.isCallExpression(node) && T.isElementAccessExpression(node.expression)) {
-      const obj = node.expression.expression;
+      const obj = unwrap(node.expression.expression);
       const arg = node.expression.argumentExpression;
       if (T.isIdentifier(obj) && fsNamespaceIdentifiers.has(obj.text)) {
         // Any computed member access on the fs namespace is suspicious;
@@ -513,6 +634,19 @@ function lintTsFile(file, text) {
     return false;
   }
 
+  // Collect, then report. Collection repeats until the binding sets stop
+  // growing, so a chain (`const a = fs; const b = a.promises`) resolves however
+  // it is ordered in the file, and a binding declared BELOW the function that
+  // uses it is still known. Bounded so a pathological file cannot spin.
+  const bindingCount = () =>
+    fsNamespaceIdentifiers.size + fsNamedDestructiveImports.size
+    + childProcessIdentifiers.size + childProcessNamedImports.size + simpleGitImports.length;
+  for (let pass = 0; pass < 5; pass += 1) {
+    const before = bindingCount();
+    visit(sf);
+    if (bindingCount() === before) break;
+  }
+  collecting = false;
   visit(sf);
 }
 
@@ -661,6 +795,9 @@ function main() {
     files = gatherAll();
   }
 
+  // Scan-coverage counters: a run that parsed nothing inspected nothing.
+  let astAttempted = 0;
+  let astParsed = 0;
   for (const file of files) {
     let text;
     try {
@@ -685,12 +822,35 @@ function main() {
     if (hasAllowComment(text)) continue;
 
     // AST lint for ts/js/mjs/cjs
+    astAttempted += 1;
     try {
       lintTsFile(file, text);
+      astParsed += 1;
     } catch (err) {
-      // Parse failure → emit a soft warning, not a violation.
+      // Parse failure → emit a soft warning, not a violation. Deliberate: one
+      // unparseable file should not fail a build over syntax this parser does
+      // not accept. The total-failure case below is a different situation.
       process.stderr.write(`[lint-no-direct-destructive] failed to parse ${rel}: ${err.message}\n`);
     }
+  }
+
+  // A run in which NOTHING parsed did not inspect anything, and "no violations
+  // found" would be a statement about a scan that never happened. Measured live
+  // on 2026-08-15: in a checkout without node_modules the `typescript` require
+  // fails for every file, so this guard against unaudited deletes reported
+  // clean and exited 0, with only stderr lines a CI log buries.
+  //
+  // This is deliberately the TOTAL-failure case only, so it cannot fail a build
+  // over one file the parser dislikes: in any working checkout, files parse.
+  if (astAttempted > 0 && astParsed === 0) {
+    process.stderr.write('\n');
+    process.stderr.write(
+      `[lint-no-direct-destructive] REFUSING TO REPORT CLEAN — ${astAttempted} file(s) were scanned `
+      + 'and NONE could be parsed, so nothing was actually inspected. This is an environment '
+      + "problem (most often a missing `typescript` dependency — run `npm install`), not a clean "
+      + 'tree. Reporting success here would silently disable the destructive-operation funnel.\n'
+    );
+    return 1;
   }
 
   if (violations.length === 0) {

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -420,7 +420,13 @@ try {
     [path.join(ROOT, 'scripts/lint-no-direct-destructive.js')],
     { cwd: ROOT, stdio: ['ignore', 'inherit', 'inherit'] },
   );
-  if (result.status !== 0) {
+  if (result.status === 2) {
+    // Exit 2 = the lint could not inspect anything (an environment problem such
+    // as a missing `typescript`), which is NOT a violation. The gate already
+    // treats a lint that failed to run as a warning; this is the same fact
+    // arriving through an exit code instead of a thrown error.
+    warnings.push('lint-no-direct-destructive could not inspect this tree (see output above)');
+  } else if (result.status !== 0) {
     errors.push('lint-no-direct-destructive: violations detected (see output above)');
   }
 } catch (err) {

--- a/tests/unit/destructive-lint-local-bindings.test.ts
+++ b/tests/unit/destructive-lint-local-bindings.test.ts
@@ -208,8 +208,15 @@ describe('a run that parsed nothing must not report clean', () => {
     }
 
     expect(out).toContain('failed to parse'); // the condition really was created
-    expect(code).toBe(1);
-    expect(out).toContain('REFUSING TO REPORT CLEAN');
+    expect(out).toContain('COULD NOT INSPECT');
+
+    // Exit 2, NOT 1, and the distinction is the whole point: "I could not look"
+    // and "I looked and found violations" are different facts, and callers act
+    // on them differently. pre-push-gate.js treats 2 as a warning and 1 as a
+    // push-blocking error. Reporting 1 here made an uninstalled scratch tree
+    // look like violations and turned three pre-push-gate tests red in CI.
+    expect(code).toBe(2);
+    expect(code).not.toBe(1);
   });
 
   it('CONTROL — a file that DOES parse and is clean still exits 0', () => {

--- a/tests/unit/destructive-lint-local-bindings.test.ts
+++ b/tests/unit/destructive-lint-local-bindings.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * `lint-no-direct-destructive` is the funnel guard for destructive git/fs
+ * operations: only SafeGitExecutor / SafeFsExecutor may call them directly, so
+ * that every delete carries an audit entry.
+ *
+ * It AST-walks, which already buys it real import resolution — a renamed import
+ * (`import { rmSync as nuke }`) is caught where a regex lint would miss it. But
+ * the identifier sets were populated ONLY from imports, never from local
+ * bindings, so one line of ordinary tidying disabled it for a whole file:
+ *
+ *     const fsp = fs.promises;
+ *     await fsp.rm(p, { recursive: true, force: true });   // exit 0 — invisible
+ *
+ * `fs.promises.rm` written out IS caught, so the difference between flagged and
+ * invisible was a variable. Aliasing a namespace to a short name is idiomatic
+ * JavaScript, not an evasion.
+ *
+ * THE DEFECT tests fail against the shipped behaviour. The CONTROL tests pass
+ * under BOTH — this lint fails builds, so flagging correct code would cost more
+ * than the gap it closes.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const LINT = path.join(ROOT, 'scripts', 'lint-no-direct-destructive.js');
+
+let tmp: string;
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'destructive-lint-'));
+});
+afterAll(() => {
+  // Through the funnel, not around it. This test exists because the funnel
+  // guard could be walked past; routing its own teardown through SafeFsExecutor
+  // is the rule applied to the file that argues for it, and it costs one audit
+  // entry per run.
+  SafeFsExecutor.safeRmSync(tmp, { operation: 'tests/unit/destructive-lint-local-bindings.test.ts:teardown', recursive: true, force: true });
+});
+
+/** Run the lint over one fixture; returns exit code and combined output. */
+function lint(source: string, name = 'probe.ts'): { code: number; out: string } {
+  const file = path.join(tmp, name);
+  fs.writeFileSync(file, source, 'utf-8');
+  try {
+    const out = execFileSync('node', [LINT, file], { encoding: 'utf-8', stdio: 'pipe' });
+    return { code: 0, out };
+  } catch (err: any) {
+    return { code: err.status ?? -1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+describe('CONTROL — the forms the shipped lint already caught still fire', () => {
+  it('flags a plain fs.rmSync', () => {
+    // The positive control. Without it, a batch where everything returns 0
+    // cannot distinguish "nothing is a violation" from "the lint did not run".
+    const { code, out } = lint('import fs from "node:fs";\nexport function w(p: string) { fs.rmSync(p); }\n');
+    expect(code).toBe(1);
+    expect(out).toContain('SafeFsExecutor');
+  });
+
+  it('flags fs.promises.rm written out in full', () => {
+    const { code } = lint(
+      'import fs from "node:fs";\nexport async function w(p: string) { await fs.promises.rm(p); }\n'
+    );
+    expect(code).toBe(1);
+  });
+
+  it('flags a renamed named import', () => {
+    const { code } = lint(
+      'import { rmSync as nuke } from "node:fs";\nexport function w(p: string) { nuke(p); }\n'
+    );
+    expect(code).toBe(1);
+  });
+});
+
+describe('THE DEFECT — local re-bindings that walked past the funnel guard', () => {
+  it('flags a namespace aliased to a local const — the idiomatic case', () => {
+    // `const fsp = fs.promises` is ordinary JavaScript. Nobody writing it is
+    // trying to get around anything, and that is exactly why it matters.
+    const { code, out } = lint([
+      'import fs from "node:fs";',
+      'const fsp = fs.promises;',
+      'export async function w(p: string) { await fsp.rm(p, { recursive: true, force: true }); }',
+    ].join('\n'));
+    expect(code).toBe(1);
+    expect(out).toContain('SafeFsExecutor');
+  });
+
+  it('flags a destructive function aliased to a local const', () => {
+    const { code } = lint([
+      'import fs from "node:fs";',
+      'const del = fs.rmSync;',
+      'export function w(p: string) { del(p); }',
+    ].join('\n'));
+    expect(code).toBe(1);
+  });
+
+  it('flags destructuring-with-rename off the namespace', () => {
+    const { code } = lint([
+      'import fs from "node:fs";',
+      'const { rmSync: del } = fs;',
+      'export function w(p: string) { del(p); }',
+    ].join('\n'));
+    expect(code).toBe(1);
+  });
+
+  it('flags computed access hidden behind a type assertion', () => {
+    // `(fs as any)['rmSync'](p)` deletes exactly what `fs.rmSync(p)` deletes.
+    // The assertion is erased at runtime; it existed only in the syntax tree.
+    const { code } = lint(
+      'import fs from "node:fs";\nexport function w(p: string) { (fs as any)["rmSync"](p); }\n'
+    );
+    expect(code).toBe(1);
+  });
+
+  it('resolves a binding declared BELOW the function that uses it', () => {
+    // Valid JavaScript, and the reason collection runs to a fixpoint before
+    // reporting rather than in one in-order pass.
+    const { code } = lint([
+      'import fs from "node:fs";',
+      'export function w(p: string) { del(p); }',
+      'const del = fs.rmSync;',
+    ].join('\n'));
+    expect(code).toBe(1);
+  });
+
+  it('follows a two-step alias chain', () => {
+    const { code } = lint([
+      'import fs from "node:fs";',
+      'const a = fs;',
+      'const b = a.promises;',
+      'export async function w(p: string) { await b.rm(p); }',
+    ].join('\n'));
+    expect(code).toBe(1);
+  });
+});
+
+describe('CONTROL — correct code stays legal (over-block fails builds)', () => {
+  it('does not flag a non-destructive fs call', () => {
+    expect(lint('import fs from "node:fs";\nexport function r(p: string) { return fs.readFileSync(p, "utf-8"); }\n').code).toBe(0);
+  });
+
+  it('does not flag a NON-destructive method on an aliased namespace', () => {
+    // The alias itself is not the violation — the destructive method is.
+    expect(lint([
+      'import fs from "node:fs";',
+      'const fsp = fs.promises;',
+      'export async function r(p: string) { return await fsp.readFile(p, "utf-8"); }',
+    ].join('\n')).code).toBe(0);
+  });
+
+  it('does not flag mkdir on an aliased namespace — creating is not deleting', () => {
+    expect(lint([
+      'import fs from "node:fs";',
+      'const fsp = fs.promises;',
+      'export async function m(p: string) { await fsp.mkdir(p, { recursive: true }); }',
+    ].join('\n')).code).toBe(0);
+  });
+
+  it('does not flag the same NAMES on an unrelated object', () => {
+    // Resolution is anchored to the fs namespace, never to a method name — an
+    // unrelated helper that happens to expose `rmSync` is not the fs module.
+    expect(lint([
+      'const helpers = { rmSync: (p: string) => p };',
+      'const del = helpers.rmSync;',
+      'export function r(p: string) { return del(p); }',
+    ].join('\n')).code).toBe(0);
+  });
+
+  it('does not flag an alias that is never called', () => {
+    expect(lint([
+      'import fs from "node:fs";',
+      'const fsp = fs.promises;',
+      'export function count() { return Object.keys(fsp).length; }',
+    ].join('\n')).code).toBe(0);
+  });
+});
+
+describe('a run that parsed nothing must not report clean', () => {
+  it('refuses to exit 0 when every scanned file failed to parse', () => {
+    // Measured live on 2026-08-15: in a checkout without node_modules the
+    // `typescript` require fails for every file, so this guard against
+    // unaudited deletes reported clean and exited 0 — with only stderr lines a
+    // CI log buries. "No violations found" was a statement about a scan that
+    // never happened.
+    //
+    // Forced deterministically rather than by manipulating the environment: an
+    // env-dependent assertion that quietly skips when it cannot create its
+    // condition is precisely the failure being fixed here.
+    const file = path.join(tmp, 'unparsed.ts');
+    fs.writeFileSync(file, 'import fs from "node:fs";\nexport const x = 1;\n', 'utf-8');
+    let code = 0;
+    let out = '';
+    try {
+      out = execFileSync('node', [LINT, file], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        env: { ...process.env, INSTAR_LINT_FORCE_PARSE_FAILURE: '1' },
+      });
+    } catch (err: any) {
+      code = err.status ?? -1;
+      out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+    }
+
+    expect(out).toContain('failed to parse'); // the condition really was created
+    expect(code).toBe(1);
+    expect(out).toContain('REFUSING TO REPORT CLEAN');
+  });
+
+  it('CONTROL — a file that DOES parse and is clean still exits 0', () => {
+    // Pins that the refusal keys on "nothing parsed", not on "a file was
+    // scanned". Without this, a refusal that fired on every run would look
+    // identical to a correct one on the defect case.
+    const { code } = lint('export const x = 1;\n', 'clean.ts');
+    expect(code).toBe(0);
+  });
+});

--- a/upgrades/next/destructive-lint-local-bindings.md
+++ b/upgrades/next/destructive-lint-local-bindings.md
@@ -1,0 +1,75 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+`scripts/lint-no-direct-destructive.js` — the funnel guard that keeps every
+destructive git/fs operation inside `SafeGitExecutor` / `SafeFsExecutor`, so each
+delete carries an audit entry — now resolves local bindings before applying its
+rules.
+
+Its identifier sets were populated ONLY from imports and requires. Measured
+against the shipped lint with a positive control (`fs.rmSync`) firing in the same
+pass:
+
+```ts
+const fsp = fs.promises;
+await fsp.rm(p, { recursive: true, force: true });   // exit 0 — EVADED
+const del = fs.rmSync; del(p);                        // exit 0 — EVADED
+const { rmSync: del } = fs; del(p);                   // exit 0 — EVADED
+(fs as any)['rmSync'](p);                             // exit 0 — EVADED
+```
+
+`fs.promises.rm` written out IS caught, so the difference between flagged and
+invisible was a variable. Aliasing a namespace to a short name is idiomatic
+JavaScript — the gap needed a tidy afternoon, not an attacker.
+
+The lint AST-walks, so it already caught renamed imports (`import { rmSync as
+nuke }`) where a regex check could not. The gap was narrower than "it doesn't
+understand names": it understood names arriving from imports and nothing about
+names a file creates itself.
+
+Added: `unwrap()` (strips parens / `as` / `!` before identity tests),
+local-binding collection for namespace aliases, function aliases and object
+binding patterns, and a collect-then-report loop that repeats until the binding
+sets stop growing — so resolution is order-independent and alias chains resolve.
+
+**Second finding, hit live rather than reasoned about.** Running the lint in a
+worktree with no `node_modules`, the `typescript` require failed for EVERY file
+and the lint reported **clean, exit 0** — a guard against unaudited deletes
+silently became a no-op, with only stderr lines a CI log buries. The per-file
+soft-warning is deliberate and right; ONE file failing and EVERY file failing are
+different situations. A run that scanned files and parsed none of them now
+refuses to report clean and names the likely cause. Scoped to the total-failure
+case only, which no working checkout can reach.
+
+**Declared open in the source:** cross-module names, runtime-assembled access,
+and indirection through a container object (`const io = { del: fs.unlinkSync }`)
+— measured, and left open because that is not an ordinary way to write a delete
+and chasing it widens over-block risk on a build-failing lint.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).
+
+## Evidence
+
+- `tests/unit/destructive-lint-local-bindings.test.ts` — 16/16 green.
+- **Negative control: 7 of 16 fail** against the shipped lint (all six defect
+  cases plus the parsed-nothing refusal). The other 9 pass both ways and are the
+  controls. Script restored byte-exact after the control.
+- Five anti-over-block controls, because this lint fails builds: a
+  non-destructive call; a non-destructive method on an aliased namespace;
+  `mkdir` through that alias (creating is not deleting); an unrelated object
+  exposing the same names; an alias that is never called.
+- Real tree: `exit 0` before AND after. Full `npm run lint` chain exit 0.
+  `tsc --noEmit` exit 0.
+- The new test routes its own teardown through `SafeFsExecutor` rather than
+  taking an allowlist entry — the test that argues for the rule follows it.

--- a/upgrades/next/destructive-lint-local-bindings.md
+++ b/upgrades/next/destructive-lint-local-bindings.md
@@ -43,8 +43,13 @@ and the lint reported **clean, exit 0** — a guard against unaudited deletes
 silently became a no-op, with only stderr lines a CI log buries. The per-file
 soft-warning is deliberate and right; ONE file failing and EVERY file failing are
 different situations. A run that scanned files and parsed none of them now
-refuses to report clean and names the likely cause. Scoped to the total-failure
-case only, which no working checkout can reach.
+refuses to report clean and names the likely cause, exiting **2** rather than 1:
+"I could not look" and "I looked and found nothing" are different facts, and
+`pre-push-gate.js` already treats a lint that failed to run as a warning and one
+that found violations as a push-blocking error. (The first version returned 1 and
+turned three pre-push-gate tests red — the gate copies itself into a scratch
+fixture with no dependencies, so my "no working checkout can reach it" claim was
+wrong; a test fixture reaches it.)
 
 **Declared open in the source:** cross-module names, runtime-assembled access,
 and indirection through a container object (`const io = { del: fs.unlinkSync }`)

--- a/upgrades/side-effects/destructive-lint-local-bindings.md
+++ b/upgrades/side-effects/destructive-lint-local-bindings.md
@@ -1,0 +1,174 @@
+# Side-Effects Review — destructive-op guard resolves local bindings
+
+**Version / slug:** `destructive-lint-local-bindings`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1 (CI-only lint script, no runtime path). The rule and the funnel are unchanged; the check now resolves one more kind of name before applying the rules it already had, and refuses to report clean on a run that inspected nothing.`
+
+## Summary of the change
+
+`scripts/lint-no-direct-destructive.js` is the funnel guard for
+`COMPREHENSIVE-DESTRUCTIVE-TOOL-CONTAINMENT-SPEC` — only `SafeGitExecutor` /
+`SafeFsExecutor` may call destructive git/fs primitives directly, so that every
+delete carries an audit entry.
+
+It AST-walks, which already buys it real import resolution. But its identifier
+sets were populated ONLY from imports and requires, never from local bindings.
+Measured against the shipped lint with a positive control (a plain `fs.rmSync`)
+firing in the same pass:
+
+| form | shipped |
+|---|---|
+| `fs.rmSync(p)` — POSITIVE CONTROL | exit 1 (caught) |
+| `import { rmSync }` / `import { rmSync as nuke }` | exit 1 (caught — better than any regex lint here) |
+| `fs.promises.rm(p)` written out | exit 1 (caught) |
+| **`const fsp = fs.promises; await fsp.rm(p, …)`** | **exit 0 — EVADES** |
+| `const del = fs.rmSync; del(p)` | **exit 0 — EVADES** |
+| `const { rmSync: del } = fs; del(p)` | **exit 0 — EVADES** |
+| `(fs as any)['rmSync'](p)` | **exit 0 — EVADES** |
+
+The first evasion is the one that matters. `fs.promises.rm` IS caught, so the
+difference between flagged and invisible was a variable — and aliasing a
+namespace to a short name is idiomatic JavaScript, not an evasion. The gap needed
+a tidy afternoon, not an attacker.
+
+Resolution now feeds the EXISTING checks rather than adding rules beside them.
+
+## The second finding, hit live rather than reasoned about
+
+Running the lint in a fresh worktree with no `node_modules`, the `typescript`
+require failed for **every** file — and the lint reported **clean, exit 0**, with
+only stderr lines a CI log buries. A guard against unaudited deletes silently
+became a no-op.
+
+The per-file soft-warning is deliberate and stated in the source ("Parse failure
+→ emit a soft warning, not a violation"), and it is right: one file the parser
+dislikes should not fail a build. But ONE file failing and EVERY file failing are
+different situations — the second means nothing was inspected, and "no violations
+found" is then a statement about a scan that never happened.
+
+Added: a run that scanned files and parsed NONE of them refuses to report clean
+and names the likely cause. Deliberately the total-failure case only, so it
+cannot fail a build over one awkward file — in any working checkout, files parse.
+
+## Decision-point inventory
+
+- `unwrap(node)` — ADD. Strips parens / `as` / `<T>` / `!` before identity tests.
+- Local-binding collection in `visit` — ADD. Namespace aliases, destructive-function
+  aliases, object-binding patterns, for both fs and child_process.
+- `addSimpleGitImport(localName)` — ADD. Idempotent; collection now runs more than
+  once and an array push is the one collector that is not naturally idempotent.
+- Collect-then-report loop — CHANGED. Collection repeats until the binding sets
+  stop growing (bounded at 5), then one reporting pass. Makes resolution
+  order-independent and resolves alias chains.
+- Parsed-nothing refusal — ADD.
+- `INSTAR_LINT_FORCE_PARSE_FAILURE` — ADD, test hook. It can ONLY force the
+  fail-closed path; there is no flag here that can make this lint pass something
+  it would otherwise flag.
+- `ALLOWLIST`, `DESTRUCTIVE_FS_NAMES`, `CHILD_PROCESS_FNS`, the violation
+  messages, the shell/package.json grep and the exit codes — UNCHANGED.
+
+## 1. Over-block
+
+**The dominant risk — this lint fails builds, and a noisy check gets switched
+off, after which it protects nothing.** Five controls, each with a test, all
+passing under BOTH the old and new behaviour:
+
+- a non-destructive fs call is not flagged;
+- a NON-destructive method on an aliased namespace is not flagged (the alias is
+  not the violation, the destructive method is);
+- `mkdir` through that same alias is not flagged — creating is not deleting;
+- an unrelated object exposing the same names is not flagged (resolution is
+  anchored to the fs/child_process namespace, never to a method name);
+- an alias that is never called is not flagged.
+
+**Real tree: exit 0 before AND after, zero violations.** Full `npm run lint`
+chain exit 0.
+
+The parsed-nothing refusal is scoped to `attempted > 0 && parsed === 0`, which no
+working checkout can reach.
+
+## 2. Under-block
+
+Stated in the source rather than implied:
+
+- **Cross-module names** — a destructive function re-exported from another file
+  is not followed. Needs a whole-program symbol graph, not one file at a time.
+- **Runtime-assembled access** — a name built from a variable, a call, or a
+  template.
+- **Indirection through a container** — `const io = { del: fs.unlinkSync }; io.del(p)`
+  remains invisible. Measured and left open: unlike the namespace alias, that is
+  not an ordinary way to write a delete, and chasing it widens over-block risk on
+  a build-failing lint for a contrived shape.
+
+## 3. Level-of-abstraction fit
+
+Same layer as the existing check — TypeScript AST over one file, no type checker,
+no new dependency. Local-binding resolution is the smallest addition that answers
+the question the existing rules already ask ("is this call a destructive fs/git
+primitive?") for names the file creates itself.
+
+## 4. Signal vs authority compliance
+
+A CI guard, not a runtime authority. It gained reach (more forms of the same
+violation) and one fail-closed condition, but no new decision-making power over
+agent behaviour. The funnel itself is untouched.
+
+## 5. Interactions
+
+- Already in the `lint` chain CI runs; membership verified explicitly rather than
+  inferred from a `package.json` reference. Chain exit 0 with this change.
+- Collection now runs up to 5 times per file plus one reporting pass. Measured on
+  the real tree: no perceptible change in chain duration.
+- **The new test routes its own teardown through `SafeFsExecutor` rather than
+  taking an allowlist entry** — the test that argues for the rule follows it. This
+  is the one behavioural cost: one audit entry per test run.
+- No source module, route, config key, or state file touched.
+
+## 6. External surfaces
+
+None. Developer tooling. The Agent Awareness Standard does not apply.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correct.** A CI-time source scan: reads files in
+one checkout, returns an exit code. No durable state, no user-facing notice, no
+generated URL, no runtime decision — nothing to replicate, merge on read, or
+strand on a topic transfer. Every machine runs it over its own checkout of the
+same tracked source and reaches the same verdict; determinism comes from the
+source tree, not from coordination.
+
+One honest note: the parsed-nothing refusal makes the verdict depend on the
+checkout being *installed*, not just present. That is the intended behaviour —
+an uninstalled checkout cannot inspect anything, and saying so is the point.
+
+## 8. Rollback cost
+
+`git revert` of one script plus the added test file. No migration, no state, no
+deployed artifact, no runtime impact.
+
+## Conclusion
+
+Ship. Four evasions closed on a safety funnel — one of them an ordinary tidying
+pattern rather than an evasion — a run that inspects nothing can no longer report
+clean, five anti-over-block controls added, and the real tree verified clean in
+both directions.
+
+## Evidence pointers
+
+- `tests/unit/destructive-lint-local-bindings.test.ts` — **16/16 green**.
+- **Negative control: 7 of 16 fail** against the shipped lint (all six defect
+  cases plus the parsed-nothing refusal). The other 9 pass **both ways** — which
+  is what makes them controls. Script restored **byte-exact** after the control
+  (sha match).
+- Reproduced by hand FIRST with a positive control firing in the same run; the
+  control is what makes the EVADES verdicts mean anything. A first probe batch in
+  an uninstalled worktree returned exit 0 for *everything including the controls*
+  — uniform results across independent subjects indicted the instrument, which is
+  how the parsed-nothing finding was discovered at all.
+- Real-tree verdict: exit 0 before and after. Full `npm run lint` chain exit 0.
+- `tsc --noEmit` exit 0.
+- Tier **1** declared: `classifyTier` reports riskFloor 1 with no safety-invariant
+  match (directional controls: `SessionReaper.ts` and `SecretStore.ts` both floor
+  2). The size heuristic suggests 2 on added LOC alone — stated openly, since the
+  tier I choose is the one that lets my own change through.

--- a/upgrades/side-effects/destructive-lint-local-bindings.md
+++ b/upgrades/side-effects/destructive-lint-local-bindings.md
@@ -49,7 +49,18 @@ found" is then a statement about a scan that never happened.
 
 Added: a run that scanned files and parsed NONE of them refuses to report clean
 and names the likely cause. Deliberately the total-failure case only, so it
-cannot fail a build over one awkward file — in any working checkout, files parse.
+cannot fail a build over one awkward file.
+
+**It exits 2, not 1, and CI taught me that distinction.** My first version
+returned 1 — the violation code — and three `pre-push-gate` tests went red,
+because the gate copies itself into a scratch fixture with no `node_modules`,
+runs this lint there, and (correctly) reads a non-zero exit as "violations
+detected". My claim that "no working checkout can reach it" was wrong: a test
+fixture reaches it. The gate ALREADY distinguishes a lint that failed to RUN
+(warning) from one that found VIOLATIONS (push-blocking error) — I was sending an
+environment problem down the violation channel. Now the lint exits **2** for
+could-not-inspect and `pre-push-gate.js` maps 2 onto its existing warning path.
+"I could not look" and "I looked and found nothing" are different facts.
 
 ## Decision-point inventory
 
@@ -65,8 +76,11 @@ cannot fail a build over one awkward file — in any working checkout, files par
 - `INSTAR_LINT_FORCE_PARSE_FAILURE` — ADD, test hook. It can ONLY force the
   fail-closed path; there is no flag here that can make this lint pass something
   it would otherwise flag.
+- Exit code **2** — ADD, for could-not-inspect. 0 and 1 keep their meanings.
+- `scripts/pre-push-gate.js` — CHANGED: maps exit 2 onto its EXISTING
+  failed-to-run warning path instead of the violations error path.
 - `ALLOWLIST`, `DESTRUCTIVE_FS_NAMES`, `CHILD_PROCESS_FNS`, the violation
-  messages, the shell/package.json grep and the exit codes — UNCHANGED.
+  messages and the shell/package.json grep — UNCHANGED.
 
 ## 1. Over-block
 
@@ -85,8 +99,13 @@ passing under BOTH the old and new behaviour:
 **Real tree: exit 0 before AND after, zero violations.** Full `npm run lint`
 chain exit 0.
 
-The parsed-nothing refusal is scoped to `attempted > 0 && parsed === 0`, which no
-working checkout can reach.
+The parsed-nothing refusal is scoped to `attempted > 0 && parsed === 0`.
+**I first wrote here that "no working checkout can reach it" — that was wrong and
+CI proved it.** The pre-push gate copies itself into a scratch fixture with no
+`node_modules` and runs this lint there, so three of its tests went red. The
+condition is reachable; what was wrong was reporting it through the VIOLATION
+exit code. Exit 2 fixes the signal rather than narrowing the condition, and the
+three tests pass with the refusal still firing.
 
 ## 2. Under-block
 


### PR DESCRIPTION
## What this fixes

`scripts/lint-no-direct-destructive.js` is the funnel guard for
`COMPREHENSIVE-DESTRUCTIVE-TOOL-CONTAINMENT-SPEC`: only `SafeGitExecutor` / `SafeFsExecutor` may
call destructive git/fs primitives directly, so that **every delete carries an audit entry**.

It AST-walks rather than pattern-matching text, and that already buys it real import resolution — a
*renamed* import (`import { rmSync as nuke }`) is caught, which no regex lint here manages. But its
identifier sets were populated **only from imports and requires**, never from local bindings.

Measured against the shipped lint, with a positive control (plain `fs.rmSync`) firing in the same
pass — without that control, "nothing was flagged" and "the lint did not run" are indistinguishable:

| form | shipped |
|---|---|
| `fs.rmSync(p)` — **POSITIVE CONTROL** | exit 1 (caught) |
| `import { rmSync as nuke }` | exit 1 (caught) |
| `fs.promises.rm(p)` written out | exit 1 (caught) |
| **`const fsp = fs.promises; await fsp.rm(p, …)`** | **exit 0 — EVADES** |
| `const del = fs.rmSync; del(p)` | **exit 0 — EVADES** |
| `const { rmSync: del } = fs; del(p)` | **exit 0 — EVADES** |
| `(fs as any)['rmSync'](p)` | **exit 0 — EVADES** |

**The first one is why this matters.** `fs.promises.rm` written out IS caught, so the difference
between flagged and invisible was a variable. Aliasing a namespace to a short name is idiomatic
JavaScript — this gap needed a tidy afternoon, not an attacker.

Resolution feeds the **existing** rules rather than adding rules beside them.

## The second finding, hit live rather than reasoned about

Running the lint in a fresh worktree with no `node_modules`, the `typescript` require failed for
**every** file — and the lint reported **clean, exit 0**. A guard against unaudited deletes silently
became a no-op, with only stderr lines a CI log buries.

The per-file soft-warning is deliberate and stated in the source, and it is right: one file the
parser dislikes should not fail everyone's build. But **one** file failing and **every** file failing
are different situations — the second means nothing was inspected, and "no violations found" is then
a statement about a scan that never happened.

A run that scanned files and parsed none of them now refuses to report clean and names the likely
cause. Deliberately the total-failure case only, so it cannot fail a build over one awkward file: in
any working checkout, files parse.

## ELI16

Deleting files is the one thing the agent cannot undo, so every destructive filesystem or git
operation has to go through a single pair of modules that record what was deleted and why. That
record is the whole point: if something disappears, there is a trail. A build check enforces it —
call a delete directly and the build fails.

**One line of ordinary tidying switched that check off for a whole file.** Assigning the filesystem
module's promise interface to a shorter name, then deleting through the shorter name, passed. Written
out in full, the same delete is caught. Giving the thing a shorter name made it invisible. Nobody
writing that is trying to get around anything — aliasing a namespace is one of the most ordinary
things in JavaScript, and that is exactly what makes it worth fixing.

Three more plain forms did the same: pulling the delete function itself into a name, destructuring it
out with a rename, and reaching it through a type assertion — which is erased before the code ever
runs, so it changes nothing except whether the check can see it.

What surprised me is that this is one of the better-built checks here. It parses the code properly
instead of matching text, and already catches an import renamed on the way in. The gap was narrower
than "it doesn't understand names": it understood names arriving from imports, and nothing about
names a file creates itself.

Halfway through I found a second thing by accident. I ran the check in a fresh copy of the repo whose
dependencies had not been installed. Every file failed to parse — and the check reported clean and
exited successfully, because a parse failure is treated as a soft warning. That is deliberate and
mostly right, but there is a difference between one file failing and every file failing. The second
means nothing was inspected at all. So a run that scans files and parses none of them now refuses to
report success and says why. It cannot fail a working checkout, because there, files parse.

Because this check blocks commits, wrongly flagging good code costs more than the gap it closes — a
noisy check gets switched off, and then it protects nothing. Five things are deliberate, each with a
test that passes under both the old and new versions: reading a file is not deleting one; a shortened
name used for something harmless is fine; creating a directory through that same shortcut is fine
(creating is not deleting); an unrelated object that happens to use the same words is fine; and a
name that is never actually called is fine.

One bit I liked: my own test needed to delete its temporary directory when it finished — exactly the
thing this check forbids. Rather than adding the file to the exemption list, I routed that cleanup
through the funnel like everything else. The test that argues for the rule now follows it.

Full version: `docs/specs/destructive-lint-local-bindings.eli16.md`.

## Evidence

- `tests/unit/destructive-lint-local-bindings.test.ts` — **16/16 green**.
- **Negative control: 7 of 16 fail** against the shipped lint (all six defect cases plus the
  parsed-nothing refusal). The other 9 pass **both ways**, which is what makes them controls. Script
  restored **byte-exact** after the control (sha match).
- **Five anti-over-block controls**, because this lint fails builds: a non-destructive call; a
  non-destructive method on an aliased namespace; `mkdir` through that alias; an unrelated object
  exposing the same names; an alias that is never called.
- **Real tree: exit 0 before AND after.** Full `npm run lint` chain exit 0. `tsc --noEmit` exit 0.
- Reproduced by hand FIRST with a positive control in the same run. A first probe batch run in an
  *uninstalled* worktree returned exit 0 for **everything, including the controls** — uniform results
  across independent subjects indicted the instrument, and chasing that is how the parsed-nothing
  finding was discovered at all.
- The `INSTAR_LINT_FORCE_PARSE_FAILURE` test hook can **only** force the fail-closed path. There is
  no flag here that can make this lint pass something it would otherwise flag.

## What it still can't see, stated in the source

- **Cross-module names** — a destructive function re-exported from another file. Needs a
  whole-program symbol graph, not one file at a time.
- **Runtime-assembled access** — a name built from a variable, a call, or a template.
- **Indirection through a container** — `const io = { del: fs.unlinkSync }; io.del(p)`. Measured and
  **left open**: unlike the namespace alias, that is not an ordinary way to write a delete, and
  chasing it widens over-block risk on a build-failing lint for a contrived shape.

## Tier

**Tier 1 declared.** `classifyTier` reports `riskFloor 1` with no safety-invariant match, verified
with directional controls (`SessionReaper.ts` → floor 2, `SecretStore.ts` → floor 2). The gate agreed:
`riskFloor=1`, and it did not record `belowFloor`. The size heuristic suggests 2 on added LOC alone —
stated openly, since the tier I choose is the one that lets my own change through. No runtime path,
no authority, no capability: an existing CI guard reaches more forms of the violation it already
forbids, plus one fail-closed condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
