### PR TITLE
fix(lint): url-log guard resolves a credentialed URL split across a concatenation

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T03-23-06-467Z-url-log-lint-split-literal.json
+++ b/.instar/instar-dev-decisions/2026-08-15T03-23-06-467Z-url-log-lint-split-literal.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T03:23:06.467Z",
+  "slug": "url-log-lint-split-literal",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 73,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-url-log.js"
+    ],
+    "addedLines": 65,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T03-46-10-306Z-url-log-lint-split-literal.json
+++ b/.instar/instar-dev-decisions/2026-08-15T03-46-10-306Z-url-log-lint-split-literal.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T03:46:10.306Z",
+  "slug": "url-log-lint-split-literal",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-url-log.js"
+    ],
+    "addedLines": 8,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T03-47-05-097Z-url-log-lint-split-literal.json
+++ b/.instar/instar-dev-decisions/2026-08-15T03-47-05-097Z-url-log-lint-split-literal.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T03:47:05.097Z",
+  "slug": "url-log-lint-split-literal",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-url-log.js"
+    ],
+    "addedLines": 8,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/url-log-lint-split-literal.eli16.md
+++ b/docs/specs/url-log-lint-split-literal.eli16.md
@@ -1,0 +1,61 @@
+# ELI16 — a credential leak guard that a tidy-up could switch off
+
+## The thing it protects
+
+On 2026-05-27 one of our commands printed a git clone URL into its log, and that
+URL had a live GitHub token inside it. Anyone reading the log had the token.
+
+A check was added so that can't happen again. It scans our source for a URL with
+a username and password baked into it — the `https://user:secret@host` shape —
+and fails the build if it finds one being logged.
+
+## What was wrong with it
+
+The check looked at one line of code at a time and only recognised the URL when
+it was written as a single piece of text. So this was caught:
+
+    "https://user:token@github.com/x.git"
+
+and this was not:
+
+    "https://user:" + "token@github.com/x.git"
+
+Those two lines build the identical string and leak the identical token. The
+second one is invisible to the check.
+
+The uncomfortable part is that nobody has to be sneaky to write the second form.
+Splitting a long string in two is something people do to keep a line short, or
+because a formatter did it for them. So the guard could be switched off by
+accident, while the code looked tidier than before.
+
+## What changed
+
+Before the check looks at a line, it now joins text pieces that are glued
+together with a plus sign, so it sees the string the code actually builds. The
+two forms above are now treated the same, because they are the same.
+
+It only joins pieces that are already written out. If one of the parts is a
+variable, the joining stops there — the check never guesses what a variable
+might hold, because guessing would mean failing builds over code that is fine.
+
+## What did NOT change, on purpose
+
+This check has a second half that works differently: it looks for five specific
+variable names being printed. Rename your variable to something not on that
+list, or print it a different way, and that half misses it. Both of those were
+measured and both still get through.
+
+That half was deliberately left alone. Adding more names to the list would catch
+a few more cases while leaving the real weakness untouched — the check is
+recognising a *habit of naming things* rather than the dangerous thing itself.
+Making that half genuinely reliable means changing what it is allowed to decide,
+which is a bigger change than a pattern edit and belongs in its own proposal.
+It is written down in the check's own header so the next reader sees it.
+
+## How we know it works
+
+The three leaking forms fail the test suite when the fix is removed, and pass
+with it. Ten other cases pass either way, which is what makes them controls
+rather than decoration. Four pieces of correct-but-similar-looking code were run
+against both the old and new versions and got identical verdicts, so the change
+adds no new false alarms. The real codebase is clean before and after.

--- a/docs/specs/url-log-lint-split-literal.eli16.md
+++ b/docs/specs/url-log-lint-split-literal.eli16.md
@@ -59,3 +59,28 @@ with it. Ten other cases pass either way, which is what makes them controls
 rather than decoration. Four pieces of correct-but-similar-looking code were run
 against both the old and new versions and got identical verdicts, so the change
 adds no new false alarms. The real codebase is clean before and after.
+
+## A correction made after this was first written
+
+The first version of the test proved the fix by dropping a small decoy file
+into the project's own source folder, letting the checker find it, and then
+deleting it. Continuous integration rejected that, and it was right to: this
+project has a separate safety rule that refuses to delete anything inside its
+own source folder, because deleting the wrong thing there once caused real
+damage. Satisfying one safety rule had walked straight into another.
+
+There was a second problem nobody had flagged, and it is the worse of the two.
+Other tests run at the same time and can see that folder. A decoy file sitting
+in it is something they could stumble over — so the test was not only unsafe,
+it was quietly unfair to everyone else's tests.
+
+The fix is not a workaround. The checker can now be pointed at a scratch folder
+made for the moment and thrown away afterwards, so the test never touches the
+real source folder at all. Left alone, the checker behaves exactly as before —
+that was confirmed by running it both ways.
+
+One honest reduction: the three leak cases now exercise the checker's decision
+directly rather than by running it as a command, so the command's own
+error-printing path is only covered in the "nothing wrong" direction. That
+wrapper is eight lines and this change does not touch it. It is written down
+rather than left for someone to discover.

--- a/scripts/lint-no-direct-url-log.js
+++ b/scripts/lint-no-direct-url-log.js
@@ -92,10 +92,15 @@ function walk(dir, out = []) {
  * test process the moment the repo had a real violation. Hence the
  * direct-invocation guard at the bottom.
  */
-export function scanForCredentialedUrlLogs() {
+// `srcDir`/`rootDir` default to this repo, so the shipped CLI behaviour is
+// unchanged. They exist so the scanner can be driven over a throwaway tree in a
+// test WITHOUT planting a probe file inside `src/` — planting one there both
+// trips SourceTreeGuard (which refuses any delete inside the instar source
+// tree) and is visible to every other test running at the same time.
+export function scanForCredentialedUrlLogs(srcDir = SRC, rootDir = ROOT) {
 const offenders = [];
-for (const file of walk(SRC)) {
-  const rel = path.relative(ROOT, file);
+for (const file of walk(srcDir)) {
+  const rel = path.relative(rootDir, file);
   if (EXEMPT.includes(rel)) continue;
   const lines = fs.readFileSync(file, 'utf-8').split('\n');
   lines.forEach((line, i) => {

--- a/scripts/lint-no-direct-url-log.js
+++ b/scripts/lint-no-direct-url-log.js
@@ -11,6 +11,26 @@
  * Conservative by design: it flags the two concrete shapes we know leak, not
  * every URL log. The redactUrl module + its tests are exempt.
  *
+ * SCOPE, split by whether the match detects the prohibited FACT or a SPELLING
+ * of it (the distinction that decides which half is worth widening):
+ *
+ *   - CREDENTIALED_URL_LITERAL is the FACT. A `user:pass@` inside a URL literal
+ *     IS the leak, whatever it is called or where it is logged. So resolving a
+ *     split literal is a real closure, not a bigger net: as of 2026-08-15 the
+ *     line is scanned with adjacent string concatenations folded, because
+ *     `"https://user:" + "tok@host"` leaked exactly as much as the one-piece
+ *     form and was invisible. Folding joins only ADJACENT literals of the same
+ *     quote style and invents no text.
+ *
+ *   - RISKY_URL_VAR_LOG is a SPELLING. It matches five variable names logged
+ *     through `console.*`. Renaming the variable (`originUrl`, `endpoint`) or
+ *     using any other sink (`logger.info`) defeats it — both measured. Growing
+ *     the name list would make the net finer while leaving the judgment inside
+ *     the pattern, so it is deliberately NOT widened here. The right repair is
+ *     to demote it from decider to candidate-gatherer and put the weighing
+ *     downstream; that changes the check's authority and belongs in a spec, not
+ *     in a regex edit.
+ *
  * Exit 0 = clean. Exit 1 = at least one offending site (printed).
  */
 
@@ -29,6 +49,23 @@ const EXEMPT = [
 /** A literal `scheme://user:pass@` in a string that is being logged. */
 const CREDENTIALED_URL_LITERAL = /['"`][a-z][a-z0-9+.-]*:\/\/[^/@'"`\s]+:[^/@'"`\s]+@/i;
 
+/**
+ * Fold `"a" + "b"` (adjacent string literals, same quote style) into `"ab"` so a
+ * credentialed URL split across a concatenation is scanned as the string it
+ * actually builds. Only literal+literal joins are folded — a variable operand
+ * ends the fold, so nothing is invented and no non-literal is assumed.
+ */
+export function collapseConcatenation(line) {
+  let out = line;
+  for (let i = 0; i < 8; i += 1) {
+    const next = out.replace(/(['"])((?:\\.|(?!\1)[^\\])*)\1\s*\+\s*(['"])((?:\\.|(?!\3)[^\\])*)\3/g,
+      (_m, q1, a, _q2, b) => `${q1}${a}${b}${q1}`);
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
 /** console.* logging a variable named like a clone/remote URL without redactUrl on the same line. */
 const RISKY_URL_VAR_LOG = /console\.(log|error|warn|info)\([^)]*\b(repoUrl|cloneUrl|remoteUrl|pushUrl|gitUrl)\b/;
 
@@ -45,6 +82,17 @@ function walk(dir, out = []) {
   return out;
 }
 
+/**
+ * The scan, callable. Returns the offender list instead of exiting, so the
+ * behaviour can be unit-tested.
+ *
+ * This module previously exported nothing, so running the whole scan at module
+ * scope and calling process.exit() was harmless. Adding an export above makes
+ * that live: importing it to test the fold would run the repo scan and kill the
+ * test process the moment the repo had a real violation. Hence the
+ * direct-invocation guard at the bottom.
+ */
+export function scanForCredentialedUrlLogs() {
 const offenders = [];
 for (const file of walk(SRC)) {
   const rel = path.relative(ROOT, file);
@@ -52,7 +100,9 @@ for (const file of walk(SRC)) {
   const lines = fs.readFileSync(file, 'utf-8').split('\n');
   lines.forEach((line, i) => {
     const hasRedact = line.includes('redactUrl') || line.includes('redactUrlsInText');
-    if (CREDENTIALED_URL_LITERAL.test(line)) {
+    // The FACT half is tested against the folded line; the SPELLING half is
+    // tested against the raw line exactly as before (unchanged behaviour).
+    if (CREDENTIALED_URL_LITERAL.test(collapseConcatenation(line))) {
       offenders.push(`${rel}:${i + 1}  credentialed-URL literal: ${line.trim().slice(0, 100)}`);
     } else if (RISKY_URL_VAR_LOG.test(line) && !hasRedact) {
       offenders.push(`${rel}:${i + 1}  logs a clone/remote URL var without redactUrl(): ${line.trim().slice(0, 100)}`);
@@ -60,11 +110,18 @@ for (const file of walk(SRC)) {
   });
 }
 
-if (offenders.length > 0) {
-  console.error('[lint-no-direct-url-log] credentialed-URL logging detected:');
-  for (const o of offenders) console.error(`  - ${o}`);
-  console.error('\nRoute the URL through redactUrl()/redactUrlsInText() from src/core/redactUrl.ts before logging.');
-  process.exit(1);
+return offenders;
 }
-console.log('[lint-no-direct-url-log] ✓ no credentialed-URL logging found');
-process.exit(0);
+
+// Only scan + exit when RUN, never when imported (see the note above).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const offenders = scanForCredentialedUrlLogs();
+  if (offenders.length > 0) {
+    console.error('[lint-no-direct-url-log] credentialed-URL logging detected:');
+    for (const o of offenders) console.error(`  - ${o}`);
+    console.error('\nRoute the URL through redactUrl()/redactUrlsInText() from src/core/redactUrl.ts before logging.');
+    process.exit(1);
+  }
+  console.log('[lint-no-direct-url-log] ✓ no credentialed-URL logging found');
+  process.exit(0);
+}

--- a/tests/unit/url-log-lint-split-literal.test.ts
+++ b/tests/unit/url-log-lint-split-literal.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 // @ts-expect-error — plain JS lint script, no types
-import { collapseConcatenation } from '../../scripts/lint-no-direct-url-log.js';
+import { collapseConcatenation, scanForCredentialedUrlLogs } from '../../scripts/lint-no-direct-url-log.js';
 
 /**
  * `lint-no-direct-url-log` exists because of the 2026-05-27 incident: `instar
@@ -30,20 +31,29 @@ import { collapseConcatenation } from '../../scripts/lint-no-direct-url-log.js';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const LINT = path.join(ROOT, 'scripts', 'lint-no-direct-url-log.js');
-const PROBE = path.join(ROOT, 'src', 'core', '__urlLogLintProbe.ts');
+const OP = 'tests/unit/url-log-lint-split-literal.test.ts';
 
-/** Run the real lint with `body` present as a source file. Returns its exit code. */
+/**
+ * Run the real scanner over a THROWAWAY tree containing `body`. Returns 1 if it
+ * would fail the build, 0 otherwise — the same two values the CLI exits with.
+ *
+ * An earlier version of this planted the probe at `src/core/__urlLogLintProbe.ts`
+ * and deleted it afterwards. That was wrong twice over, and CI caught it:
+ * SourceTreeGuard refuses ANY delete inside the instar source tree (the
+ * 2026-04-22 incident class), and a probe file sitting in `src/` is visible to
+ * every other suite running concurrently. Scanning a temp tree removes both.
+ */
 function lintWith(body: string): number {
-  fs.writeFileSync(PROBE, `${body}\n`);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'urllog-lint-'));
   try {
-    execFileSync(process.execPath, [LINT], { stdio: 'pipe' });
-    return 0;
-  } catch (e: unknown) {
-    return (e as { status?: number }).status ?? -1;
+    const core = path.join(dir, 'src', 'core');
+    fs.mkdirSync(core, { recursive: true });
+    fs.writeFileSync(path.join(core, 'probe.ts'), `${body}\n`);
+    return scanForCredentialedUrlLogs(path.join(dir, 'src'), dir).length > 0 ? 1 : 0;
   } finally {
-    // Routed through the audited funnel rather than a raw fs.rmSync: this is a
-    // test about a guard, and the destructive-op guard applies to it too.
-    SafeFsExecutor.safeRmSync(PROBE, { force: true, operation: 'tests/unit/url-log-lint-split-literal.test.ts' });
+    // Outside the source tree, so the funnel permits it — and it is still the
+    // funnel, because the destructive-op rule applies to test code too.
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: OP });
   }
 }
 
@@ -93,9 +103,17 @@ describe('ANTI-OVER-BLOCK — this lint fails builds, so correct code must pass'
     expect(lintWith('const u = "https://user:" + secret + "@h/x"; console.log(u);')).toBe(0);
   });
 
-  it('leaves the clean repository clean', () => {
-    // The decisive anti-over-block control: the real tree, unmodified.
-    expect(lintWith('export const __probeNoop = 1;')).toBe(0);
+  it('leaves the REAL repository clean — scanner defaults, nothing planted', () => {
+    // The decisive anti-over-block control, and it is stronger than the version
+    // it replaces: it asserts the actual tree is clean under the real defaults,
+    // instead of asserting a temp tree containing one inert line is clean.
+    expect(scanForCredentialedUrlLogs()).toEqual([]);
+  });
+
+  it('the shipped CLI still exits 0 on the clean tree', () => {
+    // Keeps the exit-code path covered now that the cases above drive the
+    // exported scanner directly. Plants nothing.
+    expect(() => execFileSync(process.execPath, [LINT], { stdio: 'pipe' })).not.toThrow();
   });
 });
 

--- a/tests/unit/url-log-lint-split-literal.test.ts
+++ b/tests/unit/url-log-lint-split-literal.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+// @ts-expect-error — plain JS lint script, no types
+import { collapseConcatenation } from '../../scripts/lint-no-direct-url-log.js';
+
+/**
+ * `lint-no-direct-url-log` exists because of the 2026-05-27 incident: `instar
+ * join` logged a clone URL containing a live GitHub token.
+ *
+ * Its credentialed-URL check matched a single line, so the leak survived being
+ * written across a concatenation:
+ *
+ *   const u = "https://user:" + "tok@github.com/x.git";   // invisible
+ *   const u = "https://user:tok@github.com/x.git";        // flagged
+ *
+ * Both build the same string and leak the same token. Splitting a literal is
+ * ordinary tidying, not an evasion, so the guard could be disarmed by accident.
+ *
+ * WHY ONLY THIS HALF IS WIDENED. The lint has two patterns and they are not the
+ * same kind of thing. A `user:pass@` inside a URL literal IS the prohibited
+ * fact, so teaching the matcher to see the string the code actually builds is a
+ * real closure. The sibling pattern matches five variable NAMES logged through
+ * `console.*` — that is one spelling correlated with the behaviour, and growing
+ * the name list would make a finer net without making it more of a policy. It
+ * is left alone deliberately and declared in the lint's own header.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const LINT = path.join(ROOT, 'scripts', 'lint-no-direct-url-log.js');
+const PROBE = path.join(ROOT, 'src', 'core', '__urlLogLintProbe.ts');
+
+/** Run the real lint with `body` present as a source file. Returns its exit code. */
+function lintWith(body: string): number {
+  fs.writeFileSync(PROBE, `${body}\n`);
+  try {
+    execFileSync(process.execPath, [LINT], { stdio: 'pipe' });
+    return 0;
+  } catch (e: unknown) {
+    return (e as { status?: number }).status ?? -1;
+  } finally {
+    // Routed through the audited funnel rather than a raw fs.rmSync: this is a
+    // test about a guard, and the destructive-op guard applies to it too.
+    SafeFsExecutor.safeRmSync(PROBE, { force: true, operation: 'tests/unit/url-log-lint-split-literal.test.ts' });
+  }
+}
+
+describe('THE DEFECT — a credentialed URL split across a concatenation', () => {
+  it('flags a two-piece split', () => {
+    expect(lintWith('const u = "https://user:" + "tok@github.com/x.git"; console.log(u);')).toBe(1);
+  });
+
+  it('flags a three-piece split', () => {
+    expect(lintWith('const u = "https://" + "user:" + "tok@github.com/x.git"; console.log(u);')).toBe(1);
+  });
+
+  it('flags a split written with single quotes', () => {
+    expect(lintWith("const u = 'https://user:' + 'tok@github.com/x.git'; console.log(u);")).toBe(1);
+  });
+});
+
+describe('CONTROLS — must still be caught (the fix removes no coverage)', () => {
+  it('still flags the one-piece credentialed literal', () => {
+    expect(lintWith('const u = "https://user:tok@github.com/x.git"; console.log(u);')).toBe(1);
+  });
+
+  it('still flags a template-literal interpolation', () => {
+    expect(lintWith('const p = "t"; const u = `https://user:${p}@github.com/x.git`; console.log(u);')).toBe(1);
+  });
+
+  it('still flags a risky URL variable logged through console', () => {
+    expect(lintWith('console.log(cloneUrl);')).toBe(1);
+  });
+});
+
+describe('ANTI-OVER-BLOCK — this lint fails builds, so correct code must pass', () => {
+  // Each of these is verified to behave IDENTICALLY under the shipped lint, so
+  // the fix is proven to introduce no new false positives rather than asserted to.
+  it('does not flag an ordinary concatenated URL with no credentials', () => {
+    expect(lintWith('const u = "https://api." + "example.com/v1"; console.log(u);')).toBe(0);
+  });
+
+  it('does not flag concatenated prose that merely contains a colon and an at-sign', () => {
+    expect(lintWith('const m = "contact: " + "ops@example.com"; console.log(m);')).toBe(0);
+  });
+
+  it('does not fold across a variable operand — nothing is invented', () => {
+    // The fold must never assume what a variable holds. `"https://user:" +
+    // secret + "@h/x"` is NOT joined into a credentialed literal, because that
+    // would be the lint guessing at a runtime value.
+    expect(lintWith('const u = "https://user:" + secret + "@h/x"; console.log(u);')).toBe(0);
+  });
+
+  it('leaves the clean repository clean', () => {
+    // The decisive anti-over-block control: the real tree, unmodified.
+    expect(lintWith('export const __probeNoop = 1;')).toBe(0);
+  });
+});
+
+describe('the fold itself, pinned', () => {
+  it('joins adjacent double-quoted literals', () => {
+    expect(collapseConcatenation('const u = "ab" + "cd";')).toContain('"abcd"');
+  });
+
+  it('joins adjacent single-quoted literals', () => {
+    expect(collapseConcatenation("const u = 'ab' + 'cd';")).toContain("'abcd'");
+  });
+
+  it('joins a chain of three', () => {
+    expect(collapseConcatenation('const u = "a" + "b" + "c";')).toContain('"abc"');
+  });
+
+  it('does not join across a variable', () => {
+    const out = collapseConcatenation('const u = "a" + v + "c";');
+    expect(out).not.toContain('"ac"');
+  });
+
+  it('leaves a line with no concatenation untouched', () => {
+    const line = 'const u = "https://example.com";';
+    expect(collapseConcatenation(line)).toBe(line);
+  });
+
+  it('is not fooled into inventing text — output length never exceeds input', () => {
+    // A fold that GREW the line would mean it was synthesising content rather
+    // than joining existing literals.
+    const line = 'const u = "aa" + "bb" + "cc";';
+    expect(collapseConcatenation(line).length).toBeLessThanOrEqual(line.length);
+  });
+});

--- a/upgrades/next/url-log-lint-split-literal.md
+++ b/upgrades/next/url-log-lint-split-literal.md
@@ -1,0 +1,19 @@
+<!-- internal-only -->
+
+## What Changed
+
+`scripts/lint-no-direct-url-log.js` now folds adjacent string-literal
+concatenations before testing its credentialed-URL pattern, so a
+`scheme://user:pass@host` literal split across a `+` is detected as the string it
+actually builds. The sibling variable-name pattern is unchanged.
+
+The module also gains a direct-invocation guard: it now exports its scan, and
+without the guard importing it would run the whole repo scan and `process.exit`.
+
+## Evidence
+
+- 3 new defect cases fail against the shipped fold behaviour; 13 controls pass
+  both ways. Source restored byte-identical after the mutation.
+- Four anti-over-block fixtures return identical verdicts under the shipped and
+  fixed lint — zero new false positives, measured rather than argued.
+- Real tree exit 0 before and after.

--- a/upgrades/side-effects/url-log-lint-split-literal.md
+++ b/upgrades/side-effects/url-log-lint-split-literal.md
@@ -72,3 +72,60 @@ text in a checkout; it holds no state and replicates nothing.
 
 Revert the commit. The lint returns to its previous matching behaviour; nothing
 persists and no state migrates.
+
+---
+
+## Addendum — CI caught a guard conflict in the TEST, and the fix is a redesign not a workaround
+
+**What CI found.** `Unit Tests shard 1/4` failed on node 20 AND node 22 (same shard both versions, so
+not a flake): `SourceTreeGuardError: Refusing to run ... (requested dir:
+.../src/core/__urlLogLintProbe.ts, resolved git root: ...)`. The test planted a probe file inside
+`src/` so the real lint would scan it, then removed it through `SafeFsExecutor` — and SourceTreeGuard
+refuses ANY delete inside the instar source tree (the 2026-04-22 incident class).
+
+**Why it passed locally and failed in CI is the honest part:** I did not establish that, and I am not
+guessing at it. What I did establish is that the test design was wrong on its own terms regardless of
+which environment surfaces it.
+
+**Two defects in that design, and the second is the one I had not considered:**
+1. It performs a destructive operation inside the source tree — exactly what the guard exists to stop.
+   Routing it through the audited funnel satisfied the destructive-op lint and walked into a different
+   guard. Satisfying one guard is not evidence about another.
+2. A probe file sitting at `src/core/__urlLogLintProbe.ts` is **visible to every other suite running at
+   the same time**. That is shared mutable state in a shared tree, and it would have been a latent
+   flake source for other people's tests, not just mine.
+
+**The fix.** `scanForCredentialedUrlLogs()` now takes optional `srcDir`/`rootDir` that DEFAULT to this
+repo, so the shipped CLI behaviour is unchanged. The test scans a throwaway temp tree instead. Nothing
+is written into `src/` and nothing is deleted inside the source tree.
+
+### Review answers for this addendum
+
+1. **Over-block.** None new. The CLI path takes the defaults and is behaviourally identical — verified
+   by running it before and after the change (`exit 0` both times) and by the real-tree control below.
+2. **Under-block.** One thing genuinely got WEAKER and I am naming it rather than letting it pass: the
+   defect cases now drive the exported scanner, so they no longer exercise the CLI's
+   offender-printing + `process.exit(1)` path end to end. A new test keeps the exit-code path covered
+   in the passing direction (`the shipped CLI still exits 0 on the clean tree`), but the failing
+   direction of the CLI wrapper is uncovered. That wrapper is eight lines and unchanged by this PR.
+3. **New surface introduced.** The scanner now trusts a caller-supplied root. A caller could point it
+   at an empty directory and receive a clean verdict — but this is a lint's test seam, not a decision
+   authority, and the CLI never passes arguments. Named because "a scan over nothing reports clean" is
+   the exact defect I fixed in `lint-no-direct-destructive` earlier this window; here it is reachable
+   only by a caller that deliberately supplies the wrong root.
+4. **Signal vs authority.** Unchanged — still a deterministic detector with a build-failing exit code.
+5. **Interactions.** Removes an interaction rather than adding one: no more shared probe file inside
+   `src/` for concurrent suites to observe.
+6. **Multi-machine posture.** Machine-local by design — a lint script and its unit test.
+7. **Rollback cost.** Revert the commit; the parameters are additive with defaults.
+
+### Evidence
+
+- `tests/unit/url-log-lint-split-literal.test.ts` — **17/17 green** (16 before; +1 for the CLI exit path).
+- **Negative control re-run after the redesign, because rewriting HOW a test drives its subject can
+  quietly turn it into a check that cannot fail:** removing the fold from the decision makes exactly
+  the **3 defect cases fail**, 14 pass both ways. Source restored byte-exact (sha match, 0 markers).
+- Real-tree anti-over-block control is now STRONGER: it asserts `scanForCredentialedUrlLogs()` returns
+  `[]` under the real defaults, instead of asserting a temp tree with one inert line is clean.
+- `tsc --noEmit` exit 0 (run via the real binary — `npx tsc` here is a shim that exits 0 without
+  typechecking). Full lint chain exit 0.

--- a/upgrades/side-effects/url-log-lint-split-literal.md
+++ b/upgrades/side-effects/url-log-lint-split-literal.md
@@ -1,0 +1,74 @@
+# Side effects — url-log lint resolves split credentialed literals
+
+## 1. Over-block
+
+The dominant risk: this lint fails builds, so flagging correct code is more
+expensive than missing a case (a noisy check gets switched off, and then it
+guards nothing).
+
+Bounded four ways:
+- the fold joins only ADJACENT string literals of the SAME quote style;
+- a variable operand ENDS the fold, so no runtime value is ever assumed;
+- the fold is bounded to 8 passes and returns the input unchanged if it cannot
+  make progress;
+- it can only ever JOIN existing literal text — a test pins that the folded line
+  is never longer than the input, so the fold cannot synthesise content.
+
+Measured, not asserted: four anti-over-block fixtures were run against BOTH the
+shipped lint and the fixed lint and returned identical verdicts. The real tree
+lints clean before and after.
+
+Note one verdict that looks like over-block and is not: a hardcoded
+`https://user:tok@host` literal is flagged even when the log call redacts it.
+That is pre-existing behaviour (the literal branch never consulted the redaction
+check) and it is correct — a credential hardcoded in source is a leak regardless
+of what happens at log time. Verified identical under the shipped lint.
+
+## 2. Under-block — what this does NOT close
+
+Stated by kind, because the two halves of this lint fail differently:
+
+- **The variable-name half is untouched and still defeatable.** `RISKY_URL_VAR_LOG`
+  matches five names through `console.*`. A renamed variable (`originUrl`) and a
+  different sink (`logger.info`) both evade it — measured. This is deliberate:
+  that pattern matches a SPELLING correlated with the behaviour rather than the
+  behaviour, so widening the list makes a finer net and no more of a policy. The
+  correct repair is to demote it from decider to candidate-gatherer with the
+  weighing downstream, which changes the check's authority and belongs in a spec.
+- Cross-line construction (a credentialed URL assembled over several statements)
+  is not resolved — that needs dataflow, not a line-scoped fold.
+- A credentialed URL arriving from config, argv, or another module is invisible
+  to any source-text check.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. A `user:pass@` inside a URL literal is an exact lexical fact about
+our own source, which is what a deterministic source lint is for. The runtime
+redaction funnel (`src/core/redactUrl.ts`) remains the authority for URLs whose
+credentials only exist at runtime; this lint does not and cannot replace it.
+
+## 4. Signal vs authority
+
+Unchanged. The lint holds the same blocking authority it already had, over a
+strictly more accurate view of the same prohibited fact. No new authority, no
+new decision class, no runtime surface.
+
+## 5. Interactions
+
+None. No other check reads this one's output. The direct-invocation guard is
+additive — it only changes behaviour on `import`, which nothing did before,
+because the module exported nothing until now.
+
+## 6. External surfaces
+
+None. CI-only. No runtime code path, no API, no user-visible behaviour.
+
+## 7. Multi-machine posture
+
+Not applicable — machine-local by design. This is a build-time check over source
+text in a checkout; it holds no state and replicates nothing.
+
+## 8. Rollback cost
+
+Revert the commit. The lint returns to its previous matching behaviour; nothing
+persists and no state migrates.


### PR DESCRIPTION
## What changed

`lint-no-direct-url-log` exists because of the 2026-05-27 incident: `instar join`
logged a clone URL carrying a live GitHub token.

Its credentialed-URL check matched one line at a time and only recognised the URL
written as a single literal:

```
"https://user:tok@github.com/x.git"          flagged
"https://user:" + "tok@github.com/x.git"     invisible
```

Both build the same string and leak the same token. **Splitting a literal is
ordinary tidying — a formatter can do it — so the guard could be disarmed by
accident while the code got neater.**

Adjacent string literals are now folded before the pattern runs. Only
literal+literal joins fold; a variable operand ends the fold, so no runtime value
is ever assumed.

## ELI16 overview

A check guards against us printing a web address that has a password inside it,
because we did exactly that once and a real access token ended up in a log file.

The check only recognised that address when it was written as one continuous
piece of text. If the same address was written in two halves joined by a plus
sign, the check saw nothing — even though the two forms produce the identical
address and leak the identical token.

That matters because nobody has to be sneaky to write the second form. People
split long text to keep lines short, and code formatters do it automatically. So
the protection could switch itself off during ordinary cleanup, and the code
would look tidier afterwards.

Now the check joins those halves back together before it looks, so it sees the
address the code actually builds. It only joins pieces that are already written
out — if one part is a variable, it stops, because guessing what a variable
contains would mean failing builds over perfectly good code.

## Scope is deliberately half the lint

This lint has two patterns and they are **not the same kind of thing**:

- **`CREDENTIALED_URL_LITERAL` is the prohibited fact.** A `user:pass@` inside a
  URL literal *is* the leak, whatever it is called or where it is logged. So
  resolving a split literal is a genuine class closure.
- **`RISKY_URL_VAR_LOG` is a spelling.** It matches five variable names logged
  through `console.*`. A renamed variable (`originUrl`) and a different sink
  (`logger.info`) both evade it — **measured, both reproduced**.

Growing that name list would make a finer net without making it any more of a
policy. It is deliberately **not** widened here. The right repair demotes it from
decider to candidate-gatherer with the weighing downstream — that changes what
the check is allowed to decide, so it belongs in a spec rather than a regex edit.
Written into the lint's own header so the next reader sees it.

## Evidence

- **Negative control:** 3 defect cases fail against the shipped fold behaviour;
  **13 controls pass both ways** (that is what makes them controls). Source
  restored byte-identical, sha verified.
- **Zero new false positives, measured not argued:** four anti-over-block
  fixtures were run against **both** the shipped and the fixed lint and returned
  identical verdicts. My first attempt at that comparison was broken — running a
  copy from a temp directory made it resolve the wrong repo root, and it "caught"
  all four fixtures *and* the clean tree. Uniform CAUGHT across subjects that must
  differ indicts the instrument, so it was redone in-tree with a sanity control.
- Real tree exit 0 before **and** after; full lint chain 0; `tsc` 0.
- One verdict that looks like over-block and is not: a hardcoded
  `https://user:tok@host` literal is flagged even when the log call redacts it.
  Pre-existing behaviour, verified identical under the shipped lint, and correct —
  a credential hardcoded in source is a leak regardless of what happens at log time.

## Also in here

The module gains a **direct-invocation guard**. It now exports its scan, and
without the guard importing it would run the whole repo scan and `process.exit` —
killing any test process the moment the repo had a real violation. This is the
hazard arriving exactly when an export is added, which is the transition an
earlier sweep flagged as latent across many scripts.

Test teardown routes through `SafeFsExecutor` rather than a raw `rmSync`, because
the destructive-op guard applies to this test too. The lint chain caught that —
correctly — before this was pushed.

## What this does NOT close

- The variable-name half, as above (declared, not widened).
- Cross-line construction of a credentialed URL — needs dataflow, not a
  line-scoped fold.
- A credentialed URL arriving from config, argv, or another module is invisible
  to any source-text check; the runtime redaction funnel remains the authority there.
