### PR TITLE
fix(gate): let operator replies claim the interactive spawn reserve

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T20-21-17-832Z-tone-gate-interactive-lane.json
+++ b/.instar/instar-dev-decisions/2026-08-15T20-21-17-832Z-tone-gate-interactive-lane.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T20:21:17.832Z",
+  "slug": "tone-gate-interactive-lane",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 27,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/server/routes.ts"
+    ],
+    "addedLines": 27,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tone-gate-interactive-lane.eli16.md
+++ b/docs/specs/tone-gate-interactive-lane.eli16.md
@@ -1,0 +1,65 @@
+# Replies to the operator can finally use the capacity reserved for them — Plain-English Overview
+
+> The one-line version: two slots were being held open for the agent's replies to
+> its operator, nothing ever claimed them, and replies were being blocked instead.
+
+## The problem in one breath
+
+Everything the agent asks a model to do — background classifiers, safety checks,
+and the review that every outgoing message passes through — competes for a fixed
+number of concurrent slots on this machine. Eight of them.
+
+Background work has been misbehaving: each stalled request holds a slot until it
+times out, up to a minute. When enough of them pile up, there is no slot left, and
+the check that clears the agent's replies **fails closed** — the message is held
+rather than sent.
+
+That is not hypothetical. While the operator was awake and waiting for a live
+demonstration, the agent's messages to him were refused **twelve times over about
+fifteen minutes**, purely because background work had taken every slot.
+
+## The part that makes this worth fixing rather than tuning
+
+Someone already anticipated this. **Two of the eight slots are reserved** for
+exactly this case — a check that a human is actively waiting on — and the reply
+check is on the short list of things permitted to use that reserve. The
+reservation was switched on.
+
+It claims the reserve only when told two things: that the message is going to the
+operator, and that someone is waiting for **this specific message**.
+
+It was being told the first. It was never told the second. So the condition was
+never true, the reserved slots were **never once claimed**, and the replies they
+exist to protect queued behind the very background work they were meant to be
+protected from. Measured during the failures: the reserve showed zero occupants.
+
+## What this changes
+
+One line. The reply path now says whether a human is waiting.
+
+It knows already: an ordinary reply to someone's message is exactly that case,
+while scheduled updates, health alerts and background notices are not — nobody is
+blocked on those, so they keep using ordinary capacity.
+
+## The safeguards
+
+**Only genuine replies to the operator qualify.** Two separate conditions must
+both hold. A scheduled message doesn't qualify; a conversation with someone who
+isn't the verified operator doesn't qualify. Tests cover both of those refusals,
+because a fix that made *everything* interactive would empty the reserve of meaning.
+
+**A short list already limits who may ask.** Only two components are permitted to
+claim the reserve at all; anything else asking is quietly put back on ordinary
+capacity. That guard already existed and is untouched.
+
+**It changes routing, not judgement.** This decides which queue a check waits in.
+It does not change the check, its verdict, or whether a message is allowed.
+
+**Proved by removing it.** With the change reverted, the one test asserting the
+reserve is claimed fails and the three guard tests still pass — so the tests
+measure this change and not something nearby.
+
+## What ships when
+
+All at once, and it needs no configuration. The reservation itself was already
+enabled; this simply lets the thing it was reserved for ask for it.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2930,6 +2930,33 @@ export function createRoutes(ctx: RouteContext): Router {
           templateFingerprint,
           agentState,
           recipientClass,
+          // F5 interactive reservation (spec spawn-cap-interactive-priority §A).
+          //
+          // The host spawn cap reserves slots for a lane the gate is explicitly
+          // named for — a synchronous, user-blocking review. The gate claims that
+          // reserve only when the caller says BOTH that the recipient is the
+          // operator AND that a human is waiting on THIS message. It already
+          // received the first; nothing ever sent the second, so `interactiveLane`
+          // was permanently false and the reserved slots were never claimed —
+          // operator replies queued behind background work and were held closed
+          // under load (observed: 12 refusals in ~15 minutes during a live demo,
+          // with liveInteractive reading 0 throughout).
+          //
+          // `'reply'` IS that condition, exactly: it is set only for a reply to a
+          // live inbound turn. Every other kind — automated cadence, health
+          // alerts, unknown — is proactive: nobody is blocked on it, so it stays
+          // on the background lane. Deriving it here rather than adding a
+          // parameter keeps the classification at the one place that already
+          // knows, and makes the safe value the default for every other caller.
+          //
+          // ABSENT means 'reply'. That is this file's own established convention
+          // (`kindForSignals` above resolves it the same way, and the reply route
+          // documents "absent → 'reply'"), and it is the COMMON case: an ordinary
+          // conversational reply carries no explicit kind. A strict equality here
+          // silently excluded exactly the messages this reserve exists to protect
+          // — caught by the integration test, which is why it drives the real route
+          // rather than calling the gate directly.
+          synchronousReply: (options.messageKind ?? 'reply') === 'reply',
           // Undefined in observe-only mode (the default) and on every uncertainty,
           // so the gate's verdict is unchanged until graduation (BIAS-TO-ACTION D8).
           standingAuthorization,

--- a/tests/integration/tone-gate-interactive-lane.test.ts
+++ b/tests/integration/tone-gate-interactive-lane.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Operator replies must claim the interactive spawn reserve.
+ *
+ * The host spawn cap reserves slots for a lane the tone gate is explicitly named
+ * for — a synchronous, user-blocking review. The gate claims that reserve only
+ * when its caller says BOTH that the recipient is the operator AND that a human
+ * is waiting on THIS message.
+ *
+ * It always received the first. Nothing ever sent the second, so the lane was
+ * permanently background and the reserved slots were never claimed: operator
+ * replies queued behind background work and were held closed under load.
+ * Observed, not theorised — 12 refusals in ~15 minutes during a live demo, with
+ * the limiter reporting liveInteractive: 0 the whole time.
+ *
+ * This is the integration tier deliberately, because the unit tier cannot see the
+ * defect: the gate's lane logic was already correct and already tested. What was
+ * broken was the WIRING, and only driving the real route through the real gate
+ * shows whether the flag arrives.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { MessagingToneGate } from '../../src/core/MessagingToneGate.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+
+interface TestServer {
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function listen(app: express.Express): Promise<TestServer> {
+  return await new Promise<TestServer>((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ port, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+/** Captures the attribution every review call carries — the thing under test. */
+function capturingProvider(seen: IntelligenceOptions['attribution'][]): IntelligenceProvider {
+  return {
+    evaluate: async (_prompt: string, options?: IntelligenceOptions) => {
+      seen.push(options?.attribution);
+      return JSON.stringify({ pass: true, rule: '', issue: '', suggestion: '' });
+    },
+  };
+}
+
+/** A topic whose verified operator is a single known uid → recipientClass 'operator'. */
+function operatorStore(uid = 'uid-operator'): unknown {
+  return {
+    asVerifiedOperator: () => ({ uid, displayName: 'Justin' }),
+    all: () => ({ 29723: { uid, displayName: 'Justin' } }),
+  };
+}
+
+function buildApp(opts: {
+  toneGate: MessagingToneGate | null;
+  sent: Array<{ topicId: number; text: string }>;
+  topicOperatorStore?: unknown;
+}): express.Express {
+  const app = express();
+  app.use(express.json());
+  const ctx: any = {
+    config: {
+      authToken: 'test',
+      stateDir: fs.mkdtempSync(path.join(os.tmpdir(), 'interactive-lane-')),
+      port: 0,
+      projectName: 'echo',
+    },
+    messagingToneGate: opts.toneGate,
+    topicOperatorStore: opts.topicOperatorStore ?? operatorStore(),
+    telegram: {
+      sendToTopic: async (topicId: number, text: string) => {
+        opts.sent.push({ topicId, text });
+      },
+    },
+    sessionManager: { clearInjectionTracker: () => {} },
+  };
+  app.use(createRoutes(ctx));
+  return app;
+}
+
+async function postReply(
+  port: number,
+  topicId: number,
+  body: Record<string, unknown>,
+): Promise<{ status: number; body: string }> {
+  // The topic is a PATH parameter on this route, not a body field.
+  const res = await fetch(`http://127.0.0.1:${port}/telegram/reply/${topicId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+describe('POST /telegram/reply — interactive spawn reserve', () => {
+  let server: TestServer;
+  let seen: IntelligenceOptions['attribution'][];
+  let sent: Array<{ topicId: number; text: string }>;
+
+  beforeEach(() => {
+    seen = [];
+    sent = [];
+  });
+
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it('THE FIX: an operator reply is marked as the interactive lane', async () => {
+    const app = buildApp({ toneGate: new MessagingToneGate(capturingProvider(seen)), sent });
+    server = await listen(app);
+
+    const r = await postReply(server.port, 29723, { text: 'a normal conversational reply to your message' });
+    expect(r.status, r.body).toBe(200);
+
+    expect(seen.length).toBeGreaterThan(0);
+    const attr = seen[0]!;
+    expect(attr?.component).toBe('MessagingToneGate');
+    // The load-bearing assertion: without this the reserved slots are never
+    // claimed and the reply competes with background work for the same cap.
+    expect((attr as { lane?: string })?.lane).toBe('interactive');
+  });
+
+  it('CONTROL: an AUTOMATED send stays on the background lane', async () => {
+    // Proactive cadence sends have nobody blocked on them. If this also claimed
+    // the reserve, the reserve would be meaningless — so this control is what
+    // makes the test above mean something narrower than "everything is interactive".
+    const app = buildApp({ toneGate: new MessagingToneGate(capturingProvider(seen)), sent });
+    server = await listen(app);
+
+    await postReply(server.port, 29723, {
+      text: 'a scheduled cadence update nobody is waiting on',
+      metadata: { messageKind: 'automated' },
+    });
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect((seen[0] as { lane?: string })?.lane).not.toBe('interactive');
+  });
+
+  it('CONTROL: a NON-operator recipient never claims the reserve, even for a reply', async () => {
+    // The reserve exists for the operator-facing path. A topic with no verified
+    // operator resolves 'external' and must stay on the background lane, so a
+    // stray external conversation cannot eat the operator's protected capacity.
+    const app = buildApp({
+      toneGate: new MessagingToneGate(capturingProvider(seen)),
+      sent,
+      topicOperatorStore: { asVerifiedOperator: () => null, all: () => ({}) },
+    });
+    server = await listen(app);
+
+    await postReply(server.port, 29723, { text: 'a reply to someone who is not the operator' });
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect((seen[0] as { lane?: string })?.lane).not.toBe('interactive');
+  });
+
+  it('the message still sends — the lane is capacity routing, not a verdict', async () => {
+    const app = buildApp({ toneGate: new MessagingToneGate(capturingProvider(seen)), sent });
+    server = await listen(app);
+
+    await postReply(server.port, 29723, { text: 'a normal conversational reply' });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.topicId).toBe(29723);
+  });
+});

--- a/upgrades/next/tone-gate-interactive-lane.md
+++ b/upgrades/next/tone-gate-interactive-lane.md
@@ -1,0 +1,56 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Replies to the operator now use the spawn capacity that was already reserved for them.
+
+Every model call on a machine competes for a fixed number of concurrent slots. Two of
+those are reserved for a lane the outbound message gate is explicitly named for — a
+review a human is actively waiting on. The reservation was enabled and the gate was
+allowlisted to use it.
+
+The gate claims that reserve only when told BOTH that the recipient is the operator and
+that someone is waiting on this specific message. It was told the first. Nothing ever
+told it the second — so the condition was never true and the reserved slots were never
+claimed. Operator replies queued behind background work and, under load, the gate failed
+closed and held them.
+
+Measured during a live incident: sends refused 12 times in ~15 minutes, with two slots
+reserved and zero in use.
+
+## What to Tell Your User
+
+- "If my replies ever stalled while background work was busy, that's fixed — replies now
+  use capacity that was set aside for them."
+- "It changes which queue a check waits in. It does not change what the check decides."
+
+## Summary of New Capabilities
+
+None. No endpoint, no configuration, no new behaviour to enable — this lets an existing,
+already-enabled reservation actually be used.
+
+## Compatibility Notes
+
+Only genuine replies to a verified operator qualify. Scheduled and automated sends, and
+conversations with anyone who is not the verified operator, keep using ordinary capacity
+— so the reserve cannot be diluted. The pre-existing allowlist still limits which
+components may claim it at all.
+
+Nothing to configure. If interactive priority is switched off on a given machine,
+behaviour is byte-identical to before.
+
+## Evidence
+
+4 integration tests driving the real reply route through the real gate — the integration
+tier deliberately, because the gate's own lane logic was already correct and already
+tested; what was broken was the wiring, which only the real route exposes.
+
+An operator reply is marked interactive; an automated send is NOT; a non-operator
+recipient is NOT even for a reply; and the message still sends. The two negative cases
+are controls — without them the first would pass equally well against a change that made
+everything interactive.
+
+Shown capable of failing: restoring the pre-fix behaviour fails precisely the assertion
+that the reserve is claimed, and leaves the three guard tests passing.

--- a/upgrades/side-effects/tone-gate-interactive-lane.md
+++ b/upgrades/side-effects/tone-gate-interactive-lane.md
@@ -1,0 +1,123 @@
+# Side-Effects Review — operator replies claim the interactive spawn reserve
+
+**Version / slug:** `tone-gate-interactive-lane`
+**Date:** `2026-08-15`
+**Author:** `Instar-echo`
+**Tier:** 1 (one derived field on one existing call; no new capability, no new authority)
+**Approval:** operator-approved via Observer 1 relay, and deliberately split out of the
+Window 17 enrolment/swap build so the relief can merge and deploy on its own.
+
+## Summary of the change
+
+`MessagingToneGate` claims the host spawn cap's reserved *interactive* lane only when
+its context carries BOTH `recipientClass === 'operator'` AND `synchronousReply === true`.
+
+The reply route already computed and passed `recipientClass`. **Nothing anywhere ever
+set `synchronousReply`** — so `interactiveLane` was permanently false, the reserved
+slots were never claimed, and operator replies competed with background work for the
+general cap.
+
+This derives it at the one place that already knows:
+
+```ts
+synchronousReply: (options.messageKind ?? 'reply') === 'reply',
+```
+
+Absent means `'reply'` — this file's own existing convention (`kindForSignals` resolves
+it identically, and the route documents "absent → 'reply'"), and it is the common case:
+an ordinary conversational reply carries no explicit kind.
+
+## Why it matters (observed, not theorised)
+
+Degraded background calls each hold one of 8 host spawn slots until timeout. With the
+lane unclaimed, the outbound gate is just another background competitor — and it fails
+CLOSED when it cannot get a slot. During a live operator demo, sends were refused **12
+times in ~15 minutes**, with the limiter reporting `interactivePriority {enabled: true,
+ri: 2, rb: 2}` and `liveInteractive: 0` throughout: two slots reserved, zero used.
+
+## Decision-point inventory
+
+- **Spawn-cap lane selection** — *now reachable*. The mechanism, its allowlist and its
+  reserve already existed and were enabled; this supplies the missing input.
+- **Tone verdict / message allow-or-hold** — *untouched*. Lane is capacity routing. The
+  review, its verdict, and every fail-direction rule are unchanged.
+- **Authorization** — *untouched*. Nothing here grants a permission.
+
+---
+
+## 1. Over-block
+
+None. Nothing is newly refused. The change can only move a review from a contended
+queue to a reserved one; a review that would have passed still passes.
+
+## 2. Under-block
+
+- **A reserve of 2 is not immunity.** Three simultaneous operator replies still contend.
+  This removes a structural starvation, not queueing in general.
+- **It does not fix the underlying degradation.** Background calls still hold slots for
+  their full timeout; that is what the Window 17 build addresses. This protects the
+  operator path while that lands.
+- **`messageKind` is caller-supplied.** A caller could label a proactive send `'reply'`
+  and claim the reserve. Bounded by the pre-existing allowlist (only two components may
+  claim it at all) and by `recipientClass`, which is derived from the verified-operator
+  store rather than from the request.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The route already classifies `messageKind` and already resolves
+`recipientClass`; the derivation sits beside them. Adding a parameter would push the
+classification onto every caller and make the unsafe value the easy default — here the
+safe value (background) is what every other path gets for free.
+
+## 4. Signal vs authority
+
+Pure capacity routing. It holds no blocking authority and changes no verdict.
+
+## 5. Interactions
+
+- The interactive allowlist (`MessagingToneGate`, `MessageSentinel`) is unchanged, so a
+  stray `lane:'interactive'` elsewhere is still downgraded to background.
+- The reserve is symmetric (`ri`/`rb`): interactive claims cannot starve background —
+  background keeps its own reserved share.
+- No interaction with the advisory-migration or fail-closed paths; those read the
+  verdict, not the lane.
+
+## 6. Multi-machine posture
+
+**Machine-local by design.** The spawn cap is a host-local semaphore over processes on
+one box. Nothing replicates, nothing is proxied on read, no generated URL, nothing to
+strand on topic transfer. Each machine protects its own operator path.
+
+## 7. Failure modes
+
+- Interactive priority disabled on the semaphore → `resolveLane` returns background;
+  byte-identical to today.
+- `messageKind` absent → treated as `'reply'` (the documented convention).
+- Non-operator recipient → background, whatever the kind.
+
+## 8. Rollback cost
+
+Delete one line. No config key, no data, no schema, no migration, no agent state.
+
+## Evidence
+
+4 integration tests driving the REAL route through the REAL gate — deliberately the
+integration tier, because the unit tier cannot see this defect: the gate's lane logic
+was already correct and already tested, and what was broken was the WIRING.
+
+- an operator reply is marked `lane: 'interactive'`;
+- **CONTROL** — an `automated` send is NOT (else the reserve would be meaningless);
+- **CONTROL** — a non-operator recipient is NOT, even for a reply;
+- the message still sends (the lane is routing, not a verdict).
+
+**Shown capable of failing:** forcing `synchronousReply: false` — the exact pre-fix
+behaviour — fails precisely the one assertion that the reserve is claimed, and leaves
+the three guard tests passing.
+
+**A defect this test caught in its own fix:** the first implementation used
+`messageKind === 'reply'`, which silently excluded the common case where an ordinary
+reply carries no explicit kind. The integration test failed on it. A gate-level unit
+test would have passed.
+
+**Still to prove empirically at deploy:** `liveInteractive` non-zero on the running
+server. Merged is not running — that measurement is reported separately, from the box.


### PR DESCRIPTION
## ELI16 — two slots were held open for the agent's replies, and nothing ever claimed them

Every model call on this machine competes for a fixed number of concurrent slots. Two of
those eight are deliberately **reserved** for one thing: a check that a human is actively
waiting on. The check that clears the agent's outgoing replies is on the short list
allowed to use that reserve, and the reserve was switched on.

It claims those slots only when told two things — that the message is going to the
operator, and that someone is waiting for *this particular* message. It was being told
the first. It was never told the second. So the condition was never true, the reserved
slots were **never once used**, and replies queued behind the very background work they
were supposed to be protected from. When that background work filled the cap, the check
could not run at all and the reply was held rather than sent.

It is not hypothetical: while the operator was awake and waiting for a live
demonstration, the agent's messages to him were refused twelve times in about fifteen
minutes — with two slots reserved and, measured at the time, zero of them in use.

This change is one line: the reply path now says whether a human is waiting. It already
knew.

## The problem in one breath

Everything the agent asks a model to do — background classifiers, safety checks,
and the review that every outgoing message passes through — competes for a fixed
number of concurrent slots on this machine. Eight of them.

Background work has been misbehaving: each stalled request holds a slot until it
times out, up to a minute. When enough of them pile up, there is no slot left, and
the check that clears the agent's replies **fails closed** — the message is held
rather than sent.

That is not hypothetical. While the operator was awake and waiting for a live
demonstration, the agent's messages to him were refused **twelve times over about
fifteen minutes**, purely because background work had taken every slot.

## The part that makes this worth fixing rather than tuning

Someone already anticipated this. **Two of the eight slots are reserved** for
exactly this case — a check that a human is actively waiting on — and the reply
check is on the short list of things permitted to use that reserve. The
reservation was switched on.

It claims the reserve only when told two things: that the message is going to the
operator, and that someone is waiting for **this specific message**.

It was being told the first. It was never told the second. So the condition was
never true, the reserved slots were **never once claimed**, and the replies they
exist to protect queued behind the very background work they were meant to be
protected from. Measured during the failures: the reserve showed zero occupants.

## What this changes

One line. The reply path now says whether a human is waiting.

It knows already: an ordinary reply to someone's message is exactly that case,
while scheduled updates, health alerts and background notices are not — nobody is
blocked on those, so they keep using ordinary capacity.

## The safeguards

**Only genuine replies to the operator qualify.** Two separate conditions must
both hold. A scheduled message doesn't qualify; a conversation with someone who
isn't the verified operator doesn't qualify. Tests cover both of those refusals,
because a fix that made *everything* interactive would empty the reserve of meaning.

**A short list already limits who may ask.** Only two components are permitted to
claim the reserve at all; anything else asking is quietly put back on ordinary
capacity. That guard already existed and is untouched.

**It changes routing, not judgement.** This decides which queue a check waits in.
It does not change the check, its verdict, or whether a message is allowed.

**Proved by removing it.** With the change reverted, the one test asserting the
reserve is claimed fails and the three guard tests still pass — so the tests
measure this change and not something nearby.

## What ships when

All at once, and it needs no configuration. The reservation itself was already
enabled; this simply lets the thing it was reserved for ask for it.

## UX Impact

**Who sees it:** the operator — the person the agent is replying to. Nobody else is
affected, and no other surface changes.

**What the user sees:** replies that previously stalled or never arrived while background
work was busy now go out. The user-visible failure being removed is the outbound gate
refusing to run and holding the message — observed twelve times in about fifteen minutes
while the operator sat waiting for a live demonstration.

**First contact:** the very next reply after deploy. There is nothing to enable, no
setting to find, and no new surface to learn — the change is invisible except that
messages stop being withheld under load.

The concrete string this turns on is the message kind `'reply'` in
`src/server/routes.ts`: an ordinary conversational reply (or one with no explicit kind,
which is the same thing by this file's own convention) is now marked as a message a human
is waiting on, and so is allowed into the reserved capacity. Automated and health-alert
sends keep the previous behaviour exactly.

## Evidence

4 integration tests driving the REAL reply route through the REAL gate. This is the
integration tier deliberately: the gate's lane logic was already correct and already
unit-tested, and what was broken was the WIRING — which only the real route exposes.

- an operator reply is marked interactive;
- **CONTROL** — an automated send is NOT (else the reserve would be meaningless);
- **CONTROL** — a non-operator recipient is NOT, even for a reply;
- the message still sends.

**Shown capable of failing:** restoring the exact pre-fix behaviour fails precisely the
one assertion that the reserve is claimed, and leaves the three guard tests passing.

**A defect these tests caught in this very fix:** the first implementation used a strict
`messageKind === 'reply'`, which silently excluded the common case where an ordinary
reply carries no explicit kind. The integration test failed on it. A gate-level unit test
would have passed.

**Not yet proven, and deliberately not claimed:** that `liveInteractive` goes non-zero on
the running server. Merged is not running — that measurement will be reported separately,
from the box, after deploy.
