### PR TITLE
test(setup): say once, beside the failure count, that better-sqlite3 is broken

### DIFF
--- a/docs/specs/native-module-health-banner.eli16.md
+++ b/docs/specs/native-module-health-banner.eli16.md
@@ -1,0 +1,50 @@
+# Saying once, where you will read it, that a broken part explains the mess
+
+## What happened
+
+A full test run on this machine reported 225 failing files. Nearly half of them
+had a single cause: one small piece of the software — the bit that stores things
+in a local database — had not been built properly when the project's dependencies
+were installed. Everything that depended on it failed.
+
+The software noticed. It said so clearly, in plain English, and it named the exact
+command that fixes it. It said this **one hundred and eighty-nine times**.
+
+That did not help. The message was scattered through a twenty-megabyte log among
+tens of thousands of other lines. I searched that log, counted how often the error
+appeared, and never read the three lines underneath the one I was counting — where
+the cause and the cure were written. Hours went into elaborate investigations of a
+question the output had already answered.
+
+## What changes
+
+Nothing new is detected, and nothing new is said. The **same** message is moved to
+the one place a person actually looks: printed once, at the very end of the run,
+directly beneath the failure count. It names the likely cause, says that failures
+above it are probably consequences rather than separate problems, and gives the
+one command that fixes it.
+
+## What it deliberately does not do
+
+- **It never stops anything.** The project is designed to keep working with that
+  piece missing, and most tests do not touch it. Refusing to run would trade a
+  confusing failure for a blocked one, which is worse.
+- **It is completely silent when everything is fine** — which is nearly always.
+  Adding a line to every healthy run would be adding to the very pile that caused
+  the problem.
+- **It watches one specific thing**, not "anything native". Generalising from a
+  single incident would be inventing a pattern, which is the same over-reading
+  that caused the original confusion.
+
+## How we know it works
+
+The end-to-end proof is not a claim about placement — the broken state was forced
+and the run was watched. The banner appeared after the summary, where it was
+supposed to. And the opposite case is tested too: given a healthy check, it writes
+nothing at all and returns nothing to run later.
+
+## What you would notice
+
+On a healthy machine, nothing whatsoever. On a machine where that piece is broken,
+one clear block of text at the end of the test run instead of hundreds of scattered
+lines that are easy to count and easy not to read.

--- a/tests/setup/nativeModuleHealth.globalSetup.ts
+++ b/tests/setup/nativeModuleHealth.globalSetup.ts
@@ -1,0 +1,122 @@
+/**
+ * Say ONCE, where the failure counts are, that better-sqlite3 could not load.
+ *
+ * WHY THIS EXISTS — a measured incident, 2026-08-15. A full local suite reported
+ * 225 failing files. 108 of them were downstream of ONE fact: `better-sqlite3`
+ * had no native binary in that checkout, because the install had skipped its
+ * postinstall hook. Every affected subsystem degraded correctly and instar said
+ * so in plain English, naming the exact remedy — **189 times**.
+ *
+ * And it did not help. I grepped that text and COUNTED it; I never read the three
+ * lines underneath the one I was counting. Hours went into a completion-order
+ * analysis, a replay, a prefix bisect and five dead hypotheses, for a question the
+ * output had already answered.
+ *
+ * So this is not another message. It is the SAME message moved to the one place a
+ * reader actually looks: the end of the run, beside the failure count. 189 lines
+ * scattered through 21MB of log is not a signal — it is volume, and summarising is
+ * how you avoid reading.
+ *
+ * DELIBERATELY NOT A GATE. instar degrades gracefully without better-sqlite3, and
+ * most of the suite does not touch it, so refusing to run would trade a confusing
+ * failure for a blocked one. This never fails, never skips, never changes an exit
+ * code. It only makes an existing diagnosis legible.
+ *
+ * SCOPED TO ONE MODULE ON PURPOSE. Generalising to "native modules" would be
+ * inventing a class from a single incident — the exact over-read this whole
+ * episode was caused by.
+ */
+import { createRequire } from 'node:module';
+import type { GlobalSetupContext } from 'vitest/node';
+
+// This package is `"type": "module"`, so a bare `require` is not defined here.
+// better-sqlite3 is a native CJS addon; `createRequire` is the idiom this repo
+// already uses for exactly that (see tests/unit/fix-better-sqlite3-state.test.ts).
+const requireCjs = createRequire(import.meta.url);
+
+export interface NativeProbeResult {
+  ok: boolean;
+  /** First line of the failure, already trimmed. Empty when ok. */
+  detail: string;
+}
+
+/**
+ * Probe the module the way the suite actually uses it: load it AND open an
+ * in-memory database. Loading alone is not enough — the incident's own signature
+ * was `sqlite-runtime-broken: better-sqlite3 failed to open an in-memory DB`, so a
+ * require-only probe would have reported healthy through the whole outage.
+ *
+ * `load` is injectable so both directions are testable without breaking the real
+ * module — the negative control cannot be run any other way.
+ */
+export function probeBetterSqlite(load: () => unknown): NativeProbeResult {
+  try {
+    const Ctor = load() as new (path: string) => { close(): void };
+    const db = new Ctor(':memory:');
+    db.close();
+    return { ok: true, detail: '' };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, detail: (msg.split('\n')[0] ?? '').trim() };
+  }
+}
+
+/**
+ * The banner. Pure, so a test can assert what a human would read rather than
+ * asserting that some function was called.
+ */
+export function formatBanner(detail: string): string {
+  return [
+    '',
+    '════════════════════════════════════════════════════════════════════════',
+    '  better-sqlite3 could NOT load in this checkout for this run.',
+    '',
+    `  ${detail || '(no detail reported)'}`,
+    '',
+    '  Every sqlite-backed subsystem degraded for the whole run. Test failures',
+    '  above that mention bindings, sqlite, or a store failing to open are most',
+    '  likely DOWNSTREAM of this one fact, not separate defects.',
+    '',
+    '  Fix:  npm rebuild better-sqlite3        (or reinstall WITHOUT --ignore-scripts,',
+    '                                           which skips the postinstall that',
+    '                                           builds the native binary)',
+    '',
+    '  This is a notice, not a gate: nothing was blocked or skipped because of it.',
+    '════════════════════════════════════════════════════════════════════════',
+    '',
+  ].join('\n');
+}
+
+/**
+ * The decision, with both dependencies injectable — so BOTH branches are testable
+ * with zero side effects. The silent-when-healthy branch is the one that matters
+ * for over-block: this runs at the start of every suite on every machine, and a
+ * banner on a healthy box would be pure noise. A test that could not exercise
+ * that branch would be a check that cannot fail on the case that costs.
+ */
+export function runHealthCheck(
+  probe: () => NativeProbeResult = () => probeBetterSqlite(() => requireCjs('better-sqlite3')),
+  write: (s: string) => void = (s) => { process.stderr.write(s); },
+): (() => void) | void {
+  // The probe is wrapped even though the default one already catches internally.
+  // This runs before EVERY suite on every machine: if it ever threw, it would take
+  // the whole run down, which is a strictly worse outcome than the degraded state
+  // it exists to describe. Belt-and-braces here is proportionate to that asymmetry.
+  let result: NativeProbeResult;
+  try {
+    result = probe();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    result = { ok: false, detail: `health probe itself failed: ${(msg.split('\n')[0] ?? '').trim()}` };
+  }
+  if (result.ok) return; // healthy box: completely silent, every run
+
+  // One line now (cheap, and survives if teardown output is swallowed), and the
+  // full banner at teardown — where the failure counts are.
+  write('[native-module-health] better-sqlite3 unavailable — a banner will follow the run summary.\n');
+  return () => { write(formatBanner(result.detail)); };
+}
+
+export default function setup(_ctx?: GlobalSetupContext): (() => void) | void {
+  return runHealthCheck();
+}

--- a/tests/unit/native-module-health-banner.test.ts
+++ b/tests/unit/native-module-health-banner.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  probeBetterSqlite,
+  formatBanner,
+  runHealthCheck,
+  type NativeProbeResult,
+} from '../setup/nativeModuleHealth.globalSetup.js';
+
+/**
+ * A full local suite reported 225 failing files. 108 were downstream of ONE fact:
+ * better-sqlite3 had no native binary in that checkout. instar diagnosed it
+ * correctly and printed the remedy 189 times — and that did not help, because 189
+ * lines inside a 21MB log is volume, not a signal.
+ *
+ * These tests pin the two properties that make the banner useful rather than
+ * another line in the pile: it is SILENT on a healthy box, and when it does speak
+ * it carries the remedy.
+ */
+
+describe('THE INCIDENT SHAPE — a module that loads but cannot open a database', () => {
+  it('is reported BROKEN, not healthy', () => {
+    // The load-bearing case. The real signature was "failed to open an in-memory
+    // DB", so a require-only probe would have reported healthy for the entire
+    // outage. This is why the probe constructs, not just imports.
+    class OpensNothing {
+      constructor() { throw new Error('SQLITE_CANTOPEN: unable to open database file'); }
+      close(): void { /* unreachable */ }
+    }
+    const r = probeBetterSqlite(() => OpensNothing);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain('SQLITE_CANTOPEN');
+  });
+
+  it('reports a failure to LOAD as broken too', () => {
+    const r = probeBetterSqlite(() => { throw new Error('Could not locate the bindings file. Tried:\n  …'); });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toBe('Could not locate the bindings file. Tried:');
+  });
+
+  it('keeps only the first line of a multi-line failure', () => {
+    const r = probeBetterSqlite(() => { throw new Error('first\nsecond\nthird'); });
+    expect(r.detail).toBe('first');
+  });
+
+  it('survives a non-Error throw', () => {
+    const r = probeBetterSqlite(() => { throw 'a bare string'; });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toBe('a bare string');
+  });
+});
+
+describe('CONTROLS — the healthy path, which is every run on every machine', () => {
+  class Works {
+    constructor(_p: string) { /* fine */ }
+    close(): void { /* fine */ }
+  }
+
+  it('a working module is reported healthy with no detail', () => {
+    expect(probeBetterSqlite(() => Works)).toEqual({ ok: true, detail: '' });
+  });
+
+  it('SAYS NOTHING when healthy — no setup line, no teardown', () => {
+    // The over-block control. This runs at the start of every suite; a banner on a
+    // healthy box would be noise added to the exact problem it exists to solve.
+    const written: string[] = [];
+    const teardown = runHealthCheck(() => ({ ok: true, detail: '' }), (s) => { written.push(s); });
+    expect(written).toEqual([]);
+    expect(teardown).toBeUndefined();
+  });
+
+  it('CANNOT throw — not even if the probe itself explodes', () => {
+    // It is a notice, not a gate, and it runs before every suite. If it threw it
+    // would take the whole run down — strictly worse than the degraded state it
+    // exists to describe. So a throwing probe is reported, not propagated.
+    const written: string[] = [];
+    let teardown: (() => void) | void;
+    expect(() => {
+      teardown = runHealthCheck(() => { throw new Error('probe exploded'); }, (s) => { written.push(s); });
+    }).not.toThrow();
+    (teardown as () => void)();
+    expect(written.join('')).toContain('health probe itself failed: probe exploded');
+  });
+
+  it('the real default path does not throw on this machine either', () => {
+    expect(() => runHealthCheck(undefined, () => {})).not.toThrow();
+  });
+});
+
+describe('when it does speak, it carries the remedy', () => {
+  const broken: NativeProbeResult = { ok: false, detail: 'Could not locate the bindings file.' };
+
+  it('warns once at setup and returns a teardown that prints the banner', () => {
+    const written: string[] = [];
+    const teardown = runHealthCheck(() => broken, (s) => { written.push(s); });
+    expect(written).toHaveLength(1);
+    expect(written[0]).toContain('better-sqlite3 unavailable');
+    expect(typeof teardown).toBe('function');
+
+    (teardown as () => void)();
+    expect(written).toHaveLength(2);
+    const banner = written[1]!;
+    expect(banner).toContain('Could not locate the bindings file.');
+    expect(banner).toContain('npm rebuild better-sqlite3');
+    expect(banner).toContain('--ignore-scripts');
+    expect(banner).toContain('DOWNSTREAM');
+    expect(banner).toContain('not a gate');
+  });
+
+  it('never prints an empty reason', () => {
+    expect(formatBanner('')).toContain('(no detail reported)');
+  });
+});
+
+describe('wiring — the setup is actually registered, not merely written', () => {
+  const ROOT = path.resolve(__dirname, '..', '..');
+
+  it('vitest.config.ts lists it in globalSetup', () => {
+    // "enabled ≠ running": a setup file that exists but is not in the config would
+    // be a guard that never runs, which is this window's own recurring defect.
+    const cfg = fs.readFileSync(path.join(ROOT, 'vitest.config.ts'), 'utf-8');
+    expect(cfg).toContain('tests/setup/nativeModuleHealth.globalSetup.ts');
+    // CONTROL: the pre-existing entry is still there, so the wiring was added
+    // rather than substituted.
+    expect(cfg).toContain('tests/setup/build-dist.globalSetup.ts');
+  });
+});

--- a/upgrades/next/native-module-health-banner.md
+++ b/upgrades/next/native-module-health-banner.md
@@ -1,0 +1,39 @@
+<!-- internal-only -->
+
+## What Changed
+
+Adds `tests/setup/nativeModuleHealth.globalSetup.ts`, wired into `vitest.config.ts`
+after `build-dist.globalSetup.ts`. It probes better-sqlite3 once (load AND open an
+in-memory DB) and, only when that fails, prints one line at setup and a single
+banner at TEARDOWN — which vitest renders after the run summary, beside the failure
+count.
+
+## Why
+
+Measured 2026-08-15: a local full suite reported 225 failing files; 108 were
+downstream of better-sqlite3 having no native binary in that checkout (the install
+had skipped its postinstall). instar diagnosed it correctly and printed the remedy
+**189 times**, and that did not help — 189 lines in a 21MB log is volume, not a
+signal. This does not add detection; it moves the existing diagnosis to where it is
+read.
+
+## Evidence
+
+- `tests/unit/native-module-health-banner.test.ts` — 11/11.
+- **Placement proven END-TO-END, not asserted**: the broken branch was forced by
+  mutation (count-asserted at exactly 1 — the first attempt applied 0 times and was
+  caught by that control), a suite was run, and the banner rendered AFTER the
+  `Test Files / Tests / Duration` summary. Source restored byte-exact, 0 markers.
+- Probe covers the incident's real signature — the module LOADS but cannot open a
+  database. A require-only probe would have reported healthy for the entire outage;
+  that case is pinned.
+- Over-block control: given a healthy probe it writes NOTHING and returns NO
+  teardown. It also cannot throw — a throwing probe is reported, not propagated,
+  because this runs before every suite.
+- `tsc --noEmit` exit 0 via the real binary; full lint chain exit 0.
+
+## Not closed
+
+Scoped to better-sqlite3 alone — deliberately, since generalising from one incident
+is the over-read that caused it. The install hygiene itself is unchanged; this makes
+its consequence legible, it does not prevent it.

--- a/upgrades/side-effects/native-module-health-banner.md
+++ b/upgrades/side-effects/native-module-health-banner.md
@@ -1,0 +1,60 @@
+# Side-effects review — native-module health banner
+
+## The change
+
+A vitest globalSetup that probes better-sqlite3 once and, only on failure, emits one
+setup line plus a single banner at teardown (rendered after the run summary). Adds no
+detection: it relocates a diagnosis instar already produces to where a reader looks.
+
+## Review answers
+
+1. **Over-block.** The dominant risk, because this runs before EVERY suite on every
+   machine. It writes nothing and returns no teardown on a healthy probe — pinned by a
+   control. It never fails, skips, or changes an exit code. And it cannot throw: the
+   probe is wrapped even though the default probe already catches internally, because
+   an exception here would take down every run — strictly worse than the degraded
+   state it describes.
+2. **Under-block.** It watches ONE module. A different native module breaking silently
+   gets no banner. That is deliberate: generalising to "native modules" from a single
+   incident would be inventing a class, which is the exact over-read that caused the
+   incident. It also cannot detect a module that loads, opens a DB, and misbehaves
+   later — the probe is a smoke test, not a health monitor.
+3. **Level-of-abstraction fit.** globalSetup is the right layer: a per-file check is
+   invisible to the next file (this file's sibling records that lesson explicitly),
+   and teardown is the only hook that runs after the summary.
+4. **Signal vs authority.** Pure signal. It gates nothing and rejects nothing.
+5. **Interactions.** Ordered AFTER `build-dist.globalSetup.ts`, so its teardown runs
+   FIRST (teardowns run in reverse) and the banner sits closest to the summary. It
+   shares no state with any other setup.
+6. **External surfaces.** None. Test-run stderr only; nothing ships to an agent or a
+   user, no file is written.
+7. **Multi-machine posture.** Machine-local BY DESIGN — it reports on THIS checkout's
+   node_modules. There is nothing to replicate; a peer's binary state is irrelevant to
+   a local run.
+8. **Rollback cost.** Remove the config entry, or delete the file. No migration, no
+   state, no consumer.
+
+## Class closure — what this does NOT close
+
+- **It does not prevent the cause.** An install that skips its postinstall still
+  produces a broken checkout; this only makes the consequence readable. The hygiene
+  fix (never installing with `--ignore-scripts`) is a habit, not code, and I am not
+  claiming otherwise.
+- **Only better-sqlite3**, and only at run start.
+- **Placement depends on vitest rendering teardown output after the summary.** That is
+  measured on vitest 2.1.9 here, not guaranteed by contract. If a future version
+  reorders it, the setup line still fires at the top — which is why both exist.
+
+## Evidence
+
+- 11/11 in `tests/unit/native-module-health-banner.test.ts`; `tsc --noEmit` exit 0 via
+  the real binary; full lint chain exit 0.
+- **Placement proven end-to-end.** The broken branch was forced by mutation and a real
+  suite was run; the banner rendered AFTER `Test Files / Tests / Duration`. **My first
+  mutation attempt applied 0 times and its own count control caught it** — that run
+  would have "passed" while proving nothing, which is the defect class this whole
+  change is about. Re-applied against the real line (count asserted at exactly 1),
+  re-run, restored byte-exact with 0 markers.
+- The incident's real signature is pinned: a module that LOADS but cannot open a
+  database is reported BROKEN. A require-only probe would have called the entire
+  outage healthy.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,9 @@ export default defineConfig(withTestRunnerBound('unit', {
     // globalSetup's own comment names: a per-file bootstrap is invisible to the next file
     // that needs it. Round 6 caught that `vitest.push` and `vitest.integration` got it and
     // this config did not.
-    globalSetup: ['tests/setup/build-dist.globalSetup.ts'],
+    // nativeModuleHealth is LAST in setup order, so its teardown runs FIRST —
+    // teardowns run in reverse, and the banner belongs closest to the summary.
+    globalSetup: ['tests/setup/build-dist.globalSetup.ts', 'tests/setup/nativeModuleHealth.globalSetup.ts'],
     setupFiles: ['./tests/vitest-setup.ts'],
     environment: 'node',
     testTimeout: 10000,


### PR DESCRIPTION
## ELI16 — saying once, where you will read it, that a broken part explains the mess

A full test run on this machine reported **225 failing files**. Nearly half had a single cause: the piece that stores things in a local database had not been built when dependencies were installed, so everything depending on it failed.

The software noticed. It said so clearly, named the exact fix, and said it **189 times**.

That did not help. The message was scattered through a 20MB log. I searched that log, **counted** how often the error appeared, and never read the three lines underneath the one I was counting — where the cause and the cure were written. Hours went into elaborate investigation of a question the output had already answered.

**So this adds no detection.** It moves the *same* message to the one place a person looks: printed once, at the end of the run, directly beneath the failure count — naming the likely cause, saying that failures above are probably consequences rather than separate problems, and giving the one command that fixes it.

**What it deliberately does not do:**
- **Never stops anything.** The project works with that piece missing and most tests never touch it; refusing to run would trade a confusing failure for a blocked one.
- **Completely silent when healthy** — which is nearly always. A line on every healthy run would add to the very pile that caused this.
- **Watches one specific thing**, not "anything native". Generalising from one incident is the same over-reading that caused the confusion.

## Evidence

- `tests/unit/native-module-health-banner.test.ts` — **11/11**.
- **Placement proven END-TO-END, not asserted.** The broken branch was forced by mutation and a real suite was run; the banner rendered **after** the `Test Files / Tests / Duration` summary. Source restored byte-exact, 0 markers.
- **My first mutation applied 0 times and its own count control caught it** — that run would have "passed" while proving nothing, which is exactly the defect class this change is about. Re-applied against the real line with the count asserted at 1.
- The incident's real signature is pinned: a module that **LOADS but cannot open a database** is reported broken. A require-only probe would have called the entire outage healthy, so the probe constructs rather than merely imports.
- **Over-block control:** given a healthy probe it writes nothing and returns no teardown. It also **cannot throw** — a throwing probe is reported, not propagated, because this runs before every suite and an exception here would take down every run.
- `tsc --noEmit` exit 0 via the real binary; full lint chain exit 0.

## Not closed

Scoped to better-sqlite3 alone. The install hygiene itself is unchanged — this makes the consequence legible, it does not prevent it. And placement depends on vitest rendering teardown output after the summary, which is *measured* on 2.1.9 here rather than guaranteed by contract; that is why a one-line warning also fires at setup.

Tier 1 — test-setup only, signal-only, no runtime surface.
