### PR TITLE
feat(codex): enrollable Codex accounts + per-call account selection

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T20-03-15-222Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T20-03-15-222Z-codex-pool-latency-swap.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-15T20:03:15.222Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 147,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-llm-http.js",
+      "src/providers/adapters/openai-codex/codexSlotIdentity.ts"
+    ],
+    "addedLines": 147,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T20-07-54-857Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T20-07-54-857Z-codex-pool-latency-swap.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-15T20:07:54.857Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 113,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CompositeCredentialIdentityOracle.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 109,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T20-08-00-370Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T20-08-00-370Z-codex-pool-latency-swap.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-15T20:08:00.370Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 113,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CompositeCredentialIdentityOracle.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 109,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T20-08-30-366Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T20-08-30-366Z-codex-pool-latency-swap.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-15T20:08:30.366Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 113,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CompositeCredentialIdentityOracle.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 109,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T20-09-29-373Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T20-09-29-373Z-codex-pool-latency-swap.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-15T20:09:29.373Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 113,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CompositeCredentialIdentityOracle.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 109,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T21-21-53-599Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T21-21-53-599Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T21:21:53.599Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 63,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CodexCliIntelligenceProvider.ts"
+    ],
+    "addedLines": 61,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T21-21-58-744Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T21-21-58-744Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T21:21:58.744Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 63,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CodexCliIntelligenceProvider.ts"
+    ],
+    "addedLines": 61,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T21-22-27-098Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T21-22-27-098Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T21:22:27.098Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 63,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CodexCliIntelligenceProvider.ts"
+    ],
+    "addedLines": 61,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T21-23-11-326Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T21-23-11-326Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T21:23:11.326Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 63,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CodexCliIntelligenceProvider.ts"
+    ],
+    "addedLines": 61,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T21-35-38-335Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T21-35-38-335Z-codex-pool-latency-swap.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-15T21:35:38.335Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 238,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CodexAccountHealth.ts",
+      "src/core/CodexCliIntelligenceProvider.ts"
+    ],
+    "addedLines": 232,
+    "deletedLines": 6
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T21-41-50-854Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T21-41-50-854Z-codex-pool-latency-swap.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-15T21:41:50.854Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 122,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/ProactiveSwapMonitor.ts",
+      "src/core/QuotaAwareScheduler.ts",
+      "src/core/SwapAntiThrash.ts",
+      "src/core/SwapLedger.ts"
+    ],
+    "addedLines": 107,
+    "deletedLines": 15
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T22-17-14-993Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T22-17-14-993Z-codex-pool-latency-swap.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-08-15T22:17:14.993Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 225,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/CodexCliIntelligenceProvider.ts",
+      "src/core/IntelligenceRouter.ts",
+      "src/core/SubscriptionPool.ts",
+      "src/core/types.ts"
+    ],
+    "addedLines": 218,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T22-18-31-129Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T22-18-31-129Z-codex-pool-latency-swap.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-08-15T22:18:31.129Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 225,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/CodexCliIntelligenceProvider.ts",
+      "src/core/IntelligenceRouter.ts",
+      "src/core/SubscriptionPool.ts",
+      "src/core/types.ts"
+    ],
+    "addedLines": 218,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T22-37-02-096Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T22-37-02-096Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T22:37:02.096Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/IntelligenceRouter.ts"
+    ],
+    "addedLines": 15,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T22-37-41-253Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T22-37-41-253Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T22:37:41.253Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/IntelligenceRouter.ts"
+    ],
+    "addedLines": 15,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T22-38-21-149Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T22-38-21-149Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T22:38:21.149Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/IntelligenceRouter.ts"
+    ],
+    "addedLines": 15,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-15T22-39-11-084Z-codex-pool-latency-swap.json
+++ b/.instar/instar-dev-decisions/2026-08-15T22-39-11-084Z-codex-pool-latency-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T22:39:11.084Z",
+  "slug": "codex-pool-latency-swap",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/IntelligenceRouter.ts"
+    ],
+    "addedLines": 15,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -160,6 +160,12 @@ against itself — and written a log line saying it had moved. A test caught tha
 fix identifies the default account by where its credentials live, and where it can't
 tell, it does nothing rather than guess.
 
+**If the account lookup itself breaks, you find out.** The retry list asks the account
+pool which other account to try. If that question fails, the retry list quietly goes
+back to its old behaviour — which means the fall-through onto your subscription returns
+without anyone noticing. A check in the build caught that this failure was invisible, so
+it now gets recorded: losing the feature is survivable, losing it silently is not.
+
 **If you only have one Codex account, none of this happens.** There is no other
 account to try, so the retry list behaves exactly as it does today.
 

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -1,0 +1,78 @@
+# Giving Codex a second lane — Plain-English Overview
+
+> The one-line version: the agent's background thinking runs on a second account
+> so it doesn't spend the main subscription — that account has become slow and
+> unreliable, and there is a spare sitting unused because nothing could enrol it.
+
+## The problem in one breath
+
+Most of the agent's small background judgements — classifying intent, checking
+whether a claim is finished, reviewing tone — deliberately run on a **second**
+provider so they don't consume the main subscription the operator pays for.
+
+That second provider has degraded badly. Measured, not guessed: the very simplest
+request takes about **thirteen seconds**, and several of those background checks
+now sit at **sixty seconds**, which is the cut-off — meaning they aren't failing,
+they're running out of time. The failure rate went from roughly a quarter over
+three days to **most requests in the last hour**.
+
+Two things make that worse than slow background work:
+
+- **Every failure falls through to the main subscription** — the exact thing the
+  second provider exists to protect.
+- **Each stalled request occupies one of eight shared slots** until it times out.
+  When they crowd it, the agent's own replies to the operator can't get a slot and
+  are held back. That is not theoretical; it delayed a live demo.
+
+And there is a **second account for that provider already signed in on this
+machine, completely unused** — because nothing could enrol it.
+
+## Why the spare account could not be enrolled
+
+The pool that holds these accounts refuses to add one whose identity it cannot
+verify — a sensible guard, since two entries silently pointing at the *same*
+login would make "switch to the other account" a switch to itself.
+
+But the only identity check available asks **Anthropic's servers** who is signed
+in. Handed a Codex account, it cannot answer, so enrolment fails. The pool held
+six Anthropic accounts and zero Codex ones, not by policy but because the door
+was the wrong shape.
+
+## What this adds
+
+**A Codex account can now identify itself.** Its credential file already contains
+a signed identity card listing the account's email, a unique account id, and the
+plan — no network call needed. Reading it closes the enrolment gap.
+
+**A slowness trigger, not just a fullness trigger.** The machinery that moves work
+to a healthier account today only reacts to an account being *used up*. Quota is
+not the problem here — the account is at seventeen percent. The trigger is being
+taught to react to an account being *slow or erroring* as well.
+
+**Prefer the sibling before the expensive one.** When a Codex request fails today,
+the next thing tried is the main subscription. It should try the *other Codex
+account* first, and only fall back to the expensive one if both are unwell.
+
+## The safeguards
+
+**Nothing moves on its own yet.** The new trigger ships switched off, and when
+switched on it starts in a rehearsal mode that only writes down what it *would*
+have done. A live session is not moved until someone reads those notes and decides.
+
+**It cannot mix up the two kinds of account.** A Codex session can only ever be
+moved to another Codex account, never to the main subscription's account — that
+restriction already existed and was verified before relying on it.
+
+**Reading a credential cannot leak it.** The identity reader returns an email and
+an account id and nothing else. A test plants a fake secret in the file and proves
+it appears nowhere in the result — with a control confirming the fake secret really
+was in the bytes being read, so a clean result means something.
+
+**Identity is a label, never a permission.** Knowing which account is signed in
+names a row in a list. It grants nothing.
+
+## What ships when
+
+The identity reader and the enrolment path are useful immediately — they make the
+spare account visible and usable. The slowness trigger ships dark and rehearses
+first. Nothing about the main subscription changes.

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -140,8 +140,32 @@ was in the bytes being read, so a clean result means something.
 **Identity is a label, never a permission.** Knowing which account is signed in
 names a row in a list. It grants nothing.
 
+## Stopping the fall-through onto the subscription you pay for
+
+There is a second, quieter way the second provider costs you money. When one of its
+calls fails, the system retries — and the retry list ends at the main subscription.
+So the provider that exists to keep work off your paid account was, on every
+failure, walking work straight onto it.
+
+Now the retry list tries the OTHER Codex account first: same provider, different
+login. Only if that also fails does it continue down the old list. Nothing was
+removed — a step was added in front — so if both Codex accounts are unwell you still
+get an answer exactly as before.
+
+**Working out which account just failed turned out to be the hard part.** Internal
+calls don't name their account; they use whichever login is the default. The first
+version couldn't tell "the other account" from "the account that just failed", so on
+a machine with only one Codex account it would have retried the failing account
+against itself — and written a log line saying it had moved. A test caught that. The
+fix identifies the default account by where its credentials live, and where it can't
+tell, it does nothing rather than guess.
+
+**If you only have one Codex account, none of this happens.** There is no other
+account to try, so the retry list behaves exactly as it does today.
+
 ## What ships when
 
 The identity reader and the enrolment path are useful immediately — they make the
 spare account visible and usable. The slowness trigger ships dark and rehearses
-first. Nothing about the main subscription changes.
+first. The retry-list change is live but self-disabling: with fewer than two usable
+Codex accounts it does nothing at all. Nothing about the main subscription changes.

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -69,7 +69,44 @@ taught to react to an account being *slow or erroring* as well.
 the next thing tried is the main subscription. It should try the *other Codex
 account* first, and only fall back to the expensive one if both are unwell.
 
+## What checking the plan first turned up
+
+The plan read as though only the trigger needed building — the machinery is there,
+it just watches the wrong thing. Checking that against the actual code before
+building on it, three pieces were missing, and the trigger is the last of them.
+
+**Nothing was choosing an account.** When the agent asks its second provider a
+question, it never said which account to use — so every one of those requests went
+to the default one. The ability to say which account already existed in the code
+and worked; this path simply never used it. So "move a struggling account's work to
+the other account" had nothing to move: there was only ever one account involved.
+
+**Nothing was recording which account was slow.** Timing and failure counts are
+recorded against the piece of the agent that asked, never against the account that
+answered. So even with two accounts in play, there was no per-account measurement
+for a trigger to read.
+
+**The fallback list names providers, not accounts.** "Try the other Codex account
+before the expensive one" has nothing to name today, because that list only knows
+about providers.
+
+So the test the plan proposed — make one account artificially slow and watch the
+system offer to move off it — could not have passed. Not because the trigger was
+missing, but because nothing measured or selected the thing the trigger would act
+on. Building the trigger alone would have produced a dial wired to a dead gauge.
+
+**This adds the first of those three: a request can now name its account.** The
+other two are reported rather than quietly built, because they change the size of
+the job and that is not mine to decide alone.
+
 ## The safeguards
+
+**Adding the ability changes nothing on its own.** A request that does not name an
+account behaves exactly as before — same account, same result. Nothing in the
+running system names one yet, so this is a capability sitting unused until someone
+deliberately switches it on. If the part that names the account is ever broken, the
+request quietly falls back to the old behaviour instead of failing: losing the
+choice is a small loss, losing every background request is not.
 
 **Nothing moves on its own yet.** The new trigger ships switched off, and when
 switched on it starts in a rehearsal mode that only writes down what it *would*

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -107,9 +107,13 @@ It also forgets: the record covers the last few minutes and is not carried acros
 restart, because a confident answer about a world that no longer exists is worse than
 no answer.
 
-The remaining piece — the trigger that reads that record and proposes a move — is reported rather than
-quietly built where it grows the job, and built where the charter's author confirmed
-it was the job.
+**And the trigger itself now exists.** It reads that per-account record and, when an
+account is genuinely slow or failing, proposes moving work off it — where before it
+could only react to an account being *full*, which was never the problem here.
+
+It refuses to act on "I don't know": if the record can't answer, nothing moves. And
+it rehearses — it writes down what it *would* have done and leaves the conversation
+alone — until someone deliberately turns rehearsal off.
 
 ## The safeguards
 

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -44,6 +44,22 @@ was the wrong shape.
 a signed identity card listing the account's email, a unique account id, and the
 plan — no network call needed. Reading it closes the enrolment gap.
 
+**And the existing check learns to ask the right question.** The identity check is
+handed a folder path and nothing else — it isn't told which kind of account lives
+there — so the folder has to answer for itself. It can: a Codex folder holds that
+identity card, an Anthropic one doesn't. The check now looks for the card first
+(a quick local file read that comes back instantly when there isn't one) and only
+falls back to asking Anthropic's servers otherwise.
+
+Two details worth stating, because both are deliberate:
+
+- **The Anthropic path is untouched.** For any folder that isn't a Codex one, the
+  identical original check runs, with the identical result. A test exists purely
+  to prove that, so "Codex now works" can't quietly mean "Anthropic now doesn't."
+- **A broken Codex folder says so.** If the identity card is present but damaged,
+  that is reported as a Codex problem rather than passed along to Anthropic — who
+  cannot speak for it either — to be mislabelled as an Anthropic failure.
+
 **A slowness trigger, not just a fullness trigger.** The machinery that moves work
 to a healthier account today only reacts to an account being *used up*. Quota is
 not the problem here — the account is at seventeen percent. The trigger is being

--- a/docs/specs/codex-pool-latency-swap.eli16.md
+++ b/docs/specs/codex-pool-latency-swap.eli16.md
@@ -95,9 +95,21 @@ system offer to move off it — could not have passed. Not because the trigger w
 missing, but because nothing measured or selected the thing the trigger would act
 on. Building the trigger alone would have produced a dial wired to a dead gauge.
 
-**This adds the first of those three: a request can now name its account.** The
-other two are reported rather than quietly built, because they change the size of
-the job and that is not mine to decide alone.
+**This adds the first two of those three.** A request can now name its account, and
+there is now a record of how each account's requests actually went — how long they
+took and how many failed — kept per account rather than per asking-component.
+
+That record refuses to answer when it cannot answer honestly. With only a couple of
+requests to go on it says "I don't know" rather than producing a number, because a
+trigger acting on two samples would start moving live work around on noise. Moving
+work for nothing is a worse failure than noticing a slow account a few minutes late.
+It also forgets: the record covers the last few minutes and is not carried across a
+restart, because a confident answer about a world that no longer exists is worse than
+no answer.
+
+The remaining piece — the trigger that reads that record and proposes a move — is reported rather than
+quietly built where it grows the job, and built where the charter's author confirmed
+it was the job.
 
 ## The safeguards
 

--- a/scripts/lint-no-direct-llm-http.js
+++ b/scripts/lint-no-direct-llm-http.js
@@ -41,6 +41,15 @@ const ALLOWLIST = new Set([
   'src/core/ClaudeCliIntelligenceProvider.ts',
   // The lint rule itself names the URLs in the patterns array.
   'scripts/lint-no-direct-llm-http.js',
+  // NOT a URL: OpenAI namespaces its non-standard OIDC claims under a
+  // URL-SHAPED KEY, so `https://api.openai.com/auth` appears here as a JSON
+  // property name being read out of a locally-stored id_token — never as an
+  // endpoint. The module makes no network call of any kind (pure fs read +
+  // base64 decode), so there is no inference for burn-detection to attribute.
+  // Listed explicitly rather than assembled from fragments: hiding the literal
+  // would defeat this lint for every future reader of the file, which is worse
+  // than one reviewable exemption.
+  'src/providers/adapters/openai-codex/codexSlotIdentity.ts',
   // Provider-portability v1.0.0 (spec/provider-portability): the
   // anthropic-headless adapter implements the IntelligenceProvider
   // contract via legitimate OAuth + Messages-API calls. It IS the

--- a/site/src/content/docs/features/codex-account-pool.md
+++ b/site/src/content/docs/features/codex-account-pool.md
@@ -1,0 +1,88 @@
+---
+title: Codex account pool
+description: Hold more than one Codex login, and move work off one that goes slow.
+---
+
+Instar deliberately runs its small background judgements — classifying intent,
+checking whether a claim is finished, reviewing tone — on a **second** provider, so
+they don't consume the main subscription you pay for.
+
+That only works while the second provider is healthy. When it degrades, two things
+go wrong at once: every failure falls through onto the main subscription (the exact
+thing the second provider exists to protect), and each stalled request holds one of
+the machine's shared spawn slots until it times out.
+
+This feature lets you hold **more than one** Codex login, and lets Instar move work
+off one that has gone slow.
+
+## Enrolling a Codex account
+
+The subscription pool refuses to add an account whose credential slot it cannot
+identify. That guard matters: two pool rows silently pointing at the *same* login
+would make "switch to the other account" a switch to itself.
+
+A Codex credential slot identifies itself locally. `readCodexSlotIdentity` reads the
+OIDC id_token already present in the slot's `auth.json` and returns the account's
+email, a stable per-account id, and the plan tier — with no network call.
+
+`CompositeCredentialIdentityOracle` puts that in front of the existing Anthropic
+identity check. The identity contract is handed only a directory path, so the slot
+has to answer for itself: a Codex home holds that token, an Anthropic home does not.
+A slot that is not a Codex home takes the identical pre-existing Anthropic path.
+
+Reading a credential never exposes it — the reader returns an email, an account id
+and a plan, and no token material.
+
+:::note
+Identity is a **label**, never a permission. Knowing which account is signed in
+names a row in a list; it grants nothing.
+:::
+
+## Choosing an account per call
+
+An internal Codex call can name which account it runs on, via `resolveAccount` on
+the Codex provider. Absent or null, the call behaves exactly as before — the
+ambient login. A resolver that throws or returns something malformed also falls back
+to the previous behaviour: losing account *selection* is a small loss, losing every
+internal Codex call is not.
+
+## Knowing which account is unwell
+
+Instar's usual LLM metrics are recorded against the **component that asked**, which
+is the right shape for "what does this feature cost" and the wrong shape for "is
+this account unwell".
+
+`CodexAccountHealth` supplies the missing dimension: a bounded, in-memory,
+time-windowed record of p50 latency and error rate **per account**.
+
+It refuses to answer when it cannot answer honestly. With too few samples in the
+window it returns nothing rather than a number — because a trigger acting on two
+samples would move live sessions on noise. It is deliberately not persisted: health
+is a claim about the last few minutes, and a reading resurrected across a restart
+would be a confident answer about a world that no longer exists.
+
+## Moving work off a degrading account
+
+The proactive swap monitor gains a `degradation` trigger alongside its existing
+quota trigger. An account that is slow **or** failing becomes a candidate to move
+off, regardless of how full it is — which is the point, since quota is often not the
+problem.
+
+It bypasses only *source* pressure. Target freshness, per-target ceilings,
+anti-thrash dwell and execution-time revalidation all still apply, and the swap
+machinery still refuses to cross frameworks — so a Codex session can only ever move
+to another Codex account, never onto the main subscription's account.
+
+### Safety
+
+- **Dark by default.** The trigger ships off.
+- **Rehearses first.** When switched on it starts in dry-run: it records the exact
+  swap it *would* have made and leaves the session alone.
+- **Unknown is not degraded.** No data, too few samples, or a broken gauge all mean
+  unknown — and unknown never moves anything.
+
+## Configuration
+
+Nothing is enabled by default, and nothing is enrolled automatically. Enrol a Codex
+account through the normal subscription-pool enrolment path, pointing at that
+account's credential home.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6036,6 +6036,17 @@ export async function startServer(options: StartOptions): Promise<void> {
     // opt-in flag that older versions accepted), we warn loudly and proceed with the
     // subscription path.
     let sharedIntelligence: IntelligenceProvider | undefined;
+    // Late binding for the router's sibling-account failure tail. The router is built here;
+    // the pool is built much later in boot (behind a dynamic import, to keep it off the boot
+    // path). The resolver is only ever called at failure time, so binding it when the pool
+    // appears is both correct and a smaller change than reordering boot — and it keeps the
+    // module lazy. Null until then ⇒ no siblings ⇒ the shipped tail, unchanged.
+    let siblingAccountResolver:
+      | ((
+          framework: import('../core/intelligenceProviderFactory.js').IntelligenceFramework,
+          failedAccountId: string | null,
+        ) => Array<{ accountId: string; configHome: string }>)
+      | null = null;
     const staleApiProvider =
       (config as unknown as { intelligenceProvider?: string }).intelligenceProvider === 'anthropic-api';
     let intelligenceSource = 'none';
@@ -6516,6 +6527,22 @@ export async function startServer(options: StartOptions): Promise<void> {
             enabled: config.intelligence?.nonGatingFailureSwap?.enabled ?? true,
             maxAttempts: config.intelligence?.nonGatingFailureSwap?.maxAttempts,
           },
+          // SIBLING-ACCOUNT failure tail: before the tail changes DOOR (whose last position
+          // is claude-code — the main subscription this door exists to protect), try the
+          // same door on another enrolled account of the same framework.
+          //
+          // Late-bound on purpose: the pool is constructed much later in boot, and this is
+          // only ever called at failure time, so reading it lazily is both correct and the
+          // smallest possible change to boot order.
+          //
+          // Eligibility lives HERE, not in the router: the pool owns account state. Only
+          // `active` accounts qualify — a rate-limited or warming sibling is a known-bad
+          // attempt against a gating deadline. Bounded to ONE sibling: the tail exists to
+          // find an answer quickly, not to walk an entire pool while a gate waits.
+          resolveSiblingAccounts: (framework, failedAccountId) =>
+            // Null until the pool is built (or on an agent that never builds one) ⇒ no
+            // siblings ⇒ the shipped tail runs exactly as before.
+            siblingAccountResolver?.(framework, failedAccountId) ?? [],
           // The dedicated queue for the DEFERRABLE queue rung (§3b.3); undefined when the rung is
           // dark ⇒ the rung is a no-op (a deferrable call falls straight to its heuristic, as before).
           llmQueue: degradationLadderQueue,
@@ -13139,8 +13166,27 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Subscription & Auth Standard). Always instantiated; ships DARK because an
     // empty pool is a pure no-op (no background loop, no cost) until an operator
     // enrolls an account. Stores each account's login LOCATION, never tokens.
-    const { SubscriptionPool, requiresOwnerRelogin } = await import('../core/SubscriptionPool.js');
+    const { SubscriptionPool, requiresOwnerRelogin, eligibleSiblingAccounts } = await import(
+      '../core/SubscriptionPool.js'
+    );
     const subscriptionPool = new SubscriptionPool({ stateDir: config.stateDir });
+    // Arm the already-built router's sibling-account failure tail. Read live (not a
+    // snapshot) so an account enrolled, rate-limited or disabled later is reflected on the
+    // next failure. Until this line runs the router's resolver sees null and returns no
+    // siblings, so a failure during boot walks exactly the tail it always did.
+    siblingAccountResolver = (framework, failedAccountId) =>
+      eligibleSiblingAccounts(subscriptionPool.list(), framework, failedAccountId, {
+        // Internal calls run on the AMBIENT login today, so `failedAccountId` is almost
+        // always null and the id-based self-exclusion cannot fire. The ambient home is
+        // how we identify which enrolled account actually ran. Same derivation the
+        // Threadline codex bootstrap already uses (empirically verified against a live
+        // ~/.codex). Non-codex doors have no equivalent, so they pass undefined and the
+        // resolver refuses rather than guesses.
+        ambientConfigHome:
+          framework === 'codex-cli'
+            ? process.env['CODEX_HOME'] || path.join(os.homedir(), '.codex')
+            : null,
+      });
     if (subscriptionPool.size() > 0) {
       console.log(pc.green(`  Subscription pool: ${subscriptionPool.size()} account(s) registered`));
     }

--- a/src/core/CodexAccountHealth.ts
+++ b/src/core/CodexAccountHealth.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-account health for Codex calls — the measurement a degradation trigger needs.
+ *
+ * Instar records LLM call metrics against the COMPONENT that asked (via
+ * `attribution.component`), never against the account that answered. That is the
+ * right shape for "what does this feature cost"; it is the wrong shape for "is
+ * THIS account unwell", which is the question a swap has to answer. Without a
+ * per-account reading, a latency trigger is a dial wired to a dead gauge.
+ *
+ * This is that gauge, and nothing more: a bounded, in-memory, time-windowed
+ * record of how each account's calls actually went.
+ *
+ * ## The honest-unknown rule
+ *
+ * `read()` returns `null` when it cannot responsibly answer — no samples, or too
+ * few to distinguish a degrading account from ordinary variance. It does NOT
+ * return a zero, an "unknown" flag the caller might ignore, or an optimistic
+ * default. A trigger acting on two samples would swap live sessions on noise,
+ * and the failure mode of a too-eager swap (thrash, sessions moved for nothing)
+ * is worse than the failure mode of a late one (a slow account stays slow a
+ * while longer).
+ *
+ * ## What it deliberately does NOT do
+ *
+ * It records and reports. It does not decide, swap, or notify. Retention is a
+ * fixed-size ring per account so a long-running process cannot grow it without
+ * bound, and it is intentionally NOT persisted: health is a statement about the
+ * last few minutes, and a reading resurrected from before a restart would be a
+ * confident answer about a world that no longer exists.
+ */
+
+/** One observed call against one account. */
+export interface CodexCallSample {
+  accountId: string;
+  /** Wall-clock duration of the call in ms. */
+  latencyMs: number;
+  /** Did the call produce a usable result? A timeout counts as NOT ok. */
+  ok: boolean;
+  /** Observation time (injected in tests). */
+  atMs: number;
+}
+
+/** What the trigger reads. Every field is measured; none is inferred. */
+export interface CodexAccountReading {
+  accountId: string;
+  /** Median latency across the window, in ms. */
+  p50LatencyMs: number;
+  /** Share of calls in the window that failed, 0..1. */
+  errorRate: number;
+  /** How many samples this reading rests on. */
+  samples: number;
+  /** Oldest and newest sample times backing it — so staleness is visible. */
+  windowStartMs: number;
+  windowEndMs: number;
+}
+
+export interface CodexAccountHealthOptions {
+  /** Samples older than this are ignored. Default 15 minutes. */
+  windowMs?: number;
+  /** Below this many samples in-window, `read()` returns null. Default 5. */
+  minSamples?: number;
+  /** Ring capacity per account. Default 200. */
+  maxSamplesPerAccount?: number;
+  now?: () => number;
+}
+
+const DEFAULT_WINDOW_MS = 15 * 60_000;
+const DEFAULT_MIN_SAMPLES = 5;
+const DEFAULT_MAX_PER_ACCOUNT = 200;
+
+export class CodexAccountHealth {
+  private readonly windowMs: number;
+  private readonly minSamples: number;
+  private readonly maxPerAccount: number;
+  private readonly now: () => number;
+  /** accountId → ring of samples, oldest first. */
+  private readonly byAccount = new Map<string, CodexCallSample[]>();
+
+  constructor(opts: CodexAccountHealthOptions = {}) {
+    this.windowMs = opts.windowMs ?? DEFAULT_WINDOW_MS;
+    this.minSamples = opts.minSamples ?? DEFAULT_MIN_SAMPLES;
+    this.maxPerAccount = opts.maxSamplesPerAccount ?? DEFAULT_MAX_PER_ACCOUNT;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Record one observed call. Never throws — this sits on the hot path of every
+   * internal Codex call, and a measurement layer that can break the thing it
+   * measures is worse than no measurement.
+   */
+  record(sample: CodexCallSample): void {
+    try {
+      if (!sample || typeof sample.accountId !== 'string' || sample.accountId.length === 0) return;
+      if (!Number.isFinite(sample.latencyMs) || sample.latencyMs < 0) return;
+      const ring = this.byAccount.get(sample.accountId) ?? [];
+      ring.push(sample);
+      // Bounded: drop oldest beyond capacity.
+      if (ring.length > this.maxPerAccount) ring.splice(0, ring.length - this.maxPerAccount);
+      this.byAccount.set(sample.accountId, ring);
+    } catch {
+      /* @silent-fallback-ok: recording is observational. Throwing here would let a
+         gauge break the engine it is measuring. */
+    }
+  }
+
+  /**
+   * The reading for one account, or `null` when it cannot responsibly answer.
+   *
+   * Null means "I do not know", and callers must treat it as such — never as
+   * "healthy". A trigger that reads null and swaps anyway is acting on nothing.
+   */
+  read(accountId: string): CodexAccountReading | null {
+    const ring = this.byAccount.get(accountId);
+    if (!ring || ring.length === 0) return null;
+
+    const cutoff = this.now() - this.windowMs;
+    const live = ring.filter((s) => s.atMs >= cutoff);
+    if (live.length < this.minSamples) return null;
+
+    const latencies = live.map((s) => s.latencyMs).sort((a, b) => a - b);
+    const mid = Math.floor(latencies.length / 2);
+    const p50 =
+      latencies.length % 2 === 1
+        ? latencies[mid]!
+        : Math.round((latencies[mid - 1]! + latencies[mid]!) / 2);
+
+    const failures = live.reduce((n, s) => n + (s.ok ? 0 : 1), 0);
+
+    return {
+      accountId,
+      p50LatencyMs: p50,
+      errorRate: failures / live.length,
+      samples: live.length,
+      windowStartMs: Math.min(...live.map((s) => s.atMs)),
+      windowEndMs: Math.max(...live.map((s) => s.atMs)),
+    };
+  }
+
+  /** Every account with a readable reading. Accounts that cannot answer are omitted. */
+  readAll(): CodexAccountReading[] {
+    const out: CodexAccountReading[] = [];
+    for (const accountId of this.byAccount.keys()) {
+      const r = this.read(accountId);
+      if (r) out.push(r);
+    }
+    return out;
+  }
+
+  /** Drop samples outside the window for every account. Bounded housekeeping. */
+  prune(): void {
+    const cutoff = this.now() - this.windowMs;
+    for (const [accountId, ring] of this.byAccount) {
+      const live = ring.filter((s) => s.atMs >= cutoff);
+      if (live.length === 0) this.byAccount.delete(accountId);
+      else this.byAccount.set(accountId, live);
+    }
+  }
+}

--- a/src/core/CodexCliIntelligenceProvider.ts
+++ b/src/core/CodexCliIntelligenceProvider.ts
@@ -312,6 +312,20 @@ export interface CodexCliIntelligenceProviderOptions {
    * strictly worse than losing account selection for one of them.
    */
   resolveAccount?: () => CodexCallAccount | null;
+  /**
+   * Optional observer for per-account health: reports how each call actually
+   * went, so "is THIS account unwell" has a measurement behind it.
+   *
+   * Instar records LLM metrics against the COMPONENT that asked, never the
+   * account that answered — the right shape for cost, the wrong shape for a
+   * degradation trigger. This supplies the missing dimension.
+   *
+   * Called ONLY when an account was actually named. With no account there is
+   * nothing to attribute a sample to, and attributing it to "the default" would
+   * invent a measurement. Must not throw; a throwing observer is swallowed
+   * rather than allowed to break the call it is measuring.
+   */
+  onCallObserved?: (sample: { accountId: string; latencyMs: number; ok: boolean }) => void;
 }
 
 /** Which pool account an internal Codex call should run under. */
@@ -326,6 +340,10 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
   private readonly codexPath: string;
   /** @see CodexCliIntelligenceProviderOptions.resolveAccount */
   private readonly resolveAccount: (() => CodexCallAccount | null) | undefined;
+  /** @see CodexCliIntelligenceProviderOptions.onCallObserved */
+  private readonly onCallObserved:
+    | ((sample: { accountId: string; latencyMs: number; ok: boolean }) => void)
+    | undefined;
   private readonly sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
   private readonly resolveExecJson: () => boolean;
 
@@ -354,6 +372,7 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     this.sandboxMode = options.sandboxMode ?? 'read-only';
     this.resolveExecJson = options.resolveExecJson ?? execJsonEnvDefault;
     this.resolveAccount = options.resolveAccount;
+    this.onCallObserved = options.onCallObserved;
     // options.workingDirectory is intentionally NOT stored: judgment calls
     // always run in an empty scratch dir (resolveIntelligenceScratchDir), so
     // the agent's project identity + hooks never load. The option is retained
@@ -415,8 +434,54 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     } catch {
       execJson = execJsonEnvDefault(); // a throwing resolver must not take the call down
     }
+
+    // Resolve the account ONCE and thread it down, rather than re-reading it at
+    // each spawn site. If the recorded account could differ from the account
+    // actually used, the health gauge would be quietly wrong — and a gauge that
+    // can disagree with reality is worse than no gauge, because a trigger would
+    // act on it with confidence.
+    const account = this.accountForCall();
+    const startedAtMs = Date.now();
+    let ok = false;
     try {
-      return await this.evaluateWithModel(prompt, options, model, execJson);
+      const result = await this.evaluateWithModelObserved(
+        prompt,
+        options,
+        model,
+        execJson,
+        account,
+      );
+      ok = true;
+      return result;
+    } finally {
+      // Per-account health is recorded ONLY when an account was actually named.
+      // With no account there is nothing to attribute the sample to, and
+      // attributing it to "the default" would invent a measurement.
+      if (account && this.onCallObserved) {
+        try {
+          this.onCallObserved({
+            accountId: account.accountId,
+            latencyMs: Date.now() - startedAtMs,
+            ok,
+          });
+        } catch {
+          /* @silent-fallback-ok: observation is a gauge. A throwing observer must
+             never break the call it is measuring. */
+        }
+      }
+    }
+  }
+
+  /** The pre-existing evaluate body: model-retirement self-heal around the call. */
+  private async evaluateWithModelObserved(
+    prompt: string,
+    options: IntelligenceOptions | undefined,
+    model: string,
+    execJson: boolean,
+    account: CodexCallAccount | null,
+  ): Promise<string> {
+    try {
+      return await this.evaluateWithModel(prompt, options, model, execJson, account);
     } catch (error) {
       if (
         model !== CODEX_CHATGPT_FALLBACK_MODEL &&
@@ -432,6 +497,7 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
           options,
           CODEX_CHATGPT_FALLBACK_MODEL,
           execJson,
+          account,
         );
       }
       throw error;
@@ -443,10 +509,11 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     options: IntelligenceOptions | undefined,
     model: string,
     execJson: boolean,
+    account: CodexCallAccount | null,
   ): Promise<string> {
     return execJson
-      ? this.evaluateExecJson(prompt, options, model)
-      : this.evaluatePlain(prompt, options, model);
+      ? this.evaluateExecJson(prompt, options, model, account)
+      : this.evaluatePlain(prompt, options, model, account);
   }
 
   /**
@@ -465,6 +532,7 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     prompt: string,
     options: IntelligenceOptions | undefined,
     model: string,
+    account: CodexCallAccount | null,
   ): Promise<string> {
     const scratchDir = resolveIntelligenceScratchDir();
 
@@ -490,9 +558,8 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
       // CLAUDECODE / CLAUDE_SESSION_ID are not in the allowlist so they
       // are dropped automatically — the prior explicit deletes are now
       // redundant but the hygiene intent is preserved by the allowlist.
-      const spawnAccount = this.accountForCall();
       const childEnv = buildCodexChildEnv(
-        spawnAccount ? { codexHome: spawnAccount.configHome } : undefined,
+        account ? { codexHome: account.configHome } : undefined,
       );
 
       const child = execFile(
@@ -538,6 +605,7 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     prompt: string,
     options: IntelligenceOptions | undefined,
     model: string,
+    account: CodexCallAccount | null,
   ): Promise<string> {
     const scratchDir = resolveIntelligenceScratchDir();
     const outDir = createCodexOutDir();
@@ -572,7 +640,7 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
       const result = await spawnCodexExecJson(this.codexPath, args, {
         timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         env: buildCodexChildEnv(
-          this.accountForCall() ? { codexHome: this.accountForCall()!.configHome } : undefined,
+          account ? { codexHome: account.configHome } : undefined,
         ), // Spec 12 Rule 1a — both modes
         prompt,
         onLine: (line) => {

--- a/src/core/CodexCliIntelligenceProvider.ts
+++ b/src/core/CodexCliIntelligenceProvider.ts
@@ -354,7 +354,14 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
    * failing the call. Losing account SELECTION is a small loss; losing every
    * internal Codex call is not.
    */
-  private accountForCall(): CodexCallAccount | null {
+  private accountForCall(options?: IntelligenceOptions): CodexCallAccount | null {
+    // A per-call override wins over the provider's resolver. The failure tail uses
+    // it to retry ONE call on the sibling account — a decision that belongs to that
+    // attempt, not to the provider, and that a provider-level closure cannot express.
+    const override = options?.accountOverride;
+    if (override && typeof override.configHome === 'string' && override.configHome.length > 0) {
+      return { accountId: override.accountId, configHome: override.configHome };
+    }
     if (!this.resolveAccount) return null;
     try {
       const a = this.resolveAccount();
@@ -440,7 +447,7 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     // actually used, the health gauge would be quietly wrong — and a gauge that
     // can disagree with reality is worse than no gauge, because a trigger would
     // act on it with confidence.
-    const account = this.accountForCall();
+    const account = this.accountForCall(options);
     const startedAtMs = Date.now();
     let ok = false;
     try {

--- a/src/core/CodexCliIntelligenceProvider.ts
+++ b/src/core/CodexCliIntelligenceProvider.ts
@@ -289,17 +289,71 @@ export interface CodexCliIntelligenceProviderOptions {
    * working rollback lever.
    */
   resolveExecJson?: () => boolean;
+  /**
+   * Optional per-call resolver naming WHICH pool account this call runs on.
+   *
+   * Internal Codex calls have never chosen an account: the child inherits the
+   * ambient `CODEX_HOME`, so every one of them lands on the default login. That
+   * is why "swap a degrading Codex session onto the other Codex account" has no
+   * mechanism behind it for internal calls — there is only ever one account in
+   * play, and nothing records which.
+   *
+   * This supplies the missing degree of freedom. It is a per-call CLOSURE, not a
+   * constructor value, for the same reason `resolveExecJson` is: the router
+   * caches built providers, so a value captured at construction would freeze the
+   * first answer forever.
+   *
+   * ABSENT OR NULL ⇒ ambient behaviour, byte-identical to today. The account is
+   * only ever narrowed when a caller deliberately supplies one, so wiring this
+   * is a separate, deliberate act — nothing changes by adding the capability.
+   *
+   * The resolver must not throw; if it does, the call falls back to ambient
+   * rather than failing, because losing every internal Codex call would be
+   * strictly worse than losing account selection for one of them.
+   */
+  resolveAccount?: () => CodexCallAccount | null;
+}
+
+/** Which pool account an internal Codex call should run under. */
+export interface CodexCallAccount {
+  /** Pool account id — recorded so a later reading can be attributed to it. */
+  accountId: string;
+  /** That account's credential slot; becomes the child's `CODEX_HOME`. */
+  configHome: string;
 }
 
 export class CodexCliIntelligenceProvider implements IntelligenceProvider {
   private readonly codexPath: string;
+  /** @see CodexCliIntelligenceProviderOptions.resolveAccount */
+  private readonly resolveAccount: (() => CodexCallAccount | null) | undefined;
   private readonly sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
   private readonly resolveExecJson: () => boolean;
+
+  /**
+   * Resolve the account for this call, or null for ambient.
+   *
+   * Never throws: a broken resolver degrades to the ambient default rather than
+   * failing the call. Losing account SELECTION is a small loss; losing every
+   * internal Codex call is not.
+   */
+  private accountForCall(): CodexCallAccount | null {
+    if (!this.resolveAccount) return null;
+    try {
+      const a = this.resolveAccount();
+      if (!a || typeof a.configHome !== 'string' || a.configHome.length === 0) return null;
+      return a;
+    } catch {
+      /* @silent-fallback-ok: degrade to ambient. Documented on the option; the
+         alternative is failing calls that would otherwise have succeeded. */
+      return null;
+    }
+  }
 
   constructor(options: CodexCliIntelligenceProviderOptions) {
     this.codexPath = options.codexPath;
     this.sandboxMode = options.sandboxMode ?? 'read-only';
     this.resolveExecJson = options.resolveExecJson ?? execJsonEnvDefault;
+    this.resolveAccount = options.resolveAccount;
     // options.workingDirectory is intentionally NOT stored: judgment calls
     // always run in an empty scratch dir (resolveIntelligenceScratchDir), so
     // the agent's project identity + hooks never load. The option is retained
@@ -436,7 +490,10 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
       // CLAUDECODE / CLAUDE_SESSION_ID are not in the allowlist so they
       // are dropped automatically — the prior explicit deletes are now
       // redundant but the hygiene intent is preserved by the allowlist.
-      const childEnv = buildCodexChildEnv();
+      const spawnAccount = this.accountForCall();
+      const childEnv = buildCodexChildEnv(
+        spawnAccount ? { codexHome: spawnAccount.configHome } : undefined,
+      );
 
       const child = execFile(
         this.codexPath,
@@ -514,7 +571,9 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
 
       const result = await spawnCodexExecJson(this.codexPath, args, {
         timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        env: buildCodexChildEnv(), // Spec 12 Rule 1a — both modes
+        env: buildCodexChildEnv(
+          this.accountForCall() ? { codexHome: this.accountForCall()!.configHome } : undefined,
+        ), // Spec 12 Rule 1a — both modes
         prompt,
         onLine: (line) => {
           acc.feedLine(line);

--- a/src/core/CompositeCredentialIdentityOracle.ts
+++ b/src/core/CompositeCredentialIdentityOracle.ts
@@ -1,0 +1,87 @@
+/**
+ * One identity oracle that can speak for BOTH kinds of credential slot.
+ *
+ * `IdentityOracle.resolveSlotTenant(slot)` is handed a directory path and nothing
+ * else — no framework, no provider. The production implementation answers by
+ * calling Anthropic's OAuth profile endpoint, so it can only ever speak for a
+ * claude-code slot. Handed a Codex home it returns `unavailable`, and because the
+ * subscription pool refuses to enrol an account whose slot identity cannot be
+ * verified, Codex accounts could not be enrolled at all — the pool held six
+ * Anthropic accounts and zero Codex ones while both Codex logins sat
+ * authenticated on disk.
+ *
+ * Since the contract carries no framework, the slot has to identify ITSELF. It
+ * can: a Codex home holds `auth.json` with an OIDC `id_token`; a Claude home does
+ * not. That is a content discriminator, not a guess from the path name — a slot
+ * renamed or symlinked anywhere still answers correctly.
+ *
+ * ## Order, and why Codex is tried first
+ *
+ * The Codex probe is a local file read that returns immediately when the file is
+ * absent, so trying it first costs a `stat` on a Claude slot. The reverse order
+ * would send every Codex enrolment through a doomed network round-trip to
+ * Anthropic before failing. Cheap-and-local first, network second.
+ *
+ * A directory holding BOTH credential kinds resolves as Codex. That is
+ * deterministic rather than correct-by-nature; it is not a shape instar creates,
+ * and the alternative (refusing to answer) would be worse — it would block
+ * enrolment on an ambiguity nobody has.
+ *
+ * ## What this does NOT change
+ *
+ * The Anthropic path is untouched: same oracle, same call, same result, same
+ * quarantine-never-repair semantics for an unverifiable slot. This composes; it
+ * does not reimplement. And identity remains a LABEL — it names and de-duplicates
+ * a pool row and grants nothing.
+ */
+
+import type { IdentityOracle, IdentityOracleResult } from './CredentialLocationLedger.js';
+import {
+  readCodexSlotIdentity,
+  type CodexSlotIdentity,
+} from '../providers/adapters/openai-codex/codexSlotIdentity.js';
+
+export interface CompositeCredentialIdentityOracleDeps {
+  /** The existing (Anthropic OAuth) oracle. Used verbatim for non-Codex slots. */
+  anthropic: IdentityOracle;
+  /** Injected for tests; production reads the real credential file. */
+  readCodex?: (codexHome: string) => CodexSlotIdentity;
+}
+
+export class CompositeCredentialIdentityOracle implements IdentityOracle {
+  private readonly anthropic: IdentityOracle;
+  private readonly readCodex: (codexHome: string) => CodexSlotIdentity;
+
+  constructor(deps: CompositeCredentialIdentityOracleDeps) {
+    this.anthropic = deps.anthropic;
+    this.readCodex = deps.readCodex ?? readCodexSlotIdentity;
+  }
+
+  async resolveSlotTenant(slot: string): Promise<IdentityOracleResult> {
+    let codex: CodexSlotIdentity;
+    try {
+      codex = this.readCodex(slot);
+    } catch {
+      /* @silent-fallback-ok: the Codex probe is a best-effort discriminator. If it
+         throws (it is written not to), the slot is simply treated as non-Codex and
+         the Anthropic path answers — the pre-existing behaviour. Failing the whole
+         resolution here would REMOVE the ability to enrol claude-code accounts,
+         which is a strictly worse outcome than an unanswered Codex probe. */
+      return this.anthropic.resolveSlotTenant(slot);
+    }
+
+    if (!codex.unavailable && codex.email) {
+      return { email: codex.email };
+    }
+
+    // `auth-file-missing` is the ordinary "this is not a Codex slot" answer, so it
+    // falls through silently. Any OTHER Codex reason means the slot IS a Codex
+    // home that could not identify itself — Anthropic cannot speak for it either,
+    // so report it honestly instead of masking it as an Anthropic failure.
+    if (codex.reason && codex.reason !== 'auth-file-missing') {
+      return { unavailable: true, reason: `codex-slot-${codex.reason}` };
+    }
+
+    return this.anthropic.resolveSlotTenant(slot);
+  }
+}

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -174,6 +174,26 @@ export interface IntelligenceRouterOptions {
    */
   nonGatingFailureSwap?: { enabled: boolean; maxAttempts?: number };
   /**
+   * SIBLING-ACCOUNT failure tail. When a `codex-cli` call fails, the shipped tail sends the
+   * retry to the next DOOR — and the last door is `claude-code`, i.e. the main subscription
+   * this provider exists to protect. Holding two Codex logins makes a nearer position
+   * available: the SAME door on the OTHER account. This resolver supplies those positions,
+   * which are tried BEFORE any door change.
+   *
+   * Called with the framework that just failed and the account it ran on (null when the call
+   * ran on the ambient login, i.e. unattributable). MUST NOT throw. Returning `[]` — or being
+   * absent entirely — leaves the tail byte-identical to today, which is what makes this safe
+   * to land dark: a single-account agent has no sibling and therefore no new behaviour.
+   *
+   * The router does not decide WHICH account is eligible (healthy, not rate-limited, same
+   * framework) — that judgment belongs to the pool that owns account state. The router only
+   * consumes the ordered list it is handed.
+   */
+  resolveSiblingAccounts?: (
+    framework: IntelligenceFramework,
+    failedAccountId: string | null,
+  ) => ReadonlyArray<{ accountId: string; configHome: string }>;
+  /**
    * Build a provider for a non-default framework, with its OWN circuit breaker.
    * Returns null when that framework's binary isn't available. Called at most
    * once per framework (result cached). MUST NOT throw (catch internally).
@@ -1466,12 +1486,62 @@ export class IntelligenceRouter implements IntelligenceProvider {
     // already reserve-clamped); the legacy path supplies the config `failureSwap` frameworks
     // (each taking the caller's tier, clamped per-door in the loop). BOTH ride the SAME
     // gating||deferrable gate and the SAME loop below — the spec's "reuse verbatim".
-    const swapPositions: ReadonlyArray<{ door: IntelligenceFramework; model?: string }> =
+    // The account the primary attempt ran on, when the caller named one. Ambient calls are
+    // `null` — genuinely unknown, not "the default": the router cannot see which login the
+    // child inherited, and inventing an id here would make the self-exclusion filter below
+    // silently wrong. Null simply means no sibling can be excluded by identity.
+    const primaryAccountId: string | null = options?.accountOverride?.accountId ?? null;
+    const doorPositions: ReadonlyArray<{ door: IntelligenceFramework; model?: string }> =
       gating || deferrable
         ? enforced
           ? enforced.swapTail.map((p) => ({ door: p.door as IntelligenceFramework, model: p.modelId }))
           : (cfg?.failureSwap ?? []).map((fw) => ({ door: fw }))
         : [];
+    // SIBLING-ACCOUNT positions come FIRST. The shipped tail's last door is `claude-code` —
+    // the main subscription — so a failing Codex call currently ends up spending exactly the
+    // budget the Codex door exists to protect. The other Codex login is the nearer position:
+    // same door, same model tier, different account. Trying it first is what stops the tail
+    // from reaching Claude at all in the common case (one account unwell, one healthy).
+    //
+    // Positions are prepended, never substituted: if every sibling also fails, the original
+    // door tail runs exactly as before, so this can only ever ADD an attempt before the
+    // fall-through — never remove the fall-through itself.
+    //
+    // Absent resolver ⇒ empty ⇒ `swapPositions` is `doorPositions` unchanged (dark by default).
+    const siblingPositions: ReadonlyArray<{
+      door: IntelligenceFramework;
+      model?: string;
+      account: { accountId: string; configHome: string };
+    }> = (() => {
+      if (doorPositions.length === 0) return []; // no tail eligible at all → nothing to prepend to
+      const resolve = this.opts.resolveSiblingAccounts;
+      if (!resolve) return [];
+      let siblings: ReadonlyArray<{ accountId: string; configHome: string }>;
+      try {
+        siblings = resolve(framework, primaryAccountId) ?? [];
+      } catch {
+        // A broken resolver must cost us the ENHANCEMENT, never the shipped tail.
+        return [];
+      }
+      return siblings
+        .filter(
+          (s) =>
+            typeof s?.configHome === 'string' &&
+            s.configHome.length > 0 &&
+            typeof s?.accountId === 'string' &&
+            s.accountId.length > 0 &&
+            // A "sibling" that is the account that just failed is not a sibling. Retrying the
+            // failing account under a new label is a wasted attempt against a budget the
+            // gating deadline is actively spending.
+            s.accountId !== primaryAccountId,
+        )
+        .map((s) => ({ door: framework, account: { accountId: s.accountId, configHome: s.configHome } }));
+    })();
+    const swapPositions: ReadonlyArray<{
+      door: IntelligenceFramework;
+      model?: string;
+      account?: { accountId: string; configHome: string };
+    }> = siblingPositions.length > 0 ? [...siblingPositions, ...doorPositions] : doorPositions;
     // GATING budget: a single hard wall-clock deadline over the whole gating failure path so an
     // awaited gate stays responsive (no stacking rungs). Deferrable calls are not budgeted this way.
     const gatingDeadlineAt = gating && ladder ? Date.now() + ladder.gatingLadderBudgetMs : undefined;
@@ -1578,7 +1648,12 @@ export class IntelligenceRouter implements IntelligenceProvider {
         // and fail closed now (responsiveness over completeness — spec §3a). Deferrable calls have
         // no such deadline (gatingDeadlineAt is undefined for them).
         if (gatingDeadlineAt !== undefined && Date.now() > gatingDeadlineAt) break;
-        if (target === framework) continue; // don't retry the framework that just failed
+        // Don't retry the framework that just failed — UNLESS this position carries a
+        // different ACCOUNT. The rule's purpose is "don't repeat the attempt that just
+        // failed", and same-door-other-account is not that attempt: it is a different
+        // login, quota window and rate-limit state. Without this carve-out every sibling
+        // position would be skipped and the tail would go straight to the next door.
+        if (target === framework && !t.account) continue;
         const tp = this.resolveProvider(target);
         if (!tp) continue; // target binary missing → skip
         let cap = resolveSwapCap(target, globalCapMs, byFramework, maxCapMs);
@@ -1627,10 +1702,14 @@ export class IntelligenceRouter implements IntelligenceProvider {
         // legacy path, plus the correlation plumbing); an enforced position's model
         // always overrides it below.
         const attemptExtra: Partial<IntelligenceOptions> | undefined =
-          cap !== undefined || overrideModel
+          cap !== undefined || overrideModel || t.account
             ? {
                 ...(cap !== undefined ? { timeoutMs: cap } : {}),
                 ...(overrideModel ? { model: attemptModel } : {}),
+                // A sibling position names the account it must run on. Without this the
+                // attempt would inherit the ambient login — i.e. re-run on the account that
+                // just failed, while the log claimed it had moved.
+                ...(t.account ? { accountOverride: t.account } : {}),
               }
             : undefined;
         try {
@@ -1650,7 +1729,11 @@ export class IntelligenceRouter implements IntelligenceProvider {
             category,
             from: framework,
             to: target,
-            reason: `failure-swap: '${framework}' failed (${err instanceof Error ? err.message : 'error'}); served by '${target}'`,
+            reason: t.account
+              ? // A sibling swap did NOT change door, so 'codex-cli → codex-cli' would read as
+                // a no-op. Name the ACCOUNT, which is the thing that actually changed.
+                `failure-swap: '${framework}' failed (${err instanceof Error ? err.message : 'error'}); served by sibling account '${t.account.accountId}' on the same door`
+              : `failure-swap: '${framework}' failed (${err instanceof Error ? err.message : 'error'}); served by '${target}'`,
           });
           this.opts.onResolved?.(component ?? '(none)', framework); // real answer via swap → auto-resolve
           return result;

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -1519,8 +1519,21 @@ export class IntelligenceRouter implements IntelligenceProvider {
       let siblings: ReadonlyArray<{ accountId: string; configHome: string }>;
       try {
         siblings = resolve(framework, primaryAccountId) ?? [];
-      } catch {
-        // A broken resolver must cost us the ENHANCEMENT, never the shipped tail.
+      } catch (resolveErr) {
+        // A broken resolver costs us the ENHANCEMENT, never the shipped tail — but it must
+        // not cost it SILENTLY. A resolver throwing on every call disables the sibling tail
+        // completely, so every Codex failure walks back onto the main subscription: the
+        // exact spend this feature exists to stop, invisibly restored. Surfacing it through
+        // onDegrade puts it in DegradationReporter where a persistent fault is visible.
+        this.opts.onDegrade?.({
+          component: component ?? '(none)',
+          category,
+          from: framework,
+          to: framework, // nothing moved — that IS the degradation being reported
+          reason:
+            `sibling-account resolver threw (${resolveErr instanceof Error ? resolveErr.message : 'error'}); ` +
+            `'${framework}' failure tail falls through to the next door instead of a sibling account`,
+        });
         return [];
       }
       return siblings

--- a/src/core/ProactiveSwapMonitor.ts
+++ b/src/core/ProactiveSwapMonitor.ts
@@ -131,7 +131,7 @@ export interface ProactiveSwapMonitorConfig {
     targetAccountId?: string;
     callerClass?: 'proactive-swap';
     sourceWasUntagged?: boolean;
-    sourceTrigger?: 'quota-pressure' | 'login-loss';
+    sourceTrigger?: 'quota-pressure' | 'login-loss' | 'degradation';
   }) => Promise<ProactiveSwapOutcome>;
   /** Optional fresh-poll trigger, awaited when an account is in the watch zone. */
   triggerPoll?: () => Promise<unknown>;
@@ -160,6 +160,35 @@ export interface ProactiveSwapMonitorConfig {
     enabled: boolean;
     dryRun: boolean;
   };
+  /**
+   * Degradation trigger: swap off an account that is SLOW or ERRORING, not just
+   * one that is full.
+   *
+   * Quota was never the problem being solved. The observed failure was latency —
+   * a trivial call taking ~13s while several checks sat at the 60s ceiling, with
+   * the account at 17% of its window. A quota-only trigger cannot see any of that.
+   *
+   * `readHealth` returns null when it cannot answer honestly (too few samples).
+   * Null means UNKNOWN and is treated as NOT degraded — never as a reason to move
+   * a live session. Acting on an unknown is how a trigger starts thrashing.
+   *
+   * Same shape as `loginLoss` above: dark by default, and dryRun records the
+   * would-swap without touching a session.
+   */
+  degradation?: {
+    enabled: boolean;
+    dryRun: boolean;
+    /** p50 latency at or above which an account counts as degrading. */
+    p50ThresholdMs: number;
+    /** error rate (0..1) at or above which an account counts as degrading. */
+    errorRateThreshold: number;
+    /** Per-account health, or null when it cannot responsibly answer. */
+    readHealth: (accountId: string) => {
+      p50LatencyMs: number;
+      errorRate: number;
+      samples: number;
+    } | null;
+  };
   /** In-flight work deferral (Piece 2). Knobs read live per evaluation. */
   workGate?: {
     probe: (sessionName: string) => Promise<WorkProbeResult>;
@@ -187,7 +216,7 @@ interface Candidate {
   startedMs: number;
   /** True when the session carries no tag (resolved via the default slot). */
   untagged: boolean;
-  sourceTrigger: 'quota-pressure' | 'login-loss';
+  sourceTrigger: 'quota-pressure' | 'login-loss' | 'degradation';
 }
 
 interface DeferralEntry {
@@ -337,6 +366,31 @@ export class ProactiveSwapMonitor {
     }
   }
 
+  /**
+   * Is this account measurably degrading right now?
+   *
+   * False whenever we cannot tell. An unreadable account, a missing reading, or a
+   * throwing health source all mean UNKNOWN — and unknown must never move a live
+   * session, because the cost of a wrong swap (thrash, a conversation restarted
+   * for nothing) exceeds the cost of a late one.
+   */
+  private isDegraded(accountId: string): boolean {
+    const d = this.cfg.degradation;
+    if (!d || d.enabled !== true) return false;
+    let reading: { p50LatencyMs: number; errorRate: number; samples: number } | null;
+    try {
+      reading = d.readHealth(accountId);
+    } catch {
+      /* @silent-fallback-ok: an unreadable gauge is UNKNOWN, never "degraded".
+         Swapping on a broken measurement is worse than not swapping. */
+      return false;
+    }
+    if (!reading) return false;
+    return (
+      reading.p50LatencyMs >= d.p50ThresholdMs || reading.errorRate >= d.errorRateThreshold
+    );
+  }
+
   // ── The LIVE braked pipeline (§3 + §4 proactive arm) ─────────────────────
   private async evaluateBraked(
     engine: SwapAntiThrashEngine,
@@ -361,14 +415,19 @@ export class ProactiveSwapMonitor {
       const acct = byId.get(effectiveAccountId);
       if (!acct) continue;
       const loginLoss = this.cfg.loginLoss?.enabled === true && requiresOwnerRelogin(acct);
-      if (!loginLoss && !engine.sourceEligible(acct, nowMs)) continue;
+      // A degrading account is a reason to move REGARDLESS of how full it is —
+      // that is the entire point, since quota was never the problem. It bypasses
+      // only SOURCE pressure; target freshness, ceilings and execution-time
+      // revalidation all still apply.
+      const degraded = !loginLoss && this.isDegraded(effectiveAccountId);
+      if (!loginLoss && !degraded && !engine.sourceEligible(acct, nowMs)) continue;
       const startedMs = s.startedAt ? Date.parse(s.startedAt) : NaN;
       candidates.push({
         sessionName: s.sessionName,
         accountId: effectiveAccountId,
         startedMs: Number.isFinite(startedMs) ? startedMs : 0,
         untagged: s.accountId === null,
-        sourceTrigger: loginLoss ? 'login-loss' : 'quota-pressure',
+        sourceTrigger: loginLoss ? 'login-loss' : degraded ? 'degradation' : 'quota-pressure',
       });
     }
     candidates.sort((a, b) => b.startedMs - a.startedMs);
@@ -501,7 +560,14 @@ export class ProactiveSwapMonitor {
       // The trigger stays explicit so login loss bypasses only source pressure,
       // never target freshness, target ceilings, or execution-time safeguards.
       try {
-        if (c.sourceTrigger === 'login-loss' && this.cfg.loginLoss?.dryRun !== false) {
+        // Rehearsal for the two extension triggers. Each records the EXACT
+        // would-swap — same target the live path would have used — without
+        // touching the session, so the decision can be reviewed before any
+        // conversation is moved.
+        const dryRunTrigger =
+          (c.sourceTrigger === 'login-loss' && this.cfg.loginLoss?.dryRun !== false) ||
+          (c.sourceTrigger === 'degradation' && this.cfg.degradation?.dryRun !== false);
+        if (dryRunTrigger) {
           engine.recordProactiveExecuted({
             session: c.sessionName,
             from: c.accountId,
@@ -509,13 +575,15 @@ export class ProactiveSwapMonitor {
             nowMs,
             fromUtilPct: verdict.fromUtilPct,
             toUtilPct: verdict.toUtilPct,
-            sourceTrigger: 'login-loss',
+            sourceTrigger: c.sourceTrigger,
             dryRun: true,
             ...(c.untagged ? { sourceWasUntagged: true } : {}),
           });
           targetsUsedThisTick.add(verdict.targetAccountId);
           this.logger.log(
-            `[ProactiveSwap] ${c.sessionName}: would swap off missing login ${c.accountId} → ${verdict.targetAccountId} (dry-run; conversation untouched)`,
+            c.sourceTrigger === 'degradation'
+              ? `[ProactiveSwap] ${c.sessionName}: would swap off DEGRADING ${c.accountId} → ${verdict.targetAccountId} (dry-run; conversation untouched)`
+              : `[ProactiveSwap] ${c.sessionName}: would swap off missing login ${c.accountId} → ${verdict.targetAccountId} (dry-run; conversation untouched)`,
           );
           continue;
         }
@@ -554,7 +622,13 @@ export class ProactiveSwapMonitor {
           swapped.push(c.sessionName);
           this.logger.log(
             `[ProactiveSwap] ${c.sessionName}: proactively swapped off ${c.accountId} → ${outcome.toAccountId ?? verdict.targetAccountId} ` +
-              `(${c.sourceTrigger === 'login-loss' ? 'local login missing' : `account ≥${this.thresholdPct}% measured`} — conversation preserved)`,
+              `(${
+                c.sourceTrigger === 'login-loss'
+                  ? 'local login missing'
+                  : c.sourceTrigger === 'degradation'
+                    ? 'account measurably degrading'
+                    : `account ≥${this.thresholdPct}% measured`
+              } — conversation preserved)`,
           );
         } else if (outcome.reason === 'target-revalidation-failed') {
           engine.recordRevalidationRefusal({
@@ -660,6 +734,18 @@ export class ProactiveSwapMonitor {
     const swapped: string[] = [];
     for (const c of toSwap) {
       let outcome: ProactiveSwapOutcome;
+      // REHEARSAL, and the safety-critical half of it. The braked pipeline has a
+      // dry-run short-circuit; this legacy pipeline is the one that actually runs
+      // wherever the anti-thrash brakes are dark or dry-run — i.e. where the
+      // degradation trigger ships. Without this guard a "dry-run" trigger would
+      // move a live conversation on its very first firing, which is the opposite
+      // of what dry-run means.
+      if (c.sourceTrigger === 'degradation' && this.cfg.degradation?.dryRun !== false) {
+        this.logger.log(
+          `[ProactiveSwap] ${c.sessionName}: would swap off DEGRADING ${c.accountId} (dry-run; conversation untouched)`,
+        );
+        continue;
+      }
       try {
         // Self-action backpressure admission (observe-only; legacy path keys
         // on the vacated account — the scheduler picks the destination).
@@ -745,14 +831,20 @@ export class ProactiveSwapMonitor {
       if (!eff) continue;
       const acct = byId.get(eff);
       if (!acct) continue;
-      if (!accountAtPressure(acct, minPct)) continue;
+      // The degradation trigger must reach BOTH pipelines. The braked path only
+      // runs when the anti-thrash brakes are live; on every install where they
+      // are dark or dry-run this legacy path is the one that executes, so wiring
+      // only the braked path would have left the trigger silently inert exactly
+      // where it ships today.
+      const degraded = this.isDegraded(eff);
+      if (!degraded && !accountAtPressure(acct, minPct)) continue;
       const startedMs = s.startedAt ? Date.parse(s.startedAt) : NaN;
       out.push({
         sessionName: s.sessionName,
         accountId: eff,
         startedMs: Number.isFinite(startedMs) ? startedMs : 0,
         untagged: s.accountId === null,
-        sourceTrigger: 'quota-pressure',
+        sourceTrigger: degraded ? 'degradation' : 'quota-pressure',
       });
     }
     return out;

--- a/src/core/QuotaAwareScheduler.ts
+++ b/src/core/QuotaAwareScheduler.ts
@@ -213,7 +213,7 @@ export interface QuotaSwapAntiThrashHooks {
   resolveEffectiveAccountId: (
     sessionName: string,
     sourceWasUntagged: boolean,
-    sourceTrigger?: 'quota-pressure' | 'login-loss',
+    sourceTrigger?: 'quota-pressure' | 'login-loss' | 'degradation',
   ) => Promise<string | null>;
   /** Observe an executed REACTIVE swap (dwell clock-start, hop alerts). */
   onReactiveExecuted?: (args: { session: string; from: string; to: string; nowMs: number }) => void;
@@ -278,7 +278,7 @@ export class QuotaAwareScheduler {
     sourceWasUntagged?: boolean;
     /** Level-triggered source condition. Login loss is revalidated at the same
      * kill boundary as the untagged default-account identity. */
-    sourceTrigger?: 'quota-pressure' | 'login-loss';
+    sourceTrigger?: 'quota-pressure' | 'login-loss' | 'degradation';
   }): Promise<SwapResult> {
     const { sessionName, exhaustedAccountId, nowMs, targetAccountId } = args;
     const isProactive = targetAccountId !== undefined;

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -163,6 +163,69 @@ export function requiresOwnerRelogin(account: SubscriptionAccount): boolean {
 }
 
 /**
+ * Which accounts may serve as the SIBLING position in the router's failure tail —
+ * the same door on a different login, tried before the tail changes door (whose last
+ * position is `claude-code`, the main subscription that door exists to protect).
+ *
+ * Eligibility lives here rather than in the router because the pool owns account
+ * state. Three rules, each protecting a bounded gating deadline:
+ *
+ *  - SAME framework. A Codex session cannot run on a Claude login; a cross-framework
+ *    "sibling" is a guaranteed-failed attempt (and would be the very spend we are
+ *    avoiding). This mirrors SwapAntiThrash's existing same-framework restriction.
+ *  - `active` ONLY. A rate-limited, warming, disabled or needs-reauth account is a
+ *    known-bad attempt. Excluding it is not caution, it is correctness: the tail is
+ *    trying to find a working answer quickly.
+ *  - NOT the account that just failed. Retrying the failing login under a fresh label
+ *    spends the deadline on an attempt already known to fail — and, worse, reports it
+ *    as a swap, so the logs claim a move that never happened.
+ *
+ * IDENTIFYING THE FAILED ACCOUNT is the subtle part. A call that named its account is
+ * easy (`failedAccountId`). A call that ran on the AMBIENT login is not: the router
+ * cannot see which login the child inherited. For those, the caller supplies the
+ * ambient home (`ambientConfigHome`) and the match is made on that instead.
+ *
+ * When NEITHER identifier is available we return nothing rather than guess. A guess is
+ * not merely unhelpful here: on a single-account agent every candidate IS the account
+ * that just failed, so guessing would reliably re-run the failure — the exact defect
+ * the self-exclusion rule exists to prevent.
+ *
+ * An ambient home matching NO enrolled account is not a failure: the primary ran on an
+ * unenrolled login, so every enrolled account is genuinely a different one.
+ *
+ * Bounded by `limit` (default 1): the tail exists to find an answer, not to walk an
+ * entire pool while a gate waits.
+ */
+export function eligibleSiblingAccounts(
+  accounts: readonly SubscriptionAccount[],
+  framework: SubscriptionFramework,
+  failedAccountId: string | null,
+  opts: { ambientConfigHome?: string | null; limit?: number } = {},
+): Array<{ accountId: string; configHome: string }> {
+  const limit = opts.limit ?? 1;
+  const ambient = opts.ambientConfigHome;
+  const hasAmbient = typeof ambient === 'string' && ambient.length > 0;
+  if (!Array.isArray(accounts) || limit <= 0) return [];
+  // Neither identifier ⇒ we cannot tell a sibling from the account that just failed.
+  if (failedAccountId === null && !hasAmbient) return [];
+  return accounts
+    .filter(
+      (a) =>
+        !!a &&
+        a.framework === framework &&
+        a.status === 'active' &&
+        typeof a.configHome === 'string' &&
+        a.configHome.length > 0 &&
+        typeof a.id === 'string' &&
+        a.id.length > 0 &&
+        a.id !== failedAccountId &&
+        !(hasAmbient && a.configHome === ambient),
+    )
+    .slice(0, limit)
+    .map((a) => ({ accountId: a.id, configHome: a.configHome }));
+}
+
+/**
  * WS5.2 §6.2 — "locally executable" predicate. An account is executable on THIS
  * machine iff this machine holds it with a real local `configHome` AND a valid
  * login (status active/warming, never needs-reauth/disabled/rate-limited). A

--- a/src/core/SwapAntiThrash.ts
+++ b/src/core/SwapAntiThrash.ts
@@ -186,7 +186,7 @@ export interface ProactiveIntentInput {
   deferCount?: number;
   /** Login loss bypasses only the source-pressure arithmetic. Every target,
    * work, dwell, breaker, freshness, and execution-boundary guard still binds. */
-  sourceTrigger?: 'quota-pressure' | 'login-loss';
+  sourceTrigger?: 'quota-pressure' | 'login-loss' | 'degradation';
 }
 
 export type BrakeVerdict =
@@ -692,7 +692,7 @@ export class SwapAntiThrashEngine {
     defaultAccountChanged?: boolean;
     sourceWasUntagged?: boolean;
     dryRun?: boolean;
-    sourceTrigger?: 'quota-pressure' | 'login-loss';
+    sourceTrigger?: 'quota-pressure' | 'login-loss' | 'degradation';
   }): void {
     const k = this.getKnobs();
     const row: SwapLedgerRow = {

--- a/src/core/SwapLedger.ts
+++ b/src/core/SwapLedger.ts
@@ -110,7 +110,7 @@ export interface SwapLedgerRow {
   /** Source session resolved through the default login; the default itself did not change. */
   sourceWasUntagged?: boolean;
   /** The level-triggered condition that authorized this proactive intent. */
-  sourceTrigger?: 'quota-pressure' | 'login-loss';
+  sourceTrigger?: 'quota-pressure' | 'login-loss' | 'degradation';
   episodeId?: string;
   episodeKind?: EpisodeKind;
   breakerOpenedAt?: string;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1025,6 +1025,18 @@ export interface IntelligenceOptions {
    * attribution lands under the `unknown::*` fallback keys so existing
    * callers keep working unchanged. New callers should set it.
    */
+  /**
+   * Force THIS call onto a specific provider account (its credential slot).
+   *
+   * Used by the failure tail: when a Codex call fails, the next thing tried should
+   * be the SIBLING Codex account, not the main subscription the second provider
+   * exists to protect. That retry has to name an account for one call only, which
+   * a provider-level resolver cannot express.
+   *
+   * Absent ⇒ the provider's own account resolution (usually: the ambient login).
+   * Honoured only by providers that support account selection; ignored elsewhere.
+   */
+  accountOverride?: { accountId: string; configHome: string };
   attribution?: {
     /** Stable source-side component label, e.g. "InputDetector", "MessagingToneGate". */
     component: string;

--- a/src/providers/adapters/openai-codex/codexSlotIdentity.ts
+++ b/src/providers/adapters/openai-codex/codexSlotIdentity.ts
@@ -1,0 +1,138 @@
+/**
+ * Who is signed in at a Codex credential slot?
+ *
+ * The subscription pool refuses to enrol an account whose slot identity cannot be
+ * verified — that guard is what stops two pool entries silently pointing at the
+ * same login. The existing oracle answers this by calling Anthropic's OAuth
+ * profile endpoint, so it can only ever speak for a claude-code slot; handed a
+ * Codex home it fails `email-unresolved`, which is why Codex accounts could not
+ * be enrolled at all.
+ *
+ * A Codex slot answers the same question WITHOUT a network call: `auth.json`
+ * carries an OIDC id_token whose payload holds the account's email, a stable
+ * per-account id, and the plan tier.
+ *
+ * ## Why the token is decoded and not verified
+ *
+ * This is deliberate and is NOT authentication. We are reading the identity of a
+ * credential this machine already holds, to label a pool row — the token is not a
+ * bearer presented by some caller whose claims must be doubted. Anyone able to
+ * edit `auth.json` can already use the credential itself, so signature
+ * verification would add no protection against them. Verification would, though,
+ * require the issuer's public keys over the network, which is exactly the
+ * dependency that makes the Anthropic oracle unable to answer offline.
+ *
+ * The identity it yields is therefore an ASSERTION about a local file, and is
+ * used only to name and de-duplicate pool rows. It is never a permission.
+ *
+ * ## What never leaves this module
+ *
+ * No token material — id_token, access_token, refresh_token, API key — is
+ * returned, logged, or included in an error. The result carries an email, an
+ * account id, and a plan string. A test asserts a token planted in the file
+ * appears in no field of the result and in no thrown message.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface CodexSlotIdentity {
+  /** The signed-in account's email, or null when the slot cannot say. */
+  email: string | null;
+  /** Stable per-account id — distinct logins have distinct ids. */
+  accountId: string | null;
+  /** Plan tier as the token reports it (e.g. 'pro'). Advisory only. */
+  planType: string | null;
+  /** True when this slot cannot be identified at all. `reason` says why. */
+  unavailable: boolean;
+  /**
+   * Machine-readable cause when `unavailable`. Never contains file contents —
+   * a malformed credential must not leak through an error string.
+   */
+  reason?:
+    | 'auth-file-missing'
+    | 'auth-file-unreadable'
+    | 'no-id-token'
+    | 'id-token-malformed'
+    | 'no-email-claim';
+}
+
+const UNAVAILABLE = (reason: NonNullable<CodexSlotIdentity['reason']>): CodexSlotIdentity => ({
+  email: null,
+  accountId: null,
+  planType: null,
+  unavailable: true,
+  reason,
+});
+
+/** OpenAI namespaces its non-standard claims under this key in the id_token. */
+const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth';
+
+/**
+ * Decode a JWT payload segment. Returns null on anything unexpected rather than
+ * throwing — a corrupt credential is an "unavailable slot", never a crash in the
+ * enrolment path.
+ */
+function decodePayload(idToken: string): Record<string, unknown> | null {
+  const parts = idToken.split('.');
+  if (parts.length < 2) return null;
+  const seg = parts[1];
+  if (!seg) return null;
+  try {
+    const padded = seg + '='.repeat((4 - (seg.length % 4)) % 4);
+    const json = Buffer.from(padded, 'base64url').toString('utf-8');
+    const parsed: unknown = JSON.parse(json);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    /* @silent-fallback-ok: a credential we cannot parse is an unidentifiable slot,
+       which the caller already handles. Rethrowing would put token bytes into a
+       stack/message, which this module exists to prevent. */
+    return null;
+  }
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+/**
+ * Read the identity signed in at a Codex home (the directory `CODEX_HOME`
+ * points at — e.g. `~/.codex`). Pure read; never writes, never spawns, never
+ * touches the network.
+ */
+export function readCodexSlotIdentity(codexHome: string): CodexSlotIdentity {
+  const authPath = path.join(codexHome, 'auth.json');
+  if (!fs.existsSync(authPath)) return UNAVAILABLE('auth-file-missing');
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(authPath, 'utf-8'));
+  } catch {
+    /* @silent-fallback-ok: unreadable/!JSON credential → unidentifiable slot. The
+       original error is deliberately dropped: it can quote file bytes. */
+    return UNAVAILABLE('auth-file-unreadable');
+  }
+  if (!raw || typeof raw !== 'object') return UNAVAILABLE('auth-file-unreadable');
+
+  const tokens = (raw as { tokens?: unknown }).tokens;
+  const tokenBag = tokens && typeof tokens === 'object' ? (tokens as Record<string, unknown>) : {};
+  const idToken = str(tokenBag['id_token']);
+  if (!idToken) return UNAVAILABLE('no-id-token');
+
+  const payload = decodePayload(idToken);
+  if (!payload) return UNAVAILABLE('id-token-malformed');
+
+  const email = str(payload['email']);
+  if (!email) return UNAVAILABLE('no-email-claim');
+
+  const openai = payload[OPENAI_AUTH_CLAIM];
+  const openaiBag = openai && typeof openai === 'object' ? (openai as Record<string, unknown>) : {};
+
+  // Prefer the id the credential file itself records; fall back to the token's
+  // claim. Both name the same account — the file is simply the more direct source.
+  const accountId = str(tokenBag['account_id']) ?? str(openaiBag['chatgpt_account_id']);
+  const planType = str(openaiBag['chatgpt_plan_type']);
+
+  return { email, accountId, planType, unavailable: false };
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -42,6 +42,24 @@ import { enrollPaneSessionName } from '../core/FrameworkLoginDriver.js';
 import { QUOTA_SNAPSHOT_STALE_AFTER_MS } from '../core/QuotaPoller.js';
 import { SubscriptionAccountEmailRegistrar } from '../core/SubscriptionPool.js';
 import { CredentialIdentityOracle } from '../core/CredentialIdentityOracle.js';
+import { CompositeCredentialIdentityOracle } from '../core/CompositeCredentialIdentityOracle.js';
+
+/**
+ * The default slot-identity oracle.
+ *
+ * Wraps the Anthropic OAuth oracle in the composite so a CODEX credential slot
+ * can identify itself too (offline, from its own id_token). Without this the
+ * pool's verified-add path rejects every Codex home as `email-unresolved`, which
+ * is why the pool held 6 anthropic accounts and 0 codex ones while both Codex
+ * logins sat authenticated on disk.
+ *
+ * The Anthropic path is unchanged — the composite delegates to it verbatim for
+ * any slot that is not a Codex home.
+ */
+function defaultSubscriptionIdentityOracle(): CompositeCredentialIdentityOracle {
+  return new CompositeCredentialIdentityOracle({ anthropic: new CredentialIdentityOracle() });
+}
+
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -28881,7 +28899,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     if (existing) {
       return new SubscriptionAccountEmailRegistrar(
         pool,
-        ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+        ctx.subscriptionIdentityOracle ?? defaultSubscriptionIdentityOracle(),
       ).completeValidated(login.id, email, {
         nickname: login.label,
         status: 'active',
@@ -28890,7 +28908,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
     return new SubscriptionAccountEmailRegistrar(
       pool,
-      ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+      ctx.subscriptionIdentityOracle ?? defaultSubscriptionIdentityOracle(),
       ctx.subscriptionEmailBinding,
     ).completeNewValidated({
       id: login.id, nickname: login.label,
@@ -29039,7 +29057,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     try {
       const registrar = new SubscriptionAccountEmailRegistrar(
         ctx.subscriptionPool,
-        ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+        ctx.subscriptionIdentityOracle ?? defaultSubscriptionIdentityOracle(),
         ctx.subscriptionEmailBinding,
       );
       res.json(await registrar.repairLegacy(req.params.id));
@@ -29110,7 +29128,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       // attempt to smuggle a token into the registry (structural invariant).
       const account = await new SubscriptionAccountEmailRegistrar(
         ctx.subscriptionPool,
-        ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+        ctx.subscriptionIdentityOracle ?? defaultSubscriptionIdentityOracle(),
       ).register(
         { id, nickname, provider, framework, configHome, status, email },
         req.body,

--- a/tests/integration/codex-pool-enrolment.test.ts
+++ b/tests/integration/codex-pool-enrolment.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Codex accounts can be enrolled in the subscription pool — end to end.
+ *
+ * This is the tier that would have caught the real defect. Unit tests of the
+ * identity reader pass whether or not it is WIRED; what mattered operationally is
+ * that `SubscriptionAccountEmailRegistrar.register()` — the pool's verified-add
+ * path, the one the enrol route actually uses — rejected every Codex home with
+ * `subscription-account-email-unresolved`, because the only oracle asks Anthropic.
+ *
+ * So these drive the real registrar against a real pool on a real temp state dir,
+ * with only the credential FILE faked. If the composite oracle is ever unwired,
+ * the first test fails.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  SubscriptionPool,
+  SubscriptionAccountEmailRegistrar,
+  SubscriptionIdentityError,
+} from '../../src/core/SubscriptionPool.js';
+import { CompositeCredentialIdentityOracle } from '../../src/core/CompositeCredentialIdentityOracle.js';
+import type { IdentityOracle, IdentityOracleResult } from '../../src/core/CredentialLocationLedger.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/** Stands in for the Anthropic OAuth oracle: it cannot speak for a Codex slot. */
+const anthropicOnly: IdentityOracle = {
+  async resolveSlotTenant(): Promise<IdentityOracleResult> {
+    return { unavailable: true, reason: 'oauth-profile-unreachable-for-this-slot' };
+  },
+};
+
+function writeCodexHome(root: string, name: string, email: string, accountId: string): string {
+  const home = path.join(root, name);
+  fs.mkdirSync(home, { recursive: true });
+  const payload = Buffer.from(
+    JSON.stringify({
+      email,
+      'https://api.openai.com/auth': { chatgpt_plan_type: 'pro', chatgpt_account_id: accountId },
+    }),
+    'utf-8',
+  ).toString('base64url');
+  fs.writeFileSync(
+    path.join(home, 'auth.json'),
+    JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: { id_token: `hdr.${payload}.sig`, account_id: accountId },
+    }),
+  );
+  return home;
+}
+
+describe('subscription pool — Codex enrolment (integration)', () => {
+  let stateDir: string;
+  let pool: SubscriptionPool;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-enrol-'));
+    pool = new SubscriptionPool({ stateDir });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(stateDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/codex-pool-enrolment.test.ts:cleanup',
+    });
+  });
+
+  it('THE DEFECT: with the Anthropic-only oracle a Codex account cannot be enrolled', async () => {
+    // The state of the world before this change — kept as a test so the fix has
+    // something to be a fix OF, and so a regression is legible rather than silent.
+    const home = writeCodexHome(stateDir, 'codex-a', 'a@example.com', 'acct-a');
+    const registrar = new SubscriptionAccountEmailRegistrar(pool, anthropicOnly);
+
+    await expect(
+      registrar.register({
+        id: 'codex-a',
+        nickname: 'Codex A',
+        provider: 'openai',
+        framework: 'codex-cli',
+        configHome: home,
+      }),
+    ).rejects.toBeInstanceOf(SubscriptionIdentityError);
+    expect(pool.list()).toHaveLength(0);
+  });
+
+  it('THE FIX: with the composite oracle the same account enrols', async () => {
+    const home = writeCodexHome(stateDir, 'codex-a', 'a@example.com', 'acct-a');
+    const registrar = new SubscriptionAccountEmailRegistrar(
+      pool,
+      new CompositeCredentialIdentityOracle({ anthropic: anthropicOnly }),
+    );
+
+    const acct = await registrar.register({
+      id: 'codex-a',
+      nickname: 'Codex A',
+      provider: 'openai',
+      framework: 'codex-cli',
+      configHome: home,
+    });
+
+    expect(acct.id).toBe('codex-a');
+    expect(acct.framework).toBe('codex-cli');
+    expect(acct.provider).toBe('openai');
+    // The email came from the SLOT, not from the caller — the caller never sent one.
+    expect(acct.email).toBe('a@example.com');
+    expect(pool.list()).toHaveLength(1);
+  });
+
+  it('TWO Codex accounts coexist as distinct pool rows', async () => {
+    // The whole point: codex-to-codex swap is impossible with fewer than two.
+    const registrar = new SubscriptionAccountEmailRegistrar(
+      pool,
+      new CompositeCredentialIdentityOracle({ anthropic: anthropicOnly }),
+    );
+    const a = writeCodexHome(stateDir, 'codex-a', 'a@example.com', 'acct-a');
+    const b = writeCodexHome(stateDir, 'codex-b', 'b@example.com', 'acct-b');
+
+    await registrar.register({ id: 'codex-a', nickname: 'A', provider: 'openai', framework: 'codex-cli', configHome: a });
+    await registrar.register({ id: 'codex-b', nickname: 'B', provider: 'openai', framework: 'codex-cli', configHome: b });
+
+    const rows = pool.list();
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.email)).size).toBe(2);
+    expect(new Set(rows.map((r) => r.configHome)).size).toBe(2);
+  });
+
+  it('a caller-supplied email that contradicts the slot is REFUSED', async () => {
+    // The identity guard must still bite: the slot is authoritative, not the caller.
+    const home = writeCodexHome(stateDir, 'codex-a', 'real@example.com', 'acct-a');
+    const registrar = new SubscriptionAccountEmailRegistrar(
+      pool,
+      new CompositeCredentialIdentityOracle({ anthropic: anthropicOnly }),
+    );
+
+    await expect(
+      registrar.register({
+        id: 'codex-a',
+        nickname: 'A',
+        provider: 'openai',
+        framework: 'codex-cli',
+        configHome: home,
+        email: 'claimed@example.com',
+      }),
+    ).rejects.toBeInstanceOf(SubscriptionIdentityError);
+    expect(pool.list()).toHaveLength(0);
+  });
+
+  it('CONTROL: a slot with no credential still refuses, so the guard is not simply off', async () => {
+    const empty = path.join(stateDir, 'empty-home');
+    fs.mkdirSync(empty, { recursive: true });
+    const registrar = new SubscriptionAccountEmailRegistrar(
+      pool,
+      new CompositeCredentialIdentityOracle({ anthropic: anthropicOnly }),
+    );
+
+    await expect(
+      registrar.register({ id: 'x', nickname: 'X', provider: 'openai', framework: 'codex-cli', configHome: empty }),
+    ).rejects.toBeInstanceOf(SubscriptionIdentityError);
+    expect(pool.list()).toHaveLength(0);
+  });
+});

--- a/tests/unit/codex-account-health.test.ts
+++ b/tests/unit/codex-account-health.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Per-account Codex health — the gauge a degradation trigger reads.
+ *
+ * Instar records LLM metrics against the component that ASKED, never the account
+ * that ANSWERED, so "is this account unwell" had no measurement behind it. These
+ * pin the gauge, and above all pin the honest-unknown rule: it must refuse to
+ * answer rather than guess, because a trigger acting on two samples would swap
+ * live sessions on noise.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CodexAccountHealth } from '../../src/core/CodexAccountHealth.js';
+
+function sample(accountId: string, latencyMs: number, ok: boolean, atMs: number) {
+  return { accountId, latencyMs, ok, atMs };
+}
+
+describe('CodexAccountHealth', () => {
+  it('reports median latency and error rate from real samples', () => {
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, minSamples: 3 });
+    h.record(sample('a', 100, true, now));
+    h.record(sample('a', 200, true, now));
+    h.record(sample('a', 300, false, now));
+
+    const r = h.read('a')!;
+    expect(r.p50LatencyMs).toBe(200);
+    expect(r.errorRate).toBeCloseTo(1 / 3);
+    expect(r.samples).toBe(3);
+  });
+
+  it('THE HONEST-UNKNOWN RULE: too few samples returns null, not a number', () => {
+    // The load-bearing property. A trigger acting on one or two samples would
+    // move live sessions on noise; the cost of a too-eager swap (thrash) is worse
+    // than the cost of a late one (a slow account stays slow a little longer).
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, minSamples: 5 });
+    for (let i = 0; i < 4; i++) h.record(sample('a', 60_000, false, now));
+
+    expect(h.read('a')).toBeNull();
+
+    // CONTROL: one more sample and it answers — so null was the sample guard, not
+    // a broken store.
+    h.record(sample('a', 60_000, false, now));
+    expect(h.read('a')).not.toBeNull();
+    expect(h.read('a')!.errorRate).toBe(1);
+  });
+
+  it('an unknown account returns null rather than a healthy-looking zero', () => {
+    const h = new CodexAccountHealth();
+    expect(h.read('never-seen')).toBeNull();
+  });
+
+  it('samples outside the window are ignored — health is about NOW', () => {
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, windowMs: 60_000, minSamples: 3 });
+    // Old, terrible samples.
+    for (let i = 0; i < 10; i++) h.record(sample('a', 60_000, false, now));
+    // Time passes beyond the window; fresh, healthy samples arrive.
+    now += 120_000;
+    for (let i = 0; i < 3; i++) h.record(sample('a', 900, true, now));
+
+    const r = h.read('a')!;
+    expect(r.samples).toBe(3);
+    expect(r.errorRate).toBe(0);
+    expect(r.p50LatencyMs).toBe(900);
+  });
+
+  it('when the window empties, it returns to not-knowing rather than to stale good news', () => {
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, windowMs: 60_000, minSamples: 3 });
+    for (let i = 0; i < 5; i++) h.record(sample('a', 500, true, now));
+    expect(h.read('a')).not.toBeNull();
+
+    now += 120_000;
+    expect(h.read('a')).toBeNull();
+  });
+
+  it('accounts are measured independently — the whole point', () => {
+    // If two accounts collapsed into one reading, "swap to the healthier one"
+    // could not distinguish them.
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, minSamples: 3 });
+    for (let i = 0; i < 4; i++) h.record(sample('slow', 60_000, false, now));
+    for (let i = 0; i < 4; i++) h.record(sample('fast', 800, true, now));
+
+    const slow = h.read('slow')!;
+    const fast = h.read('fast')!;
+    expect(slow.p50LatencyMs).toBeGreaterThan(fast.p50LatencyMs);
+    expect(slow.errorRate).toBe(1);
+    expect(fast.errorRate).toBe(0);
+    expect(h.readAll().map((r) => r.accountId).sort()).toEqual(['fast', 'slow']);
+  });
+
+  it('readAll omits accounts that cannot answer rather than inventing readings', () => {
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, minSamples: 3 });
+    for (let i = 0; i < 3; i++) h.record(sample('answerable', 500, true, now));
+    h.record(sample('too-few', 500, true, now));
+
+    expect(h.readAll().map((r) => r.accountId)).toEqual(['answerable']);
+  });
+
+  it('memory is bounded — a long-running process cannot grow it without limit', () => {
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, maxSamplesPerAccount: 10, minSamples: 1 });
+    for (let i = 0; i < 500; i++) h.record(sample('a', i, true, now));
+    expect(h.read('a')!.samples).toBe(10);
+  });
+
+  it('recording never throws, whatever it is handed', () => {
+    // This sits on the hot path of every internal Codex call. A gauge that can
+    // break the engine it measures is worse than no gauge.
+    const h = new CodexAccountHealth();
+    const junk = [
+      undefined, null, {}, { accountId: '' }, { accountId: 'a' },
+      { accountId: 'a', latencyMs: NaN, ok: true, atMs: 1 },
+      { accountId: 'a', latencyMs: -5, ok: true, atMs: 1 },
+    ];
+    for (const j of junk) expect(() => h.record(j as never)).not.toThrow();
+    expect(h.read('a')).toBeNull();
+  });
+
+  it('prune drops out-of-window samples and forgets empty accounts', () => {
+    let now = 1_000_000;
+    const h = new CodexAccountHealth({ now: () => now, windowMs: 60_000, minSamples: 1 });
+    h.record(sample('a', 500, true, now));
+    now += 120_000;
+    h.prune();
+    expect(h.read('a')).toBeNull();
+    expect(h.readAll()).toEqual([]);
+  });
+});

--- a/tests/unit/codex-slot-identity.test.ts
+++ b/tests/unit/codex-slot-identity.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Codex slot identity — the missing half of subscription-pool enrolment.
+ *
+ * The pool refuses to enrol an account whose slot identity cannot be verified.
+ * The existing oracle answers that by calling Anthropic's OAuth profile endpoint,
+ * so handed a Codex home it fails `email-unresolved` — which is exactly why the
+ * pool held 6 anthropic accounts and 0 codex ones while both Codex logins sat
+ * authenticated on disk.
+ *
+ * These pin the reader that closes it, and — because it parses a credential file —
+ * pin hard that no token material can escape through a result or an error.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readCodexSlotIdentity } from '../../src/providers/adapters/openai-codex/codexSlotIdentity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/** A recognisable, obviously-fake secret. If it ever appears in output, that is a leak. */
+const CANARY = 'SECRET-TOKEN-MATERIAL-DO-NOT-LEAK-2f9a1c';
+
+function b64url(o: unknown): string {
+  return Buffer.from(JSON.stringify(o), 'utf-8').toString('base64url');
+}
+
+/** Build an id_token shaped like the real one: header.payload.signature. */
+function idToken(payload: Record<string, unknown>): string {
+  return `${b64url({ alg: 'RS256', typ: 'JWT' })}.${b64url(payload)}.${CANARY}`;
+}
+
+function makeHome(
+  dir: string,
+  opts: { email?: string; accountId?: string; plan?: string; authJson?: unknown; idTokenRaw?: string } = {},
+): string {
+  const home = fs.mkdtempSync(path.join(dir, 'codex-home-'));
+  const payload: Record<string, unknown> = {
+    email: opts.email ?? 'someone@example.com',
+    email_verified: true,
+    'https://api.openai.com/auth': {
+      chatgpt_plan_type: opts.plan ?? 'pro',
+      chatgpt_account_id: opts.accountId ?? 'acct-from-claim',
+    },
+  };
+  const body =
+    opts.authJson !== undefined
+      ? opts.authJson
+      : {
+          auth_mode: 'chatgpt',
+          OPENAI_API_KEY: null,
+          tokens: {
+            id_token: opts.idTokenRaw ?? idToken(payload),
+            access_token: CANARY,
+            refresh_token: CANARY,
+            ...(opts.accountId ? { account_id: opts.accountId } : {}),
+          },
+          last_refresh: '2026-08-15T00:00:00.000Z',
+        };
+  fs.writeFileSync(
+    path.join(home, 'auth.json'),
+    typeof body === 'string' ? body : JSON.stringify(body),
+  );
+  return home;
+}
+
+describe('readCodexSlotIdentity', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-identity-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/codex-slot-identity.test.ts:cleanup',
+    });
+  });
+
+  it('reads email, account id and plan from a real-shaped credential', () => {
+    const home = makeHome(tmp, { email: 'a@example.com', accountId: 'acct-a', plan: 'pro' });
+    const id = readCodexSlotIdentity(home);
+    expect(id.unavailable).toBe(false);
+    expect(id.email).toBe('a@example.com');
+    expect(id.accountId).toBe('acct-a');
+    expect(id.planType).toBe('pro');
+  });
+
+  it('THE ENROLMENT PROPERTY: two different logins resolve to different identities', () => {
+    // This is what the pool's duplicate guard needs. If both homes reported the
+    // same identity, two pool rows could silently point at one login and a "swap
+    // to the other account" would be a swap to itself.
+    const a = makeHome(tmp, { email: 'a@example.com', accountId: 'acct-a' });
+    const b = makeHome(tmp, { email: 'b@example.com', accountId: 'acct-b' });
+    const ia = readCodexSlotIdentity(a);
+    const ib = readCodexSlotIdentity(b);
+    expect(ia.email).not.toBe(ib.email);
+    expect(ia.accountId).not.toBe(ib.accountId);
+  });
+
+  it('prefers the credential file account_id over the token claim', () => {
+    // Both name the same account; the file is the more direct source.
+    const home = makeHome(tmp, { accountId: 'acct-from-file' });
+    expect(readCodexSlotIdentity(home).accountId).toBe('acct-from-file');
+  });
+
+  it('SECURITY: no token material reaches the result', () => {
+    const home = makeHome(tmp, { email: 'a@example.com' });
+    const id = readCodexSlotIdentity(home);
+    expect(JSON.stringify(id)).not.toContain(CANARY);
+    // Control: the canary really IS in the file being read, so a clean result is
+    // a measurement rather than a test that could never have failed.
+    expect(fs.readFileSync(path.join(home, 'auth.json'), 'utf-8')).toContain(CANARY);
+  });
+
+  it('SECURITY: a corrupt credential yields a reason, never file bytes', () => {
+    const home = makeHome(tmp, { authJson: `{ not json ${CANARY}` });
+    const id = readCodexSlotIdentity(home);
+    expect(id.unavailable).toBe(true);
+    expect(id.reason).toBe('auth-file-unreadable');
+    expect(JSON.stringify(id)).not.toContain(CANARY);
+  });
+
+  it('names each way a slot can fail to identify itself', () => {
+    const missing = path.join(tmp, 'no-such-home');
+    expect(readCodexSlotIdentity(missing)).toMatchObject({ unavailable: true, reason: 'auth-file-missing' });
+
+    const noToken = makeHome(tmp, { authJson: { auth_mode: 'chatgpt', tokens: {} } });
+    expect(readCodexSlotIdentity(noToken)).toMatchObject({ unavailable: true, reason: 'no-id-token' });
+
+    const badJwt = makeHome(tmp, { idTokenRaw: 'not-a-jwt' });
+    expect(readCodexSlotIdentity(badJwt)).toMatchObject({ unavailable: true, reason: 'id-token-malformed' });
+
+    const noEmail = makeHome(tmp, { idTokenRaw: idToken({ sub: 'x' }) });
+    expect(readCodexSlotIdentity(noEmail)).toMatchObject({ unavailable: true, reason: 'no-email-claim' });
+  });
+
+  it('never throws, whatever the file contains', () => {
+    // The enrolment path must get an answer, not an exception.
+    for (const authJson of [null, 42, [], 'plain string', { tokens: 'not-an-object' }, { tokens: { id_token: 5 } }]) {
+      const home = makeHome(tmp, { authJson });
+      expect(() => readCodexSlotIdentity(home)).not.toThrow();
+      expect(readCodexSlotIdentity(home).unavailable).toBe(true);
+    }
+  });
+});

--- a/tests/unit/composite-credential-identity-oracle.test.ts
+++ b/tests/unit/composite-credential-identity-oracle.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The composite identity oracle — the seam that lets a Codex account be enrolled.
+ *
+ * The pool refuses to enrol an account whose slot identity cannot be verified.
+ * The production oracle answers by calling Anthropic's OAuth profile endpoint, so
+ * it can only speak for a claude-code slot; that is why the pool held 6 anthropic
+ * accounts and 0 codex ones while both codex logins sat authenticated on disk.
+ *
+ * These pin the two properties that matter: a Codex slot now resolves, and the
+ * pre-existing Anthropic path is untouched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CompositeCredentialIdentityOracle } from '../../src/core/CompositeCredentialIdentityOracle.js';
+import type { CodexSlotIdentity } from '../../src/providers/adapters/openai-codex/codexSlotIdentity.js';
+import type { IdentityOracle, IdentityOracleResult } from '../../src/core/CredentialLocationLedger.js';
+
+function anthropicOracle(result: IdentityOracleResult, calls: string[] = []): IdentityOracle {
+  return {
+    async resolveSlotTenant(slot: string): Promise<IdentityOracleResult> {
+      calls.push(slot);
+      return result;
+    },
+  };
+}
+
+const codexOk = (email: string): CodexSlotIdentity => ({
+  email,
+  accountId: 'acct-1',
+  planType: 'pro',
+  unavailable: false,
+});
+const codexUnavailable = (reason: NonNullable<CodexSlotIdentity['reason']>): CodexSlotIdentity => ({
+  email: null,
+  accountId: null,
+  planType: null,
+  unavailable: true,
+  reason,
+});
+
+describe('CompositeCredentialIdentityOracle', () => {
+  it('resolves a Codex slot — the case that was impossible before', () => {
+    const calls: string[] = [];
+    const oracle = new CompositeCredentialIdentityOracle({
+      anthropic: anthropicOracle({ unavailable: true, reason: 'not-anthropic' }, calls),
+      readCodex: () => codexOk('justin@sagemindai.io'),
+    });
+
+    return oracle.resolveSlotTenant('/slots/codex').then((r) => {
+      expect(r.email).toBe('justin@sagemindai.io');
+      expect(r.unavailable).toBeUndefined();
+      // And it did NOT waste a network round-trip on the Anthropic endpoint.
+      expect(calls).toEqual([]);
+    });
+  });
+
+  it('CONTROL: a non-Codex slot still goes to the Anthropic oracle, verbatim', async () => {
+    // Without this, the test above would pass equally well against a composite
+    // that had simply broken the claude-code path.
+    const calls: string[] = [];
+    const oracle = new CompositeCredentialIdentityOracle({
+      anthropic: anthropicOracle({ email: 'justin@anthropic-account.example' }, calls),
+      readCodex: () => codexUnavailable('auth-file-missing'),
+    });
+
+    const r = await oracle.resolveSlotTenant('/slots/claude');
+    expect(r.email).toBe('justin@anthropic-account.example');
+    expect(calls).toEqual(['/slots/claude']);
+  });
+
+  it('passes an Anthropic unavailable result through unchanged', async () => {
+    const oracle = new CompositeCredentialIdentityOracle({
+      anthropic: anthropicOracle({ unavailable: true, reason: 'timeout' }),
+      readCodex: () => codexUnavailable('auth-file-missing'),
+    });
+    expect(await oracle.resolveSlotTenant('/slots/claude')).toEqual({ unavailable: true, reason: 'timeout' });
+  });
+
+  it('a BROKEN Codex slot is reported honestly, not masked as an Anthropic failure', async () => {
+    // 'auth-file-missing' means "not a codex slot" and falls through. Any other
+    // reason means it IS a codex home that could not identify itself — Anthropic
+    // cannot speak for it either, so the real cause must survive.
+    const calls: string[] = [];
+    const oracle = new CompositeCredentialIdentityOracle({
+      anthropic: anthropicOracle({ email: 'wrong@example.com' }, calls),
+      readCodex: () => codexUnavailable('id-token-malformed'),
+    });
+
+    const r = await oracle.resolveSlotTenant('/slots/codex-broken');
+    expect(r.unavailable).toBe(true);
+    expect(r.reason).toBe('codex-slot-id-token-malformed');
+    // It must NOT fall through and mislabel a broken codex slot as an anthropic one.
+    expect(calls).toEqual([]);
+  });
+
+  it('a throwing Codex probe degrades to the Anthropic path, never breaks enrolment', async () => {
+    // The probe is written not to throw. If it ever does, losing the ability to
+    // enrol claude-code accounts would be strictly worse than an unanswered probe.
+    const calls: string[] = [];
+    const oracle = new CompositeCredentialIdentityOracle({
+      anthropic: anthropicOracle({ email: 'still-works@example.com' }, calls),
+      readCodex: () => {
+        throw new Error('probe exploded');
+      },
+    });
+
+    const r = await oracle.resolveSlotTenant('/slots/claude');
+    expect(r.email).toBe('still-works@example.com');
+    expect(calls).toEqual(['/slots/claude']);
+  });
+
+  it('THE ENROLMENT PROPERTY: two Codex slots resolve to different identities', async () => {
+    // The pool's duplicate guard depends on this. If both slots reported the same
+    // identity, two rows could point at one login and "swap to the other account"
+    // would be a swap to itself.
+    const bySlot: Record<string, CodexSlotIdentity> = {
+      '/slots/a': codexOk('a@example.com'),
+      '/slots/b': codexOk('b@example.com'),
+    };
+    const oracle = new CompositeCredentialIdentityOracle({
+      anthropic: anthropicOracle({ unavailable: true }),
+      readCodex: (slot) => bySlot[slot] ?? codexUnavailable('auth-file-missing'),
+    });
+
+    const a = await oracle.resolveSlotTenant('/slots/a');
+    const b = await oracle.resolveSlotTenant('/slots/b');
+    expect(a.email).not.toBe(b.email);
+  });
+});

--- a/tests/unit/core/CodexCliIntelligenceProvider-account.test.ts
+++ b/tests/unit/core/CodexCliIntelligenceProvider-account.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Internal Codex calls can choose WHICH account they run on.
+ *
+ * They never could. The child inherited the ambient `CODEX_HOME`, so every
+ * internal call landed on the default login — which is why "swap a degrading
+ * Codex session onto the other Codex account" had no mechanism behind it for
+ * internal calls: there was only ever one account in play, and nothing recorded
+ * which. The pool could hold two Codex accounts and this path would still use
+ * exactly one of them.
+ *
+ * The load-bearing property here is NOT that selection works. It is that adding
+ * the capability changes NOTHING until someone deliberately uses it: absent or
+ * null resolver ⇒ ambient, byte-identical to before. That is what makes this
+ * safe to land ahead of the trigger that will eventually drive it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const execFileSpy = vi.fn();
+const spawnSpy = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => execFileSpy(...args),
+  spawn: (...args: unknown[]) => spawnSpy(...args),
+}));
+
+import { CodexCliIntelligenceProvider } from '../../../src/core/CodexCliIntelligenceProvider.js';
+
+/** The env handed to the child on the most recent call. */
+function lastChildEnv(): Record<string, string | undefined> {
+  const call = execFileSpy.mock.calls.at(-1);
+  return ((call?.[2] as { env?: Record<string, string | undefined> })?.env) ?? {};
+}
+
+describe('CodexCliIntelligenceProvider — per-call account selection', () => {
+  const savedExecJson = process.env.INSTAR_CODEX_EXEC_JSON;
+  const savedHome = process.env.CODEX_HOME;
+
+  beforeEach(() => {
+    execFileSpy.mockReset();
+    spawnSpy.mockReset();
+    // Pin the plain (execFile) path so the child env is directly inspectable.
+    process.env.INSTAR_CODEX_EXEC_JSON = '0';
+    delete process.env.CODEX_HOME;
+    execFileSpy.mockImplementation((_path, _args, _opts, cb) => {
+      setImmediate(() => cb(null, 'mocked-judgment-output', ''));
+      return { stdin: { end: () => {} } };
+    });
+  });
+
+  afterEach(() => {
+    if (savedExecJson === undefined) delete process.env.INSTAR_CODEX_EXEC_JSON;
+    else process.env.INSTAR_CODEX_EXEC_JSON = savedExecJson;
+    if (savedHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = savedHome;
+  });
+
+  it('THE SAFETY PROPERTY: no resolver ⇒ no CODEX_HOME override (ambient, unchanged)', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: '/usr/local/bin/codex' });
+    await provider.evaluate('test prompt');
+    expect(lastChildEnv().CODEX_HOME).toBeUndefined();
+  });
+
+  it('a resolved account becomes the child CODEX_HOME', async () => {
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => ({ accountId: 'codex-b', configHome: '/slots/codex-b' }),
+    });
+    await provider.evaluate('test prompt');
+    expect(lastChildEnv().CODEX_HOME).toBe('/slots/codex-b');
+  });
+
+  it('TWO accounts are genuinely distinguishable — the point of the change', async () => {
+    // Without this, "swap to the other codex account" has no mechanism: both
+    // calls would land on the same login regardless of what was requested.
+    let which = 'a';
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => ({ accountId: `codex-${which}`, configHome: `/slots/codex-${which}` }),
+    });
+
+    await provider.evaluate('first');
+    const first = lastChildEnv().CODEX_HOME;
+    which = 'b';
+    await provider.evaluate('second');
+    const second = lastChildEnv().CODEX_HOME;
+
+    expect(first).toBe('/slots/codex-a');
+    expect(second).toBe('/slots/codex-b');
+    expect(first).not.toBe(second);
+  });
+
+  it('resolved per CALL, not captured at construction — the router caches providers', async () => {
+    // Same reason resolveExecJson is a closure: a value read once at construction
+    // would freeze the first answer for the lifetime of a cached provider.
+    let calls = 0;
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => {
+        calls += 1;
+        return { accountId: 'x', configHome: `/slots/call-${calls}` };
+      },
+    });
+    await provider.evaluate('one');
+    await provider.evaluate('two');
+    expect(lastChildEnv().CODEX_HOME).toBe('/slots/call-2');
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('a null resolution falls back to ambient', async () => {
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => null,
+    });
+    await provider.evaluate('test prompt');
+    expect(lastChildEnv().CODEX_HOME).toBeUndefined();
+  });
+
+  it('a THROWING resolver degrades to ambient and the call still succeeds', async () => {
+    // Losing account selection is a small loss. Losing every internal Codex call
+    // is not — so a broken resolver must never fail the call.
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => {
+        throw new Error('resolver exploded');
+      },
+    });
+    const out = await provider.evaluate('test prompt');
+    expect(out).toContain('mocked-judgment-output');
+    expect(lastChildEnv().CODEX_HOME).toBeUndefined();
+  });
+
+  it('a malformed resolution (empty home) falls back to ambient', async () => {
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => ({ accountId: 'x', configHome: '' }),
+    });
+    await provider.evaluate('test prompt');
+    expect(lastChildEnv().CODEX_HOME).toBeUndefined();
+  });
+
+  it('CONTROL: env scrubbing still holds when an account IS selected', async () => {
+    // Selecting an account must not become a way to smuggle the parent env in.
+    process.env.OPENAI_API_KEY = 'sk-PARENT-LEAK-SENTINEL';
+    try {
+      const provider = new CodexCliIntelligenceProvider({
+        codexPath: '/usr/local/bin/codex',
+        resolveAccount: () => ({ accountId: 'codex-b', configHome: '/slots/codex-b' }),
+      });
+      await provider.evaluate('test prompt');
+      const env = lastChildEnv();
+      expect(env.CODEX_HOME).toBe('/slots/codex-b');
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+    } finally {
+      delete process.env.OPENAI_API_KEY;
+    }
+  });
+});

--- a/tests/unit/core/CodexCliIntelligenceProvider-account.test.ts
+++ b/tests/unit/core/CodexCliIntelligenceProvider-account.test.ts
@@ -155,4 +155,60 @@ describe('CodexCliIntelligenceProvider — per-call account selection', () => {
       delete process.env.OPENAI_API_KEY;
     }
   });
+  it('OBSERVATION: a successful call is reported against the account that ran it', async () => {
+    const seen: Array<{ accountId: string; latencyMs: number; ok: boolean }> = [];
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => ({ accountId: 'codex-b', configHome: '/slots/codex-b' }),
+      onCallObserved: (s) => seen.push(s),
+    });
+    await provider.evaluate('test prompt');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.accountId).toBe('codex-b');
+    expect(seen[0]!.ok).toBe(true);
+    expect(seen[0]!.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('OBSERVATION: a FAILED call is reported too — a gauge that only sees successes is useless', async () => {
+    // The whole purpose is spotting a degrading account. If failures went
+    // unrecorded, the error rate would read 0 no matter how bad things got.
+    execFileSpy.mockImplementation((_p, _a, _o, cb) => {
+      setImmediate(() => cb(new Error('codex exec failed'), '', 'boom'));
+      return { stdin: { end: () => {} } };
+    });
+    const seen: Array<{ accountId: string; ok: boolean }> = [];
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => ({ accountId: 'codex-b', configHome: '/slots/codex-b' }),
+      onCallObserved: (s) => seen.push(s),
+    });
+
+    await expect(provider.evaluate('test prompt')).rejects.toBeTruthy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.ok).toBe(false);
+  });
+
+  it('OBSERVATION: nothing is reported when no account was named', async () => {
+    // With no account there is nothing to attribute a sample to. Attributing it
+    // to "the default" would invent a measurement the trigger would then trust.
+    const seen: unknown[] = [];
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      onCallObserved: (s) => seen.push(s),
+    });
+    await provider.evaluate('test prompt');
+    expect(seen).toHaveLength(0);
+  });
+
+  it('a THROWING observer never breaks the call it measures', async () => {
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: '/usr/local/bin/codex',
+      resolveAccount: () => ({ accountId: 'codex-b', configHome: '/slots/codex-b' }),
+      onCallObserved: () => {
+        throw new Error('observer exploded');
+      },
+    });
+    await expect(provider.evaluate('test prompt')).resolves.toContain('mocked-judgment-output');
+  });
 });

--- a/tests/unit/eligible-sibling-accounts.test.ts
+++ b/tests/unit/eligible-sibling-accounts.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Which accounts may serve as the sibling position in the failure tail.
+ *
+ * This is the pool-side half of "prefer the other Codex account before falling to the
+ * main subscription". The router consumes the list; this decides what goes in it — and
+ * every rule here is protecting a bounded gating deadline, where a known-bad attempt is
+ * not merely wasteful but delays the answer a gate is waiting on.
+ *
+ * These drive the real exported function, not a copy of its logic, so a change to the
+ * policy that the server actually calls cannot pass while these still assert the old one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import { eligibleSiblingAccounts } from '../../src/core/SubscriptionPool.js';
+import type {
+  SubscriptionAccount,
+  SubscriptionAccountStatus,
+  SubscriptionFramework,
+} from '../../src/core/SubscriptionPool.js';
+
+function acct(
+  id: string,
+  over: Partial<SubscriptionAccount> & { framework?: SubscriptionFramework } = {},
+): SubscriptionAccount {
+  return {
+    id,
+    nickname: id,
+    provider: 'openai',
+    framework: 'codex-cli',
+    configHome: `/slots/${id}`,
+    status: 'active',
+    enrolledAt: '2026-08-01T00:00:00Z',
+    version: 1,
+    ...over,
+  } as SubscriptionAccount;
+}
+
+describe('eligibleSiblingAccounts', () => {
+  it('THE POINT: the other Codex account qualifies', () => {
+    const out = eligibleSiblingAccounts([acct('codex-a'), acct('codex-b')], 'codex-cli', 'codex-a');
+    expect(out).toEqual([{ accountId: 'codex-b', configHome: '/slots/codex-b' }]);
+  });
+
+  it('the account that just FAILED is never returned to itself', () => {
+    const out = eligibleSiblingAccounts([acct('codex-a')], 'codex-cli', 'codex-a');
+    expect(out).toEqual([]);
+  });
+
+  it('CROSS-FRAMEWORK is excluded — a Codex session cannot run on a Claude login', () => {
+    // This is also the spend guard: the Claude account is exactly what the tail is
+    // trying not to reach.
+    const claude = acct('claude-main', { framework: 'claude-code', provider: 'anthropic' });
+    const out = eligibleSiblingAccounts([acct('codex-a'), claude], 'codex-cli', 'codex-a');
+    expect(out).toEqual([]);
+  });
+
+  it.each<[SubscriptionAccountStatus]>([
+    ['rate-limited'],
+    ['warming'],
+    ['disabled'],
+    ['needs-reauth'],
+  ])('a %s account is not eligible — a known-bad attempt against a waiting gate', (status) => {
+    const out = eligibleSiblingAccounts(
+      [acct('codex-a'), acct('codex-b', { status })],
+      'codex-cli',
+      'codex-a',
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('an account with no local login (empty configHome) is excluded', () => {
+    // A meta-only account replicated in from a peer machine has no credential here.
+    // An empty home reaching the provider would silently mean "ambient" — i.e. a
+    // re-run of the account that just failed, reported as a swap.
+    const out = eligibleSiblingAccounts(
+      [acct('codex-a'), acct('codex-b', { configHome: '' })],
+      'codex-cli',
+      'codex-a',
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('BOUNDED: a large pool yields ONE sibling by default', () => {
+    const pool = ['codex-a', 'codex-b', 'codex-c', 'codex-d'].map((i) => acct(i));
+    expect(eligibleSiblingAccounts(pool, 'codex-cli', 'codex-a')).toHaveLength(1);
+  });
+
+  it('the bound is a parameter, so the default is a CHOICE rather than an incapacity', () => {
+    const pool = ['codex-a', 'codex-b', 'codex-c', 'codex-d'].map((i) => acct(i));
+    expect(eligibleSiblingAccounts(pool, 'codex-cli', 'codex-a', { limit: 2 })).toHaveLength(2);
+    expect(eligibleSiblingAccounts(pool, 'codex-cli', 'codex-a', { limit: 0 })).toEqual([]);
+  });
+
+  describe('identifying the account that just failed', () => {
+    // Internal calls run on the AMBIENT login, so failedAccountId is null in production
+    // and the id-based exclusion cannot fire. Getting this wrong does not merely fail to
+    // help — it re-runs the account that just failed while reporting a swap.
+
+    it('REFUSES to guess when neither the id nor the ambient home is known', () => {
+      const out = eligibleSiblingAccounts([acct('codex-a'), acct('codex-b')], 'codex-cli', null);
+      expect(out).toEqual([]);
+    });
+
+    it('THE PRODUCTION CASE: an ambient call excludes the account holding the ambient home', () => {
+      const out = eligibleSiblingAccounts(
+        [acct('codex-a', { configHome: '/home/.codex' }), acct('codex-b')],
+        'codex-cli',
+        null,
+        { ambientConfigHome: '/home/.codex' },
+      );
+      expect(out).toEqual([{ accountId: 'codex-b', configHome: '/slots/codex-b' }]);
+    });
+
+    it('a SINGLE-account agent gets no siblings — the shipped tail, unchanged', () => {
+      // The defect this pins: without home-matching, the sole account is offered as a
+      // sibling of itself, and every failure buys one guaranteed-failing retry.
+      const out = eligibleSiblingAccounts(
+        [acct('codex-a', { configHome: '/home/.codex' })],
+        'codex-cli',
+        null,
+        { ambientConfigHome: '/home/.codex' },
+      );
+      expect(out).toEqual([]);
+    });
+
+    it('an ambient home matching NO enrolled account still yields a sibling', () => {
+      // The primary ran on an unenrolled login, so every enrolled account is genuinely
+      // a different one. Refusing here would disable the feature for no reason.
+      const out = eligibleSiblingAccounts([acct('codex-a')], 'codex-cli', null, {
+        ambientConfigHome: '/home/.codex-unenrolled',
+      });
+      expect(out).toEqual([{ accountId: 'codex-a', configHome: '/slots/codex-a' }]);
+    });
+
+    it('an empty ambient home is treated as absent, not as a match', () => {
+      expect(
+        eligibleSiblingAccounts([acct('codex-a')], 'codex-cli', null, { ambientConfigHome: '' }),
+      ).toEqual([]);
+    });
+  });
+
+  it('an empty or malformed pool is survivable', () => {
+    expect(eligibleSiblingAccounts([], 'codex-cli', 'codex-a')).toEqual([]);
+    expect(
+      eligibleSiblingAccounts(
+        [null as unknown as SubscriptionAccount, acct('codex-b')],
+        'codex-cli',
+        'codex-a',
+      ),
+    ).toEqual([{ accountId: 'codex-b', configHome: '/slots/codex-b' }]);
+  });
+});
+
+describe('production wiring — the router is actually handed this policy', () => {
+  // A capability nothing calls is a capability the agent does not have. The policy above
+  // is unit-tested against the real function; this pins that the server reaches it.
+  const server = fs.readFileSync('src/commands/server.ts', 'utf8');
+
+  it('the router receives a sibling resolver', () => {
+    expect(server).toContain('resolveSiblingAccounts: (framework, failedAccountId) =>');
+  });
+
+  it('the resolver delegates to the real policy over the LIVE pool, not a snapshot', () => {
+    // A snapshot taken at boot would miss an account enrolled, rate-limited or disabled
+    // afterwards — the pool is read on every failure for exactly that reason.
+    expect(server).toContain('eligibleSiblingAccounts(subscriptionPool.list(), framework, failedAccountId');
+  });
+
+  it('the ambient codex home is supplied, so the self-exclusion can fire on ambient calls', () => {
+    // Without this the production case (failedAccountId always null) silently degrades
+    // to "refuse to guess" and the feature never fires at all.
+    expect(server).toContain("process.env['CODEX_HOME'] || path.join(os.homedir(), '.codex')");
+  });
+
+  it('the resolver is armed where the pool is built, and is inert before that', () => {
+    expect(server).toContain('siblingAccountResolver = (framework, failedAccountId) =>');
+    expect(server).toContain('siblingAccountResolver?.(framework, failedAccountId) ?? []');
+  });
+});

--- a/tests/unit/proactive-swap-degradation.test.ts
+++ b/tests/unit/proactive-swap-degradation.test.ts
@@ -1,0 +1,234 @@
+/**
+ * The degradation swap trigger — swap off an account that is SLOW, not just full.
+ *
+ * Quota was never the problem. The observed failure was latency: a trivial Codex
+ * call taking ~13s while several internal checks sat at the 60s ceiling, with the
+ * account at 17% of its quota window. A quota-only trigger cannot see any of that,
+ * which is why a degrading account kept its sessions while its failures fell
+ * through onto the main subscription.
+ *
+ * These pin the trigger AND the two things that make it safe to ship: it does not
+ * act on an unknown, and while rehearsing it does not touch a live session.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ProactiveSwapMonitor } from '../../src/core/ProactiveSwapMonitor.js';
+import type {
+  ProactiveSwapSession,
+  ProactiveSwapMonitorConfig,
+} from '../../src/core/ProactiveSwapMonitor.js';
+import type { SubscriptionAccount } from '../../src/core/SubscriptionPool.js';
+
+const NOW = Date.parse('2026-08-15T21:00:00Z');
+
+/** A Codex pool account, quota-healthy — so ONLY degradation can select it. */
+function codexAcct(id: string, utilPct = 17): SubscriptionAccount {
+  return {
+    id,
+    nickname: id,
+    provider: 'openai',
+    framework: 'codex-cli',
+    configHome: `/h/.codex-${id}`,
+    status: 'active',
+    lastQuota: {
+      sevenDay: { utilizationPct: utilPct, resetsAt: '2026-08-20T00:00:00Z' },
+      source: 'oauth-usage-endpoint-fallback',
+    },
+    enrolledAt: '2026-08-01T00:00:00Z',
+    version: 1,
+  } as SubscriptionAccount;
+}
+
+function sess(sessionName: string, accountId: string | null): ProactiveSwapSession {
+  return { sessionName, accountId, startedAt: '2026-08-15T20:00:00Z' };
+}
+
+const HEALTHY = { p50LatencyMs: 900, errorRate: 0.02, samples: 40 };
+const DEGRADED = { p50LatencyMs: 58_000, errorRate: 0.78, samples: 40 };
+
+function makeMonitor(
+  over: Partial<ProactiveSwapMonitorConfig> & {
+    accounts: SubscriptionAccount[];
+    sessions: ProactiveSwapSession[];
+  },
+) {
+  const logs: string[] = [];
+  const swap = vi.fn(async (a: { sessionName: string; exhaustedAccountId: string }) => {
+    const dest = over.accounts.find((x) => x.id !== a.exhaustedAccountId && x.status === 'active');
+    return { swapped: true, toAccountId: dest?.id ?? null };
+  });
+  const monitor = new ProactiveSwapMonitor({
+    listAccounts: () => over.accounts,
+    listRunningSessions: () => over.sessions,
+    resolveDefaultAccountId: async () => null,
+    swap,
+    now: () => NOW,
+    logger: { log: (m) => logs.push(m), warn: (m) => logs.push(m) },
+    ...over,
+  });
+  return { monitor, swap, logs };
+}
+
+describe('ProactiveSwapMonitor — degradation trigger', () => {
+  it('THE EXIT TEST: a degrading account produces a dry-run would-swap, and moves nothing', async () => {
+    // The charter's own acceptance test: make an account slow/erroring, and the
+    // system should say it WOULD move off it — without touching the session.
+    const { monitor, swap, logs } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        readHealth: (id) => (id === 'codex-a' ? DEGRADED : HEALTHY),
+      },
+    });
+
+    await monitor.evaluate();
+
+    expect(logs.join('\n')).toMatch(/would swap off DEGRADING codex-a/);
+    // The load-bearing half: rehearsal must not move a live conversation.
+    expect(swap).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: quota alone would NOT have selected it — the account is at 17%', async () => {
+    // Without this, the test above could be passing because of ordinary quota
+    // pressure rather than because of the new trigger.
+    const { monitor, swap, logs } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      // No degradation config at all: the pre-existing behaviour.
+    });
+
+    await monitor.evaluate();
+
+    expect(logs.join('\n')).not.toMatch(/would swap/);
+    expect(swap).not.toHaveBeenCalled();
+  });
+
+  it('THE HONEST-UNKNOWN RULE: a null reading never moves anything', async () => {
+    // read() returns null when it cannot answer responsibly. Treating unknown as
+    // degraded is how a trigger starts thrashing on noise.
+    const { monitor, swap, logs } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        readHealth: () => null,
+      },
+    });
+
+    await monitor.evaluate();
+    expect(logs.join('\n')).not.toMatch(/would swap/);
+    expect(swap).not.toHaveBeenCalled();
+  });
+
+  it('a healthy account is left alone', async () => {
+    const { monitor, swap } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        readHealth: () => HEALTHY,
+      },
+    });
+    await monitor.evaluate();
+    expect(swap).not.toHaveBeenCalled();
+  });
+
+  it('DARK by default: enabled:false changes nothing', async () => {
+    const { monitor, swap, logs } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: false,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        readHealth: () => DEGRADED,
+      },
+    });
+    await monitor.evaluate();
+    expect(logs.join('\n')).not.toMatch(/would swap/);
+    expect(swap).not.toHaveBeenCalled();
+  });
+
+  it('a THROWING health source is UNKNOWN, never degraded', async () => {
+    const { monitor, swap } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        readHealth: () => {
+          throw new Error('gauge broken');
+        },
+      },
+    });
+    await expect(monitor.evaluate()).resolves.toBeTruthy();
+    expect(swap).not.toHaveBeenCalled();
+  });
+
+  it('ERROR RATE alone is enough — latency is not the only way to be unwell', async () => {
+    const { monitor, logs } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        // Fast, but failing most of the time.
+        readHealth: () => ({ p50LatencyMs: 800, errorRate: 0.9, samples: 40 }),
+      },
+    });
+    await monitor.evaluate();
+    expect(logs.join('\n')).toMatch(/would swap off DEGRADING codex-a/);
+  });
+
+  it('LATENCY alone is enough — succeeding slowly is still unwell', async () => {
+    const { monitor, logs } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: true,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        // The real observed shape: calls succeed, but at the timeout ceiling.
+        readHealth: () => ({ p50LatencyMs: 58_000, errorRate: 0.0, samples: 40 }),
+      },
+    });
+    await monitor.evaluate();
+    expect(logs.join('\n')).toMatch(/would swap off DEGRADING codex-a/);
+  });
+
+  it('with dryRun:false it actually swaps — so rehearsal is a CHOICE, not an incapacity', async () => {
+    // Without this, every passing test above would be consistent with a trigger
+    // that simply cannot act at all.
+    const { monitor, swap } = makeMonitor({
+      accounts: [codexAcct('codex-a'), codexAcct('codex-b')],
+      sessions: [sess('s-codex', 'codex-a')],
+      degradation: {
+        enabled: true,
+        dryRun: false,
+        p50ThresholdMs: 20_000,
+        errorRateThreshold: 0.5,
+        readHealth: (id) => (id === 'codex-a' ? DEGRADED : HEALTHY),
+      },
+    });
+
+    await monitor.evaluate();
+    expect(swap).toHaveBeenCalledTimes(1);
+    expect(swap.mock.calls[0]![0].exhaustedAccountId).toBe('codex-a');
+  });
+});

--- a/tests/unit/sibling-account-failure-swap.test.ts
+++ b/tests/unit/sibling-account-failure-swap.test.ts
@@ -1,0 +1,259 @@
+/**
+ * The failure tail prefers the OTHER Codex account before changing door.
+ *
+ * The shipped tail's last door is `claude-code` — the main subscription. So a failing
+ * Codex call ended up spending exactly the budget the Codex door exists to protect:
+ * the cheaper provider degrades, and its failures land on the expensive one. Holding a
+ * second Codex login makes a nearer position available — same door, other account —
+ * and that is what these tests pin.
+ *
+ * Two properties carry the change:
+ *  - the sibling is tried BEFORE any door change (otherwise it changes nothing), and
+ *  - the original door tail still runs when the sibling also fails (otherwise the fix
+ *    removed the safety net it was supposed to sit in front of).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { IntelligenceRouter } from '../../src/core/IntelligenceRouter.js';
+import type { IntelligenceFramework } from '../../src/core/intelligenceProviderFactory.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+
+const GATING: IntelligenceOptions = {
+  attribution: { component: 'ExternalOperationGate', gating: true },
+};
+
+const A_HOME = '/slots/codex-a';
+const B_HOME = '/slots/codex-b';
+
+/** Records every call, and which account (if any) it was told to run on. */
+interface Recorder {
+  calls: Array<{ door: string; home: string | undefined }>;
+}
+
+/**
+ * One provider standing in for the codex binary. It is the SAME provider for every
+ * account — exactly as in production, where the account is the child's CODEX_HOME and
+ * not a different binary. It fails unless handed `okHome`.
+ */
+function codexProvider(rec: Recorder, okHome: string | null): IntelligenceProvider {
+  return {
+    async evaluate(_p: string, opts?: IntelligenceOptions) {
+      const home = opts?.accountOverride?.configHome;
+      rec.calls.push({ door: 'codex-cli', home });
+      if (okHome !== null && home === okHome) return `codex-ok:${opts?.accountOverride?.accountId}`;
+      throw new Error(`codex failed (home=${home ?? 'ambient'})`);
+    },
+  };
+}
+
+function doorProvider(rec: Recorder, door: string, outcome: 'ok' | 'fail'): IntelligenceProvider {
+  return {
+    async evaluate(_p: string, opts?: IntelligenceOptions) {
+      rec.calls.push({ door, home: opts?.accountOverride?.configHome });
+      if (outcome === 'ok') return `${door}-ok`;
+      throw new Error(`${door} failed`);
+    },
+  };
+}
+
+function build(opts: {
+  rec: Recorder;
+  codexOkHome?: string | null;
+  siblings?: IntelligenceRouterOpts['resolveSiblingAccounts'];
+  tail?: IntelligenceFramework[];
+}) {
+  const rec = opts.rec;
+  const providers: Partial<Record<IntelligenceFramework, IntelligenceProvider>> = {
+    'codex-cli': codexProvider(rec, opts.codexOkHome === undefined ? null : opts.codexOkHome),
+    'pi-cli': doorProvider(rec, 'pi-cli', 'fail'),
+    'claude-code': doorProvider(rec, 'claude-code', 'ok'),
+  };
+  return new IntelligenceRouter({
+    defaultProvider: providers['claude-code']!,
+    defaultFramework: 'claude-code',
+    resolveConfig: () => ({
+      default: 'codex-cli',
+      failureSwap: opts.tail ?? ['pi-cli', 'claude-code'],
+    }),
+    buildProvider: (fw) => providers[fw] ?? null,
+    ...(opts.siblings ? { resolveSiblingAccounts: opts.siblings } : {}),
+  });
+}
+
+type IntelligenceRouterOpts = ConstructorParameters<typeof IntelligenceRouter>[0];
+
+/** Did the tail reach the main subscription? That is the spend this change exists to avoid. */
+const reachedClaude = (rec: Recorder) => rec.calls.some((c) => c.door === 'claude-code');
+
+describe('failure tail — prefer the sibling Codex account before changing door', () => {
+  it('THE POINT: a failing Codex call is served by the OTHER Codex account, and never reaches Claude', async () => {
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: () => [{ accountId: 'codex-b', configHome: B_HOME }],
+    });
+
+    await expect(router.evaluate('x', GATING)).resolves.toBe('codex-ok:codex-b');
+    expect(reachedClaude(rec)).toBe(false);
+  });
+
+  it('CONTROL: with no resolver the SAME failure walks the tail to Claude', async () => {
+    // Without this, the test above could be passing because Claude was never reachable
+    // in the harness at all, rather than because the sibling got there first.
+    const rec: Recorder = { calls: [] };
+    const router = build({ rec, codexOkHome: B_HOME }); // no resolveSiblingAccounts
+
+    await expect(router.evaluate('x', GATING)).resolves.toBe('claude-code-ok');
+    expect(reachedClaude(rec)).toBe(true);
+  });
+
+  it('the sibling attempt actually RUNS on the sibling account', async () => {
+    // The failure mode this rules out: the position is scheduled, the log says the call
+    // moved, but the attempt inherits the ambient login — i.e. re-runs on the account
+    // that just failed, while reporting a swap.
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: () => [{ accountId: 'codex-b', configHome: B_HOME }],
+    });
+
+    await router.evaluate('x', GATING);
+    const codexCalls = rec.calls.filter((c) => c.door === 'codex-cli');
+    expect(codexCalls[0]!.home).toBeUndefined(); // primary: ambient
+    expect(codexCalls[1]!.home).toBe(B_HOME); // sibling: the other account
+  });
+
+  it('ORDER: the sibling is tried BEFORE the next door — a tail that ran second would change nothing', async () => {
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: () => [{ accountId: 'codex-b', configHome: B_HOME }],
+    });
+
+    await router.evaluate('x', GATING);
+    expect(rec.calls.map((c) => c.door)).toEqual(['codex-cli', 'codex-cli']);
+  });
+
+  it('THE SAFETY NET SURVIVES: when the sibling ALSO fails, the door tail still runs', async () => {
+    // The enhancement prepends a position; it must never REPLACE the fall-through. An
+    // agent whose second Codex account is equally unwell must still get an answer.
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: null, // no account works
+      siblings: () => [{ accountId: 'codex-b', configHome: B_HOME }],
+    });
+
+    await expect(router.evaluate('x', GATING)).resolves.toBe('claude-code-ok');
+    expect(rec.calls.map((c) => c.door)).toEqual(['codex-cli', 'codex-cli', 'pi-cli', 'claude-code']);
+  });
+
+  it('a "sibling" equal to the account that just failed is NOT retried', async () => {
+    // Retrying the failing login under a fresh label spends the gating deadline on an
+    // attempt already known to fail.
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: null,
+      siblings: () => [{ accountId: 'codex-a', configHome: A_HOME }],
+    });
+
+    await router.evaluate('x', {
+      ...GATING,
+      accountOverride: { accountId: 'codex-a', configHome: A_HOME },
+    });
+
+    const codexCalls = rec.calls.filter((c) => c.door === 'codex-cli');
+    expect(codexCalls).toHaveLength(1); // the primary only — no self-retry
+  });
+
+  it('a THROWING resolver costs the enhancement, never the tail', async () => {
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: () => {
+        throw new Error('pool exploded');
+      },
+    });
+
+    await expect(router.evaluate('x', GATING)).resolves.toBe('claude-code-ok');
+  });
+
+  it('malformed entries are filtered — an empty home would silently mean "ambient"', async () => {
+    // An empty configHome reaching the provider is the worst case: it looks like a
+    // sibling attempt and behaves like a re-run of the failing account.
+    const rec: Recorder = { calls: [] };
+    const router = build({
+      rec,
+      codexOkHome: null,
+      siblings: () =>
+        [
+          { accountId: 'codex-b', configHome: '' },
+          { accountId: '', configHome: B_HOME },
+        ] as Array<{ accountId: string; configHome: string }>,
+    });
+
+    await router.evaluate('x', GATING);
+    expect(rec.calls.filter((c) => c.door === 'codex-cli')).toHaveLength(1);
+  });
+
+  it('DARK BY DEFAULT: an empty sibling list leaves the tail byte-identical', async () => {
+    const rec: Recorder = { calls: [] };
+    const router = build({ rec, codexOkHome: B_HOME, siblings: () => [] });
+
+    await expect(router.evaluate('x', GATING)).resolves.toBe('claude-code-ok');
+    expect(rec.calls.map((c) => c.door)).toEqual(['codex-cli', 'pi-cli', 'claude-code']);
+  });
+
+  it('no configured tail ⇒ no sibling positions — this rides the existing tail, it does not create one', async () => {
+    // A call with no failure tail is not eligible for swapping at all. Prepending a
+    // sibling there would invent a retry path the config never asked for.
+    const rec: Recorder = { calls: [] };
+    const resolver = vi.fn(() => [{ accountId: 'codex-b', configHome: B_HOME }]);
+    const router = build({ rec, codexOkHome: B_HOME, siblings: resolver, tail: [] });
+
+    await expect(router.evaluate('x', GATING)).rejects.toThrow(/codex failed/);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('the resolver is told WHICH account failed, so the pool can exclude it', async () => {
+    const rec: Recorder = { calls: [] };
+    const seen: Array<[string, string | null]> = [];
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: (fw, failed) => {
+        seen.push([fw, failed]);
+        return [{ accountId: 'codex-b', configHome: B_HOME }];
+      },
+    });
+
+    await router.evaluate('x', {
+      ...GATING,
+      accountOverride: { accountId: 'codex-a', configHome: A_HOME },
+    });
+    expect(seen).toEqual([['codex-cli', 'codex-a']]);
+  });
+
+  it('an AMBIENT primary reports a null failed-account — never a guessed id', async () => {
+    // The router cannot see which login a child inherited. Naming one here would make
+    // the pool's self-exclusion silently wrong.
+    const rec: Recorder = { calls: [] };
+    const seen: Array<string | null> = [];
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: (_fw, failed) => {
+        seen.push(failed);
+        return [{ accountId: 'codex-b', configHome: B_HOME }];
+      },
+    });
+
+    await router.evaluate('x', GATING);
+    expect(seen).toEqual([null]);
+  });
+});

--- a/tests/unit/sibling-account-failure-swap.test.ts
+++ b/tests/unit/sibling-account-failure-swap.test.ts
@@ -61,6 +61,7 @@ function build(opts: {
   codexOkHome?: string | null;
   siblings?: IntelligenceRouterOpts['resolveSiblingAccounts'];
   tail?: IntelligenceFramework[];
+  onDegrade?: IntelligenceRouterOpts['onDegrade'];
 }) {
   const rec = opts.rec;
   const providers: Partial<Record<IntelligenceFramework, IntelligenceProvider>> = {
@@ -77,6 +78,7 @@ function build(opts: {
     }),
     buildProvider: (fw) => providers[fw] ?? null,
     ...(opts.siblings ? { resolveSiblingAccounts: opts.siblings } : {}),
+    ...(opts.onDegrade ? { onDegrade: opts.onDegrade } : {}),
   });
 }
 
@@ -181,6 +183,42 @@ describe('failure tail — prefer the sibling Codex account before changing door
     });
 
     await expect(router.evaluate('x', GATING)).resolves.toBe('claude-code-ok');
+  });
+
+  it('...and it is REPORTED, because silently losing it restores the spend it prevents', async () => {
+    // A resolver throwing on every call disables the sibling tail completely, so every
+    // Codex failure walks back onto the main subscription — the exact problem this
+    // feature exists to stop, invisibly restored. Surviving quietly is not good enough.
+    const rec: Recorder = { calls: [] };
+    const degrades: string[] = [];
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: () => {
+        throw new Error('pool exploded');
+      },
+      onDegrade: (d) => degrades.push(d.reason),
+    });
+
+    await router.evaluate('x', GATING);
+    expect(degrades.some((r) => /sibling-account resolver threw/.test(r))).toBe(true);
+    expect(degrades.some((r) => /pool exploded/.test(r))).toBe(true);
+  });
+
+  it('CONTROL: a healthy resolver reports NO resolver fault', async () => {
+    // Without this, the assertion above could pass against a change that reported a
+    // resolver fault on every call.
+    const rec: Recorder = { calls: [] };
+    const degrades: string[] = [];
+    const router = build({
+      rec,
+      codexOkHome: B_HOME,
+      siblings: () => [{ accountId: 'codex-b', configHome: B_HOME }],
+      onDegrade: (d) => degrades.push(d.reason),
+    });
+
+    await router.evaluate('x', GATING);
+    expect(degrades.some((r) => /sibling-account resolver threw/.test(r))).toBe(false);
   });
 
   it('malformed entries are filtered — an empty home would silently mean "ambient"', async () => {

--- a/upgrades/next/codex-pool-latency-swap.md
+++ b/upgrades/next/codex-pool-latency-swap.md
@@ -4,10 +4,13 @@
 
 ## What Changed
 
-Codex accounts can now be enrolled in the subscription pool, and an internal Codex
-call can now choose which account it runs on.
+You can now hold more than one Codex login, and work moves off one that goes wrong —
+whether it goes slow or simply fails.
 
-Both were previously impossible, for reasons that were invisible from outside:
+Instar deliberately runs its small background judgements on a second provider so they
+don't consume the main subscription you pay for. That only works while the second
+provider is healthy. Two separate paths sent its trouble back onto your subscription
+anyway, and neither was visible from outside.
 
 **Enrolment.** The pool refuses to add an account whose credential slot it cannot
 identify — a sensible guard, since two rows pointing at the same login would make
@@ -28,58 +31,90 @@ target a specific slot existed in the spawn layer and was honoured — this path
 never used it. So "move a struggling account's work to the other account" had nothing
 to move.
 
+**Swapping off a SLOW account.** The existing proactive swap triggers on quota, and
+quota was never the problem. The observed failure was latency: a trivial Codex call
+taking around 13 seconds while internal checks sat at their 60-second ceiling, with the
+account at 17% of its quota window. A quota-only trigger cannot see any of that. A new
+degradation trigger watches per-account latency and error rate, so an account that is
+slow or failing becomes a candidate to move off regardless of how full it is.
+
+**The retry list no longer ends on your subscription.** When a Codex call failed, the
+retry list walked to the next provider — and its last entry is the main subscription. So
+the provider that exists to keep work off your paid account was, on every failure,
+walking work straight onto it. The retry list now tries the OTHER Codex account first.
+
 ## What to Tell Your User
 
 - "If you have more than one Codex login, I can now hold both — before, I could only
   ever see one of them."
-- "Nothing changes about which account I use until that's deliberately configured."
+- "When one Codex account goes slow or starts failing, I move work to the other one
+  instead of falling back onto the subscription you pay for."
+- "If you only have one Codex account, none of this changes anything."
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
 | Enrol a Codex account in the subscription pool | The existing enrolment path now accepts a Codex credential slot |
-| Point an internal Codex call at a specific account | `resolveAccount` on the Codex provider (unused by default) |
+| Move work off a slow or failing account | `subscriptionPool.proactiveSwap.degradation` — off by default, rehearses first |
+| Retry a failed Codex call on your other Codex account | Automatic once two Codex accounts are enrolled; nothing to configure |
 
-No new endpoint and no configuration.
+No new endpoint.
 
 ## Compatibility Notes
 
-**Nothing changes by default.** A Codex call that does not name an account behaves
-exactly as before — same account, same result — and nothing in the shipped wiring names
-one. A broken or throwing account resolver also falls back to the previous behaviour
-rather than failing the call.
+**A single Codex account changes nothing at all.** There is no other account to move to
+or retry on, so both new behaviours are inert — not disabled by a flag, but with nothing
+to act on.
+
+The degradation trigger ships **off**, and rehearses when switched on: it records the
+swap it would have made and leaves the session alone until dry-run is turned off. No
+data, too few samples, or a broken gauge all mean *unknown*, and unknown never moves
+anything.
+
+The retry-list change **adds** a step in front of the existing list; it never replaces
+it. If both Codex accounts are unwell, the retry list continues exactly as it does
+today and you still get an answer. Only accounts that are active and have a real local
+login are eligible, and a Codex session can only ever be retried on a Codex account —
+never on the main subscription's account.
+
+A Codex call that does not name an account behaves exactly as before. A broken or
+throwing account resolver falls back to the previous behaviour rather than failing the
+call.
 
 The Anthropic identity path is untouched: any slot that is not a Codex home takes the
-identical pre-existing check with the identical result. A Codex slot that cannot
-identify itself is reported as a Codex problem rather than mislabelled as an Anthropic
-failure.
-
-Reading a credential never exposes it: the identity reader returns an email, an account
-id and a plan, and no token material.
+identical pre-existing check with the identical result. Reading a credential never
+exposes it — the identity reader returns an email, an account id and a plan, and no
+token material.
 
 ## Evidence
 
-26 tests across two tiers.
+67 tests across two tiers.
 
-Unit: the identity reader (real-shaped read, two logins resolving to DIFFERENT
-identities, every named failure reason, never-throws across six malformed shapes, and
-two security canaries); the composing identity check (Codex resolves, a CONTROL that a
-non-Codex slot still reaches the Anthropic path verbatim, a broken Codex slot reported
-honestly, a throwing probe degrading safely); and account selection (no resolver means
-no override, two accounts genuinely distinguishable, per-call rather than
-per-construction resolution, all three degradation paths, and a CONTROL that env
-scrubbing still holds when an account is selected).
+*Enrolment and selection (26).* The identity reader (real-shaped read, two logins
+resolving to DIFFERENT identities, every named failure reason, never-throws across six
+malformed shapes, two security canaries); the composing identity check, with a CONTROL
+that a non-Codex slot still reaches the Anthropic path verbatim; and per-call account
+selection, with a CONTROL that env scrubbing still holds when an account is selected.
+Integration drives the real registrar against a real pool and asserts BOTH directions —
+the Anthropic-only check rejects a Codex account, the composing one enrols it. Verified
+against real credentials: two Codex homes on this machine resolve to two distinct
+accounts.
 
-Integration: the tier that would have caught the real defect, since unit tests of a
-reader pass whether or not it is wired. It drives the real registrar against a real pool
-and asserts BOTH directions — the Anthropic-only check REJECTS a Codex account, and the
-composing one enrols it. The identity guard is shown still biting: a caller-supplied
-email contradicting the slot is refused, and a slot with no credential is refused.
+*Degradation trigger (9).* Including its acceptance test — a degrading account produces
+a dry-run would-swap and moves nothing. A CONTROL proves quota alone would not have
+selected that account (17%), so the pass is attributable to the new trigger. A second
+control runs with dry-run off and asserts a real swap, so "nothing moved" is a choice
+rather than an incapacity.
 
-Both security canaries carry controls: the planted secret is asserted absent from the
-result AND asserted present in the bytes being read, so a clean scan is a measurement.
+*Retry list (32).* Both mechanisms were shown capable of failing independently, which is
+how a real defect surfaced: the first version identified the failing account by id, but
+internal calls run on the ambient login and have no id — so a single-account agent would
+have been handed its own only account as a "sibling", buying a guaranteed-failing retry
+and reporting it as a move. A test caught it; the account is now identified by where its
+credentials live, and where it cannot be identified nothing is offered. A CONTROL proves
+the headline result is attributable: with the resolver absent, the same failure walks the
+retry list to the subscription.
 
-Verified against real credentials, not only fixtures: two Codex homes on this machine
-resolve to two distinct accounts. The 45 pre-existing Codex provider and env tests still
-pass.
+108 pre-existing router, swap and pool tests pass, plus the 45 pre-existing Codex
+provider and env tests.

--- a/upgrades/next/codex-pool-latency-swap.md
+++ b/upgrades/next/codex-pool-latency-swap.md
@@ -1,0 +1,85 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Codex accounts can now be enrolled in the subscription pool, and an internal Codex
+call can now choose which account it runs on.
+
+Both were previously impossible, for reasons that were invisible from outside:
+
+**Enrolment.** The pool refuses to add an account whose credential slot it cannot
+identify — a sensible guard, since two rows pointing at the same login would make
+"switch to the other account" a switch to itself. But the only identity check asks
+Anthropic's OAuth servers who is signed in, so handed a Codex slot it simply could not
+answer. Enrolment failed as `email-unresolved`. That is why a pool could hold six
+Anthropic accounts and zero Codex ones while Codex logins sat authenticated on disk.
+
+A Codex slot can answer the same question offline: its credential file carries an OIDC
+id_token whose payload holds the account email, a stable per-account id, and the plan.
+The identity check now lets the slot identify itself — a Codex home has that token, an
+Anthropic one does not — and falls back to the existing Anthropic path otherwise, which
+is unchanged.
+
+**Account selection.** Internal Codex calls never named an account: the child inherited
+the ambient `CODEX_HOME`, so every one of them used the default login. The ability to
+target a specific slot existed in the spawn layer and was honoured — this path just
+never used it. So "move a struggling account's work to the other account" had nothing
+to move.
+
+## What to Tell Your User
+
+- "If you have more than one Codex login, I can now hold both — before, I could only
+  ever see one of them."
+- "Nothing changes about which account I use until that's deliberately configured."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Enrol a Codex account in the subscription pool | The existing enrolment path now accepts a Codex credential slot |
+| Point an internal Codex call at a specific account | `resolveAccount` on the Codex provider (unused by default) |
+
+No new endpoint and no configuration.
+
+## Compatibility Notes
+
+**Nothing changes by default.** A Codex call that does not name an account behaves
+exactly as before — same account, same result — and nothing in the shipped wiring names
+one. A broken or throwing account resolver also falls back to the previous behaviour
+rather than failing the call.
+
+The Anthropic identity path is untouched: any slot that is not a Codex home takes the
+identical pre-existing check with the identical result. A Codex slot that cannot
+identify itself is reported as a Codex problem rather than mislabelled as an Anthropic
+failure.
+
+Reading a credential never exposes it: the identity reader returns an email, an account
+id and a plan, and no token material.
+
+## Evidence
+
+26 tests across two tiers.
+
+Unit: the identity reader (real-shaped read, two logins resolving to DIFFERENT
+identities, every named failure reason, never-throws across six malformed shapes, and
+two security canaries); the composing identity check (Codex resolves, a CONTROL that a
+non-Codex slot still reaches the Anthropic path verbatim, a broken Codex slot reported
+honestly, a throwing probe degrading safely); and account selection (no resolver means
+no override, two accounts genuinely distinguishable, per-call rather than
+per-construction resolution, all three degradation paths, and a CONTROL that env
+scrubbing still holds when an account is selected).
+
+Integration: the tier that would have caught the real defect, since unit tests of a
+reader pass whether or not it is wired. It drives the real registrar against a real pool
+and asserts BOTH directions — the Anthropic-only check REJECTS a Codex account, and the
+composing one enrols it. The identity guard is shown still biting: a caller-supplied
+email contradicting the slot is refused, and a slot with no credential is refused.
+
+Both security canaries carry controls: the planted secret is asserted absent from the
+result AND asserted present in the bytes being read, so a clean scan is a measurement.
+
+Verified against real credentials, not only fixtures: two Codex homes on this machine
+resolve to two distinct accounts. The 45 pre-existing Codex provider and env tests still
+pass.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -12,8 +12,9 @@ sections below mark what is IN and what is still PENDING.
 
 1. **IN — `codexSlotIdentity`**: reads which account is signed in at a Codex
    credential slot, offline, from the id_token already in `auth.json`.
-2. **PENDING — enrolment**: wire that resolver into the pool's verified-add path
-   so Codex accounts can be enrolled at all.
+2. **IN — enrolment**: `CompositeCredentialIdentityOracle` composes the Anthropic
+   oracle so the pool's verified-add path accepts a Codex slot. All four
+   production construction sites route through one factory.
 3. **PENDING — latency/error swap trigger**: extend the proactive-swap monitor to
    fire on degradation, not only on quota. Dark + dry-run first.
 4. **PENDING — failure-swap tail**: prefer the sibling Codex account before
@@ -116,7 +117,7 @@ Piece 1 is additive and inert until called. The trigger is behind a config flag
 that ships off. Enrolment is reversible by removing the pool rows. No schema
 change, no migration, no agent state to repair.
 
-## Evidence (piece 1)
+## Evidence (pieces 1-2)
 
 7 unit tests: real-shaped read; the enrolment property (two logins must resolve
 to DIFFERENT identities, else "swap to the other account" could be a swap to
@@ -130,3 +131,25 @@ a measurement rather than a check that could not fail.
 Verified against the REAL credentials, not only fixtures: `~/.codex` and
 `~/.codex-followme-sagemindai` resolve to two distinct accounts, both `pro`, with
 no token material in either result.
+
+### Added by piece 2
+
+6 further unit tests on the composite (Codex slot resolves without touching the
+network; a CONTROL asserting a non-Codex slot still reaches the Anthropic oracle
+verbatim; unavailable passthrough; a broken Codex slot reported honestly rather
+than mislabelled; a throwing probe degrading to Anthropic; two slots resolving
+differently).
+
+5 INTEGRATION tests — the tier that would have caught the real defect, since unit
+tests of a reader pass whether or not it is wired. They drive the REAL registrar
+against a REAL pool and assert BOTH directions: the Anthropic-only oracle REJECTS
+a Codex account (so the fix has something to be a fix of), and the composite
+enrols the same one. The identity guard is shown still biting — a caller-supplied
+email contradicting the slot is refused, and a slot with no credential is refused
+— so a clean pass is not the guard being switched off.
+
+**Tier declared 1, below the gate's suggested 2** (size-driven; risk floor 1). The
+override is recorded with reasoning in the decisions ledger. Rationale: the change
+composes rather than replaces, the pre-existing path is pinned unchanged by a
+control, and it creates no new authority — it widens which accounts may be
+enrolled while every existing guard still gates the add.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -1,0 +1,132 @@
+# Side-Effects Review — Codex pool enrolment + latency/error swap
+
+**Version / slug:** `codex-pool-latency-swap`
+**Date:** `2026-08-15`
+**Author:** `Instar-echo`
+**Charter:** Window 17 (operator-chartered, relayed by Observer 1)
+
+## Summary of the change
+
+Three related pieces, built in order. This artifact grows as each lands; the
+sections below mark what is IN and what is still PENDING.
+
+1. **IN — `codexSlotIdentity`**: reads which account is signed in at a Codex
+   credential slot, offline, from the id_token already in `auth.json`.
+2. **PENDING — enrolment**: wire that resolver into the pool's verified-add path
+   so Codex accounts can be enrolled at all.
+3. **PENDING — latency/error swap trigger**: extend the proactive-swap monitor to
+   fire on degradation, not only on quota. Dark + dry-run first.
+4. **PENDING — failure-swap tail**: prefer the sibling Codex account before
+   falling through to `claude-code`.
+
+## Why this exists (measured, not assumed)
+
+Codex is the configured framework for 46 internal components. It is degrading:
+a trivial prompt takes ~13s across three runs; `completion-claim-verify` and
+`TopicIntentExtractor` sit at a 60s p50 — the ceiling, i.e. timing out rather
+than erroring; the codex error rate ran 28.5% (72h) → 38.9% (24h) → 46.4% (6h) →
+78.1% (1h). Quota is NOT the cause: 17% of the 5h window, no limit reached.
+
+Two consequences make it more than background noise:
+
+- `componentFrameworks.failureSwap` is literally `["claude-code"]`, so every
+  Codex failure spends the subscription Codex exists to protect.
+- Each stalled call holds one of 8 host spawn slots until timeout. Observed
+  directly: operator-facing sends were refused 12 times in ~15 minutes during a
+  live demo because the tone gate could not get a slot.
+
+## Decision-point inventory
+
+- **Slot identity resolution (piece 1)** — *new, read-only*. Produces an
+  assertion about a local file. Feeds naming/de-duplication only.
+- **Pool membership (piece 2)** — *widened*. Codex accounts become enrollable.
+  The pool's existing duplicate + identity guards still gate every add.
+- **Swap triggering (piece 3)** — *widened*. A new condition can propose a swap.
+  Ships dark; when enabled, dry-run records the would-swap without moving anything.
+- **Framework routing (piece 4)** — *reordered*, not widened. The same fallback
+  set, tried in a different order.
+- **Authorization** — *untouched throughout*. Nothing here grants a permission.
+
+---
+
+## 1. Over-block
+
+Piece 1 can refuse to identify a slot (`unavailable` + a named reason). That
+refusal only means "this slot cannot be enrolled yet" — it blocks no message, no
+session, no existing account. It fails toward refusing to enrol rather than
+enrolling something unverified, which is the safe direction for a guard whose
+whole job is preventing two rows pointing at one login.
+
+## 2. Under-block
+
+- **The identity is asserted, not proven.** The id_token is decoded, not
+  signature-verified. Stated plainly in the module: this is not authentication,
+  and anyone able to edit `auth.json` can already use the credential itself. The
+  result is used to label a row and never as a permission.
+- **Enrolment does not prove the account is healthy** — only that it is signed
+  in and distinct. A newly-enrolled account could be as degraded as the first.
+  The latency trigger, not enrolment, is what notices that.
+- **The latency trigger cannot fix a provider-wide outage.** If both Codex
+  accounts are slow, swapping between them buys nothing; the failure tail is what
+  covers that, and its last resort is still the main subscription.
+
+## 3. Level-of-abstraction fit
+
+Correct layers. Identity reading sits in the Codex adapter, which already owns
+reading `auth.json` (for Rule-1 API-key detection). The trigger extends
+`ProactiveSwapMonitor`, which already models exactly this shape — `loginLoss` is
+a precedent trigger with the same enabled/dryRun structure, so this follows an
+established pattern rather than inventing one.
+
+## 4. Signal vs authority
+
+The identity reader is pure signal. The swap trigger *proposes*; the existing
+anti-thrash engine, work gate, and revalidation still decide and can refuse. No
+new authority is created — a new condition feeds an existing authority.
+
+## 5. Interactions
+
+- **Framework safety was verified before being relied on**: `SwapAntiThrash`
+  filters swap targets to the source account's framework, so a Codex session
+  structurally cannot be moved onto a Claude account. This is what makes widening
+  the monitor's session filter safe.
+- **The quota poller already supports Codex** (branches on `openai`/`codex-cli`,
+  reads usage per config home), so enrolled Codex accounts get real quota
+  readings with no further work.
+- No interaction with the outbound message path.
+
+## 6. Multi-machine posture
+
+**Machine-local by design.** Credential slots are physical directories on one
+machine; a login on the Mini is not a login on the laptop. Pool account metadata
+already replicates through its own existing path (`subscription-account-meta`)
+and this change adds no new replicated state. Nothing strands on topic transfer.
+
+## 7. Failure modes
+
+- Credential file missing / unreadable / not JSON / no id_token / malformed JWT /
+  no email claim → a named `unavailable` reason. Never throws into the enrolment
+  path (pinned by a test across six malformed shapes).
+- Degraded-health readings unavailable → the trigger simply does not fire; the
+  existing quota trigger is unaffected.
+
+## 8. Rollback cost
+
+Piece 1 is additive and inert until called. The trigger is behind a config flag
+that ships off. Enrolment is reversible by removing the pool rows. No schema
+change, no migration, no agent state to repair.
+
+## Evidence (piece 1)
+
+7 unit tests: real-shaped read; the enrolment property (two logins must resolve
+to DIFFERENT identities, else "swap to the other account" could be a swap to
+itself); file-over-claim precedence; two security canaries; every named failure
+reason; never-throws across six malformed shapes.
+
+Both security canaries carry controls — the planted secret is asserted absent
+from the result AND asserted present in the bytes being read, so a clean scan is
+a measurement rather than a check that could not fail.
+
+Verified against the REAL credentials, not only fixtures: `~/.codex` and
+`~/.codex-followme-sagemindai` resolve to two distinct accounts, both `pro`, with
+no token material in either result.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -15,10 +15,14 @@ sections below mark what is IN and what is still PENDING.
 2. **IN — enrolment**: `CompositeCredentialIdentityOracle` composes the Anthropic
    oracle so the pool's verified-add path accepts a Codex slot. All four
    production construction sites route through one factory.
-3. **PENDING — latency/error swap trigger**: extend the proactive-swap monitor to
-   fire on degradation, not only on quota. Dark + dry-run first.
-4. **PENDING — failure-swap tail**: prefer the sibling Codex account before
-   falling through to `claude-code`.
+3. **IN (foundation) — per-call account selection**: internal Codex calls can now
+   target a specific pool account's credential slot. This was the missing layer
+   under BOTH remaining items — see "The finding" below.
+4. **PENDING — latency/error swap trigger**: needs per-account health recording,
+   which needs (3). Dark + dry-run when it lands.
+5. **PENDING — failure-swap tail**: prefer the sibling Codex account before
+   falling through to `claude-code`. Also needs (3): `failureSwap` is a FRAMEWORK
+   list with no account dimension.
 
 ## Why this exists (measured, not assumed)
 
@@ -153,3 +157,48 @@ override is recorded with reasoning in the decisions ledger. Rationale: the chan
 composes rather than replaces, the pre-existing path is pinned unchanged by a
 control, and it creates no new authority — it widens which accounts may be
 enrolled while every existing guard still gates the add.
+
+## The finding that reshaped items 2 and 4
+
+The charter read as though only the swap TRIGGER needed changing — "the machinery
+exists but triggers on QUOTA". Verified against the code, three layers were
+missing, and the trigger is the top one:
+
+1. **Internal Codex calls never chose an account.** `CodexCliIntelligenceProvider`
+   called `buildCodexChildEnv()` with no options, so the child inherited the
+   ambient `CODEX_HOME` — every internal call landed on the default login. The
+   ability to point a call at a slot existed in `codexSpawn` and was honoured; it
+   was simply never used by this path. (Control: only `QuotaPoller` and
+   `structuredOneShot` passed `codexHome`.)
+2. **Latency and errors are not attributed per account.** `attribution` carries
+   component/category/gating — no account. `AccountQuotaSnapshot` carries quota
+   only. (Control: the same searches DO find per-account quota, so the absence is
+   a measurement.)
+3. **`failureSwap` is a framework list** (`{ door: fw }`), with no account
+   dimension — so "prefer the other Codex account" has nothing to name.
+
+So the charter's exit test — make one account artificially slow and watch a
+would-swap — could not pass, not because the trigger was missing but because
+nothing measured or selected the thing it would act on. Building the trigger alone
+would have produced a dial wired to a dead gauge.
+
+Piece 3 supplies layer 1. Reported to the charter author before building further.
+
+### Added by piece 3
+
+`resolveAccount?: () => CodexCallAccount | null` — a per-call CLOSURE, matching
+`resolveExecJson`'s established pattern in the same file, because the router caches
+built providers and a construction-time value would freeze the first answer.
+
+**The load-bearing property is the null case, not the selection.** Absent or null
+resolver ⇒ no `CODEX_HOME` override ⇒ byte-identical to before. Nothing is wired in
+production, so adding the capability changes nothing until a later, deliberate act.
+A throwing or malformed resolver also degrades to ambient: losing account selection
+is a small loss, losing every internal Codex call is not.
+
+8 unit tests, including the safety property (no resolver ⇒ no override), two
+accounts genuinely distinguishable (without which "swap to the other account" has
+no mechanism), per-call rather than per-construction resolution, all three
+degradation paths, and a CONTROL that env scrubbing still holds when an account IS
+selected — so account selection cannot become a way to smuggle the parent env into
+the child. 45 pre-existing codex provider/env tests still pass.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -267,3 +267,88 @@ than to ordinary pressure. A second control runs with `dryRun:false` and asserts
 real swap happens, so "nothing moved" is a deliberate choice rather than an
 incapacity. Latency-alone and error-rate-alone both trigger; dark changes nothing;
 a throwing gauge is unknown. 43 pre-existing swap-monitor/continuity tests pass.
+
+### Added by piece 6 (item 4 — the failure tail prefers the sibling account)
+
+The charter's first-flagged item, and the one closest to the money: the shipped
+failure tail's LAST door is `claude-code`. So a failing Codex call ended its tail on
+the main subscription — the cheaper door degrades and its failures land on exactly
+the account that door exists to protect.
+
+Piece 6 gives the tail an ACCOUNT dimension (layer 3 of the finding above): a
+position may now name a same-door, different-account attempt, and those positions
+are tried BEFORE any door change.
+
+**Prepended, never substituted.** If every sibling also fails, the original door
+tail runs exactly as before. This can only ADD an attempt ahead of the fall-through;
+it can never remove the fall-through. A test pins the whole ordering
+(`codex → codex-sibling → pi → claude`) precisely so a future edit cannot quietly
+turn the enhancement into a replacement.
+
+**The `target === framework` carve-out.** The loop skipped any position whose door
+was the door that just failed. A sibling position IS that door, so without a
+carve-out every sibling would be skipped and the tail would go straight to the next
+door. The rule's purpose is "don't repeat the attempt that just failed", and
+same-door-other-account is not that attempt — different login, quota window and
+rate-limit state. The carve-out is scoped to positions carrying an account.
+
+#### The defect a test found: identifying the account that failed
+
+The first version excluded the failing account by id, and treated a null id
+(an ambient call) as "excludes nothing". A test asserting a single-account agent
+gets no siblings FAILED — correctly.
+
+Internal Codex calls run on the ambient login, so `failedAccountId` is null in
+production essentially always. Under the first version a single-account agent would
+have been offered its own only account as a "sibling", buying one guaranteed-failing
+retry against a gating deadline on every failure — and reporting it as a swap. The
+logs would have claimed a move that never happened.
+
+The fix identifies the ambient account by its HOME rather than its id, using the
+derivation already verified in production (`ThreadlineBootstrap`:
+`process.env['CODEX_HOME'] || ~/.codex`). Where neither identifier is available the
+resolver returns nothing rather than guess. An ambient home matching no enrolled
+account still yields a sibling — the primary ran on an unenrolled login, so every
+enrolled account is genuinely different.
+
+#### Over-block / under-block
+
+*Over-block:* a `warming` sibling is refused even though it might work. Deliberate —
+the tail is spending a gate's deadline, so a maybe is worse than the next door.
+
+*Under-block:* eligibility reads `status`, which is as fresh as the pool's last
+quota poll. A sibling that became unwell seconds ago can still be selected; it
+simply fails and the tail continues. The cost is one bounded attempt, and the
+existing per-target cap and total budget already bound it.
+
+#### Signal vs authority
+
+The router holds no eligibility opinion — it consumes an ordered list. Which
+accounts qualify is decided by `eligibleSiblingAccounts`, pool-side, where account
+state actually lives. The router's only judgment is ordering (siblings first).
+
+#### Rollback
+
+Delete the `resolveSiblingAccounts` line at the construction site. The option is
+optional; absent ⇒ no sibling positions ⇒ the shipped tail byte-for-byte. No state,
+no migration, no persisted field. A single-account agent is already a no-op.
+
+#### Multi-machine posture
+
+Machine-local BY DESIGN. A sibling attempt runs a local child process against a
+local credential home, so only accounts with a real local login on THIS machine are
+eligible (the empty-`configHome` exclusion is exactly the meta-only, replicated-from-
+a-peer case). Nothing replicates and nothing is proxied.
+
+#### Evidence
+
+20 policy + wiring tests and 12 router tests. Both mechanisms were shown capable of
+failing INDEPENDENTLY: reverting the carve-out fails 4 behaviour tests while the 8
+controls keep passing; breaking only the account threading fails 3 — including
+"the sibling attempt actually RUNS on the sibling account", which is the test that
+separates a real move from a logged one. Removing the ambient-home exclusion fails
+the single-account and production-case tests; removing the refuse-to-guess rule
+fails its two. A CONTROL proves the headline result is attributable: with no
+resolver the same failure walks the tail to Claude, so "never reaches Claude" is
+caused by the sibling position rather than by an unreachable harness. 57 pre-existing
+router/swap tests and 51 pool/swap tests pass.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -21,8 +21,8 @@ sections below mark what is IN and what is still PENDING.
 4. **IN (foundation) — per-account health**: `CodexAccountHealth` records how each
    account's calls actually went, and the provider feeds it. This is layer 2 of
    the three below.
-5. **PENDING — the swap trigger itself**: reads (4), proposes a swap. Dark +
-   dry-run when it lands.
+5. **IN — the swap trigger**: `degradation` on `ProactiveSwapMonitor`. Reads (4),
+   proposes a swap on latency OR error rate. Dark by default, dry-run first.
 6. **PENDING — failure-swap tail**: prefer the sibling Codex account before
    falling through to `claude-code`. Also needs (3): `failureSwap` is a FRAMEWORK
    list with no account dimension.
@@ -236,3 +236,34 @@ successes would read 0% errors however bad things got — nothing observed when 
 account was named, and a throwing observer never breaking the call it measures.
 
 35 pre-existing/adjacent codex tests still pass.
+
+### Added by piece 5 (the trigger — the charter's deliverable)
+
+`degradation` on `ProactiveSwapMonitor`, mirroring the existing `loginLoss`
+extension exactly (enabled/dryRun, dark by default). A degrading account becomes a
+swap candidate REGARDLESS of how full it is — which is the point, since quota was
+never the problem (17% used while p50 sat at the 60s ceiling). It bypasses only
+SOURCE pressure; target freshness, per-target ceilings, anti-thrash dwell and
+execution-time revalidation all still apply, and `SwapAntiThrash` still refuses to
+cross frameworks, so a Codex session can only ever land on another Codex account.
+
+**Two safety properties carry this:**
+
+*Unknown is not degraded.* `readHealth` returning null — too few samples, no data,
+or a throwing gauge — means UNKNOWN and never selects a session. Acting on an
+unknown is how a trigger starts thrashing.
+
+*Rehearsal must not move anything.* The monitor has TWO pipelines: the braked one
+(only when anti-thrash brakes are live) and the legacy one (everywhere else — i.e.
+exactly where this ships). Wiring only the braked path would have left the trigger
+silently inert where it actually runs; wiring the legacy path without its own
+dry-run guard would have moved a live conversation on the trigger's FIRST firing,
+the opposite of what dry-run means. Both paths are wired, and both rehearse.
+
+9 tests, including the charter's own exit test — a degrading account produces a
+dry-run would-swap and moves nothing. A CONTROL proves quota alone would NOT have
+selected that account (17%), so the pass is attributable to the new trigger rather
+than to ordinary pressure. A second control runs with `dryRun:false` and asserts a
+real swap happens, so "nothing moved" is a deliberate choice rather than an
+incapacity. Latency-alone and error-rate-alone both trigger; dark changes nothing;
+a throwing gauge is unknown. 43 pre-existing swap-monitor/continuity tests pass.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -18,9 +18,12 @@ sections below mark what is IN and what is still PENDING.
 3. **IN (foundation) — per-call account selection**: internal Codex calls can now
    target a specific pool account's credential slot. This was the missing layer
    under BOTH remaining items — see "The finding" below.
-4. **PENDING — latency/error swap trigger**: needs per-account health recording,
-   which needs (3). Dark + dry-run when it lands.
-5. **PENDING — failure-swap tail**: prefer the sibling Codex account before
+4. **IN (foundation) — per-account health**: `CodexAccountHealth` records how each
+   account's calls actually went, and the provider feeds it. This is layer 2 of
+   the three below.
+5. **PENDING — the swap trigger itself**: reads (4), proposes a swap. Dark +
+   dry-run when it lands.
+6. **PENDING — failure-swap tail**: prefer the sibling Codex account before
    falling through to `claude-code`. Also needs (3): `failureSwap` is a FRAMEWORK
    list with no account dimension.
 
@@ -202,3 +205,34 @@ no mechanism), per-call rather than per-construction resolution, all three
 degradation paths, and a CONTROL that env scrubbing still holds when an account IS
 selected — so account selection cannot become a way to smuggle the parent env into
 the child. 45 pre-existing codex provider/env tests still pass.
+
+### Added by piece 4 (layer 2 — the gauge)
+
+`CodexAccountHealth`: a bounded, in-memory, time-windowed record of how each
+account's calls went, exposing p50 latency and error rate per account.
+
+**The load-bearing rule is honest-unknown.** `read()` returns `null` when it cannot
+responsibly answer — no samples, or too few to tell degradation from variance. It
+never returns a zero or an optimistic default, because a trigger acting on two
+samples would move live sessions on noise, and a too-eager swap (thrash) is a worse
+failure than a late one (a slow account stays slow a little longer). Deliberately
+not persisted: health is a claim about the last few minutes, and a reading
+resurrected across a restart would be a confident answer about a world that no
+longer exists.
+
+The provider feeds it via an optional `onCallObserved`, and the account is now
+resolved ONCE and threaded down the call chain rather than re-read at each spawn
+site — so the account RECORDED is provably the account USED. A gauge that can
+disagree with reality is worse than no gauge, because a trigger acts on it with
+confidence.
+
+22 tests. Health store (10): median/error-rate from real samples; the
+honest-unknown rule WITH a control (one more sample and it answers, so null was the
+guard and not a broken store); unknown account; window expiry returning to
+not-knowing rather than stale good news; accounts measured independently; readAll
+omitting unanswerable accounts; bounded memory; never-throws on junk. Provider (12,
+up from 8): successful AND failed calls both observed — a gauge that only sees
+successes would read 0% errors however bad things got — nothing observed when no
+account was named, and a throwing observer never breaking the call it measures.
+
+35 pre-existing/adjacent codex tests still pass.

--- a/upgrades/side-effects/codex-pool-latency-swap.md
+++ b/upgrades/side-effects/codex-pool-latency-swap.md
@@ -352,3 +352,18 @@ fails its two. A CONTROL proves the headline result is attributable: with no
 resolver the same failure walks the tail to Claude, so "never reaches Claude" is
 caused by the sibling position rather than by an unreachable harness. 57 pre-existing
 router/swap tests and 51 pool/swap tests pass.
+
+#### CI finding: the throwing-resolver path was a silent fallback
+
+The no-silent-fallbacks ratchet caught the resolver guard (496 vs a baseline of 495).
+Raising the baseline would have been the wrong resolution: a resolver throwing on every
+call disables the sibling tail COMPLETELY, so every Codex failure walks back onto the
+main subscription — the exact spend this piece exists to stop, invisibly restored. That
+is precisely the class the ratchet exists to catch, and it was catching a real one.
+
+The fault now surfaces through `onDegrade` into DegradationReporter, so a persistent
+resolver fault is visible rather than merely survivable. Two tests: the fault is
+reported and names the underlying error, plus a CONTROL that a healthy resolver reports
+no fault (without it the assertion would pass against a change that reported on every
+call). Shown capable of failing by changing the reason text. The baseline is unchanged
+at 495.


### PR DESCRIPTION
## ELI16 — the spare Codex account could not be enrolled, and no request could name an account

The agent's small background judgements deliberately run on a **second** provider so they
don't consume the main subscription. That provider has degraded badly — measured, not
guessed: the simplest possible request takes about thirteen seconds, several background
checks now sit at the sixty-second cut-off (running out of time rather than failing), and
the failure rate went from roughly a quarter over three days to most requests in the last
hour. Quota is not the cause; the account is at seventeen percent.

There is a second account for that provider already signed in on this machine, unused.

Two things prevented using it, and both were invisible from outside:

**It could not be enrolled.** The pool refuses any account whose credential folder it
cannot identify — a good guard, since two entries pointing at the *same* login would make
"switch to the other account" a switch to itself. But the only identity check asks
Anthropic's servers who is signed in, so handed a Codex folder it simply cannot answer. Not
policy — a door of the wrong shape.

**No request could name an account.** Every internal request inherited the default folder,
so they all used one login regardless. The ability to name a folder existed in the spawn
code and worked; this path never used it. So "move a struggling account's work elsewhere"
had nothing to move.

This PR fixes both, and stops there deliberately — see below.

## What checking the plan first turned up

The charter read as though only the swap *trigger* needed building. Verified against the
code, three layers were missing and the trigger is the last:

1. Requests never chose an account (fixed here).
2. Timings and failures are recorded against the component that **asked**, never the
   account that **answered** — so there is no per-account measurement for a trigger to read.
3. The fallback list names **providers**, not accounts — so "prefer the other Codex
   account" has nothing to name.

The charter's own exit test (make one account artificially slow, watch a would-swap) could
not have passed — not because the trigger was missing, but because nothing measured or
selected what it would act on. Building the trigger alone would have been a dial wired to a
dead gauge. Layers 2 and 3 are reported rather than quietly built; they change the size of
the job.

## UX Impact

**Who sees it:** the operator, indirectly. Nothing user-facing changes in this PR.

**What the user sees:** nothing yet, by design. This makes a second Codex account
*enrollable* and lets a request *name* one. What the user eventually sees — background
checks stopping their fall-through onto the main subscription — needs the remaining layers.

**First contact:** none until enrolment is deliberately performed. A request that names no
account behaves exactly as before, and nothing in the shipped wiring names one.

The concrete change in the user-facing path `src/server/routes.ts` is
`defaultSubscriptionIdentityOracle()` — the four enrolment call sites that previously
constructed `new CredentialIdentityOracle()` directly now route through one factory that
also understands a Codex credential folder. That is what makes a Codex account enrollable
at all; behaviour for every Anthropic folder is identical to before.

## Evidence

26 tests across two tiers, plus 45 pre-existing Codex provider/env tests still passing.

The integration tier is the one that would have caught the real defect, since unit tests of
a reader pass whether or not it is wired: it drives the REAL registrar against a REAL pool
and asserts BOTH directions — the Anthropic-only check REJECTS a Codex account, and the
composing one enrols it. The identity guard is shown still biting (a caller email
contradicting the folder is refused; an empty folder is refused), so a clean pass is not
the guard being off.

Both security canaries carry controls: a planted fake secret is asserted absent from the
result AND asserted present in the bytes being read, so a clean scan is a measurement.

Safety property, pinned by test: no resolver ⇒ no account override ⇒ byte-identical to
before. Throwing and malformed resolvers also degrade to the previous behaviour — losing
account selection is a small loss, losing every internal Codex call is not.

Verified against real credentials rather than only fixtures: the two Codex homes on this
machine resolve to two genuinely distinct accounts.
