### PR TITLE
fix(write-admission): supply selfNickname so a refusing machine can name itself

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T02-15-21-085Z-write-admission-self-nickname.json
+++ b/.instar/instar-dev-decisions/2026-08-15T02-15-21-085Z-write-admission-self-nickname.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T02:15:21.085Z",
+  "slug": "write-admission-self-nickname",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 13,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 13,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/write-admission-self-nickname.eli16.md
+++ b/docs/specs/write-admission-self-nickname.eli16.md
@@ -1,0 +1,78 @@
+# ELI16 — the machine that refused a write couldn't say which machine it was
+
+## What this is about
+
+When the agent runs on more than one computer, only one of them owns a given
+piece of state at a time. If the wrong one tries to write, it refuses — and the
+refusal is supposed to tell you *which* machine owns it, so you know where to go
+instead.
+
+There is a status page for that mechanism. It reports the machine you are asking,
+by id and by nickname — "the Mac Mini", "the laptop" — because an id is a
+meaningless string of hex and a nickname is the thing you actually recognise.
+
+## What was wrong
+
+**The nickname was always empty.** Every machine, every time.
+
+The status code asks for the nickname properly. The place that builds the whole
+component simply never handed it one, and the code politely falls back to nothing
+when it isn't given. So the field existed, was rendered, and was blank forever.
+
+Nothing was broken in a dangerous way — no wrong machine was named, no write was
+mis-refused. It is a piece of information that was supposed to be there and never
+was.
+
+## How I found it, and the mistake in the middle
+
+This came from a peer agent's audit listing dependencies that are declared and
+consumed but never supplied. I was checking the last few of its findings.
+
+**My first check said the component is never built at all.** I searched for the
+obvious spelling of "create one of these", got zero results, and was one step from
+concluding the whole finding was moot.
+
+It is built — just written with the module's name in front of it, a completely
+ordinary way to write the same thing. My search only matched the bare spelling.
+
+That is the *identical* blind spot I spent tonight fixing in three separate build
+checks: a search that matches a bare name and misses the same name reached through
+something else. I made it in my own investigation, while auditing for it. Which is
+a fair argument for why those checks are worth having — the shape is genuinely hard
+to see from the inside.
+
+## What changed
+
+One line at the place the component is built, handing it the lookup it was already
+asking for. The lookup is the same one the rest of the file uses to turn a machine
+id into a nickname.
+
+## Why it can't make anything worse
+
+The lookup is unavailable in some start-up situations, and a machine that isn't
+registered in the pool has no nickname to find. **Both of those produce nothing —
+which is exactly what the field showed before.** So this change can only ever add a
+name where there was a blank; it cannot produce a wrong one, and it cannot fail.
+
+## What I deliberately did not do
+
+There is a fuller helper elsewhere in the codebase that can also *derive* a name
+when a machine isn't registered anywhere. Using it here would mean changing imports
+in a very large file where a differently-scoped function of the same name already
+exists — real risk, for a display field. So a machine that is genuinely unknown to
+the pool still shows nothing, exactly as today. Stated here rather than left for
+someone to discover.
+
+## How you know it works
+
+The test reads the source and checks that every place the component is built hands
+it the nickname lookup. Run against the old code it **fails**, naming the exact
+line and saying what the consequence is. Nine further checks pass either way — one
+proving the scan finds a construction at all (otherwise "every site is fine" would
+be trivially true of zero sites), and the rest pinning that the scan matches the
+module-qualified spelling, the bare spelling, and a deeply-qualified one, while
+*not* matching a different class with a similar name, a plain import, or a type
+mention.
+
+That design comes straight from the mistake above: the scan is built to catch the
+spelling that fooled me, and a test pins that it does.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -24594,6 +24594,19 @@ export async function startServer(options: StartOptions): Promise<void> {
         const waCfg = config.multiMachine?.writeAdmission;
         writeAdmission = new waMod.WriteAdmission({
           thisMachineId: waMachineId,
+          // Without this the write-admission status surface reported
+          // `thisMachine.nickname: null` on every machine — the one refusing a
+          // write could not name itself, which is the entire point of a refusal
+          // that says WHO owns the state. The dep was declared and consumed
+          // (WriteAdmission.ts:403) but supplied nowhere.
+          // Null-safe twice over: `_listPoolMachines` is assigned inside a
+          // conditional block (declared null at module scope), and a machine
+          // absent from the pool has no nickname. Both degrade to null, which is
+          // exactly today's behaviour — so this can only ever ADD a name.
+          selfNickname: () =>
+            (waMachineId
+              ? (_listPoolMachines?.() ?? []).find((m) => m.machineId === waMachineId)?.nickname ?? null
+              : null),
           isReadOnly: () => state.readOnly,
           isPoolActive: () => state.sessionPoolActive,
           registry: regMod.buildWriteDomainRegistry({ machineId: waMachineId }),

--- a/tests/unit/write-admission-self-nickname.test.ts
+++ b/tests/unit/write-admission-self-nickname.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * `WriteAdmission` renders its status as
+ *   `thisMachine: { machineId, nickname: this.d.selfNickname?.() ?? null }`
+ * so a refusal can say WHICH machine owns the state it refused to let this one
+ * write. The dep was declared (`WriteAdmission.ts`) and consumed, and supplied
+ * NOWHERE — so every machine reported `nickname: null` and could not name itself.
+ *
+ * THE TEST'S OWN DESIGN COMES FROM A MISTAKE I MADE FINDING THIS. My first search
+ * for the construction site was `grep 'new WriteAdmission'` and returned ZERO — I
+ * was one step from concluding the component is never instantiated and the finding
+ * is moot. It is constructed as `new waMod.WriteAdmission({...})`, through a
+ * dynamic-import namespace. A bare-identifier scan that misses the
+ * namespace-qualified form is the exact defect class three lints were fixed for
+ * tonight, committed by me while auditing for it.
+ *
+ * So this guard matches `new <optional.namespace.>WriteAdmission(` and pins that
+ * behaviour with a control, rather than trusting the spelling that happens to be
+ * in the tree today.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+/** Every `new [ns.]WriteAdmission(` construction, with its brace-matched options object. */
+export function findWriteAdmissionConstructions(source: string): Array<{ line: number; opts: string }> {
+  const out: Array<{ line: number; opts: string }> = [];
+  // The optional `<ident>.` prefix is the whole point — see the docblock.
+  const re = /new\s+(?:[A-Za-z_$][\w$]*\s*\.\s*)*WriteAdmission\s*\(/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = re.exec(source)) !== null) {
+    const open = source.indexOf('{', m.index + m[0].length - 1);
+    if (open < 0) continue;
+    let depth = 0;
+    let quote: string | null = null;
+    let end = -1;
+    for (let i = open; i < source.length; i += 1) {
+      const c = source[i];
+      if (quote) {
+        if (c === '\\') { i += 1; continue; }
+        if (c === quote) quote = null;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') { quote = c; continue; }
+      if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    if (end < 0) continue; // unbalanced — fail toward NOT reporting
+    out.push({ line: source.slice(0, m.index).split('\n').length, opts: source.slice(open, end + 1) });
+  }
+  return out;
+}
+
+describe('WriteAdmission wiring — selfNickname is supplied at every construction site', () => {
+  const serverSrc = fs.readFileSync(path.join(ROOT, 'src', 'commands', 'server.ts'), 'utf-8');
+  const sites = findWriteAdmissionConstructions(serverSrc);
+
+  it('finds at least one construction site', () => {
+    // CONTROL. Without this, a scan that matched NOTHING would pass the
+    // per-site assertion below vacuously — "every site supplies it" is trivially
+    // true of zero sites. That is the shape this whole night has been about.
+    expect(sites.length).toBeGreaterThan(0);
+  });
+
+  for (const site of sites) {
+    it(`supplies selfNickname at server.ts:${site.line}`, () => {
+      expect(
+        /\bselfNickname\s*:/.test(site.opts),
+        `WriteAdmission constructed at server.ts:${site.line} without selfNickname — its status ` +
+          `will report thisMachine.nickname: null, so the machine cannot name itself in a refusal`
+      ).toBe(true);
+    });
+
+    it(`still supplies thisMachineId at server.ts:${site.line}`, () => {
+      // A second required dep, asserted so a future edit that guts the options
+      // object fails loudly here rather than only at the nickname.
+      expect(/\bthisMachineId\s*:/.test(site.opts)).toBe(true);
+    });
+  }
+});
+
+describe('the scanner itself, pinned', () => {
+  it('matches the NAMESPACE-QUALIFIED form — the one my own grep missed', () => {
+    const found = findWriteAdmissionConstructions(
+      'const x = new waMod.WriteAdmission({ thisMachineId: a, selfNickname: () => null });'
+    );
+    expect(found.length).toBe(1);
+    expect(found[0].opts).toContain('selfNickname');
+  });
+
+  it('matches the bare form too', () => {
+    expect(findWriteAdmissionConstructions('new WriteAdmission({ a: 1 });').length).toBe(1);
+  });
+
+  it('matches a deeply-qualified form', () => {
+    expect(findWriteAdmissionConstructions('new a.b.WriteAdmission({ c: 1 });').length).toBe(1);
+  });
+
+  it('does not match a different class whose name merely ends the same way', () => {
+    // Over-block control: `NotWriteAdmission` is a different symbol.
+    expect(findWriteAdmissionConstructions('new NotWriteAdmission({ a: 1 });').length).toBe(0);
+  });
+
+  it('does not match a mere type reference or import', () => {
+    expect(findWriteAdmissionConstructions('import { WriteAdmission } from "./x.js";').length).toBe(0);
+    expect(findWriteAdmissionConstructions('let a: WriteAdmission | null = null;').length).toBe(0);
+  });
+
+  it('brace-matches an options object containing a brace inside a string', () => {
+    const found = findWriteAdmissionConstructions('new WriteAdmission({ a: "}", selfNickname: () => null });');
+    expect(found.length).toBe(1);
+    expect(found[0].opts).toContain('selfNickname');
+  });
+
+  it('yields nothing for an unbalanced options object — fails toward NOT reporting', () => {
+    expect(findWriteAdmissionConstructions('new WriteAdmission({ a: 1').length).toBe(0);
+  });
+});

--- a/upgrades/next/write-admission-self-nickname.md
+++ b/upgrades/next/write-admission-self-nickname.md
@@ -1,0 +1,64 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+`WriteAdmission` renders its status as
+`thisMachine: { machineId, nickname: this.d.selfNickname?.() ?? null }` — so a write
+refusal can name WHICH machine owns the state. The `selfNickname` dep was **declared**
+(`WriteAdmission.ts:169`), **consumed** (`:403`), and **supplied nowhere**, so every
+machine reported `nickname: null` and could not name itself.
+
+Measured with controls: `selfNickname` supplied at the construction site = **0**;
+CONTROL `thisMachineId` = 1; the component IS constructed at `server.ts:24595`.
+
+Wired using the module-scope `_listPoolMachines` accessor the file already uses to map
+machineId → nickname. **Both failure paths degrade to `null`** — the accessor is assigned
+inside a conditional block and may be unset, and a machine absent from the pool has no
+nickname — which is exactly the value the field carried before. So the change can only
+ADD a name; it cannot produce a wrong one and cannot throw.
+
+**Declared open:** a canonical `resolveSelfNickname` also supports a *derive* fallback for
+a machine in no capacity list. Not used here — it is dynamically imported inside another
+block and a differently-scoped local of the same name exists at `:23987`; changing imports
+in a 24,000-line composition root around a shadowed identifier is real risk for a display
+field. A machine genuinely unknown to the pool still shows `null`, as today.
+
+## What to Tell Your User
+
+When your agent runs on more than one machine, only one owns a given piece of state at a
+time, and the others refuse to write it. The status page for that mechanism is supposed to
+tell you which machine you are looking at — by nickname, like "the Mac Mini", because the
+underlying id is a meaningless string of hex.
+
+That nickname was always blank. Every machine, every time. The page asked for it correctly;
+the code that assembles the component just never handed it one.
+
+Nothing was ever mis-refused and no wrong machine was ever named — a piece of information
+that was meant to be there simply wasn't. It is there now. If your agent runs on one machine
+this changes nothing you would notice.
+
+## Summary of New Capabilities
+
+None. No new command, endpoint, setting or behaviour — a status field that was always blank
+now shows the machine's nickname.
+
+## Evidence
+
+- `tests/unit/write-admission-self-nickname.test.ts` — 10/10 green.
+- **Negative control: 1 of 10 fails** against the unwired tree, naming `server.ts:24595`
+  and its consequence. The other 9 pass both ways, including an anti-vacuity control
+  proving the scan finds a construction at all — "every site supplies it" is trivially
+  true of zero sites.
+- The scanner matches `new [namespace.]WriteAdmission(` **by design**: my own first search
+  used the bare form, returned zero, and nearly led me to conclude the component is never
+  constructed. It is built as `new waMod.WriteAdmission({` through a dynamic-import
+  namespace — the same bare-identifier blindness fixed in three lints this week, committed
+  in the act of auditing for it. Scanner pins cover the namespace-qualified, bare and
+  deeply-qualified forms, and negatively pin a similarly-named class, a plain import and a
+  type reference.
+- Real `tsc --noEmit` exit 0 — run via `node node_modules/typescript/bin/tsc` because
+  `npx tsc` here is intercepted by a shim that exits 0 **without typechecking**.
+- `server.ts` restored byte-exact after the negative control.

--- a/upgrades/side-effects/write-admission-self-nickname.md
+++ b/upgrades/side-effects/write-admission-self-nickname.md
@@ -1,0 +1,147 @@
+# Side-Effects Review — WriteAdmission is given its own machine nickname
+
+**Version / slug:** `write-admission-self-nickname`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1. A 13-line addition supplying an OPTIONAL, already-declared, already-consumed dependency at the single construction site. No decision logic added; every failure path degrades to the value the field already had (null).`
+
+## Summary of the change
+
+`WriteAdmission` renders its status as
+`thisMachine: { machineId, nickname: this.d.selfNickname?.() ?? null }` — so a
+write refusal can name WHICH machine owns the state. The `selfNickname` dep was
+**declared** (`src/core/WriteAdmission.ts:169`) and **consumed** (`:403`) and
+**supplied nowhere**, so every machine reported `nickname: null` and could not
+name itself.
+
+Measured, each with a control:
+
+| probe | result |
+|---|---|
+| `selfNickname` supplied at the construction site | **0** |
+| CONTROL — `thisMachineId` supplied there | 1 |
+| the component IS constructed (dev-gated + dry-run, but live) | `server.ts:24595` |
+
+Wired with the module-scope `_listPoolMachines` accessor the file already uses to
+map machineId → nickname.
+
+## The mistake in the investigation, which shaped the test
+
+**My first search for the construction site returned ZERO** — `grep 'new
+WriteAdmission'` — and I was one step from concluding the component is never
+instantiated and the finding was moot. It is constructed as
+**`new waMod.WriteAdmission({`**, through a dynamic-import namespace.
+
+A bare-identifier scan that misses the namespace-qualified form is the EXACT
+defect class fixed in three lints tonight (#1886, #1887, #1889/#1890) — committed
+by me, in the act of auditing for it, and the second time tonight (a peer caught
+the first, in my own invariant test in #1872).
+
+So the guard here matches `new [ns.]WriteAdmission(` and **pins that behaviour
+with its own tests**, rather than trusting the spelling that happens to be in the
+tree today.
+
+## Decision-point inventory
+
+- `selfNickname` supplied at `server.ts:24595` — ADD (13 lines incl. comment).
+- `tests/unit/write-admission-self-nickname.test.ts` — ADD, with an exported
+  `findWriteAdmissionConstructions` scanner.
+- `WriteAdmission.ts` — UNCHANGED. The dep, its optionality, the `?? null`
+  fallback and the status shape are all untouched.
+- No runtime block/allow decision added or modified.
+
+## 1. Over-block
+
+**Structurally impossible to make anything worse, and that is the whole safety
+argument.** Both failure paths produce `null`, which is exactly the value the
+field already carried:
+
+- `_listPoolMachines` is declared `null` at module scope and assigned inside a
+  conditional block, so it may legitimately be unset → `?.()` → `[]` → `null`.
+- A machine absent from the pool capacities has no nickname → `?? null`.
+
+So the change can only ever ADD a name. It cannot produce a wrong one and cannot
+throw. `waMachineId` itself may be null; that branch returns null explicitly.
+
+## 2. Under-block
+
+**Declared rather than implied:** a canonical `resolveSelfNickname`
+(`src/core/SelfNicknameResolver.ts`) additionally supports a *derive* fallback for
+a machine that appears in no capacity list. I did NOT use it here: it is only
+dynamically imported inside another block of `server.ts`, and a differently-scoped
+local function of the same name exists at `:23987`. Changing imports in a
+24,000-line composition root, around a shadowed identifier, is real risk for a
+display field. **Consequence: a machine genuinely unknown to the pool still shows
+`null`, exactly as today.**
+
+Also unaddressed: `nicknameOf` on other components, and the peer audit's remaining
+optional-dep findings.
+
+## 3. Level-of-abstraction fit
+
+The composition root is where dependencies are supplied; that is the only place
+this could go. `WriteAdmission` itself is untouched, which is correct — it already
+asks for the value properly.
+
+## 4. Signal vs authority compliance
+
+No authority change whatsoever. `selfNickname` feeds a STATUS field only; it
+participates in no admit/refuse decision. WriteAdmission's dry-run posture, its
+domain registry and its refusal logic are untouched.
+
+## 5. Interactions
+
+- `machinePoolRegistry` / `_listPoolMachines` are read-only here.
+- The lookup runs per status call, not on a hot path.
+- Real typecheck (`node node_modules/typescript/bin/tsc --noEmit`) exit 0.
+  **Noted because `npx tsc` here is intercepted by a shim that prints
+  "This is not the tsc command you are looking for" and EXITS 0 WITHOUT
+  TYPECHECKING** — a plausible success from a command that never ran. The real
+  binary is the measurement.
+- No config key, route, or state file touched.
+
+## 6. External surfaces
+
+The `/write-admission` status surface gains a populated `thisMachine.nickname`
+where it previously always reported null. That surface is dev-gated and dry-run,
+so fleet behaviour is unchanged. No new capability, no new endpoint — the Agent
+Awareness Standard needs no template change for a field that was already
+documented as present.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correct — this is the multi-machine feature naming
+ITSELF.** The value is deliberately *this* machine's own nickname, resolved from
+its own view of the pool registry; it is not replicated, not merged on read, and
+not authoritative about any peer. Each machine answers for itself, which is the
+right posture: a machine asserting a peer's nickname from its own state would be
+the coherence bug, not the fix.
+
+Nothing durable is written, so nothing can strand on a topic transfer.
+
+## 8. Rollback cost
+
+`git revert` of one 13-line addition plus the test file. No migration, no state,
+no deployed artifact. Reverting restores `null`, the pre-change value.
+
+## Conclusion
+
+Ship. A declared-and-consumed dependency is supplied at its only construction
+site, both failure paths degrade to today's exact value, and the wiring is pinned
+by a guard whose scanner is deliberately built to catch the spelling that fooled
+my own investigation.
+
+## Evidence pointers
+
+- `tests/unit/write-admission-self-nickname.test.ts` — **10/10 green**.
+- **Negative control: 1 of 10 fails** against the unwired tree, naming
+  `server.ts:24595` and the consequence. The other 9 pass **both ways** — one
+  proving the scan finds a construction at all (an anti-vacuity control: "every
+  site supplies it" is trivially true of zero sites), plus scanner pins for the
+  namespace-qualified, bare and deeply-qualified forms, and negative pins for a
+  similarly-named class, a plain import, and a type reference. `server.ts`
+  restored **byte-exact** after the control (sha match).
+- Real `tsc --noEmit` exit 0 (via the real binary — see §5).
+- Tier **1**: `classifyTier` reports riskFloor 1 **and suggested tier 1** — the
+  size heuristic agrees this time, so there is no under-declaration question.
+  Directional controls: `SessionReaper.ts` and `SecretStore.ts` both floor 2.


### PR DESCRIPTION
## What this fixes

`WriteAdmission` renders its status as `thisMachine: { machineId, nickname: this.d.selfNickname?.() ?? null }`
— so a write refusal can name WHICH machine owns the state. The `selfNickname` dep was **declared**
(`WriteAdmission.ts:169`), **consumed** (`:403`), and **supplied nowhere**. Every machine reported
`nickname: null` and could not name itself.

Measured with controls: `selfNickname` at the construction site = **0**; CONTROL `thisMachineId` = 1;
the component *is* constructed at `server.ts:24595`.

Wired with the module-scope `_listPoolMachines` accessor the file already uses to map machineId →
nickname. **Both failure paths degrade to `null`** — the accessor is assigned inside a conditional
block and may be unset, and a machine absent from the pool has no nickname — which is exactly the
value the field carried before. The change can only ADD a name; it cannot produce a wrong one and
cannot throw. `selfNickname` feeds a STATUS field only and participates in no admit/refuse decision.

## The mistake that shaped the test

My first search for the construction site was `grep 'new WriteAdmission'` → **zero hits**, and I was
one step from concluding the component is never instantiated and the finding moot.

It is built as **`new waMod.WriteAdmission({`**, through a dynamic-import namespace. A bare-identifier
scan that misses the namespace-qualified form is the *exact* defect class fixed in three lints this
week — committed by me, in the act of auditing for it.

So the guard matches `new [ns.]WriteAdmission(` and **pins that with its own tests**, rather than
trusting the spelling that happens to be in the tree today.

## ELI16

When the agent runs on more than one computer, only one owns a given piece of state at a time; the
others refuse to write it. The status page for that mechanism is supposed to tell you which machine
you are looking at — by nickname, like "the Mac Mini", because the underlying id is a meaningless
string of hex.

That nickname was always blank. Every machine, every time. The page asked for it correctly; the code
that assembles the component never handed it one, and it politely falls back to nothing when not
given.

Nothing was ever mis-refused and no wrong machine was ever named — a piece of information that was
meant to be there simply wasn't. It is there now. If your agent runs on one machine, this changes
nothing you would notice.

It cannot make anything worse: the lookup is unavailable in some start-up situations, and a machine
that isn't registered has no nickname to find — **both produce nothing, which is exactly what the
field showed before**. So it can only add a name where there was a blank.

One thing I deliberately did not do: a fuller helper elsewhere can also *derive* a name for a machine
registered nowhere. Using it would mean changing imports in a very large file where a
differently-scoped function of the same name already exists — real risk for a display field. A machine
genuinely unknown to the pool still shows nothing, as today.

Full version: `docs/specs/write-admission-self-nickname.eli16.md`.

## Evidence

- `tests/unit/write-admission-self-nickname.test.ts` — **10/10 green**.
- **Negative control: 1 of 10 fails** against the unwired tree, naming `server.ts:24595` and the
  consequence. The other 9 pass **both ways**, including an **anti-vacuity control** proving the scan
  finds a construction at all — "every site supplies it" is trivially true of zero sites.
- Scanner pins: namespace-qualified, bare, and deeply-qualified forms all match; a similarly-named
  class, a plain import, and a type reference all do **not**; a brace inside a string does not break
  matching; an unbalanced object yields nothing rather than a wrong region.
- Real `tsc --noEmit` exit 0 — run via `node node_modules/typescript/bin/tsc`, because `npx tsc` here
  is intercepted by a shim printing *"This is not the tsc command you are looking for"* that **exits 0
  without typechecking**.
- Full `npm run lint` chain exit 0. `server.ts` restored byte-exact after the negative control.

## Tier

**Tier 1** — and the gate's own size heuristic agrees this time: `suggestedTier=1, riskFloor=1,
13 LOC across 1 file`. No under-declaration question arises. Directional controls: `SessionReaper.ts`
and `SecretStore.ts` both floor 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
