### PR TITLE
test(parity): drop a CI exclusion for a file that no longer exists

### DIFF
--- a/tests/unit/recheck-parked-tests.test.ts
+++ b/tests/unit/recheck-parked-tests.test.ts
@@ -55,11 +55,26 @@ describe('parked-test re-check', () => {
     expect(report.parkedTotal).toBeGreaterThan(50);
   });
 
-  it('finds the dangling entry that excludes a file which does not exist', () => {
+  it('RATCHET: the live exclusion list has no entry for a file that does not exist', () => {
+    // This used to assert the OPPOSITE — that the report CONTAINS
+    // 'tests/unit/slack-stall-active-gate.test.ts', the one real dangling entry
+    // in the repo at the time. That made a known defect load-bearing: fixing the
+    // dangling entry broke the test that used it as a fixture, and the only way
+    // to go green was to put the defect back.
+    //
+    // The capability this was reaching for — "the tool detects an exclusion whose
+    // file is gone" — is proven properly by the synthetic-config test below,
+    // which builds two missing files and requires both to be found. That proof
+    // does not need the repo to keep a defect around.
+    //
+    // So the assertion is inverted into a ratchet: the list must stay clean. Park
+    // a test and later delete the file, and this goes red — which is the failure
+    // the parked-list re-check exists to surface.
     const report = runAgainstRealRepo();
-    expect(report.missingFiles).toContain('tests/unit/slack-stall-active-gate.test.ts');
-    // Exactly one, not the 42 the naive parser hallucinated.
-    expect(report.missingFiles.length).toBeLessThan(5);
+    expect(
+      report.missingFiles,
+      'an exclusion points at a file that no longer exists — remove the exclusion, do not re-add the file',
+    ).toEqual([]);
   });
 
   it('reports glob patterns separately rather than pretending they are files', () => {

--- a/vitest.push.config.ts
+++ b/vitest.push.config.ts
@@ -225,8 +225,6 @@ const FLAKY_TESTS = [
   'tests/integration/server-full.test.ts',
   'tests/e2e/phase4-multi-machine-coordination.test.ts',
 
-  // ── Test-first stubs (feature not yet implemented) ────────────────
-  'tests/unit/slack-stall-active-gate.test.ts',
 ];
 
 export default defineConfig(withTestRunnerBound('push', {


### PR DESCRIPTION
## ELI16 — deleting a rule that guards a file that no longer exists

Some tests are deliberately kept out of the automatic checks because they fail
unpredictably and would block everyone. That's a reasonable thing to do — but the list
of exclusions is only trustworthy if someone revisits it, and nobody had.

A recent measurement found that list keeps **97 real test files out of the automatic
checks entirely** — they run on a developer's machine and are executed by no automated
job at all. One entry on it points at a test file that **has since been deleted**. The
rule outlived the thing it was written for, and would have sat there indefinitely,
because a rule excluding a file that doesn't exist never fails and never complains.

This removes that one entry. It was the only item under its heading, so the now-empty
heading goes too. Ninety-one exclusions become ninety.

**Why only one, when 96 remain.** The other 96 each need their own verdict — genuinely
unreliable, fine and safe to restore, or simply stale. Removing them in bulk would
recreate the exact carelessness that produced the list. Those are dispatched to
parallel lanes for individual judgement. This one needed no judgement: the file is
gone, which is checkable rather than arguable.

## User-visible impact

None. No code, no behaviour, no configuration anyone sets. One dead line removed from a
test-runner exclusion list.

## Evidence

The excluded file is absent from disk **and** untracked in `main`.

Checked with a control: the same probe run against a file known to exist returns 1,
while this one returns 0 — so the zero is a measurement rather than a broken search. A
bare "not found" is exactly the result worth distrusting, so it was not accepted on its
own.

After the change: TypeScript compiles clean, and the push config still resolves the full
test-file set, confirming the list is still syntactically live and only shorter.

Source of the finding: `docs/audits/local-ci-test-parity.md`.
