### PR TITLE
docs(grok): retract a false reassurance — the crash-loop pauser ships dry-run

### DIFF
--- a/docs/specs/grok-build-framework-integration.eli16.md
+++ b/docs/specs/grok-build-framework-integration.eli16.md
@@ -240,6 +240,25 @@ I verified the fix by running the tests with the tools deliberately hidden, whic
 first reproduced the failure and then passed. Checking on a machine that has them
 installed would have proved nothing — that's exactly what it had been doing.
 
+## A correction to something I already shipped
+
+The document said that when those background jobs fail, a safety mechanism stops them
+after a few tries, so the damage is limited. That isn't true, and I only found out by
+watching the Grok agent run after it shipped.
+
+That mechanism defaults to practising rather than acting: it writes "I would have
+stopped this job" in the log and then doesn't stop it. Unless someone has explicitly
+switched it to act, nothing is stopped. I watched one job fail six times, then eight,
+with the log dutifully noting each time that it would have intervened.
+
+So the real limit is just the schedule. Two of those thirty-three jobs run every five
+minutes, which means they keep failing indefinitely rather than settling down.
+
+I'm recording this as a retraction rather than quietly editing the sentence, because
+it's an exact example of the mistake this project keeps catching: writing a reassuring
+claim about a safeguard without checking whether the safeguard was actually switched
+on. I did that, and shipped it.
+
 ## What you're deciding
 
 Whether instar ships a fifth, dark-by-default framework whose billing sink is

--- a/docs/specs/grok-build-framework-integration.md
+++ b/docs/specs/grok-build-framework-integration.md
@@ -467,6 +467,14 @@ framework is not "wired" on a passing test alone.
   exist. I wrote a reassurance about a guard without checking that the guard was
   armed, and shipped it.
 
+  **And the check was one read away.** `GET /guards` reports this guard's posture
+  directly — `{"key":"monitoring.crashLoopPauser","effective":"on-dry-run",
+  "runtime":{"enabled":true,"dryRun":true}}`. instar has a surface built to answer
+  exactly the question I answered from assumption instead. Note also what it does
+  NOT do: the row carries no `loadBearing` marker, so the load-bearing-gap alarm
+  would not have raised it either — the plain read would have, the alarm would not.
+  **Before writing that any guard bounds anything, read `/guards` for that guard.**
+
   **AND THE CONSEQUENCE THAT BULLET *ALSO* NEVER TRACED — observed live the same
   day, one step further out.** Scheduled jobs are not the only thing that needs a
   headless spawn. **Agent-to-agent ingress does too.** A Threadline message sent

--- a/docs/specs/grok-build-framework-integration.md
+++ b/docs/specs/grok-build-framework-integration.md
@@ -446,8 +446,26 @@ framework is not "wired" on a passing test alone.
   scheduled jobs**. Each one fails, and failure alerting is per job, so the
   operator's group fills with "Job Alert: … 2 consecutive failures … last error:
   grok-headless-cwd-ungated" — two were already delivered before this was
-  noticed. The crash-loop pauser bounds it (jobs pause rather than retry
-  forever), so it is finite, not endless.
+  noticed.
+
+  **CORRECTION (2026-08-16, post-merge) — this bullet's reassurance was FALSE and
+  is retracted.** It read: *"The crash-loop pauser bounds it (jobs pause rather
+  than retry forever), so it is finite, not endless."* The pauser defaults to
+  DRY-RUN (`CrashLoopPauser.ts`: `const dryRun = opts.dryRun ?? true`), so unless
+  an operator explicitly sets `dryRun: false` it only LOGS the pause it would have
+  made and the job keeps failing on its schedule. Measured on the live grok agent:
+  `CrashLoopPauser: wired at boot (DRY-RUN — logs intended pauses only)`, then
+  `WOULD pause 1 job(s) — commitment-detection (6 failures)` and, 36 minutes later,
+  the same job at 8 failures. Nothing was paused.
+
+  So the honest bound is the SCHEDULE, not the pauser: two of the 33 jobs run every
+  five minutes, so a grok-only agent with the headless lane closed retries
+  indefinitely rather than converging. Carrier: CMT-1317.
+
+  Recorded rather than quietly amended, because this is the exact defect class this
+  document names as its own most-repeated failure — a claim whose carrier does not
+  exist. I wrote a reassurance about a guard without checking that the guard was
+  armed, and shipped it.
 
   **AND THE CONSEQUENCE THAT BULLET *ALSO* NEVER TRACED — observed live the same
   day, one step further out.** Scheduled jobs are not the only thing that needs a


### PR DESCRIPTION
Retracts a reassurance I merged in #1905.

## What was wrong

The spec told a reader that a grok-only agent's failing scheduled jobs are bounded:

> The crash-loop pauser bounds it (jobs pause rather than retry forever), so it is finite, not endless.

`CrashLoopPauser` defaults to dry-run — `const dryRun = opts.dryRun ?? true` — so unless an operator
explicitly sets `dryRun: false` it only LOGS the pause it would have made. The job keeps failing on
its schedule.

## Measured, not inferred

On the live grok agent after #1905 merged:

```
CrashLoopPauser: wired at boot (DRY-RUN — logs intended pauses only)
WOULD pause 1 job(s) — commitment-detection (failures, 6 failures)
... 36 minutes later ...
WOULD pause 1 job(s) — commitment-detection (failures, 8 failures)
```

Nothing was paused. The honest bound is the SCHEDULE, not the pauser: two of the 33 jobs run every
five minutes, so the failures repeat indefinitely rather than converging.

## Why a separate PR rather than a quiet amend

This is the exact defect class the document names as its own most-repeated failure — a claim whose
carrier does not exist. I wrote a reassurance about a guard without checking the guard was armed,
22 review rounds did not catch it, and it shipped. Retracting it in visible history is the point;
burying it in an edit would repeat the original mistake in a quieter register.

Docs only. No behaviour change.

## ELI16 — a safeguard I promised was working turns out to be practising

The document said that when those background jobs fail, a safety mechanism stops them after a few
tries, so the damage is limited. That isn't true, and I only found out by watching the agent run
after it shipped.

That mechanism defaults to practising rather than acting: it writes "I would have stopped this job"
into the log and then doesn't stop it. Unless someone has explicitly switched it to act, nothing is
stopped. I watched one job fail six times, then eight, with the log dutifully noting each time that
it would have intervened.

So the real limit is just the schedule. Two of those thirty-three jobs run every five minutes, which
means they keep failing indefinitely rather than settling down. Anyone deciding what to do about
those jobs should know they are not self-limiting the way the document claimed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSngJ4srUeMF5tmbo8NdBf
