### PR TITLE
fix(test-setup): regenerate the registry asset when it is STALE, not only absent

### DIFF
--- a/docs/specs/registry-asset-freshness.eli16.md
+++ b/docs/specs/registry-asset-freshness.eli16.md
@@ -1,0 +1,51 @@
+# Regenerating a build file when it is out of date, not only when it is missing
+
+## What this is
+
+Part of the test setup generates a file from a source document before the tests
+run. Two different setup files decide whether that generation is needed. Both
+asked the same question: *does the generated file exist?* If it did, they moved on.
+
+That question cannot tell the difference between a generated file that is correct
+and one that was made from an older version of the source. Existing was the whole
+test, so a stale file passed forever.
+
+## How we know it is real
+
+This was measured, not imagined. In one working copy the generated file had been
+made at 17:59 from a source document that was almost three hours newer. Three test
+files failed there with eight failed checks. Regenerating the file made all
+seventy-seven checks in those files pass. Nothing else changed.
+
+The uncomfortable detail is that the correct approach was already sitting twelve
+lines above one of the broken checks: a sibling function that decides whether to
+rebuild the compiled code does it properly, by comparing timestamps. One function
+compared timestamps; the function directly below it checked only for existence.
+
+## What changes
+
+Both setups now ask whether the generated file is older than anything it is
+generated from. If it is, they regenerate it. If it is not, they skip, exactly as
+before. The comparison lives in one shared place, because two copies of a rule
+that must agree is just a later bug.
+
+## What is deliberately unchanged
+
+Regenerating on every run would be wasteful, and being too eager here is the real
+risk — this runs at the start of every test suite. So the rule is conservative in
+three specific ways, each with a test:
+
+- Equal timestamps count as fresh, so a file written in the same second as its
+  source does not cause a regeneration on every run.
+- If none of the source documents can be read, nothing is reported stale. A
+  missing source must not trigger a regeneration that would then fail on the
+  missing source.
+- A genuinely absent file is still treated as needing generation, which is what
+  the old check already did.
+
+## What you would notice
+
+Nothing, if your copy was already up to date. If it was not, tests that compare
+against that generated file stop failing for a reason that has nothing to do with
+the code you are working on — which is exactly the kind of failure that sends
+someone hunting in the wrong place for an afternoon.

--- a/tests/setup/build-dist.globalSetup.ts
+++ b/tests/setup/build-dist.globalSetup.ts
@@ -14,6 +14,7 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { registryAssetIsStale } from './registryAssetFreshness.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -110,6 +111,11 @@ function ensureRegistryAsset(): void {
     path.join(ROOT, 'dist', 'data', 'standards-guard-index.json'),
     path.join(ROOT, 'dist', 'data', 'standards-guard-index.meta.json'),
   ];
-  if (needed.every((p) => fs.existsSync(p))) return;
+  // PRESENCE IS NOT FRESHNESS. This used to return whenever every output existed,
+  // so an asset generated from an older source was accepted forever — while
+  // `ensureDistBuilt()` twelve lines up already compared mtimes. Measured cost:
+  // three test files, eight assertions, in a checkout whose asset was three hours
+  // behind its source. See tests/setup/registryAssetFreshness.ts.
+  if (!registryAssetIsStale(ROOT, needed)) return;
   execSync('node scripts/generate-standards-registry-asset.mjs', { cwd: ROOT, stdio: 'inherit' });
 }

--- a/tests/setup/ensure-registry-asset.globalSetup.ts
+++ b/tests/setup/ensure-registry-asset.globalSetup.ts
@@ -15,6 +15,7 @@ import {
   runRegistryCanary,
 } from '../../src/core/StandardsRegistryParser.js';
 import { buildGuardTreeIndex } from '../../src/core/StandardsEnforcementAuditor.js';
+import { registryAssetIsStale } from './registryAssetFreshness.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -31,7 +32,10 @@ export function ensureRegistryAsset(root: string): void {
     path.join(dir, 'standards-guard-index.json'),
     path.join(dir, 'standards-guard-index.meta.json'),
   ]);
-  if (outputs.every(output => fs.existsSync(output))) return;
+  // PRESENCE IS NOT FRESHNESS — same defect as the sibling setup, same fix. An
+  // asset that exists but was generated from an older source is the case a
+  // presence check is structurally unable to see.
+  if (!registryAssetIsStale(root, outputs)) return;
 
   const sourceRelative = 'docs/STANDARDS-REGISTRY.md';
   const bytes = fs.readFileSync(path.join(root, sourceRelative));

--- a/tests/setup/registryAssetFreshness.ts
+++ b/tests/setup/registryAssetFreshness.ts
@@ -1,0 +1,74 @@
+/**
+ * Is the generated standards-registry asset STALE relative to the sources it is
+ * generated from?
+ *
+ * WHY THIS EXISTS. Two globalSetup files decide whether to regenerate that asset,
+ * and both decided on PRESENCE alone — `if (outputs.every(exists)) return`. So an
+ * asset generated from an older revision of the source was never regenerated: it
+ * existed, therefore it was accepted. Twelve lines above one of those checks, its
+ * own sibling `ensureDistBuilt()` does it correctly, by comparing mtimes.
+ *
+ * MEASURED, not hypothesised (2026-08-15). In a checkout whose asset was generated
+ * at 17:59 from a source that was three hours newer, three test files failed with
+ * eight assertions. Regenerating the asset made all 77 tests pass. The presence
+ * check could detect an absent asset and was structurally unable to detect a wrong
+ * one — a guard that can only find the failure mode nobody hits.
+ *
+ * ONE RULE, ONE PLACE. Both call sites share this function rather than each
+ * carrying a copy of the comparison, because two copies of a rule that must agree
+ * is simply the next bug with a delay on it.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * What the generator actually reads, taken from the generator's own source rather
+ * than guessed: the registry document, the committed article-count floor, and the
+ * package version that is stamped into the emitted metadata.
+ */
+export const REGISTRY_ASSET_INPUTS = [
+  'docs/STANDARDS-REGISTRY.md',
+  'docs/standards-registry-floor.json',
+  'package.json',
+] as const;
+
+/**
+ * True when the asset must be regenerated.
+ *
+ * Fails toward the EXISTING behaviour in every uncertain case, deliberately:
+ *  - an absent output is stale (what the presence check already did);
+ *  - if NO input is readable there is nothing to compare against, so it is NOT
+ *    reported stale — a missing source must not trigger a regeneration that would
+ *    then fail on the missing source;
+ *  - equal mtimes are NOT stale, so a same-second write does not cause a
+ *    regeneration on every single run.
+ */
+export function registryAssetIsStale(root: string, outputs: readonly string[]): boolean {
+  if (outputs.length === 0) return false;
+
+  let oldestOutput = Number.POSITIVE_INFINITY;
+  for (const output of outputs) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(output);
+    } catch {
+      return true; // absent (or unreadable) — regenerate, exactly as before
+    }
+    oldestOutput = Math.min(oldestOutput, stat.mtimeMs);
+  }
+
+  let newestInput = 0;
+  let sawAnyInput = false;
+  for (const relative of REGISTRY_ASSET_INPUTS) {
+    try {
+      newestInput = Math.max(newestInput, fs.statSync(path.join(root, relative)).mtimeMs);
+      sawAnyInput = true;
+    } catch {
+      // An input we cannot read tells us nothing about freshness. Skip it rather
+      // than treating "cannot read" as "changed".
+    }
+  }
+  if (!sawAnyInput) return false;
+
+  return newestInput > oldestOutput;
+}

--- a/tests/unit/registry-asset-freshness.test.ts
+++ b/tests/unit/registry-asset-freshness.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { registryAssetIsStale, REGISTRY_ASSET_INPUTS } from '../setup/registryAssetFreshness.js';
+
+/**
+ * Two globalSetup files decided whether to regenerate the packed constitution by
+ * asking only whether its outputs EXIST. An asset generated from an older source
+ * therefore survived forever, because existing was the whole test.
+ *
+ * Measured on 2026-08-15: in a checkout whose asset was generated three hours
+ * before its source, three test files failed with eight assertions; regenerating
+ * the asset made all 77 pass. The presence check could see an ABSENT asset and was
+ * structurally unable to see a WRONG one.
+ */
+
+const OP = 'tests/unit/registry-asset-freshness.test.ts';
+
+/** A throwaway root with real inputs and outputs, and control over their mtimes. */
+function makeRoot(opts: { outputsOlderThanInputs: boolean; omitOutput?: boolean; omitInputs?: boolean }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-freshness-'));
+  const outDir = path.join(root, 'src', 'data');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+
+  const outputs = ['standards-registry.md', 'standards-registry.meta.json'].map(f => path.join(outDir, f));
+
+  const OLD = new Date('2026-01-01T00:00:00Z');
+  const NEW = new Date('2026-06-01T00:00:00Z');
+
+  // Outputs first, then inputs, so the ORDER of writes never decides the answer —
+  // only the mtimes we set explicitly do.
+  for (const o of outputs) fs.writeFileSync(o, 'generated\n');
+  // Through the audited funnel, not a raw removal — the destructive-op rule applies
+  // to fixtures too, and I have tripped that lint three times this week by
+  // forgetting it in exactly this position.
+  if (opts.omitOutput) SafeFsExecutor.safeRmSync(outputs[1], { force: true, operation: OP });
+
+  if (!opts.omitInputs) {
+    for (const rel of REGISTRY_ASSET_INPUTS) {
+      const p = path.join(root, rel);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, 'source\n');
+      fs.utimesSync(p, opts.outputsOlderThanInputs ? NEW : OLD, opts.outputsOlderThanInputs ? NEW : OLD);
+    }
+  }
+  for (const o of outputs) {
+    if (fs.existsSync(o)) fs.utimesSync(o, opts.outputsOlderThanInputs ? OLD : NEW, opts.outputsOlderThanInputs ? OLD : NEW);
+  }
+  return { root, outputs };
+}
+
+function withRoot(opts: Parameters<typeof makeRoot>[0], fn: (r: { root: string; outputs: string[] }) => void) {
+  const r = makeRoot(opts);
+  try { fn(r); } finally {
+    SafeFsExecutor.safeRmSync(r.root, { recursive: true, force: true, operation: OP });
+  }
+}
+
+describe('THE DEFECT — an asset that exists but is older than its source', () => {
+  it('is reported STALE', () => {
+    withRoot({ outputsOlderThanInputs: true }, ({ root, outputs }) => {
+      // Every output exists, so the presence check this replaces returned "fine".
+      expect(outputs.every(o => fs.existsSync(o))).toBe(true);
+      expect(registryAssetIsStale(root, outputs)).toBe(true);
+    });
+  });
+});
+
+describe('CONTROLS — the cases that must NOT regenerate (this runs on every suite start)', () => {
+  it('an asset NEWER than every input is not stale', () => {
+    withRoot({ outputsOlderThanInputs: false }, ({ root, outputs }) => {
+      expect(registryAssetIsStale(root, outputs)).toBe(false);
+    });
+  });
+
+  it('equal mtimes are not stale — otherwise a same-second write regenerates on every run', () => {
+    withRoot({ outputsOlderThanInputs: false }, ({ root, outputs }) => {
+      const when = new Date('2026-03-03T03:03:03Z');
+      for (const rel of REGISTRY_ASSET_INPUTS) fs.utimesSync(path.join(root, rel), when, when);
+      for (const o of outputs) fs.utimesSync(o, when, when);
+      expect(registryAssetIsStale(root, outputs)).toBe(false);
+    });
+  });
+
+  it('no readable input means NOT stale — a missing source must not trigger a doomed regeneration', () => {
+    withRoot({ outputsOlderThanInputs: false, omitInputs: true }, ({ root, outputs }) => {
+      expect(registryAssetIsStale(root, outputs)).toBe(false);
+    });
+  });
+
+  it('an empty output list is not stale', () => {
+    withRoot({ outputsOlderThanInputs: true }, ({ root }) => {
+      expect(registryAssetIsStale(root, [])).toBe(false);
+    });
+  });
+});
+
+describe('the pre-existing behaviour is preserved, not replaced', () => {
+  it('an ABSENT output is still stale', () => {
+    withRoot({ outputsOlderThanInputs: false, omitOutput: true }, ({ root, outputs }) => {
+      expect(registryAssetIsStale(root, outputs)).toBe(true);
+    });
+  });
+});
+
+describe('wiring — every setup that regenerates the asset asks about freshness', () => {
+  const SETUP_DIR = path.resolve(__dirname, '..', 'setup');
+
+  /**
+   * Matched on the MODULE SPECIFIER, not the imported name. A wiring guard keyed
+   * on an identifier is defeated by `import { registryAssetIsStale as fresh }` —
+   * the alias blindness that shipped in an invariant test earlier this same week
+   * and was found by a peer, not by me.
+   */
+  const setupsThatGenerate = fs.readdirSync(SETUP_DIR)
+    .filter(f => f.endsWith('.ts'))
+    .map(f => ({ file: f, src: fs.readFileSync(path.join(SETUP_DIR, f), 'utf-8') }))
+    .filter(({ src }) => /standards-registry\.md/.test(src) && /standards-guard-index\.json/.test(src));
+
+  it('finds the setups that generate the asset', () => {
+    // Anti-vacuity control: with zero files found, every per-file assertion below
+    // is trivially true. Both known generators must be in the set.
+    expect(setupsThatGenerate.map(s => s.file).sort()).toEqual(
+      ['build-dist.globalSetup.ts', 'ensure-registry-asset.globalSetup.ts'],
+    );
+  });
+
+  for (const { file } of setupsThatGenerate) {
+    it(`${file} imports the freshness rule rather than carrying its own`, () => {
+      const src = fs.readFileSync(path.join(SETUP_DIR, file), 'utf-8');
+      expect(
+        /from\s+'\.\/registryAssetFreshness\.js'/.test(src),
+        `${file} decides regeneration without the shared freshness rule — a presence-only `
+          + 'check cannot see an asset that exists and is wrong',
+      ).toBe(true);
+    });
+  }
+});

--- a/upgrades/next/registry-asset-freshness.md
+++ b/upgrades/next/registry-asset-freshness.md
@@ -1,0 +1,29 @@
+<!-- internal-only -->
+
+## What Changed
+
+The two vitest globalSetup files that prepare the packed standards-registry asset
+(`tests/setup/build-dist.globalSetup.ts` and
+`tests/setup/ensure-registry-asset.globalSetup.ts`) decided whether to regenerate it
+on PRESENCE alone — `if (outputs.every(exists)) return`. An asset generated from an
+older revision of `docs/STANDARDS-REGISTRY.md` was therefore never regenerated.
+
+Both now consult a shared `registryAssetIsStale()` helper that compares the oldest
+output's mtime against the newest input's (`docs/STANDARDS-REGISTRY.md`,
+`docs/standards-registry-floor.json`, `package.json`) — the same shape the sibling
+`ensureDistBuilt()` twelve lines above already used.
+
+## Evidence
+
+- Measured 2026-08-15: in a checkout whose asset was generated at 17:59 from a source
+  three hours newer, `standards-registry-asset`, `standards-enforcement-auditor` and
+  `standards-coverage-route` failed with 8 assertions. Regenerating the asset alone
+  made all 77 pass.
+- `tests/unit/registry-asset-freshness.test.ts` — 9/9.
+- Negative controls, both fired: reverting the comparison fails THE DEFECT case
+  (1 failed / 8 passed); reverting one call site to the presence check fails the
+  wiring case, naming the file. Both sources restored byte-exact.
+- The wiring guard matches the MODULE SPECIFIER, not the imported identifier, so an
+  aliased import cannot defeat it — the alias blindness found in an invariant test
+  earlier this week.
+- `tsc --noEmit` exit 0; full lint chain exit 0 across 45 lints.

--- a/upgrades/side-effects/registry-asset-freshness.md
+++ b/upgrades/side-effects/registry-asset-freshness.md
@@ -1,0 +1,76 @@
+# Side-effects review — registry asset freshness
+
+## The change
+
+Two vitest globalSetup files decided whether to regenerate the packed
+standards-registry asset by asking only whether its outputs EXIST. Both now share a
+`registryAssetIsStale()` helper that compares the oldest output's mtime against the
+newest input's. Test-only; no runtime surface.
+
+## Review answers
+
+1. **Over-block.** This is the dominant risk and it got the most care, because the
+   check runs at the START of every suite and an over-eager rule regenerates on every
+   run. Three conservative cases, each with its own test: equal mtimes are NOT stale;
+   no readable input is NOT stale; an empty output list is NOT stale. Measured cost of
+   a genuine regeneration is one generator invocation (~1s), and it self-limits — a
+   freshly written asset is newer than its inputs, so the next run skips.
+
+2. **Under-block.** mtime is a proxy for content, not content itself. A source edited
+   and reverted leaves a newer mtime and triggers one unnecessary regeneration
+   (harmless). A content-identical touch does the same. Conversely, a filesystem that
+   does not preserve mtimes, or a checkout that sets all mtimes equal, would report
+   fresh when stale. A content hash would be exact — the generator already writes a
+   `sha256` into its metadata — and that is the stronger version of this fix. NOT done
+   here: it means reading and hashing a 450KB document on every suite start, where the
+   mtime compare is four `stat` calls, and the sibling `ensureDistBuilt()` this mirrors
+   uses mtimes too. Stated rather than implied.
+
+3. **Level-of-abstraction fit.** Correct layer: the setup layer is where every test
+   file inherits the guarantee. The file's own history says this explicitly — a
+   per-file `beforeAll` bootstrap was found to be invisible to the next file that
+   needed it.
+
+4. **Signal vs authority.** Not a gate. It decides whether to run a generator; it
+   blocks nothing and rejects no input.
+
+5. **Interactions.** `ensureRegistryAsset()` must still run AFTER `ensureDistBuilt()`
+   (the generator imports from `dist/`). Unchanged — only the early-return predicate
+   moved. The exported `ensureRegistryAsset(root)` keeps its signature, so the
+   production-generator parity ratchet that imports it is unaffected.
+
+6. **External surfaces.** None. Test setup only; nothing ships to an agent or a user.
+
+7. **Multi-machine posture.** Machine-local BY DESIGN — a per-checkout build artifact.
+   There is nothing to replicate: each checkout generates its own copy, and the whole
+   defect was one checkout trusting its own stale copy.
+
+8. **Rollback cost.** Revert the commit. The helper is additive; the two call sites
+   return to a presence check.
+
+## Class closure — what this does NOT close
+
+- **Only these two sites.** A sweep of `tests/setup/` and `scripts/` for
+  regenerate-on-presence guards found exactly these two making a regeneration decision
+  on existence alone; the other `existsSync` hits are ordinary existence guards, not
+  regeneration decisions. The wiring test pins both and fails if either drifts, but it
+  knows only about setups that generate THIS asset.
+- **`src/data/builtin-manifest.json`** is named in the generator's own comment as
+  having a related defect (generated only into `src/data/` while its reader resolves
+  module-relative from `dist/data/`). Different feature, different defect, untouched.
+- **mtime is not content** — see review answer 2.
+
+## Evidence
+
+- `tests/unit/registry-asset-freshness.test.ts` — 9/9 green.
+- Negative controls, BOTH fired and both restored byte-exact: reverting the comparison
+  fails THE DEFECT case (1 failed / 8 passed — the 8 passing are the controls, which is
+  what makes them controls); reverting one call site to the presence check fails the
+  wiring case and names the file.
+- Observed live: running the new test in a fresh checkout regenerated the asset
+  ("88 articles → src/data + dist/data"). Under the presence check it would have
+  skipped, because the outputs existed.
+- The originating measurement: three test files / eight assertions failing against a
+  three-hour-stale asset; regeneration alone made all 77 pass.
+- `tsc --noEmit` exit 0 (run via the real binary — `npx tsc` here is intercepted by a
+  shim that exits 0 without typechecking). Full lint chain exit 0 across 45 lints.


### PR DESCRIPTION
## ELI16 — regenerating a build file when it is out of date, not only when it is missing

Part of the test setup generates a file from a source document before the tests run. Two different setup files decide whether that generation is needed, and both asked only: *does the generated file exist?* If it did, they moved on.

That question cannot tell a correct generated file from one built out of an older version of the source. Existing was the whole test, so a stale file survived indefinitely — while the sibling function twelve lines above one of those checks already did it properly, by comparing timestamps.

**Measured, not hypothesised.** In a checkout whose asset was generated at 17:59 from a source three hours newer, three test files failed with eight assertions. Regenerating the asset alone made all 77 pass; nothing else changed.

Both setups now share one `registryAssetIsStale()` helper comparing the oldest output's mtime against the newest input's. One rule in one place — two copies of a rule that must agree is the next bug with a delay on it.

**Deliberately conservative**, because this runs at every suite start and over-eagerness is the real risk: equal mtimes are not stale, no readable input is not stale, an empty output list is not stale. Each has a control that passes both ways.

**Declared open:** mtime is a proxy for content. A content hash would be exact — the generator already writes a sha256 — and costs hashing a 450KB document at every suite start, where this is four stat calls, and the sibling it mirrors uses mtimes too.

## Evidence

- `tests/unit/registry-asset-freshness.test.ts` — 9/9.
- **Negative controls, both fired, both restored byte-exact:** reverting the comparison fails THE DEFECT case (1 failed / 8 passed — the 8 passers are the controls); reverting one call site to the presence check fails the wiring case and names the file.
- The wiring guard matches the **module specifier**, not the imported identifier, so an aliased import cannot defeat it — the alias blindness a peer found in one of my invariant tests earlier this week.
- Observed live: running the new test in a fresh checkout regenerated the asset (`88 articles → src/data + dist/data`). Under the presence check it would have skipped.
- `tsc --noEmit` exit 0 (real binary — `npx tsc` here is a shim that exits 0 without typechecking); full lint chain exit 0 across 45 lints.

Tier 1 — test-setup only, no runtime surface, no authority change.
