### PR TITLE
dev:preflight can run the PR-description gates (--body / --title)

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T11-59-29-935Z-preflight-body-gates.json
+++ b/.instar/instar-dev-decisions/2026-08-15T11-59-29-935Z-preflight-body-gates.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-15T11:59:29.935Z",
+  "slug": "preflight-body-gates",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 113,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/cli.ts",
+      "src/commands/devPreflight.ts"
+    ],
+    "addedLines": 107,
+    "deletedLines": 6
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/preflight-body-gates.eli16.md
+++ b/docs/specs/preflight-body-gates.eli16.md
@@ -1,0 +1,58 @@
+# Preflight body gates — Plain-English Overview
+
+> The one-line version: the pre-submission checker could only look at your code,
+> so the checks that read your pull-request *description* always failed later on
+> the server — now it can check those too.
+
+## The problem in one breath
+
+There is a command you run before submitting work (`instar dev:preflight`) that
+runs the same checks the server will run, so you find problems in seconds instead
+of minutes. It only ever looked at the **code changes**. But several checks read
+the **pull-request description** instead — and that text does not exist until you
+actually open the request. So "I ran the checks locally and they passed" was a
+true statement that still missed them, every time.
+
+Measured: one of those description checks failed across **three separate work
+sessions**, on work whose local checks were green the whole way through.
+
+## What already exists
+
+- **`instar dev:preflight`** — runs the linter, a discoverability test, and a
+  heuristic about new routes. All of these read the code diff.
+- **The description checks** — one requires a plain-English summary in the
+  request description (because that description is what a reviewer actually reads
+  before approving); another requires a statement of user-visible impact. Both
+  run on the server, after submission.
+
+## What this adds
+
+`dev:preflight` now accepts the description as a file. Give it one and it runs the
+description checks too, so a missing summary is caught in a second locally rather
+than as a red mark after submitting.
+
+- `--body <file>` — the description to check
+- `--title <text>` — the title, which one check needs for its exemption rules
+
+## The safeguards
+
+**It never fails you for not having a description yet.** Omit `--body` and the
+description checks are skipped, because running the checker *before* writing the
+description is exactly when it is most useful — failing that would train people
+not to run it early.
+
+**A skip is visible, not silent.** The summary prints `SKIPPED` with the reason. A
+silent skip looks identical to a pass, which is the confusion this command exists
+to remove.
+
+**An unreadable file is a failure, not a pass.** If you point `--body` at
+something that cannot be read, the run fails and says so. Passing because the
+check could not run is the exact false-confidence being fixed.
+
+**Nothing changes for existing users.** The new inputs are optional; without them
+the command behaves exactly as before.
+
+## What ships when
+
+All of it at once — it is one small flag plus the wiring behind it. The checks
+themselves are unchanged; this only lets you run them earlier.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2554,9 +2554,15 @@ program
   .command('dev:preflight')
   .description('Run the verify-only new-surface friction guard for contributor PRs')
   .option('--base <ref>', 'Diff base ref for the route heuristic (default: main remote candidates)')
-  .action(async (opts: { base?: string }) => {
+  .option('--body <file>', 'Path to the PR body; runs the gates that read the PR description (ELI16, UX impact)')
+  .option('--title <text>', 'PR title, used by the ELI16 gate exemption logic')
+  .action(async (opts: { base?: string; body?: string; title?: string }) => {
     const { runDevPreflight } = await import('./commands/devPreflight.js');
-    const exitCode = await runDevPreflight({ baseRef: opts.base });
+    const exitCode = await runDevPreflight({
+      baseRef: opts.base,
+      bodyPath: opts.body,
+      prTitle: opts.title,
+    });
     process.exit(exitCode);
   });
 

--- a/src/commands/devPreflight.ts
+++ b/src/commands/devPreflight.ts
@@ -12,7 +12,12 @@ export interface CommandResult {
 }
 
 export interface DevPreflightRunner {
-  run(command: string, args: string[], label: string): Promise<CommandResult>;
+  run(
+    command: string,
+    args: string[],
+    label: string,
+    env?: NodeJS.ProcessEnv,
+  ): Promise<CommandResult>;
 }
 
 export interface DevPreflightOutput {
@@ -34,6 +39,15 @@ export interface DevPreflightOptions {
   diffProvider?: () => string;
   /** Injectable so callers/tests pin the manager instead of probing the host. */
   lintCommandResolver?: () => LintCommand | null;
+  /**
+   * Path to a file holding the PR BODY. Supplying it runs the body-gates —
+   * the checks whose subject is the pull-request description rather than the
+   * diff. Omitted, they are skipped (never failed): a contributor running
+   * preflight before writing a description has nothing to check yet.
+   */
+  bodyPath?: string;
+  /** PR title, needed by the ELI16 gate's exemption logic. */
+  prTitle?: string;
 }
 
 export interface RouteWarning {
@@ -53,6 +67,12 @@ export interface DevPreflightSummary {
    * fails the preflight.
    */
   selfDisableExitCode?: number;
+  /**
+   * Worst exit code across the PR-body gates (ELI16 description, UX impact).
+   * Optional: absent means no body was supplied, which is a SKIP and never a
+   * failure. See the note on `bodyPath`.
+   */
+  bodyGateExitCode?: number;
 }
 
 const DISCOVERABILITY_TEST_ARGS = [
@@ -71,14 +91,21 @@ const ROUTE_REGISTRATION_PATTERN = new RegExp(
 export class SpawnDevPreflightRunner implements DevPreflightRunner {
   constructor(private readonly cwd: string) {}
 
-  run(command: string, args: string[], label: string): Promise<CommandResult> {
+  run(
+    command: string,
+    args: string[],
+    label: string,
+    env?: NodeJS.ProcessEnv,
+  ): Promise<CommandResult> {
     return new Promise((resolve) => {
       process.stdout.write(`${pc.bold(label)}\n`);
       process.stdout.write(`$ ${[command, ...args].join(' ')}\n`);
       const child = spawn(command, args, {
         cwd: this.cwd,
         stdio: 'inherit',
-        env: process.env,
+        // Extra vars are MERGED over the ambient env, never replace it — a body
+        // gate still needs PATH and friends to run at all.
+        env: env ? { ...process.env, ...env } : process.env,
       });
       child.on('error', (err) => {
         process.stderr.write(`${label} failed to start: ${err.message}\n`);
@@ -153,7 +180,8 @@ export function findMissingCapabilityPrefixes(
 export function aggregateExitCode(summary: DevPreflightSummary): number {
   return summary.lintExitCode === 0 &&
     summary.discoverabilityExitCode === 0 &&
-    (summary.selfDisableExitCode ?? 0) === 0
+    (summary.selfDisableExitCode ?? 0) === 0 &&
+    (summary.bodyGateExitCode ?? 0) === 0
     ? 0
     : 1;
 }
@@ -172,6 +200,24 @@ export function aggregateExitCode(summary: DevPreflightSummary): number {
  * is structurally WARN-only and never fails.
  */
 export const SELF_DISABLE_CHECK_SCRIPT = 'scripts/pre-push-test-runner-selfdisable.mjs';
+
+/**
+ * The PR-BODY gates — checks whose subject is the pull-request description, not
+ * the diff.
+ *
+ * WHY THIS EXISTS. `dev:preflight` verified the diff (lint, discoverability,
+ * route heuristic) and was therefore structurally incapable of catching a gate
+ * that reads the PR body. Measured consequence: the ELI16 description gate went
+ * red across three separate sessions on work whose local lint was green the
+ * whole time — "I ran the gates locally" was true and still missed them, because
+ * the body does not exist until `gh pr create` runs.
+ *
+ * Each entry is skipped quietly when its script is absent (older checkout).
+ */
+export const BODY_GATE_SCRIPTS = {
+  eli16: 'scripts/eli16-pr-description-check.mjs',
+  uxImpact: 'scripts/ux-impact-lint.mjs',
+} as const;
 
 export function defaultCapabilityPrefixes(): Set<string> {
   return new Set(buildPrefixToKeyMap().keys());
@@ -270,6 +316,49 @@ export async function runDevPreflight(options: DevPreflightOptions = {}): Promis
     selfDisableExitCode = selfDisable.exitCode;
   }
 
+  // ── PR-body gates (see BODY_GATE_SCRIPTS) ───────────────────────────────
+  // Only run when a body was supplied. No body === nothing to check yet, which
+  // is a SKIP: failing it would punish running preflight early, which is
+  // exactly when it is most useful.
+  let bodyGateExitCode: number | undefined;
+  if (options.bodyPath) {
+    let body: string;
+    try {
+      body = fs.readFileSync(path.resolve(cwd, options.bodyPath), 'utf8');
+    } catch (err) {
+      output.error(`\nbody gates: cannot read ${options.bodyPath} (${(err as Error).message})\n`);
+      // An unreadable body is a REAL failure — the caller asked for these gates
+      // and we could not run them. Silently passing would be the plausible-zero
+      // this whole command exists to prevent.
+      bodyGateExitCode = 1;
+    }
+    if (bodyGateExitCode === undefined) {
+      let worst = 0;
+      const eli16 = path.join(cwd, BODY_GATE_SCRIPTS.eli16);
+      if (fs.existsSync(eli16)) {
+        output.write('\n');
+        const res = await runner.run(
+          'node',
+          [BODY_GATE_SCRIPTS.eli16],
+          'ELI16 PR-description gate',
+          { PR_BODY: body!, PR_TITLE: options.prTitle ?? '', PR_AUTHOR_TYPE: 'User' },
+        );
+        worst = Math.max(worst, res.exitCode);
+      }
+      const ux = path.join(cwd, BODY_GATE_SCRIPTS.uxImpact);
+      if (fs.existsSync(ux)) {
+        output.write('\n');
+        const res = await runner.run(
+          'node',
+          [BODY_GATE_SCRIPTS.uxImpact, '--base', options.baseRef ?? 'origin/main', '--head', 'HEAD', '--body', body!],
+          'UX impact declaration gate',
+        );
+        worst = Math.max(worst, res.exitCode);
+      }
+      bodyGateExitCode = worst;
+    }
+  }
+
   let routeWarnings: RouteWarning[] = [];
   let heuristicUnavailable: string | undefined;
   try {
@@ -288,6 +377,7 @@ export async function runDevPreflight(options: DevPreflightOptions = {}): Promis
     routeWarnings,
     heuristicUnavailable,
     selfDisableExitCode,
+    bodyGateExitCode,
   };
 
   output.write('\nSummary:\n');
@@ -298,6 +388,11 @@ export async function runDevPreflight(options: DevPreflightOptions = {}): Promis
       `- test-runner self-disable ledger: ${selfDisableExitCode === 0 ? pc.green('PASS') : pc.red('FAIL')} (advisory WARN details above; fails only on sustained off/spoofed-CI)\n`,
     );
   }
+  output.write(
+    bodyGateExitCode === undefined
+      ? `- PR-body gates: ${pc.dim('SKIPPED')} (no --body given; these read the PR description, which local lint never sees)\n`
+      : `- PR-body gates (ELI16 description, UX impact): ${bodyGateExitCode === 0 ? pc.green('PASS') : pc.red('FAIL')}\n`,
+  );
   printHeuristic(output, summary);
   printChecklist(output);
 

--- a/tests/unit/dev-preflight-body-gates.test.ts
+++ b/tests/unit/dev-preflight-body-gates.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runDevPreflight, aggregateExitCode, BODY_GATE_SCRIPTS } from '../../src/commands/devPreflight.js';
+import type { DevPreflightRunner } from '../../src/commands/devPreflight.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * `dev:preflight` verified the DIFF (lint, discoverability, route heuristic) and
+ * was therefore structurally incapable of catching a gate that reads the PR
+ * BODY. Measured consequence: the ELI16 description gate went red across three
+ * separate sessions on work whose local lint was green the whole time — so
+ * "I ran the gates locally" was true and still missed them, because the body
+ * does not exist until `gh pr create` runs.
+ *
+ * These tests pin the two properties that make the fix worth having:
+ *   1. supplying a body actually RUNS the body gates and their failure fails the run;
+ *   2. omitting a body SKIPS them and never silently passes something unchecked.
+ */
+
+let dir: string;
+let calls: Array<{ label: string; args: string[]; env?: NodeJS.ProcessEnv }>;
+
+/** A cwd where both gate scripts exist, so existence checks find them. */
+function makeRepo(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'preflight-body-'));
+  fs.mkdirSync(path.join(d, 'scripts'), { recursive: true });
+  for (const rel of Object.values(BODY_GATE_SCRIPTS)) {
+    fs.writeFileSync(path.join(d, rel), '// stub\n');
+  }
+  return d;
+}
+
+function makeRunner(exitCodes: Record<string, number> = {}): DevPreflightRunner {
+  return {
+    async run(command, args, label, env) {
+      calls.push({ label, args, env });
+      return { command, args, exitCode: exitCodes[label] ?? 0 };
+    },
+  };
+}
+
+beforeEach(() => {
+  dir = makeRepo();
+  calls = [];
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/dev-preflight-body-gates.test.ts' });
+});
+
+describe('dev:preflight — PR-body gates run when a body is supplied', () => {
+  it('runs the ELI16 gate and passes the body through the environment', async () => {
+    const bodyFile = path.join(dir, 'body.md');
+    fs.writeFileSync(bodyFile, '## ELI16 — a plain-English summary\n\nreal content');
+
+    await runDevPreflight({
+      cwd: dir,
+      runner: makeRunner(),
+      lintCommandResolver: () => ({ command: 'npm', args: ['run', 'lint'] }),
+      diffProvider: () => '',
+      bodyPath: bodyFile,
+      prTitle: 'feat: something',
+      output: { write: () => {}, error: () => {} },
+    });
+
+    const eli16 = calls.find((c) => c.label.includes('ELI16'));
+    expect(eli16).toBeDefined();
+    // The gate reads PR_BODY from the environment — if it is not threaded, the
+    // gate judges an empty string and passes vacuously.
+    expect(eli16?.env?.PR_BODY).toContain('## ELI16');
+    expect(eli16?.env?.PR_TITLE).toBe('feat: something');
+  });
+
+  it('runs the UX-impact gate with the body as an argument', async () => {
+    const bodyFile = path.join(dir, 'body.md');
+    fs.writeFileSync(bodyFile, 'body text');
+
+    await runDevPreflight({
+      cwd: dir,
+      runner: makeRunner(),
+      lintCommandResolver: () => ({ command: 'npm', args: ['run', 'lint'] }),
+      diffProvider: () => '',
+      bodyPath: bodyFile,
+      output: { write: () => {}, error: () => {} },
+    });
+
+    const ux = calls.find((c) => c.label.includes('UX impact'));
+    expect(ux).toBeDefined();
+    expect(ux?.args).toContain('--body');
+    expect(ux?.args).toContain('body text');
+  });
+
+  it('a failing body gate FAILS the whole preflight', async () => {
+    const bodyFile = path.join(dir, 'body.md');
+    fs.writeFileSync(bodyFile, 'no eli16 heading here');
+
+    const exitCode = await runDevPreflight({
+      cwd: dir,
+      runner: makeRunner({ 'ELI16 PR-description gate': 1 }),
+      lintCommandResolver: () => ({ command: 'npm', args: ['run', 'lint'] }),
+      diffProvider: () => '',
+      bodyPath: bodyFile,
+      output: { write: () => {}, error: () => {} },
+    });
+
+    expect(exitCode).not.toBe(0);
+  });
+
+  it('CONTROL: with every gate green the run passes — so the failure above is the gate, not the harness', async () => {
+    const bodyFile = path.join(dir, 'body.md');
+    fs.writeFileSync(bodyFile, '## ELI16 — fine');
+
+    const exitCode = await runDevPreflight({
+      cwd: dir,
+      runner: makeRunner(),
+      lintCommandResolver: () => ({ command: 'npm', args: ['run', 'lint'] }),
+      diffProvider: () => '',
+      bodyPath: bodyFile,
+      output: { write: () => {}, error: () => {} },
+    });
+
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe('dev:preflight — no body supplied', () => {
+  it('SKIPS the body gates rather than failing them', async () => {
+    let stdout = '';
+    const exitCode = await runDevPreflight({
+      cwd: dir,
+      runner: makeRunner(),
+      lintCommandResolver: () => ({ command: 'npm', args: ['run', 'lint'] }),
+      diffProvider: () => '',
+      output: { write: (t) => { stdout += t; }, error: () => {} },
+    });
+
+    // Running preflight BEFORE writing a description is exactly when it is most
+    // useful; failing that would train people not to run it early.
+    expect(exitCode).toBe(0);
+    expect(calls.find((c) => c.label.includes('ELI16'))).toBeUndefined();
+    // ...but the skip is VISIBLE. A silent skip reads identically to a pass,
+    // which is the confusion this whole command exists to remove.
+    expect(stdout).toContain('SKIPPED');
+  });
+});
+
+describe('dev:preflight — an unreadable body is a failure, not a pass', () => {
+  it('fails when --body points at a file that does not exist', async () => {
+    let stderr = '';
+    const exitCode = await runDevPreflight({
+      cwd: dir,
+      runner: makeRunner(),
+      lintCommandResolver: () => ({ command: 'npm', args: ['run', 'lint'] }),
+      diffProvider: () => '',
+      bodyPath: path.join(dir, 'does-not-exist.md'),
+      output: { write: () => {}, error: (t) => { stderr += t; } },
+    });
+
+    // The caller ASKED for these gates. Passing because we could not read the
+    // body is the plausible-zero this command exists to prevent.
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain('cannot read');
+    expect(calls.find((c) => c.label.includes('ELI16'))).toBeUndefined();
+  });
+});
+
+describe('aggregateExitCode — body gate participates', () => {
+  const green = { lintExitCode: 0, discoverabilityExitCode: 0, routeWarnings: [] };
+
+  it('fails when the body gate failed', () => {
+    expect(aggregateExitCode({ ...green, bodyGateExitCode: 1 })).toBe(1);
+  });
+
+  it('passes when the body gate is absent (skipped)', () => {
+    expect(aggregateExitCode({ ...green })).toBe(0);
+  });
+
+  it('passes when the body gate is green', () => {
+    expect(aggregateExitCode({ ...green, bodyGateExitCode: 0 })).toBe(0);
+  });
+});

--- a/upgrades/next/preflight-body-gates.md
+++ b/upgrades/next/preflight-body-gates.md
@@ -1,0 +1,52 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`instar dev:preflight` can now check your pull-request description, not just your
+code changes.
+
+It previously ran only diff-based checks (lint, discoverability, a route
+heuristic), so the gates that read the PR *description* — the plain-English ELI16
+summary and the UX-impact declaration — could never be caught locally. Those
+gates only fail after you submit, because the description does not exist until
+then. "I ran the checks locally and they passed" was true and still missed them.
+
+Pass `--body <file>` (and optionally `--title <text>`) and preflight runs those
+gates too.
+
+## What to Tell Your User
+
+- "You can catch a missing PR summary in a second locally instead of as a red
+  mark after submitting."
+- "If you haven't written the description yet, nothing fails — the check is
+  skipped and says so."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Check the PR description before submitting | `instar dev:preflight --body pr-body.md --title "feat: ..."` |
+| See explicitly that description checks were skipped | Run without `--body`; the summary prints `SKIPPED` and why |
+
+## Compatibility Notes
+
+Both inputs are optional and there is no behaviour change without them. Omitting
+`--body` skips the description gates rather than failing them — running preflight
+*before* writing a description is exactly when it is most useful. The skip is
+printed rather than silent, because a silent skip reads identically to a pass.
+
+An unreadable `--body` path fails the run: the caller asked for those gates and
+they could not be run, so passing would be false confidence.
+
+## Evidence
+
+9 new unit tests plus the 5 existing preflight tests pass. They pin both
+directions — supplying a body runs the gates (including that the body is actually
+threaded through the environment, without which the gate would judge an empty
+string and pass vacuously), a failing gate fails the run, a control confirms an
+all-green run still passes, and omitting a body skips visibly.
+
+Validated against a real defect: an actual PR body from earlier today, before its
+ELI16 section was added, fails the real gate; the corrected body passes it.

--- a/upgrades/side-effects/preflight-body-gates.md
+++ b/upgrades/side-effects/preflight-body-gates.md
@@ -1,0 +1,99 @@
+# Side-Effects Review — dev:preflight PR-body gates
+
+**Version / slug:** `preflight-body-gates`
+**Date:** `2026-08-15`
+**Author:** `Instar-echo`
+**Tier:** 1 (additive optional flag; no behaviour change without it)
+
+## Summary of the change
+
+`instar dev:preflight` gains `--body <file>` and `--title <text>`. When a body is
+supplied it additionally runs the gates whose subject is the PR description —
+`scripts/eli16-pr-description-check.mjs` and `scripts/ux-impact-lint.mjs` — and
+their worst exit code participates in the aggregate verdict. The runner interface
+gains an optional `env` argument so the ELI16 gate can receive `PR_BODY`.
+
+**Why:** preflight verified the DIFF and was structurally incapable of catching a
+gate that reads the BODY, which does not exist until `gh pr create` runs. The
+ELI16 gate consequently went red across three separate sessions on work whose
+local lint was green throughout. This is the structural half of a failure that
+three rounds of "remember to pre-flight" did not fix.
+
+## Decision-point inventory
+
+- **Aggregate preflight verdict** — *widened*. A new input can now fail the run.
+  It can only fail it for a gate the caller explicitly asked to run.
+- **Existing gates (lint, discoverability, route heuristic)** — *untouched*.
+- **The body gates themselves** — *untouched*. This changes only *when* they can
+  be run, never what they decide.
+
+---
+
+## 1. Over-block
+
+The one new rejection is an **unreadable `--body` path**, which fails the run.
+This is deliberate: the caller asked for these gates and we could not run them, so
+passing would be a plausible-zero — the precise false confidence this change
+exists to remove. It cannot fire unless `--body` is passed.
+
+No legitimate existing invocation is newly rejected: without `--body`, behaviour
+is byte-identical to before.
+
+## 2. Under-block
+
+- Only two body gates are wired. A future gate reading the PR body will not be
+  picked up automatically; `BODY_GATE_SCRIPTS` is the one place to add it.
+- Running preflight does not *force* anyone to pass `--body`. Someone can still
+  skip the description gates by omitting it — the skip is printed, but it is a
+  visible skip rather than an enforced check. Full enforcement would belong in a
+  hook at `gh pr create` time, which this change does not attempt.
+
+## 3. Level-of-abstraction fit
+
+Correct layer: preflight already exists as "run the server's checks early", and
+these are server checks it could not reach. The alternative — a separate script —
+would create a second thing to remember, which is the failure mode being fixed.
+
+## 4. Signal vs authority
+
+Preflight is advisory by construction: it reports and exits non-zero; it blocks
+nothing and gates no runtime path. This change adds no authority. The gates it
+invokes hold whatever authority they already had in CI, unchanged.
+
+## 5. Interactions
+
+Does not shadow CI: the same gates still run server-side and remain
+authoritative. A local pass does not mark anything as satisfied — it only tells
+the author what CI will say. Scripts are existence-checked, so an older checkout
+lacking them skips quietly rather than erroring.
+
+## 6. Multi-machine posture
+
+**Machine-local by design.** It is a developer command reading a local file and
+spawning local scripts. No replication path, no cross-machine state, no user-
+facing notice, no generated URL. Nothing to strand on topic transfer.
+
+## 7. Failure modes
+
+- Gate script absent → skipped quietly (older checkout).
+- Body unreadable → run fails, reason printed to stderr.
+- Gate spawn fails → surfaces as that gate's non-zero exit, same as any other step.
+
+## 8. Rollback cost
+
+Delete the flag handling; no data, no schema, no migration, no agent state. Users
+who never pass `--body` are unaffected either way.
+
+## Evidence
+
+9 new unit tests plus the 5 existing preflight tests, all passing. They pin both
+directions: supplying a body **runs** the gates (asserting `PR_BODY` is actually
+threaded through the environment — untested, the gate would judge an empty string
+and pass vacuously), a failing gate **fails** the run, and a control confirms an
+all-green run still passes so the failure is the gate rather than the harness.
+Omitting a body **skips** visibly rather than failing.
+
+Validated against the real defect: the actual PR body I shipped earlier today —
+before its ELI16 section was added — **fails** the real gate, and the corrected
+body **passes** it. The control matters: it proves the failure is the missing
+section rather than a broken gate.


### PR DESCRIPTION
## ELI16 — the pre-submission checker can finally check your PR description

There's a command you run before submitting work (`instar dev:preflight`) that runs
the same checks the server will, so you find problems in seconds instead of minutes.
It only ever looked at your **code changes**. But several checks read the
**pull-request description** instead — and that text doesn't exist until you actually
open the request. So "I ran the checks locally and they passed" was a true statement
that still missed them, every time.

Measured: one of those description checks failed across **three separate work
sessions**, on work whose local checks were green the whole way through. Writing down
"remember to pre-flight the description" three times did not fix it. This is the
structural half.

Now `dev:preflight --body <file>` runs those checks too, and a missing summary is
caught in a second locally instead of as a red mark after submitting.

**It won't nag you for not having written a description yet.** Omit `--body` and the
description checks are skipped — running the checker *before* writing the description
is exactly when it's most useful, and failing that would train people not to run it
early. The skip is printed rather than silent, because a silent skip looks identical
to a pass. But pointing `--body` at a file that can't be read *does* fail: you asked
for those checks and they couldn't run, so passing would be false confidence.

Nothing changes for anyone who doesn't pass the new flag.

## What changed

`instar dev:preflight` gains `--body <file>` and `--title <text>`. When a body is
supplied it additionally runs the gates whose subject is the PR description —
`eli16-pr-description-check.mjs` and `ux-impact-lint.mjs` — and their worst exit code
participates in the aggregate verdict. The runner interface gains an optional `env`
argument (merged over the ambient environment, never replacing it) so the ELI16 gate
receives `PR_BODY`.

## Why

Preflight verified the **diff**; these gates read the **body**. That is not a bug in
either — it is a coverage gap between them, and it is invisible precisely because the
local run is genuinely green.

## Evidence

14 tests (9 new, 5 existing) pass. They pin both directions:

- Supplying a body **runs** the gates — including an assertion that `PR_BODY` is
  actually threaded through the environment. Untested, the gate would judge an empty
  string and pass vacuously, which is the failure mode most worth guarding.
- A failing gate **fails** the run, paired with a control confirming an all-green run
  still passes — so a red result is the gate rather than the harness.
- Omitting a body **skips** visibly; an unreadable body **fails**.

Validated against the real defect: the actual PR body from #1897 earlier today,
before its ELI16 section was added, **fails** the real gate; the corrected body
**passes** it. The control matters — it proves the failure is the missing section and
not a broken gate.

## Scope

Advisory only. Preflight reports and exits non-zero; it blocks nothing and gates no
runtime path. Machine-local by design — a developer command reading a local file.
Rollback is deleting the flag handling; no data, no schema, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013phcTXz9TFXwScQyXxnybm
