### PR TITLE
fix(test): land the gemini environmental-refusal classifier on its own

### DIFF
--- a/docs/specs/gemini-env-refusal-extract.eli16.md
+++ b/docs/specs/gemini-env-refusal-extract.eli16.md
@@ -1,0 +1,46 @@
+# A test that fails because this computer is not logged in, not because the code broke
+
+## The situation
+
+Two tests run the real Gemini command-line tool and check that it answers. They
+decide whether to run by asking one question: *is the tool installed?*
+
+That is the wrong question. A tool can be installed and not logged in. When that
+happens it refuses immediately, before it ever sees what we asked it — so the check
+underneath cannot pass and cannot meaningfully fail either. It just reports that
+this computer has no credentials.
+
+The shared build machines have no Gemini tool installed at all, so they skip
+cleanly and everything looks green. The only machine that goes red is a developer's
+machine that happens to have the tool installed. That is backwards: the better
+equipped the machine, the more it fails.
+
+## What changes
+
+The tests now look at the reason the tool gave. If it named one of the reasons that
+are about this computer rather than about our code — no credentials, a quota used
+up, a version manager pointing at nothing — the test skips and says loudly why. Any
+other failure still fails, exactly as before.
+
+## Why not something simpler
+
+The tempting version is to ask up front "can this machine talk to Gemini at all?"
+and skip everything if not. That is worse, and deliberately rejected: it would also
+skip when something is genuinely broken but intermittently, so a real problem would
+vanish on a bad afternoon. Matching only the reasons the tool itself names means we
+skip for causes it explicitly reported and let everything else fail visibly. A false
+red is annoying and gets investigated; a silent skip is invisible and does not.
+
+## Why this is arriving on its own
+
+This fix already exists. It was written a few hours ago inside a much larger change
+that is waiting on a human decision about something unrelated. So a working fix for
+a genuinely failing test has been sitting behind a gate that has nothing to do with
+it. Pulling it out on its own is the whole point of this change — nothing here is
+new work, it is the same fix, standing by itself where it can land.
+
+## What you would notice
+
+On a machine with Gemini installed but not logged in, two tests stop failing and
+start saying "skipped — this machine has no Gemini credentials." Nothing else
+changes.

--- a/tests/e2e/gemini-cli-alive-lifecycle.test.ts
+++ b/tests/e2e/gemini-cli-alive-lifecycle.test.ts
@@ -19,9 +19,23 @@
  *      v0.25.2 installed): a real `gemini -m gemini-2.5-flash --approval-mode
  *      default -p "<known-answer>"` returns the expected PONG-style text. A
  *      genuine alive proof, not a mock.
+ *
+ * MEASURED 2026-08-14 (round 10) — WHERE THAT CLAIM CURRENTLY STOPS. On this dev box the smoke
+ * assertion has never actually executed. The binary IS present, so layer 2 runs and the file
+ * reports green — but the CLI cannot authenticate by any path here, so it always reaches the
+ * environmental skip instead of the assertion. Two independent facts, both measured rather than
+ * inferred: the child env is key-free BY DESIGN (the API-key vars are hard-deleted as billing
+ * vars — see tests/helpers/geminiEnvRefusal.ts), and there is no cached `oauth_creds.json` under
+ * ~/.gemini either. Run directly in a shell with no filtering at all, `gemini` still exits 41.
+ *
+ * So "a genuine alive proof, not a mock" describes what this test WOULD prove on a credentialed
+ * box, not what it has proven on this one. The skip is loud, and nothing here is broken — but a
+ * reader counting this file among the green ones should not conclude the gemini body was exercised.
+ * Stated rather than fixed: making it exercisable needs a credential decision that is the operator's.
  */
 
 import { describe, it, expect } from 'vitest';
+import { geminiEnvRefusal } from '../helpers/geminiEnvRefusal.js';
 import { buildIntelligenceProvider } from '../../src/core/intelligenceProviderFactory.js';
 import { GeminiCliIntelligenceProvider } from '../../src/core/GeminiCliIntelligenceProvider.js';
 import { CircuitBreakingIntelligenceProvider } from '../../src/core/CircuitBreakingIntelligenceProvider.js';
@@ -69,10 +83,22 @@ describe('Gemini CLI body — feature is alive (E2E)', () => {
 
       // A deterministic known-answer prompt — the gemini analog of the codex
       // Reply-with-PONGXYZ smoke. Run through the ALIVE provider, not a mock.
-      const out = await provider!.evaluate(
-        'Reply with exactly the single word: PONGGEMINI and nothing else.',
-        { model: 'fast', timeoutMs: 45_000 },
-      );
+      let out: string;
+      try {
+        out = await provider!.evaluate(
+          'Reply with exactly the single word: PONGGEMINI and nothing else.',
+          { model: 'fast', timeoutMs: 45_000 },
+        );
+      } catch (err) {
+        // `haveGemini` proves the binary is INSTALLED, not that it is USABLE. An uncredentialed CLI
+        // exits before it reads our prompt, so there is nothing here to assert about our code — the
+        // provider embeds the CLI's own stderr in this message, and only that named cause is skipped.
+        // Anything else rethrows, because a non-zero exit is also what a genuine break looks like.
+        const refusal = geminiEnvRefusal(err instanceof Error ? err.message : String(err));
+        if (!refusal) throw err;
+        console.warn(`Skipping live Gemini smoke assertion: ${refusal}.`);
+        return;
+      }
       expect(out.toUpperCase()).toContain('PONGGEMINI');
     },
     60_000,

--- a/tests/e2e/gemini-setup-narrative-lifecycle.test.ts
+++ b/tests/e2e/gemini-setup-narrative-lifecycle.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { geminiEnvRefusal } from '../helpers/geminiEnvRefusal.js';
 import { detectGeminiPath } from '../../src/core/Config.js';
 import { GEMINI_WIZARD_MODEL } from '../../src/commands/setup-wizard/model-constants.js';
 import {
@@ -59,8 +60,12 @@ paths, tool names, bullet lists, or questions. Output prose only.
         }
       }
 
-      if (result.exitCode !== 0 && /QUOTA_EXHAUSTED|exhausted your capacity|quota/i.test(result.stderr)) {
-        console.warn('Skipping live Gemini narrative assertion: Gemini CLI quota is exhausted.');
+      // The binary being INSTALLED is not the binary being USABLE — see tests/helpers/geminiEnvRefusal.ts.
+      // This hatch previously covered quota only; an uncredentialed CLI exits 41 before it reads our
+      // prompt, which made this test red on the one kind of box that actually runs it.
+      const refusal = result.exitCode !== 0 ? geminiEnvRefusal(result.stderr) : null;
+      if (refusal) {
+        console.warn(`Skipping live Gemini narrative assertion: ${refusal}.`);
         return;
       }
 

--- a/tests/helpers/geminiEnvRefusal.ts
+++ b/tests/helpers/geminiEnvRefusal.ts
@@ -1,0 +1,81 @@
+/**
+ * Did the gemini CLI refuse for an ENVIRONMENTAL reason — one that says nothing about our code?
+ *
+ * WHY THIS EXISTS. The two live-gemini E2Es gate on `haveGemini = !!detectGeminiPath()`, which asks
+ * whether the BINARY IS INSTALLED. That is not the precondition they need: an installed-but-
+ * uncredentialed CLI exits before it ever processes our prompt, so the assertion downstream can
+ * neither pass nor meaningfully fail — it only reports that this box is not logged in.
+ *
+ * Measured 2026-08-14: a full-suite run was red on exactly this. `gemini` was on PATH, so both
+ * tests ran, and both died with `exited 41 — you must specify the GEMINI_API_KEY environment
+ * variable`. CI stays green only by accident (no binary installed there ⇒ clean skip); the box that
+ * has gemini installed is the one that goes red.
+ *
+ * WHY A NARROW POST-HOC MATCH RATHER THAN A PREFLIGHT. The tempting fix is a live preflight ("can
+ * this box complete any one-shot?") because it collapses every environmental cause into one
+ * predicate instead of a growing list. It is the wrong trade here: a preflight skips on ANY failure,
+ * including a transient one, so a real regression on a flaky afternoon disappears silently. Matching
+ * the CLI's OWN NAMED refusal skips only for causes it explicitly reported and lets everything else
+ * fail loudly. Between a false red (visible, diagnosable, blocks a push) and a silent skip (invisible),
+ * the silent skip is the worse error.
+ *
+ * WHY IT IS SHARED. This is the third environmental cause handled in these tests — the file already
+ * carried hatches for an asdf version miss and for quota exhaustion. Three patches to one guard is
+ * the point at which the list stops being maintainable in two places at once, so the CLASSIFICATION
+ * lives here, once, and the tests decide what to do with the answer.
+ *
+ * NEVER match on exit code alone. A non-zero exit is exactly what a genuine break in our argv
+ * building or transport looks like; only the CLI naming its own cause is evidence of an
+ * environmental refusal.
+ */
+
+/**
+ * Causes the CLI reports about ITS OWN configuration, never about our request.
+ *
+ * ROUND 9 — A CARVE-OUT WITHDRAWN, BECAUSE IT FIRED ON CORRECT BEHAVIOUR.
+ *
+ * Round 8 added a condition here: treat "no credentials" as OUR bug whenever the ambient
+ * environment holds a `GEMINI_API_KEY`, reasoning that `buildGeminiChildEnv()` is our code, so a
+ * dropped credential would be our regression. That reasoning never read what the function is FOR.
+ *
+ * Measured: `GEMINI_API_KEY` and `GOOGLE_API_KEY` are in `GEMINI_BILLING_ENV_VARS` and are
+ * HARD-DELETED from the child env — deliberately, so the CLI can never run on a metered key
+ * ("Never billed"). The allowlist says so explicitly: "benign — model/dir overrides, NOT keys". A
+ * probe confirms both arrive `undefined` in the child while HOME passes through.
+ *
+ * So the carve-out inverted its own purpose. On any box where the operator has the key exported —
+ * an ordinary thing to have — the child correctly has none, the CLI correctly complains, and the
+ * carve-out would have FAILED the test on specified behaviour. Withdrawn: the credential cause is
+ * environmental, full stop, because the child is designed to have no key and "no key" is therefore
+ * the expected state rather than evidence of anything.
+ *
+ * RESIDUAL, stated rather than guarded: the CLI authenticates via cached OAuth credentials it finds
+ * under HOME/XDG_CONFIG_HOME. If the allowlist ever regressed and dropped those, the CLI would emit
+ * this same "no credentials" message and this classifier would skip — hiding a real break. A guard
+ * for that would check the child env still carries the vars the OAuth path needs, NOT the API-key
+ * vars, which are irrelevant to it. Not built: it guards a hypothetical regression, and this file
+ * has now twice demonstrated what speculative tightening costs.
+ */
+const ENVIRONMENTAL_REFUSALS: ReadonlyArray<{ reason: string; pattern: RegExp }> = [
+  {
+    reason: 'no credentials configured (the child env is key-free by design; OAuth creds absent)',
+    pattern:
+      /must specify the (?:GEMINI|GOOGLE)_API_KEY|(?:GEMINI|GOOGLE)_API_KEY environment variable|please (?:set|select) an auth method|not authenticated|no auth method/i,
+  },
+  {
+    reason: 'quota exhausted',
+    pattern: /QUOTA_EXHAUSTED|exhausted your capacity|\bquota\b/i,
+  },
+];
+
+/**
+ * @param text stderr, or a thrown provider error message (the provider embeds the CLI's stderr).
+ * @returns a human-readable reason when the CLI named an environmental cause, else null.
+ */
+export function geminiEnvRefusal(text: string | null | undefined): string | null {
+  if (!text) return null;
+  for (const { reason, pattern } of ENVIRONMENTAL_REFUSALS) {
+    if (pattern.test(text)) return reason;
+  }
+  return null;
+}

--- a/tests/unit/gemini-env-refusal.test.ts
+++ b/tests/unit/gemini-env-refusal.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit — the live-gemini E2Es skip ONLY when the CLI named an environmental cause, and still fail
+ * for everything else.
+ *
+ * The whole value of this classifier is the NEGATIVE direction. A skip that is too broad converts a
+ * real regression into a green run with a warning nobody reads, which is strictly worse than the red
+ * it replaces. So the cases below that must return `null` are the load-bearing ones: every shape a
+ * genuine break in our argv building, transport, or the model's answer would take.
+ */
+import { describe, it, expect } from 'vitest';
+import { geminiEnvRefusal } from '../helpers/geminiEnvRefusal.js';
+
+describe('geminiEnvRefusal — recognises the CLI refusing on its own configuration', () => {
+  it('the exact message that made the suite red on 2026-08-14', () => {
+    // Verbatim from the failing run, via the provider's thrown Error.
+    const msg =
+      'Gemini CLI exited 41 — When using Gemini API, you must specify the GEMINI_API_KEY ' +
+      'environment variable.\nUpdate your environment and try again (no reload needed if using .env)!';
+    // Deliberately environment-independent: the classifier reads only the CLI's own message, which
+    // is what makes this verdict the same on every box. Round 8 briefly made it env-dependent and
+    // round 9 withdrew that — see the ROUND 9 case below.
+    expect(geminiEnvRefusal(msg)).toMatch(/credential/i);
+  });
+
+  it.each([
+    ['GOOGLE_API_KEY spelling', 'you must specify the GOOGLE_API_KEY environment variable'],
+    ['bare env-var mention', 'GEMINI_API_KEY environment variable is required'],
+    ['auth method unset', 'Please set an Auth method in your settings'],
+    ['not authenticated', 'Error: not authenticated'],
+  ])('credential cause: %s', (_name, stderr) => {
+    expect(geminiEnvRefusal(stderr)).toMatch(/credential/i);
+  });
+
+  it.each([
+    ['upstream code', 'status: QUOTA_EXHAUSTED'],
+    ['prose form', 'You have exhausted your capacity for this model'],
+    ['bare word', 'daily quota reached'],
+  ])('quota cause: %s', (_name, stderr) => {
+    expect(geminiEnvRefusal(stderr)).toBe('quota exhausted');
+  });
+});
+
+describe('geminiEnvRefusal — a genuine break is NEVER absorbed', () => {
+  it.each([
+    ['our argv is wrong', 'error: unknown option `--aproval-mode`'],
+    ['our binary path is wrong', 'spawn /usr/local/bin/gemini ENOENT'],
+    ['the model refused the prompt', 'Response blocked by safety settings'],
+    ['a plain non-zero exit with no cause', 'Gemini CLI exited 1 — '],
+    ['a timeout in our transport', 'Gemini CLI timed out after 45000ms'],
+    ['an empty answer', 'Gemini CLI produced no output'],
+    ['a network fault', 'FetchError: request to https://generativelanguage.googleapis.com failed'],
+    ['a wrong-model error', 'models/gemini-9.9-nonexistent is not found for API version v1beta'],
+  ])('%s → not environmental, so the test still fails', (_name, stderr) => {
+    expect(geminiEnvRefusal(stderr)).toBeNull();
+  });
+
+  it('ROUND 9: an ambient credential is IRRELEVANT — the child env is key-free by design', () => {
+    // This replaces a round-8 assertion that was exactly backwards. Round 8 claimed that an ambient
+    // GEMINI_API_KEY meant the CLI's "no credentials" complaint had to be OUR bug, since our own
+    // buildGeminiChildEnv() would have had to drop it. Round 9 read what that function is FOR: the
+    // API-key vars are in GEMINI_BILLING_ENV_VARS and are hard-deleted from the child on purpose, so
+    // the CLI never runs on a metered key. Probed and confirmed — both arrive undefined in the child
+    // while HOME passes through.
+    //
+    // So the old assertion would have FAILED this test on any box where the operator simply has the
+    // key exported, which is ordinary. The weaker, true statement is that the ambient environment
+    // does not enter into it at all.
+    const msg = 'Gemini CLI exited 41 — you must specify the GEMINI_API_KEY environment variable.';
+    expect(geminiEnvRefusal(msg)).toMatch(/credential/i);
+  });
+
+  it('an exit code alone proves nothing — only the CLI naming its cause counts', () => {
+    // The tests pass stderr, never the code; this pins the reason why. `41` is the credential exit
+    // TODAY, and keying on it would silently start skipping whatever gemini assigns 41 next release.
+    expect(geminiEnvRefusal('41')).toBeNull();
+    expect(geminiEnvRefusal('exited 41')).toBeNull();
+  });
+
+  it.each([['null', null], ['undefined', undefined], ['empty', '']])(
+    '%s input is not a refusal',
+    (_name, input) => {
+      expect(geminiEnvRefusal(input as string | null | undefined)).toBeNull();
+    },
+  );
+});

--- a/upgrades/next/gemini-env-refusal-extract.md
+++ b/upgrades/next/gemini-env-refusal-extract.md
@@ -1,0 +1,32 @@
+<!-- internal-only -->
+
+## What Changed
+
+Extracted `tests/helpers/geminiEnvRefusal.ts` and its two call sites
+(`tests/e2e/gemini-cli-alive-lifecycle.test.ts`,
+`tests/e2e/gemini-setup-narrative-lifecycle.test.ts`) plus its unit test out of the
+blocked `echo/authorship-provenance` branch and onto main on their own.
+
+The two live-gemini E2Es gate on `haveGemini = !!detectGeminiPath()` — whether the
+BINARY IS INSTALLED. An installed-but-uncredentialed CLI exits 41 before processing
+the prompt, so the assertion downstream can neither pass nor meaningfully fail. CI is
+green only because no gemini binary exists there; the box that HAS gemini is the one
+that goes red.
+
+## Evidence
+
+- A full unit+integration+e2e run on a current checkout (3070 files) produced
+  **exactly 2 failures — both of these files**, both on
+  `Gemini CLI exited 41 — you must specify the GEMINI_API_KEY environment variable`.
+- The helper is ABSENT from main (404 via the contents API, against a control showing
+  7 files DO exist in `tests/helpers/`), and the failing test on main references it 0
+  times — so the fix genuinely never landed.
+- Main has not modified either e2e file since the authorship branch's base, so this
+  reverts nothing; the diff is +37/-6 against main.
+- `tsc --noEmit` exit 0 via the real binary.
+
+## Why it is separate
+
+Out-of-charter work absorbed into a large blocked change becomes hostage to that
+change's gate. The Zero-Failure Standard was satisfied on a branch and NOT on main,
+which is the only place it counts.

--- a/upgrades/side-effects/gemini-env-refusal-extract.md
+++ b/upgrades/side-effects/gemini-env-refusal-extract.md
@@ -1,0 +1,60 @@
+# Side-effects review — extracting the gemini environmental-refusal classifier
+
+## The change
+
+Moves `tests/helpers/geminiEnvRefusal.ts`, its unit test, and its two E2E call sites out of the blocked
+`echo/authorship-provenance` branch and onto main on their own. No new code: the same four files,
+standing alone where they can land. Test-only; no runtime surface.
+
+## Why it is separate, which is the actual point
+
+The two live-gemini E2Es gate on whether the BINARY IS INSTALLED. An installed-but-uncredentialed CLI
+exits 41 before it processes the prompt, so the assertion downstream can neither pass nor meaningfully
+fail. CI is green only because no gemini binary exists there — the box that HAS gemini is the one that
+goes red. That is a Zero-Failure Standard violation on main today.
+
+The fix was written hours ago, out-of-charter, and committed to whichever branch was checked out at the
+time — a large change now blocked at an approval gate for reasons unrelated to gemini. So the standard
+was satisfied on a branch and NOT on main, which is the only place it counts. **Out-of-charter work
+absorbed into a blocked change becomes hostage to that change's gate.**
+
+## Review answers
+
+1. **Over-block.** The classifier skips ONLY on causes the CLI itself names (missing credentials, quota
+   exhaustion, a version-manager miss). Everything else still fails. The rejected alternative — a live
+   preflight asking "can this box reach gemini at all?" — is recorded in the helper's own header as the
+   wrong trade: it would also skip on a transient failure, so a real regression would vanish silently.
+   Between a false red (visible, blocks a push) and a silent skip (invisible), the silent skip is worse.
+2. **Under-block.** A NEW environmental cause with different wording still fails loudly. That is the
+   intended direction; the list grows only when a real cause is observed.
+3. **Level-of-abstraction fit.** The classification is shared once and the tests decide what to do with
+   the answer — this is the third environmental cause these files handle, which is the point at which
+   two copies stop being maintainable.
+4. **Signal vs authority.** Not a gate. It decides whether a test asserts or skips.
+5. **Interactions.** None outside the three test files. No production import.
+6. **External surfaces.** None.
+7. **Multi-machine posture.** Machine-local BY DESIGN — it classifies THIS box's credential state.
+8. **Rollback cost.** Revert; the two e2e files return to failing on an uncredentialed box.
+
+## Evidence
+
+- **The negative control is main itself, measured rather than mutated.** A full run on a current
+  checkout (3073 files) produced exactly 2 failures — these two files — both on
+  `Gemini CLI exited 41 — you must specify the GEMINI_API_KEY environment variable`.
+- On this branch the same three files pass, 24 tests, with the E2E bodies skipping loudly:
+  *"Skipping live Gemini narrative assertion: no credentials configured (the child env is key-free by
+  design; OAuth creds absent)."*
+- The helper is ABSENT from main (404 via the contents API, against a control showing 7 files DO exist
+  in `tests/helpers/`), and the failing test on main references it 0 times — the fix genuinely never
+  landed.
+- Main has not modified either e2e file since the source branch's base, so this reverts nothing; the
+  diff against main is +37/-6 on the e2e files plus the two new files.
+- `tsc --noEmit` exit 0 via the real binary.
+
+## Class closure — what this does NOT close
+
+- **The live smoke assertion still never executes on this box.** It skips, correctly and loudly. Making
+  it exercisable needs a credential decision that is the operator's, not a code change.
+- **Only gemini.** No audit was done of other live-CLI E2Es for the same installed-vs-usable confusion.
+- **The stranding pattern itself is untouched.** Nothing prevents the next out-of-charter fix from being
+  committed to a branch that later blocks. That is a process observation, recorded rather than solved.


### PR DESCRIPTION
## ELI16 — a test that fails because this computer is not logged in, not because the code broke

Two tests run the real Gemini command-line tool and check that it answers. They decide whether to run by asking one question: *is the tool installed?*

That is the wrong question. A tool can be installed and not logged in. When that happens it refuses immediately, before it ever sees what we asked it — so the check underneath can neither pass nor meaningfully fail. It only reports that this computer has no credentials.

The shared build machines have no Gemini tool installed at all, so they skip cleanly and everything looks green. **The only machine that goes red is one that happens to have the tool installed.** The better equipped the machine, the more it fails.

The tests now look at the reason the tool gave. If it named a cause that is about this computer rather than about our code — no credentials, quota used up, a version manager pointing at nothing — the test skips and says loudly why. Any other failure still fails.

**Why not something simpler.** The tempting version asks up front "can this machine reach Gemini at all?" and skips everything if not. That is worse and deliberately rejected: it would also skip when something is genuinely broken but intermittent, so a real regression would vanish on a bad afternoon. Matching only the reasons the tool itself names skips for causes it explicitly reported and lets everything else fail visibly.

**Why this is arriving on its own.** This fix already exists. It was written hours ago inside a much larger change that is waiting on a human decision about something unrelated — so a working fix for a genuinely failing test has been stranded behind a gate that has nothing to do with it. Nothing here is new work.

## Evidence

- **The negative control is `main` itself, measured rather than mutated.** A full unit+integration+e2e run on a current checkout (3073 files) produced **exactly 2 failures — these two files**, both on `Gemini CLI exited 41 — you must specify the GEMINI_API_KEY environment variable`.
- On this branch the same three files pass (24 tests) with the E2E bodies skipping loudly: *"Skipping live Gemini narrative assertion: no credentials configured (the child env is key-free by design; OAuth creds absent)."*
- Verified it never reached main rather than assumed: the helper is **absent from main** (404 via the contents API, against a control showing 7 files DO exist in `tests/helpers/`), and the failing test on main references it **0** times.
- Reverts nothing: main has not modified either e2e file since the source branch's base, so the diff is purely additive (+37/−6 on the e2e files, plus two new files).
- `tsc --noEmit` exit 0 via the real binary.

## Declared open

The live smoke assertion still never executes on this box — it skips, correctly and loudly. Making it exercisable needs a credential decision that is the operator's. And nothing prevents the next out-of-charter fix from being stranded in a branch that later blocks; that is a process observation, recorded rather than solved.

Tier 1 — test-only, no runtime surface, no new logic.
