### PR TITLE
fix(pool): ask the identity layer what it covers, don't restate it at the route

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T23-34-01-720Z-codex-enrolment-route-gate.json
+++ b/.instar/instar-dev-decisions/2026-08-15T23-34-01-720Z-codex-enrolment-route-gate.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-15T23:34:01.720Z",
+  "slug": "codex-enrolment-route-gate",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 45,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CompositeCredentialIdentityOracle.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 43,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/codex-enrolment-route-gate.eli16.md
+++ b/docs/specs/codex-enrolment-route-gate.eli16.md
@@ -1,0 +1,60 @@
+# Enrolling a Codex account — the second door
+
+## What this is
+
+A one-line fix to a gate that was refusing something it should have allowed, and the test
+that stops it happening again.
+
+## The story
+
+The previous change taught the system to recognise which account is signed in to a Codex
+credential slot. That was the thing standing between you and holding two Codex logins, and
+it worked.
+
+Except enrolling a Codex account still failed.
+
+There were two doors, not one. The first door asks "can we identify who is signed in here?"
+— that is the one that got fixed. The second door sits in front of it and asks a cruder
+question: "is this even a kind of account we know how to identify?" That second door had
+the answer written into it directly: Anthropic only. It was correct when it was written,
+because Anthropic was the only kind we could identify. Nobody updated it when Codex became
+identifiable, so it kept turning Codex away without ever asking the first door.
+
+## The fix
+
+The second door now asks the identity layer what it can handle instead of carrying its own
+copy of the answer. The list of what can be identified lives next to the code that does the
+identifying, so adding a new kind of account and declaring that we can identify it are the
+same edit. Writing the answer in two places is what caused this; writing it in two places
+again would cause it on the next one.
+
+To be clear about what this door does and does not do: it only decides whether the question
+is worth asking. It grants nothing. A Codex slot that cannot prove who is signed in is still
+refused, exactly as before — this only stops us refusing without asking.
+
+## How it was found, and why that matters
+
+Not by reading the code. By trying to actually enrol the account on a running system and
+watching it fail.
+
+The previous change came with a test that enrolled a Codex account successfully. That test
+was real and it passed — but it started one step past the second door, so it never touched
+the thing that was broken. Every test was green while the operation those tests existed to
+enable did not work.
+
+That is the useful lesson here, more than the fix itself: a test that stops just short of
+the real entry point can be perfectly green over a broken feature. The new test covers the
+door that was missed, and it was checked by putting the bug back and confirming the test
+fails.
+
+## What could still go wrong
+
+The risk now runs the other way. If someone adds an account type to that list without
+anything behind it that can actually identify it, the door would wave through an enrolment
+we cannot verify — a false yes, which is worse than the false no we just fixed. So there is
+a test that walks every entry on the list and proves something can genuinely answer for it.
+
+## What you would notice
+
+Nothing changes for accounts you already have. If you have a second Codex login, it can now
+be enrolled.

--- a/src/core/CompositeCredentialIdentityOracle.ts
+++ b/src/core/CompositeCredentialIdentityOracle.ts
@@ -85,3 +85,36 @@ export class CompositeCredentialIdentityOracle implements IdentityOracle {
     return this.anthropic.resolveSlotTenant(slot);
   }
 }
+
+/**
+ * The (provider, framework) pairs whose credential slot identity can actually be
+ * VERIFIED — i.e. the pairs some oracle above can answer for.
+ *
+ * This exists because the enrolment route used to carry the answer inline as
+ * `provider !== 'anthropic' || framework !== 'claude-code'`. That was correct while
+ * Anthropic was the only oracle, and it went stale the moment a Codex oracle was
+ * added: the route refused Codex BEFORE the oracle was ever asked, so a Codex account
+ * still could not be enrolled even though the identity layer could now identify it.
+ *
+ * Hardcoding a second pair at the callsite would repeat exactly that bug on the third
+ * oracle. Keeping the list HERE, beside the oracle that implements it, means adding an
+ * oracle and declaring what it covers are the same edit.
+ *
+ * Note what this list is NOT: it is not a claim that a given slot WILL verify, only
+ * that something can be asked. The oracle still decides, and an unidentifiable slot is
+ * still refused — this gate only stops us refusing without asking.
+ */
+export const IDENTITY_VERIFIABLE_SLOTS: ReadonlyArray<{
+  readonly provider: string;
+  readonly framework: string;
+}> = [
+  { provider: 'anthropic', framework: 'claude-code' },
+  { provider: 'openai', framework: 'codex-cli' },
+];
+
+/** True when some identity oracle can be asked about this provider/framework pair. */
+export function isIdentityVerifiableSlot(provider: unknown, framework: unknown): boolean {
+  return IDENTITY_VERIFIABLE_SLOTS.some(
+    (s) => s.provider === provider && s.framework === framework,
+  );
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -42,7 +42,10 @@ import { enrollPaneSessionName } from '../core/FrameworkLoginDriver.js';
 import { QUOTA_SNAPSHOT_STALE_AFTER_MS } from '../core/QuotaPoller.js';
 import { SubscriptionAccountEmailRegistrar } from '../core/SubscriptionPool.js';
 import { CredentialIdentityOracle } from '../core/CredentialIdentityOracle.js';
-import { CompositeCredentialIdentityOracle } from '../core/CompositeCredentialIdentityOracle.js';
+import {
+  CompositeCredentialIdentityOracle,
+  isIdentityVerifiableSlot,
+} from '../core/CompositeCredentialIdentityOracle.js';
 
 /**
  * The default slot-identity oracle.
@@ -29144,7 +29147,12 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           return;
         }
       }
-      if (provider !== 'anthropic' || framework !== 'claude-code') {
+      // Ask the identity layer what it covers rather than restating it here. The inline
+      // pair this replaced (`anthropic`/`claude-code`) was correct while Anthropic was the
+      // only oracle, and went stale the moment the Codex oracle landed: the route refused
+      // Codex before the oracle was ever asked, so a Codex account could not be enrolled
+      // even though its identity was by then perfectly resolvable.
+      if (!isIdentityVerifiableSlot(provider, framework)) {
         res.status(400).json({
           error: `provider identity verification is not supported for ${String(provider)}/${String(framework)}`,
           code: 'subscription-account-identity-provider-unsupported',

--- a/tests/integration/codex-pool-enrolment.test.ts
+++ b/tests/integration/codex-pool-enrolment.test.ts
@@ -21,7 +21,11 @@ import {
   SubscriptionAccountEmailRegistrar,
   SubscriptionIdentityError,
 } from '../../src/core/SubscriptionPool.js';
-import { CompositeCredentialIdentityOracle } from '../../src/core/CompositeCredentialIdentityOracle.js';
+import {
+  CompositeCredentialIdentityOracle,
+  IDENTITY_VERIFIABLE_SLOTS,
+  isIdentityVerifiableSlot,
+} from '../../src/core/CompositeCredentialIdentityOracle.js';
 import type { IdentityOracle, IdentityOracleResult } from '../../src/core/CredentialLocationLedger.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
@@ -161,5 +165,73 @@ describe('subscription pool — Codex enrolment (integration)', () => {
       registrar.register({ id: 'x', nickname: 'X', provider: 'openai', framework: 'codex-cli', configHome: empty }),
     ).rejects.toBeInstanceOf(SubscriptionIdentityError);
     expect(pool.list()).toHaveLength(0);
+  });
+});
+
+/**
+ * The layer the tests above did NOT cover, and the defect that hid there.
+ *
+ * Everything above drives the REGISTRAR. The enrol route sits one layer higher and
+ * carried its own gate — `provider !== 'anthropic' || framework !== 'claude-code'` —
+ * so it refused Codex BEFORE the oracle was ever asked. Every registrar test passed
+ * while enrolling a real Codex account through the real route still returned
+ * `subscription-account-identity-provider-unsupported`. Found by attempting the
+ * actual enrolment on a live server, not by reading.
+ */
+describe('enrolment gate — the route must not disagree with the identity layer', () => {
+  it('the gate admits every pair the identity layer covers', () => {
+    expect(isIdentityVerifiableSlot('anthropic', 'claude-code')).toBe(true);
+    expect(isIdentityVerifiableSlot('openai', 'codex-cli')).toBe(true);
+  });
+
+  it('CONTROL: it still refuses a pair no oracle can answer for', () => {
+    // Without this the gate could pass by admitting everything, which would push an
+    // unanswerable slot down to the oracle and fail with a confusing reason.
+    expect(isIdentityVerifiableSlot('google', 'gemini-cli')).toBe(false);
+    expect(isIdentityVerifiableSlot('openai', 'claude-code')).toBe(false); // provider/framework must AGREE
+    expect(isIdentityVerifiableSlot(undefined, undefined)).toBe(false);
+  });
+
+  it('THE REGRESSION: every advertised pair is genuinely answerable by the oracle', async () => {
+    // This is what keeps the list honest in the other direction. Adding a pair here
+    // without an oracle behind it would let the route accept an enrolment it cannot
+    // verify — trading a false refusal for a false acceptance, which is worse.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-consist-'));
+    try {
+      const codexHome = writeCodexHome(root, 'codex', 'someone@example.com', 'acct-consistency');
+      const anthropicHome = path.join(root, 'anthropic');
+      fs.mkdirSync(anthropicHome, { recursive: true });
+
+      let anthropicAsked = false;
+      const oracle = new CompositeCredentialIdentityOracle({
+        anthropic: {
+          async resolveSlotTenant(): Promise<IdentityOracleResult> {
+            anthropicAsked = true;
+            return { email: 'anthropic@example.com' };
+          },
+        },
+      });
+
+      for (const pair of IDENTITY_VERIFIABLE_SLOTS) {
+        const slot = pair.framework === 'codex-cli' ? codexHome : anthropicHome;
+        const res = await oracle.resolveSlotTenant(slot);
+        expect(res.unavailable, `${pair.provider}/${pair.framework} is advertised but unanswerable`).toBeFalsy();
+        expect(res.email).toBeTruthy();
+      }
+      expect(anthropicAsked, 'the anthropic pair should still route to the anthropic oracle').toBe(true);
+    } finally {
+      SafeFsExecutor.safeRmSync(root, {
+        recursive: true,
+        force: true,
+        operation: 'tests/integration/codex-pool-enrolment.test.ts:gate-consistency',
+      });
+    }
+  });
+
+  it('the route asks the identity layer instead of restating it', () => {
+    // The inline pair is exactly what went stale. If it comes back, so does the bug.
+    const routes = fs.readFileSync('src/server/routes.ts', 'utf8');
+    expect(routes).toContain('isIdentityVerifiableSlot(provider, framework)');
+    expect(routes).not.toContain("provider !== 'anthropic' || framework !== 'claude-code'");
   });
 });

--- a/upgrades/next/codex-enrolment-route-gate.md
+++ b/upgrades/next/codex-enrolment-route-gate.md
@@ -1,0 +1,57 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Enrolling a Codex account now actually works.
+
+The previous release taught the system to recognise which account is signed in to a Codex
+credential slot — the thing standing between you and holding two Codex logins. It worked,
+and enrolment still failed, because there were two doors rather than one.
+
+The second door asks a cruder question than the first: not "who is signed in here?" but "is
+this even a kind of account we know how to identify?" That door had its answer written into
+it directly — Anthropic only. Correct when written, since Anthropic was the only kind we
+could identify. It was not updated when Codex became identifiable, so it kept turning Codex
+away without ever asking the door behind it.
+
+It now asks the identity layer what it covers instead of carrying its own copy of the
+answer, and that list lives beside the code that does the identifying — so adding a new kind
+of account and declaring it identifiable are the same edit.
+
+## What to Tell Your User
+
+- "If you have a second Codex login, it can now be enrolled — the last release got close but
+  a second check was still turning it away."
+- "Nothing changes for accounts you already have."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Enrol a Codex account | The existing verified-add path now accepts an `openai` / `codex-cli` slot |
+
+No new endpoint and no configuration.
+
+## Compatibility Notes
+
+The gate decides only whether the identity question is worth asking; it grants nothing. A
+Codex slot that cannot prove which account is signed in is still refused, with the same
+reason as before. The credential-field guard still runs first, so the registry still cannot
+be handed a token. Accounts already enrolled are untouched.
+
+## Evidence
+
+9 tests. The load-bearing one is a regression test: restoring the old inline check makes it
+fail, so it catches precisely the defect that shipped. A control proves the gate still
+refuses a kind of account nothing can identify — without it, a gate that admitted everything
+would pass equally well. A consistency test drives the real identity layer for every
+advertised kind and asserts each is genuinely answerable, which guards the opposite failure:
+advertising something with nothing behind it would trade a false refusal for a false
+acceptance.
+
+Worth recording how this was found: by attempting the enrolment on a running system, not by
+reading the code. The previous release's integration test enrolled a Codex account
+successfully, but started one step past the door that was broken — green tests over a
+feature that did not work.

--- a/upgrades/side-effects/codex-enrolment-route-gate.md
+++ b/upgrades/side-effects/codex-enrolment-route-gate.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — the enrolment route must not disagree with the identity layer
+
+## Summary of the change
+
+The enrol route carried its own gate — `provider !== 'anthropic' || framework !== 'claude-code'`
+— which refused a Codex account BEFORE the identity oracle was consulted. It now asks the
+identity layer what it covers (`isIdentityVerifiableSlot`), and the list of covered pairs
+lives beside the oracle that implements it.
+
+## How it was found
+
+By attempting the actual enrolment against a live server after the identity fix deployed,
+and getting `subscription-account-identity-provider-unsupported`. Not by reading the code.
+
+The previous PR's integration test drove `SubscriptionAccountEmailRegistrar.register()` —
+the pool's verified-add path — and proved a Codex slot enrols. That was one layer BELOW
+the route. The route's own gate was untested, so every test passed while the operation the
+tests existed to enable still failed. The lesson is specific: an integration test that
+stops short of the real entry point can be green over a broken feature.
+
+## Decision-point inventory
+
+One: may this (provider, framework) pair be submitted for identity verification? It gates
+enrolment only. It grants nothing — the oracle still decides, and an unidentifiable slot is
+still refused.
+
+## 1. Over-block
+
+Previously: over-blocked every non-Anthropic pair, including one the identity layer could
+answer for. That was the defect.
+
+Now: over-blocks only pairs no oracle covers, which is the correct refusal — reaching the
+oracle with an unanswerable pair yields a more confusing error, not a better outcome.
+
+## 2. Under-block
+
+The gate admits a pair; it does not admit an ACCOUNT. A Codex home that cannot identify
+itself is still refused downstream by the registrar, with its own reason. A test pins that
+every advertised pair is genuinely answerable, so the list cannot drift into admitting
+something unverifiable — the failure direction that would trade a false refusal for a false
+acceptance, which is strictly worse.
+
+## 3. Level-of-abstraction fit
+
+The capability list belongs beside the oracles, not at the callsite. Restating it at the
+callsite is what went stale: adding an oracle and declaring what it covers are now the same
+edit. Hardcoding a second pair at the route would have repeated the bug on the third oracle.
+
+## 4. Signal vs authority
+
+The route holds no identity opinion. It asks a capability question and defers the identity
+decision to the oracle, which is where the evidence is.
+
+## 5. Interactions
+
+The credential-field guard above it is untouched and still runs first, so the registry
+still cannot be handed a token. The `email-mismatch` and `email-unresolved` paths are
+unchanged. No change to any account already enrolled.
+
+## 6. Multi-machine posture
+
+Machine-local BY DESIGN, matching the identity layer it fronts: the gate is about a
+credential slot on THIS machine's disk. Nothing replicates.
+
+## 7. Failure modes
+
+The predicate is a pure array membership test over a frozen literal; it has no I/O and
+cannot throw for a caller passing anything, including `undefined` (pinned by a control).
+
+## 8. Rollback cost
+
+Remove `openai`/`codex-cli` from the list — one line, no state, no migration. That restores
+the previous refusal exactly.
+
+## Evidence
+
+9 tests. The load-bearing one is the regression: restoring the inline pair fails it, so it
+catches precisely the defect that shipped. A CONTROL proves the gate still refuses an
+uncovered pair (without it, a gate that admitted everything would pass). A consistency test
+drives the real composite oracle for EVERY advertised pair and asserts each is genuinely
+answerable, with an assertion that the Anthropic pair still routes to the Anthropic oracle
+— so the list cannot advertise a pair with no oracle behind it.


### PR DESCRIPTION
## ELI16 — Enrolling a Codex account was still blocked by a second, stale door

The last release taught the system to recognise which account is signed in to a Codex credential slot — the thing standing between the operator and holding two Codex logins. It worked. Enrolling a Codex account still failed, because there were two doors rather than one. The door in front asks a cruder question: not "who is signed in here?" but "is this even a kind of account we know how to identify?" That door had its answer written into it directly — Anthropic only — which was correct when written and went stale the moment a Codex oracle existed. It refused Codex without ever asking the door behind it. It now asks the identity layer what it covers, and that list lives beside the code that does the identifying, so adding an oracle and declaring its coverage are the same edit.

## UX Impact

Who sees this: an operator with a second Codex login. Before this, `POST /subscription-pool` with an `openai` / `codex-cli` slot returned `provider identity verification is not supported for openai/codex-cli` — a refusal that named the provider as unsupported even though its identity was, by then, perfectly resolvable. After this, that same request enrols the account. Nothing changes for accounts already enrolled, and a Codex slot that cannot prove who is signed in is still refused with its own distinct reason (`subscription-account-email-unresolved`), because this gate only decides whether the question is worth asking — it grants nothing.

## How this was found

By attempting the enrolment on a running server after the identity fix deployed, and reading the refusal. Not by reading the code.

That is the part worth keeping. The previous PR shipped an integration test that enrols a Codex account successfully — a real test that really passes. It drives `SubscriptionAccountEmailRegistrar.register()`, which is one layer below the route, so it never touched the gate that was broken. Every test was green over the exact operation the tests existed to enable.

## Evidence

9 tests.

- **The regression test**: the route must ask `isIdentityVerifiableSlot` and must not carry the inline pair. Verified by restoring the old check — it fails, so it catches precisely the defect that shipped.
- **A control**: the gate still refuses a pair nothing can answer for (`google`/`gemini-cli`, a mismatched provider/framework, and `undefined`). Without it, a gate that admitted everything would pass equally well.
- **A consistency test**: drives the real composite oracle for *every* advertised pair and asserts each is genuinely answerable, including that the Anthropic pair still routes to the Anthropic oracle. This guards the opposite failure — advertising a pair with no oracle behind it would trade a false refusal for a false acceptance, which is worse.

## Rollback

Remove `openai`/`codex-cli` from `IDENTITY_VERIFIABLE_SLOTS`. One line, no state, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013phcTXz9TFXwScQyXxnybm
