### PR TITLE
fix(write-admission): supply nicknameOf so a refusal names the OWNING machine

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T02-46-52-634Z-write-admission-owner-nickname.json
+++ b/.instar/instar-dev-decisions/2026-08-15T02-46-52-634Z-write-admission-owner-nickname.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T02:46:52.634Z",
+  "slug": "write-admission-owner-nickname",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 10,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 10,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/write-admission-owner-nickname.eli16.md
+++ b/docs/specs/write-admission-owner-nickname.eli16.md
@@ -1,0 +1,41 @@
+# ELI16 — the refusal that named the machine in hex
+
+## What this is about
+
+When the agent runs on several computers, only one owns a given piece of state. If another tries to
+write it, the write is refused — and the refusal is supposed to tell you *which* machine owns it, so
+you know where to go instead.
+
+## What was wrong
+
+The refusal message already has two ways to say it: by nickname if one is known, and by raw machine id
+if not. The nickname lookup was never handed to it, so **every refusal took the fallback**, and what
+you got was a thirty-two character string of hex instead of "the Mac Mini".
+
+The nicer branch existed and was unreachable — the same shape as the earlier fix where a work-queue
+priority could never be assigned because the value it depended on was never supplied.
+
+## Why it matters more than the last one
+
+The previous fix made a machine able to name *itself*. This one makes it able to name **the other
+machine** — which is the entire point of a refusal whose job is telling you where to re-send.
+
+## Why it can't make anything worse
+
+The lookup is unavailable in some start-up situations, and a machine not registered in the pool has no
+nickname. **Both produce nothing — exactly what the message already fell back to.** So this can only
+replace hex with a name; it cannot produce a wrong name and cannot fail.
+
+## How I found it
+
+By reading my own note. When I shipped the previous fix I wrote down, in the review, that this second
+dependency was still unwired and untouched. Following that note is what produced this — the fourth
+time tonight a fix came from a written record of what the previous one did *not* close, rather than
+from looking for something new.
+
+## How you know it works
+
+The existing guard already scans every place the component is built. It now also requires this second
+lookup. Against the old code it **fails**, naming the exact line and saying the consequence. Ten other
+checks pass either way, including one proving the scan finds a construction at all — otherwise "every
+site supplies it" would be trivially true of zero sites.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -24607,6 +24607,16 @@ export async function startServer(options: StartOptions): Promise<void> {
             (waMachineId
               ? (_listPoolMachines?.() ?? []).find((m) => m.machineId === waMachineId)?.nickname ?? null
               : null),
+          // Same gap, other direction, and the more useful half: `refusal()` builds
+          //   `This write belongs to ${ownerNick ? `'${ownerNick}'` : `machine ${ownerId}`}`
+          // so with nicknameOf unsupplied, ownerNick was ALWAYS null and every
+          // refusal fell to the raw-hex branch. The readable branch was
+          // unreachable — and naming the owning machine is the entire point of a
+          // refusal that tells you where to re-send. Same source and same
+          // null-safety as selfNickname above: both degrade to null, which is
+          // exactly today's value, so this can only ever ADD a name.
+          nicknameOf: (machineId: string) =>
+            (_listPoolMachines?.() ?? []).find((m) => m.machineId === machineId)?.nickname ?? null,
           isReadOnly: () => state.readOnly,
           isPoolActive: () => state.sessionPoolActive,
           registry: regMod.buildWriteDomainRegistry({ machineId: waMachineId }),

--- a/tests/unit/write-admission-self-nickname.test.ts
+++ b/tests/unit/write-admission-self-nickname.test.ts
@@ -77,6 +77,20 @@ describe('WriteAdmission wiring — selfNickname is supplied at every constructi
       ).toBe(true);
     });
 
+    it(`supplies nicknameOf at server.ts:${site.line}`, () => {
+      // The other half of the same gap, and the more useful one. `refusal()`
+      // builds  `This write belongs to ${ownerNick ? `'${ownerNick}'` : `machine ${ownerId}`}`
+      // so with nicknameOf unsupplied, ownerNick was ALWAYS null and every
+      // refusal fell to the raw-hex branch — the readable branch unreachable.
+      // Naming the owning machine is the entire point of a refusal that tells
+      // you where to re-send.
+      expect(
+        /\bnicknameOf\s*:/.test(site.opts),
+        `WriteAdmission constructed at server.ts:${site.line} without nicknameOf — every refusal ` +
+          `will name the owner by raw machine id instead of nickname`
+      ).toBe(true);
+    });
+
     it(`still supplies thisMachineId at server.ts:${site.line}`, () => {
       // A second required dep, asserted so a future edit that guts the options
       // object fails loudly here rather than only at the nickname.

--- a/upgrades/next/write-admission-owner-nickname.md
+++ b/upgrades/next/write-admission-owner-nickname.md
@@ -1,0 +1,41 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+`WriteAdmission.refusal()` builds `This write belongs to ${ownerNick ? ... : `machine ${ownerId}`}`.
+`nicknameOf` was declared (`WriteAdmission.ts:168`), consumed (`:370`) and **supplied nowhere**, so
+`ownerNick` was ALWAYS null and **every refusal took the raw-hex branch** — the readable branch was
+unreachable.
+
+Measured with controls: `nicknameOf` at the construction site = 0; CONTROL `selfNickname` = 1.
+
+This is the more consequential half of the same gap: the previous change let a machine name ITSELF,
+this one lets it name the OTHER machine — the entire point of a refusal that says where to re-send.
+
+Both failure paths degrade to `null` (the accessor may be unset; an unregistered machine has no
+nickname), which is exactly what the message already fell back on — so it can only replace hex with a
+name.
+
+**Where it came from:** my own class-closure note on the previous change, which named `nicknameOf` as
+not addressed.
+
+## What to Tell Your User
+
+When your agent runs on more than one machine and a write is refused, the message tells you which
+machine owns it so you know where to go instead. It was naming that machine by a long string of hex
+instead of its nickname — the friendlier wording existed but could never be reached. It now says "the
+Mac Mini" where it used to print an id. If you run one machine, nothing changes for you.
+
+## Summary of New Capabilities
+
+None. No new command, endpoint or setting — an existing refusal message can now reach its readable form.
+
+## Evidence
+
+- `tests/unit/write-admission-self-nickname.test.ts` — 11/11 green.
+- Negative control: 1 of 11 fails against the unwired tree, naming the line and the consequence; the
+  other 10 pass both ways including the anti-vacuity control.
+- Real `tsc --noEmit` exit 0. `server.ts` restored byte-exact after the control.

--- a/upgrades/side-effects/write-admission-owner-nickname.md
+++ b/upgrades/side-effects/write-admission-owner-nickname.md
@@ -1,0 +1,98 @@
+# Side-Effects Review — WriteAdmission can name the OWNING machine in a refusal
+
+**Version / slug:** `write-admission-owner-nickname`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1. A 2-line addition supplying an OPTIONAL, already-declared, already-consumed dependency at the single construction site. No decision logic; both failure paths degrade to null, which is the value the message already fell back on.`
+
+## Summary of the change
+
+`WriteAdmission.refusal()` builds:
+
+```
+`This write belongs to ${ownerNick ? `'${ownerNick}'` : `machine ${ownerId}`} — re-send it there.`
+```
+
+`nicknameOf` was **declared** (`WriteAdmission.ts:168`), **consumed** (`:370`, producing `ownerNick`)
+and **supplied nowhere** — so `ownerNick` was ALWAYS null and **every refusal took the raw-hex
+branch**. The readable branch was unreachable.
+
+Measured with controls: `nicknameOf` at the construction site = **0**; CONTROL `selfNickname` (wired
+in the immediately preceding change) = **1**.
+
+**This is the more consequential half of the same gap.** The previous change let a machine name
+ITSELF; this one lets it name the OTHER machine — which is the entire purpose of a refusal that tells
+you where to re-send.
+
+## Where it came from
+
+**From my own class-closure note.** The `write-admission-self-nickname` side-effects doc names
+`nicknameOf` as not addressed. Following that written record produced this fix — the fourth time this
+window a fix came from a declaration of what the previous one did NOT close.
+
+## Decision-point inventory
+
+- `nicknameOf` supplied at `server.ts` construction site — ADD (2 lines + comment).
+- `tests/unit/write-admission-self-nickname.test.ts` — one assertion added per construction site.
+- `WriteAdmission.ts` — UNCHANGED. The dep, its optionality, the `?? null` fallback and the message
+  shape are untouched.
+- No runtime block/allow decision added or modified.
+
+## 1. Over-block
+
+**Structurally cannot regress.** Both failure paths yield `null`, which is what `ownerNick` already
+was in every case:
+- `_listPoolMachines` is declared null at module scope and assigned inside a conditional block;
+- a machine absent from the pool capacities has no nickname.
+
+So the change can only replace hex with a name. It cannot produce a wrong name and cannot throw. Same
+source and same null-safety as the `selfNickname` line directly above it, deliberately — mixed sources
+in one options object would be the drift worth avoiding.
+
+## 2. Under-block
+
+A machine genuinely unknown to the pool still shows the raw id, exactly as today. The canonical
+`resolveSelfNickname` (with its derive fallback) is still not used here, for the reason recorded in the
+previous change: it is dynamically imported inside another block and a differently-scoped local of the
+same name exists at `:23987`.
+
+## 3. Level-of-abstraction fit
+
+The composition root is where dependencies are supplied. `WriteAdmission` already asks correctly.
+
+## 4. Signal vs authority compliance
+
+No authority change. `nicknameOf` affects only the human-readable HINT on a refusal that has already
+been decided; it participates in no admit/refuse decision.
+
+## 5. Interactions
+
+- `_listPoolMachines` is read-only here; the lookup runs per refusal, not on a hot path.
+- Real `tsc --noEmit` exit 0 (via `node node_modules/typescript/bin/tsc` — `npx tsc` here is
+  intercepted by a shim that exits 0 WITHOUT typechecking).
+- No config key, route, or state file touched.
+
+## 6. External surfaces
+
+A write refusal now names the owning machine by nickname where it previously printed a raw machine id.
+That surface is dev-gated and dry-run, so fleet behaviour is unchanged. No new capability.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Correct by construction, and this is the multi-machine feature naming its PEER.** The nickname is
+resolved from THIS machine's own view of the pool registry — the same view the pool surfaces already
+use. It is advisory text on a refusal, never authoritative about the peer, and nothing durable is
+written, so nothing can strand on a topic transfer.
+
+## 8. Rollback cost
+
+`git revert` of a 2-line addition plus one test assertion. Reverting restores the raw-id fallback.
+
+## Evidence pointers
+
+- `tests/unit/write-admission-self-nickname.test.ts` — **11/11 green**.
+- **Negative control: 1 of 11 fails** against the unwired tree, naming `server.ts:24595` and the
+  consequence. The other 10 pass both ways, including the anti-vacuity control.
+- `server.ts` restored **byte-exact** after the control (sha match).
+- Real `tsc --noEmit` exit 0.
+- Tier **1**: 2 added lines in one in-scope file, no authority, no capability.


### PR DESCRIPTION
## What changed

`WriteAdmission` declares an optional `nicknameOf` dependency and its refusal path consumes it:

```
This write belongs to ${ownerNick ? `'${ownerNick}'` : `machine ${ownerId}`} — re-send it there.
```

Nothing supplied it. `ownerNick` was therefore **always** `null`, so every write refusal took the
raw-machine-id branch and the readable branch was unreachable. Naming the owning machine is the
entire point of a refusal whose job is to tell you where to re-send.

Wired at the single construction site (`src/commands/server.ts:24595`) from `_listPoolMachines()` —
the same registry the sibling `selfNickname` wiring uses (#1891). Both failure paths degrade to
`null`, which is exactly today's value, so this can only ever **add** a name.

## ELI16 overview

When this agent runs on more than one machine, some pieces of state belong to one specific machine.
If a different machine tries to write that state, it refuses and tells you which machine actually
owns it, so you can send the write to the right place.

That message was built to say something friendly like *"this belongs to 'the mini' — re-send it
there"*. It has never once been able to say that. The code that looks up a machine's friendly name
was declared and used, but nobody ever handed the lookup in — so the name always came back empty and
the message always fell back to the raw internal machine id, a long string of hex that means nothing
to a reader.

This change hands in the lookup. Nothing else about the refusal changes: the same writes are refused
for the same reasons. The only difference is that the refusal can now name the machine the way a
human would, and if the lookup fails for any reason it falls back to exactly what it prints today.

## Testing

- The wiring test now asserts **both** halves of the dependency at every construction site.
- **Negative control, run:** deleting the property makes the suite fail **1 of 11**, naming the exact
  site and the consequence. Source restored byte-identical (sha match).
- **The control surfaced why this shipped:** deleting the property **typechecks cleanly (0 errors)**,
  because the dependency is optional. The compiler could never have caught this class. Renaming the
  key *is* caught (TS2353) — so the type system covers a typo and is blind to an omission, and this
  test is the only thing standing in that gap.
- The scanner matches `new [namespace.]WriteAdmission(`, pinned by 7 tests. That shape is deliberate:
  my own first search for the construction site used a bare identifier, returned **zero**, and nearly
  had me conclude the component was never built — it is constructed through a dynamic-import
  namespace. An anti-vacuity control fails the suite if the scan ever matches nothing.

## What this does NOT close

- Only `WriteAdmission`. Codey's optional-dependency audit lists further declared-but-unsupplied deps
  (`ParallelActivityIndex.nicknameFor` / `.purposeFor`, `TelemetryHeartbeat.agentCountFn`) that are
  **not** touched here. Two of those I deliberately declined: wiring them requires inventing what the
  field means, and a guessed semantic in an observability surface is worse than an honest null.
- The scanner is per-file text resolution, not a symbol graph. A construction reached through a
  re-export chain would not be seen.
- No behaviour changes for a single-machine agent: with one machine there is nothing to name.
