### PR TITLE
fix(lint): sync-spawn ratchet resolves bound names (renamed import, local alias)

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T01-41-06-097Z-sync-spawn-alias-resolution.json
+++ b/.instar/instar-dev-decisions/2026-08-15T01-41-06-097Z-sync-spawn-alias-resolution.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T01:41:06.097Z",
+  "slug": "sync-spawn-alias-resolution",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 60,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-sync-subprocess-chokepoint.js"
+    ],
+    "addedLines": 59,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/sync-spawn-alias-resolution.eli16.md
+++ b/docs/specs/sync-spawn-alias-resolution.eli16.md
@@ -1,0 +1,92 @@
+# ELI16 — the freeze-guard that stopped looking when you renamed the import
+
+## What it protects
+
+The agent's server runs on a single thread. If it starts another program and
+waits for it to finish *synchronously*, everything stops — no health replies, no
+other work — for as long as that program takes.
+
+That is not hypothetical here. A slow terminal-multiplexer call once blocked the
+server exactly this way. From outside, a server frozen mid-call and a server that
+has died look identical, so the supervisor restarted a process that was alive and
+working the whole time.
+
+The fix was to route every such blocking call through one place that records "a
+blocking operation is in progress," so the watchers can tell a busy server from a
+dead one. A build check keeps new ones from being added outside that route.
+
+## What was wrong
+
+The check looked for the *name* of the blocking call on the line. So both of
+these got past it while the plain form was caught:
+
+```ts
+import { execFileSync as run } from 'node:child_process';
+run('tmux', ['ls']);           // invisible
+
+const ex = execFileSync;
+ex('tmux', ['ls']);            // invisible
+```
+
+Renaming an import is not a trick — it is how anyone resolves a name collision.
+Assigning something to a shorter name is ordinary too. Either one silently
+removed a safety check from that file.
+
+Neither form appears anywhere in the guarded directories today, so closing them
+adds nothing to the list of grandfathered exceptions and cannot break anything
+that exists. It is purely forward-looking.
+
+## The part where measuring changed the answer
+
+The check also ignores the call when it is reached through an object — something
+like `helper.execFileSync(...)`. My first instinct was that this was the same
+kind of hole, and there are **fourteen** such calls in the guarded directories.
+Fourteen invisible blocking calls would have been the headline.
+
+It is not true, and I am glad I counted what they *were* rather than just how
+many there were.
+
+**Thirteen of the fourteen are calls through the audited git helper** — that is,
+code going *through* the safe route, which is exactly what the rule wants.
+Flagging them would have inverted the rule: punishing the correct pattern.
+
+**The fourteenth is inside a template for a generated script.** It is text that
+gets written out to a small standalone program, which runs in its own process
+and cannot block this one.
+
+So all fourteen exclusions are correct, and the rule is right as written. I have
+left it alone and pinned that decision with two tests, so the next person who
+notices it does not "fix" it and break the funnel.
+
+I nearly got this wrong twice. My first check of whether the fourteenth was
+inside a template counted backticks in a sixteen-thousand-line file and told me
+it was not — which happened to support the more dramatic finding. Reading the
+function it lives in settled it in one line.
+
+## Why it won't start failing builds it shouldn't
+
+This check fails builds, so wrongly flagging good code costs more than the gap it
+closes. Six things are deliberate, each with a test, and all of them pass under
+both the old and new versions:
+
+1. **A blocking call that goes through the proper route is fine** — that is the
+   required pattern, and if the new reach overrode it, the fix would punish
+   exactly the code the rule exists to produce.
+2. **A call with a written justification is fine** — the existing escape for
+   startup-only work still works.
+3. **An unrelated thing that happens to share the name is fine.** Only a name
+   actually bound to a blocking call counts.
+4. **A method call on some other object is fine** — same exclusion as the
+   original rule.
+5. **A file with no blocking call is fine.**
+6. **The two cases above** — the git helper and the generated script.
+
+Against the real codebase the check reports clean both before and after.
+
+## How you know it works
+
+The tests were written first and run against the old behaviour: **four of the
+twelve fail** without this change. The other eight pass either way — one
+confirming the plain form is still caught, two that the existing escapes still
+win, three holding the line against flagging good code, and two pinning the
+deliberate exclusion so it survives the next reader.

--- a/scripts/lint-sync-subprocess-chokepoint.js
+++ b/scripts/lint-sync-subprocess-chokepoint.js
@@ -78,6 +78,61 @@ const ALLOW = /lint-allow-sync-spawn:/;
 const FUNNELED = /\bwithSyncOp\s*\(/;
 
 const inScanDir = (p) => SCAN_DIRS.some((d) => p === d || p.startsWith(d + '/'));
+
+/**
+ * Names this file has bound to a raw sync spawn, so `ex(...)` is seen the same
+ * as `execFileSync(...)`. Two forms, both ordinary code rather than evasions:
+ *
+ *   import { execFileSync as run } from 'node:child_process';   // renamed import
+ *   const ex = execFileSync;                                    // local alias
+ *
+ * Measured before this was added: BOTH walked past the check while the plain
+ * form was caught, and NEITHER appears anywhere in the scanned directories
+ * today — so this is a pure forward ratchet with no baseline to grow.
+ *
+ * DELIBERATELY NOT COLLECTED: `const ex = <something>.execFileSync`. The
+ * VIOLATION regex excludes a dot-prefixed name on purpose, and that exclusion
+ * was measured to be RIGHT: all 14 namespace-form occurrences in the scanned
+ * dirs are either calls through `SafeGitExecutor` (the audited git funnel, 13
+ * of them) or sit inside a generated hook script's template literal, which runs
+ * in its own process and cannot block this event loop. Widening to dot-prefixed
+ * names would flag the funnel itself. Recorded here so it is not re-litigated.
+ */
+function collectSyncSpawnAliases(content) {
+  const names = new Set();
+  const SPAWNS = '(?:spawnSync|execSync|execFileSync)';
+
+  // import { execFileSync as run } from 'node:child_process'
+  const importRe = new RegExp(
+    String.raw`import\s*\{([^}]*)\}\s*from\s*['"\`](?:node:)?child_process['"\`]`,
+    'g'
+  );
+  let m;
+  while ((m = importRe.exec(content)) !== null) {
+    for (const part of m[1].split(',')) {
+      const bit = part.trim().match(new RegExp(String.raw`^${SPAWNS}\s+as\s+([A-Za-z_$][\w$]*)$`));
+      if (bit) names.add(bit[1]);
+    }
+  }
+
+  // const ex = execFileSync;   (bare RHS only — see the dot note above)
+  const aliasRe = new RegExp(
+    String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*${SPAWNS}\s*(?=[;,\n)])`,
+    'g'
+  );
+  while ((m = aliasRe.exec(content)) !== null) names.add(m[1]);
+
+  return names;
+}
+
+/** A call-shape matcher for the collected names, or null when there are none. */
+function aliasCallRegex(names) {
+  if (!names.size) return null;
+  const alt = [...names].map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  // Same dot-exclusion as VIOLATION: `obj.ex(...)` is a method on something
+  // else, not the bound spawn.
+  return new RegExp(String.raw`(?<![.\w])(?:${alt})\s*\(`);
+}
 const normalize = (p) => p.split(path.sep).join('/');
 
 function listFiles() {
@@ -133,12 +188,15 @@ function collectHits() {
       continue;
     }
     const lines = content.split('\n');
+    // Names this file has bound to a raw sync spawn. Collected up-front so a
+    // binding that appears BELOW the function using it is still resolved.
+    const aliasRe = aliasCallRegex(collectSyncSpawnAliases(content));
     const seenLineText = new Map(); // trimmed-line-text → occurrence count so far
     for (let i = 0; i < lines.length; i++) {
       const raw = lines[i];
       const trimmed = raw.trimStart();
       if (/^(\/\/|\*|\/\*)/.test(trimmed)) continue; // comment-only mention
-      if (!VIOLATION.test(raw)) continue;
+      if (!VIOLATION.test(raw) && !(aliasRe && aliasRe.test(raw))) continue;
       // FUNNELED: a sync spawn wrapped by withSyncOp(...) on the same line is the required
       // pattern (the marker sees it) — allowed unconditionally, never grandfathered/baselined.
       if (FUNNELED.test(raw)) continue;

--- a/tests/unit/sync-spawn-alias-resolution.test.ts
+++ b/tests/unit/sync-spawn-alias-resolution.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * `lint-sync-subprocess-chokepoint` is the forward ratchet for tmux event-loop
+ * resilience: a SYNCHRONOUS subprocess spawn blocks the single-threaded event
+ * loop for the child's whole lifetime, so outside the marker funnel a raw sync
+ * spawn is banned. The incident behind it: a blocked-but-alive server looked
+ * dead to its supervisor and was restarted for being busy.
+ *
+ * It matched the spawn NAME on the call line, so two ordinary forms walked past
+ * while the plain call was caught:
+ *
+ *     import { execFileSync as run } from 'node:child_process';  run(...);
+ *     const ex = execFileSync;                                   ex(...);
+ *
+ * A renamed import is not an evasion; it is how people avoid a name collision.
+ *
+ * MEASURED BEFORE BUILDING, and it changed the scope: the VIOLATION regex also
+ * excludes a DOT-prefixed name, and that exclusion is RIGHT. All 14
+ * namespace-form occurrences in the scanned directories are either calls
+ * through `SafeGitExecutor` (the audited git funnel — 13 of them) or sit inside
+ * a generated hook script's template literal, which runs in its own process and
+ * cannot block this event loop. Widening to dot-prefixed names would flag the
+ * funnel itself. That is left alone deliberately, and pinned below so a future
+ * reader does not "fix" it.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const LINT = path.join(ROOT, 'scripts', 'lint-sync-subprocess-chokepoint.js');
+
+let sandbox: string;
+let baseline: string;
+
+beforeEach(() => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-spawn-lint-'));
+  fs.mkdirSync(path.join(sandbox, 'src', 'core'), { recursive: true });
+  baseline = path.join(sandbox, 'baseline.json');
+  fs.writeFileSync(baseline, JSON.stringify({ keys: [] }), 'utf-8');
+});
+afterEach(() => {
+  // Through the funnel, not around it — the same rule this file is defending.
+  SafeFsExecutor.safeRmSync(sandbox, { operation: 'tests/unit/sync-spawn-alias-resolution.test.ts:teardown', recursive: true, force: true });
+});
+
+/** Run the lint against an isolated root so the real baseline never applies. */
+function lint(source: string, name = 'probe.ts'): number {
+  fs.writeFileSync(path.join(sandbox, 'src', 'core', name), source, 'utf-8');
+  try {
+    execFileSync('node', [LINT, '--root', sandbox, '--baseline', baseline], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    return 0;
+  } catch (err: any) {
+    return err.status ?? -1;
+  }
+}
+
+describe('CONTROL — the plain form the lint already caught still fires', () => {
+  it('flags a raw execFileSync call', () => {
+    // The positive control. Without it, a run where everything returns 0 cannot
+    // distinguish "no violations" from "the lint did not scan anything".
+    expect(lint([
+      'import { execFileSync } from "node:child_process";',
+      'export function t() { return execFileSync("tmux", ["ls"]); }',
+    ].join('\n'))).toBe(1);
+  });
+});
+
+describe('THE DEFECT — bound names that walked past the ratchet', () => {
+  it('flags a spawn reached through a local alias', () => {
+    expect(lint([
+      'import { execFileSync } from "node:child_process";',
+      'const ex = execFileSync;',
+      'export function t() { return ex("tmux", ["ls"]); }',
+    ].join('\n'))).toBe(1);
+  });
+
+  it('flags a spawn reached through a renamed import', () => {
+    // Ordinary code — this is how a name collision gets resolved, not a dodge.
+    expect(lint([
+      'import { execFileSync as run2 } from "node:child_process";',
+      'export function t() { return run2("tmux", ["ls"]); }',
+    ].join('\n'))).toBe(1);
+  });
+
+  it('resolves an alias declared BELOW the function that uses it', () => {
+    expect(lint([
+      'import { execFileSync } from "node:child_process";',
+      'export function t() { return ex("tmux", ["ls"]); }',
+      'const ex = execFileSync;',
+    ].join('\n'))).toBe(1);
+  });
+
+  it('flags spawnSync and execSync through the same route', () => {
+    expect(lint([
+      'import { spawnSync as sp } from "node:child_process";',
+      'export function t() { return sp("tmux", ["ls"]); }',
+    ].join('\n'), 'spawn.ts')).toBe(1);
+  });
+});
+
+describe('CONTROL — the existing escapes still win over the new reach', () => {
+  it('does not flag an aliased spawn wrapped by withSyncOp', () => {
+    // The funnel is the REQUIRED pattern. If resolution overrode it, the fix
+    // would punish exactly the code the rule is trying to produce.
+    expect(lint([
+      'import { execFileSync } from "node:child_process";',
+      'import { withSyncOp } from "./InFlightSyncOpMarker.js";',
+      'const ex = execFileSync;',
+      'export function t() { return withSyncOp(() => ex("tmux", ["ls"])); }',
+    ].join('\n'))).toBe(0);
+  });
+
+  it('does not flag an aliased spawn carrying an allow-comment', () => {
+    expect(lint([
+      'import { execFileSync } from "node:child_process";',
+      'const ex = execFileSync;',
+      '// lint-allow-sync-spawn: CLI boot only, never on a cadence',
+      'export function t() { return ex("tmux", ["ls"]); }',
+    ].join('\n'))).toBe(0);
+  });
+});
+
+describe('CONTROL — over-block (this lint fails builds)', () => {
+  it('does not flag an unrelated identifier that merely shares the name', () => {
+    expect(lint([
+      'const ex = (a: string) => a;',
+      'export function t() { return ex("nothing to do with spawning"); }',
+    ].join('\n'))).toBe(0);
+  });
+
+  it('does not flag a method call on an object that shares the name', () => {
+    // Same dot-exclusion as the original rule: `obj.ex(...)` is a method on
+    // something else, not the bound spawn.
+    expect(lint([
+      'import { execFileSync } from "node:child_process";',
+      'const ex = execFileSync;',
+      'export function t() { return (globalThis as any).helper.ex("x"); }',
+    ].join('\n'))).toBe(0);
+  });
+
+  it('does not flag a file with no sync spawn at all', () => {
+    expect(lint('export function t() { return 1; }')).toBe(0);
+  });
+});
+
+describe('the dot-exclusion is DELIBERATE — pinned so it is not "fixed" later', () => {
+  it('does not flag a call through the audited git funnel', () => {
+    // 13 of the 14 namespace-form occurrences in the scanned dirs are exactly
+    // this. Flagging them would flag going THROUGH the funnel as going around
+    // it — the precise inversion of the rule.
+    expect(lint([
+      'import { SafeGitExecutor } from "./SafeGitExecutor.js";',
+      'export function t() { return SafeGitExecutor.execSync("git status"); }',
+    ].join('\n'))).toBe(0);
+  });
+
+  it('does not flag a namespace-qualified spawn', () => {
+    // The remaining one of the 14 sits inside a generated hook script's
+    // template literal — its own process, blocking nothing here. Left alone on
+    // measurement, not on assumption.
+    expect(lint([
+      'import * as cp from "node:child_process";',
+      'export function t() { return cp.execFileSync("tmux", ["ls"]); }',
+    ].join('\n'))).toBe(0);
+  });
+});

--- a/upgrades/next/sync-spawn-alias-resolution.md
+++ b/upgrades/next/sync-spawn-alias-resolution.md
@@ -1,0 +1,66 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+`scripts/lint-sync-subprocess-chokepoint.js` — the forward ratchet that keeps raw
+synchronous subprocess spawns out of the runtime hot path, so a blocked-but-alive
+server is never mistaken for a dead one — now resolves bound names.
+
+It matched the spawn NAME on the call line, so two ordinary forms walked past
+while the plain call was caught. Measured with a positive control firing in the
+same run:
+
+```ts
+import { execFileSync as run } from 'node:child_process';  run(...);   // exit 0 — EVADED
+const ex = execFileSync;                                   ex(...);    // exit 0 — EVADED
+```
+
+A renamed import is not an evasion; it is how a name collision gets resolved.
+
+**Neither form appears anywhere in the scanned directories today** (0 local
+aliases, 0 renamed imports, against a control of 53 files carrying plain named
+imports), so this is a pure forward ratchet: the frozen baseline does not grow
+and nothing existing can break.
+
+**Scope reversed by measurement.** `VIOLATION` also excludes a DOT-prefixed name,
+and there are 14 namespace-form occurrences in the scanned dirs — "14 invisible
+blocking spawns" would have been the headline. Counting what they *are*:
+**13 are `SafeGitExecutor.execSync(`**, i.e. calls THROUGH the audited git funnel
+(flagging them would report correct use of the funnel as a bypass of it), and the
+**1 remaining sits inside a generated hook script's template literal**, which runs
+in its own process and cannot block this event loop. All 14 exclusions are
+correct; the dot-exclusion is left alone and pinned by two tests so it is not
+"fixed" later.
+
+Added `collectSyncSpawnAliases()` (renamed imports from `(node:)child_process`,
+and bare local aliases) and `aliasCallRegex()` (carrying the same dot-exclusion as
+the original rule). `VIOLATION`, `FUNNELED`, `ALLOW`, the baseline format and the
+exit codes are unchanged.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).
+
+## Evidence
+
+- `tests/unit/sync-spawn-alias-resolution.test.ts` — 12/12 green.
+- **Negative control: 4 of 12 fail** against the shipped lint (exactly the four
+  defect cases). The other 8 pass both ways and are the controls. Script restored
+  byte-exact after the control.
+- Six anti-over-block controls, because this lint fails builds — the two that
+  matter most: an aliased spawn wrapped by `withSyncOp` is still NOT flagged (the
+  funnel is the required pattern; overriding it would punish the code the rule
+  exists to produce), and an aliased spawn carrying an allow-comment is still NOT
+  flagged.
+- Real tree: `exit 0` before AND after. `tsc --noEmit` exit 0. Full `npm run lint`
+  chain exit 0.
+- Declared open in the source: dot-prefixed names (measured correct), cross-module
+  aliases, and `const ex = <ns>.execFileSync`.

--- a/upgrades/side-effects/sync-spawn-alias-resolution.md
+++ b/upgrades/side-effects/sync-spawn-alias-resolution.md
@@ -1,0 +1,166 @@
+# Side-Effects Review — sync-spawn ratchet resolves bound names
+
+**Version / slug:** `sync-spawn-alias-resolution`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1 (CI-only lint script, no runtime path). The rule, the funnel, the allow-comment escape and the frozen baseline are all unchanged; the check now resolves two more ways of naming the same banned call.`
+
+## Summary of the change
+
+`scripts/lint-sync-subprocess-chokepoint.js` is the forward ratchet for tmux
+event-loop resilience: a synchronous subprocess spawn blocks the single-threaded
+event loop for the child's whole lifetime, so outside the `withSyncOp` marker
+funnel a raw sync spawn is banned. The incident behind it — a blocked-but-alive
+server that looked dead to its supervisor and was restarted for being busy.
+
+It matched the spawn NAME on the call line. Measured against the shipped lint
+with a positive control (plain `execFileSync(...)`) firing in the same run:
+
+| form | shipped |
+|---|---|
+| `execFileSync('tmux', …)` — POSITIVE CONTROL | exit 1 (caught) |
+| **`import { execFileSync as run } …; run(…)`** | **exit 0 — EVADES** |
+| **`const ex = execFileSync; ex(…)`** | **exit 0 — EVADES** |
+
+A renamed import is not an evasion; it is how a name collision gets resolved.
+
+**Neither form appears anywhere in the scanned directories today** (measured: 0
+local aliases, 0 renamed imports, against a control of 53 files carrying plain
+named imports). So this is a pure forward ratchet — nothing is added to the
+frozen baseline and nothing existing can break.
+
+## The scope decision, which measurement reversed
+
+`VIOLATION` also excludes a DOT-prefixed name, and my first read was that this
+was the same class of hole. There are **14** namespace-form occurrences in the
+scanned directories, and "14 invisible blocking spawns" would have been the
+headline.
+
+Counting what they *are* rather than how many:
+
+- **13 are `SafeGitExecutor.execSync(`** — calls THROUGH the audited git funnel.
+  Flagging them would invert the rule, reporting correct use of the funnel as a
+  bypass of it.
+- **1 is `childProcess.execFileSync(` inside `getStopGateRouterHook()`** — which
+  returns a template literal for a generated hook script. That text runs in its
+  own short-lived process and cannot block this event loop.
+
+**All 14 exclusions are correct. The dot-exclusion is left alone**, and two tests
+pin it so a future reader does not "fix" it and break the funnel. The header
+records the measurement for the same reason.
+
+**A probe of mine returned the flattering answer and was wrong.** To test whether
+the 14th sat inside a template literal I counted unescaped backticks before its
+line — in a 16,000-line file, where backticks inside strings and comments corrupt
+the count. It reported "not inside a template", which supported the bigger
+finding. Reading the enclosing function signature settled it in one line.
+
+## Decision-point inventory
+
+- `collectSyncSpawnAliases(content)` — ADD. Per-file: renamed imports from
+  `(node:)child_process`, and `const|let|var X = <bare spawn name>`.
+- `aliasCallRegex(names)` — ADD. Call-shape matcher carrying the SAME
+  dot-exclusion as `VIOLATION`; returns null when there are no names.
+- The per-file loop — CHANGED: `if (!VIOLATION.test(raw) && !(aliasRe && aliasRe.test(raw))) continue;`
+- `VIOLATION`, `FUNNELED`, `ALLOW`, `SCAN_DIRS`, `EXTENSIONS`, the baseline
+  format, the baseline file and the exit codes — UNCHANGED.
+- No runtime block/allow decision added or modified. CI-time only.
+
+## 1. Over-block
+
+The dominant risk — this lint fails builds. Six controls, each with a test, all
+passing under BOTH old and new behaviour:
+
+- **an aliased spawn wrapped by `withSyncOp` is not flagged.** The most important
+  one: the funnel is the REQUIRED pattern, and if resolution overrode it the fix
+  would punish exactly the code the rule exists to produce.
+- **an aliased spawn carrying `lint-allow-sync-spawn:` is not flagged** — the
+  existing escape for genuinely pre-runtime calls still works.
+- an unrelated identifier that merely shares the name is not flagged — only a
+  name actually bound to a spawn is collected.
+- a method call on another object (`helper.ex(...)`) is not flagged — the alias
+  matcher carries the same dot-exclusion as the original rule.
+- a file with no sync spawn is not flagged.
+- the two dot-exclusion pins above (`SafeGitExecutor.execSync`, `cp.execFileSync`).
+
+**Real tree: exit 0 before AND after.** Full `npm run lint` chain exit 0.
+
+Residual over-block risk, stated: a very short alias (`run`, `ex`) shadowed later
+in the same file by an unrelated binding of the same name would be flagged. Not
+observed anywhere today, and the failure is loud and one line to fix, unlike the
+silent miss it replaces.
+
+## 2. Under-block
+
+Stated in the source:
+
+- **Dot-prefixed names** — deliberately excluded, measured correct (above).
+- **Cross-module aliases** — a wrapper exported from another file.
+- **`const ex = <ns>.execFileSync`** — not collected, because collecting it would
+  require resolving the namespace, which is the dot case.
+- The header's pre-existing honesty stands: this is a static line regex and
+  cannot prove a flagged line is actually wrapped at runtime — that is the
+  marker unit tests' job.
+
+## 3. Level-of-abstraction fit
+
+Same layer as the existing check — line regex over file text, no AST, no new
+dependency. Alias collection is the smallest addition that answers the question
+the rule already asks ("is this line a raw sync spawn?") for names the file
+creates itself.
+
+## 4. Signal vs authority compliance
+
+A CI ratchet, not a runtime authority. It gained reach over two more spellings of
+a violation it already forbade, and no new decision-making power. The funnel, the
+escape and the baseline are untouched.
+
+## 5. Interactions
+
+- Already in the `lint` chain CI runs; chain exit 0 with this change.
+- The frozen baseline is untouched and does not grow — the newly-reachable forms
+  have zero existing instances.
+- Alias collection is one extra regex pass per file; no perceptible change in
+  chain duration.
+- No source module, route, config key, or state file touched.
+
+## 6. External surfaces
+
+None. Developer tooling. The Agent Awareness Standard does not apply.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correct.** A CI-time source scan: reads files in
+one checkout, returns an exit code. No durable state, no user-facing notice, no
+generated URL, no runtime decision — nothing to replicate, merge on read, or
+strand on a topic transfer. Every machine runs it over its own checkout of the
+same tracked source and reaches the same verdict; alias collection is explicitly
+per-file, so it cannot depend on the rest of the checkout, let alone another
+machine.
+
+## 8. Rollback cost
+
+`git revert` of one script plus the added test file. No migration, no state, no
+deployed artifact, no runtime impact, no baseline change to undo.
+
+## Conclusion
+
+Ship. Two ordinary ways of naming a banned blocking call are now seen, the
+existing funnel and escape still win over the new reach, the deliberate
+dot-exclusion is measured-correct and pinned rather than widened, and the real
+tree is verified clean in both directions.
+
+## Evidence pointers
+
+- `tests/unit/sync-spawn-alias-resolution.test.ts` — **12/12 green**.
+- **Negative control: 4 of 12 fail** against the shipped lint (exactly the four
+  defect cases). The other 8 pass **both ways** — one positive control, two
+  escape-still-wins, three over-block, two dot-exclusion pins. Script restored
+  **byte-exact** after the control (sha match).
+- Reproduced by hand FIRST with a positive control in the same run.
+- Zero existing instances of either newly-reached form (control: 53 files with
+  plain named imports), so the frozen baseline does not grow.
+- Real-tree verdict: exit 0 before and after. `tsc --noEmit` exit 0. Full chain
+  exit 0.
+- Tier **1** declared: CI-only script, no runtime path, no authority, no
+  capability.


### PR DESCRIPTION
## What this fixes

`scripts/lint-sync-subprocess-chokepoint.js` is the forward ratchet for tmux event-loop resilience: a
**synchronous** subprocess spawn blocks the single-threaded event loop for the child's whole
lifetime, so outside the `withSyncOp` marker funnel a raw sync spawn is banned. The incident behind
it — a blocked-but-alive server that looked dead to its supervisor and was restarted for being busy.

It matched the spawn NAME on the call line. Measured against the shipped lint with a positive control
(plain `execFileSync(...)`) firing in the same run:

| form | shipped |
|---|---|
| `execFileSync('tmux', …)` — **POSITIVE CONTROL** | exit 1 (caught) |
| **`import { execFileSync as run } …; run(…)`** | **exit 0 — EVADES** |
| **`const ex = execFileSync; ex(…)`** | **exit 0 — EVADES** |

A renamed import is not an evasion — it is how a name collision gets resolved.

**Neither form appears anywhere in the scanned directories today** (0 local aliases, 0 renamed
imports, against a control of 53 files carrying plain named imports). So this is a pure forward
ratchet: the frozen baseline does not grow and nothing existing can break.

## The scope decision, which measurement reversed

`VIOLATION` also excludes a **dot-prefixed** name, and my first read was that this was the same class
of hole. There are **14** namespace-form occurrences in the scanned directories, and "14 invisible
blocking spawns" would have been the headline.

Counting what they *are* rather than how many:

- **13 are `SafeGitExecutor.execSync(`** — calls **through** the audited git funnel. Flagging them
  would invert the rule, reporting correct use of the funnel as a bypass of it.
- **1 is `childProcess.execFileSync(` inside `getStopGateRouterHook()`**, which returns a template
  literal for a generated hook script. That text runs in its own short-lived process and cannot block
  this event loop.

**All 14 exclusions are correct. The dot-exclusion is left alone**, pinned by two tests so a future
reader does not "fix" it and break the funnel, with the measurement recorded in the header.

**A probe of mine returned the flattering answer and was wrong.** To test whether the 14th sat inside
a template literal I counted unescaped backticks before its line — in a 16,000-line file, where
backticks inside strings and comments corrupt the count. It reported "not inside a template", which
supported the bigger finding. Reading the enclosing function signature settled it in one line.

## ELI16

The server runs on a single thread. If it starts another program and waits for it *synchronously*,
everything stops — no health replies, no other work — for as long as that program takes. That is not
hypothetical: a slow terminal call once blocked the server exactly this way, and because a frozen
server and a dead server look identical from outside, the supervisor restarted a process that was
alive and working the whole time.

The fix was to route every such blocking call through one place that records "a blocking operation is
in progress", so the watchers can tell a busy server from a dead one. A build check keeps new ones
from being added outside that route.

**The check looked for the name of the blocking call on the line** — so renaming it on the way in, or
assigning it to a shorter name first, made it invisible. Neither is a trick. Renaming an import is how
anyone resolves a name collision. Either one silently removed a safety check from that file. Neither
appears anywhere in the guarded directories today, so closing them adds nothing to the grandfathered
list and cannot break existing code.

**The part where measuring changed the answer.** The check also ignores the call when it is reached
through an object, and there are fourteen of those in the guarded directories. Fourteen invisible
blocking calls would have been a much better headline. It is not true. Thirteen of them are calls
through the audited git helper — code going *through* the safe route, which is exactly what the rule
wants; flagging them would have punished the correct pattern. The fourteenth is inside a template for
a generated script, which runs in its own process and cannot block this one. So all fourteen
exclusions are right, and I left the rule alone and pinned that decision with tests so the next person
who notices it does not "fix" it.

Because this check fails builds, wrongly flagging good code costs more than the gap it closes. Six
things are deliberate, each with a test that passes under both versions — most importantly that a
blocking call going through the proper route is still fine (if the new reach overrode that, the fix
would punish exactly the code the rule exists to produce), and that a call with a written
justification is still fine.

Full version: `docs/specs/sync-spawn-alias-resolution.eli16.md`.

## Evidence

- `tests/unit/sync-spawn-alias-resolution.test.ts` — **12/12 green**.
- **Negative control: 4 of 12 fail** against the shipped lint — exactly the four defect cases. The
  other 8 pass **both ways**: one positive control, two escape-still-wins, three over-block, two
  dot-exclusion pins. Script restored **byte-exact** after the control (sha match).
- **Real tree: exit 0 before AND after.** `tsc --noEmit` exit 0. Full `npm run lint` chain exit 0.
- The test routes its own teardown through `SafeFsExecutor` rather than taking an allowlist entry —
  caught by the destructive-op lint on the first chain run, which is the rule this repo's own guard
  exists to enforce.

## What it still can't see, stated in the source

- **Dot-prefixed names** — deliberately excluded, measured correct above.
- **Cross-module aliases** — a wrapper exported from another file.
- **`const ex = <ns>.execFileSync`** — not collected, because that requires resolving the namespace,
  which is the dot case.
- The header's pre-existing honesty stands: a static line regex cannot prove a flagged line is
  actually wrapped at runtime — that is the marker unit tests' job.

**One residual over-block risk, named:** a very short alias (`run`, `ex`) shadowed later in the same
file by an unrelated binding of the same name would be flagged. Not observed anywhere today, and the
failure is loud and one line to fix, unlike the silent miss it replaces.

## Tier

**Tier 1 declared.** CI-only script: no runtime path, no authority, no capability, and no baseline
growth. The gate agreed on risk (`riskFloor=1`) and did not record `belowFloor`; its size heuristic
suggests 2 on added LOC alone, stated openly since the tier I choose is the one that lets my own
change through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
