### PR TITLE
feat(dashboard): group the accounts list by provider

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3634,6 +3634,11 @@
 
     <!-- subscriptions tab (Subscription & Auth Standard P2.2 — live quota + pending logins) -->
     <style>
+      /* Provider group heading — only rendered when more than one provider is
+         enrolled, so a single-provider install looks exactly as it did before. */
+      .sub-provider-heading { font-size:12px; font-weight:700; letter-spacing:.06em; text-transform:uppercase;
+        opacity:.6; margin:14px 0 8px; padding-bottom:6px; border-bottom:1px solid var(--border,#2a2a2a); }
+      .sub-provider-heading:first-child { margin-top:0; }
       .sub-account { border:1px solid var(--border,#2a2a2a); border-radius:10px; padding:14px 16px; margin-bottom:12px; }
       .sub-account-inuse { border-color:#16a34a; box-shadow:0 0 0 1px #16a34a44; }
       .sub-account-inuse-badge { font-size:11px; font-weight:600; color:#22c55e; margin-right:auto; }

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -195,6 +195,47 @@ export function quotaBar(doc, label, pct, resetIso, now = Date.now()) {
   return wrap;
 }
 
+/**
+ * Order accounts so each provider's accounts sit together, interleaving a heading
+ * marker before each group. Returns a flat list of accounts with `{__providerHeading}`
+ * markers spliced in, so the caller keeps ONE loop and one card-rendering path.
+ *
+ * Two deliberate choices:
+ *
+ * - **Groups appear in first-appearance order, and accounts keep their order within a
+ *   group.** Nothing is sorted. The pool's order carries meaning the dashboard cannot
+ *   see (enrolment order, which account is the default), so grouping re-associates
+ *   without re-ranking.
+ *
+ * - **A single-provider list gets NO heading.** Every instar install with one provider
+ *   renders exactly as it did before — the heading only appears once there is genuinely
+ *   something to tell apart, which is the condition that prompted this. That property is
+ *   pinned by a test, because "we grouped everything" would quietly add a redundant
+ *   heading to the common case.
+ */
+export function groupAccountsByProvider(accounts) {
+  if (!Array.isArray(accounts)) return [];
+  const groups = new Map(); // provider key (raw) → accounts, in first-appearance order
+  for (const a of accounts) {
+    const key = a && typeof a.provider === 'string' ? a.provider : '';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(a);
+  }
+  const out = [];
+  const multi = groups.size > 1;
+  for (const [key, members] of groups) {
+    if (multi) {
+      // friendlyProvider maps anthropic→Claude / openai→Codex and SANITIZES anything
+      // else, so an unrecognised or hostile provider string cannot reach the DOM raw.
+      // An absent provider has no honest name, so say so rather than invent one.
+      const label = friendlyProvider(key) || 'Other';
+      out.push({ __providerHeading: label });
+    }
+    for (const m of members) out.push(m);
+  }
+  return out;
+}
+
 /** Per-account rows: nickname, status, provider·framework, 5h + weekly quota bars.
  *  `inUseAccountId` (optional) is the account the agent is CURRENTLY running on —
  *  that card gets an "In use" marker so "active" (healthy) reads distinct from
@@ -206,7 +247,15 @@ export function renderAccounts(doc, target, accounts, now = Date.now(), inUseAcc
     target.appendChild(el(doc, 'div', 'sub-empty', 'No subscription accounts enrolled yet.'));
     return;
   }
-  for (const a of accounts) {
+  for (const a of groupAccountsByProvider(accounts)) {
+    // A group marker, not an account: render the provider heading and continue.
+    // (The operator's complaint was a flat interleaved list — Claude and Codex
+    // accounts mixed together with only a small per-card meta line to tell them
+    // apart. The heading is what makes the split scannable.)
+    if (a && a.__providerHeading) {
+      target.appendChild(el(doc, 'div', 'sub-provider-heading', a.__providerHeading));
+      continue;
+    }
     const inUse = !!(inUseAccountId && a && a.id === inUseAccountId);
     const card = el(doc, 'div', inUse ? 'sub-account sub-account-inuse' : 'sub-account');
     const head = el(doc, 'div', 'sub-account-head');

--- a/docs/specs/subscriptions-group-by-provider.eli16.md
+++ b/docs/specs/subscriptions-group-by-provider.eli16.md
@@ -1,0 +1,46 @@
+# Grouping the accounts list by provider
+
+## What this is
+
+A small change to how the Subscriptions tab lists your accounts: all your Claude accounts
+together, all your Codex accounts together, each under a heading.
+
+## Why
+
+Right now the list is one flat run of cards in whatever order the accounts were enrolled, so
+a Codex account can sit between two Claude ones. Each card does say which provider it belongs
+to, but in small text partway down, so telling them apart means reading every card. With one
+provider that was fine. With two it stopped being fine, which is what prompted this.
+
+## What it does and does not change
+
+It changes the ORDER things are drawn in, and adds a heading above each group. It does not
+change any card, any number, or any quota bar. The quota bars live inside the account cards,
+so grouping the accounts groups the quota view with them.
+
+Two choices are worth naming because they could have gone the other way:
+
+**Accounts keep their existing order inside each group.** Nothing is sorted alphabetically.
+The order accounts arrive in carries meaning the dashboard cannot see — which was enrolled
+first, which one is the default — so the change re-associates them without re-ranking them.
+
+**If you only have one provider, nothing appears at all.** No heading, no change, identical to
+before. A heading saying "Claude" above a list of only Claude accounts is noise. Most installs
+have one provider, so the common case is deliberately untouched. There is a test holding that
+line, because a change described as "group everything" would naturally add the redundant
+heading and nobody would notice.
+
+## Safety
+
+The heading is the one new piece of text reaching the page, and it goes through the same
+cleaning every other value on that tab already uses — the provider name is written as plain
+text, so a malformed or hostile provider string cannot become markup. A test plants a hostile
+one and confirms no live element survives.
+
+An account whose provider is missing is still shown, under a heading that says Other rather
+than being silently dropped or filed under a provider it does not belong to.
+
+## What you would notice
+
+Your accounts list gets two headings instead of none, and the Codex account stops sitting in
+the middle of the Claude ones.

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -717,3 +717,98 @@ describe('renderPendingLogins — expected-account, liveness, wording floors, ou
 function el(): HTMLElement {
   return doc.createElement('div');
 }
+
+/**
+ * Provider grouping (operator request, 2026-08-15): the accounts list was a flat
+ * interleaved run of Claude and Codex cards, distinguishable only by a small meta
+ * line on each card. Grouping makes the split scannable.
+ *
+ * The load-bearing property is NOT that grouping happens — it is that grouping
+ * RE-ASSOCIATES without RE-RANKING, and that a single-provider install is untouched.
+ */
+describe('renderAccounts — provider grouping', () => {
+  const acct = (id: string, provider: string) => ({
+    id, nickname: id, provider, framework: provider === 'openai' ? 'codex-cli' : 'claude-code',
+    status: 'active', configHome: `/h/${id}`,
+  });
+
+  const headings = (t: Element) =>
+    Array.from(t.querySelectorAll('.sub-provider-heading')).map((n) => n.textContent);
+  const order = (t: Element) =>
+    Array.from(t.querySelectorAll('.sub-provider-heading, .sub-account-nick')).map((n) => n.textContent);
+
+  it('THE POINT: mixed providers are grouped, each under its own heading', () => {
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [acct('a1', 'anthropic'), acct('c1', 'openai'), acct('a2', 'anthropic')], NOW);
+    expect(headings(t)).toEqual(['Claude', 'Codex']);
+    // Every Claude account sits under Claude; the Codex one does not get stranded.
+    expect(order(t)).toEqual(['Claude', 'a1', 'a2', 'Codex', 'c1']);
+  });
+
+  it('CONTROL: a single-provider list is UNCHANGED — no heading at all', () => {
+    // Most installs have one provider. Without this, "we grouped everything" would
+    // silently add a redundant heading to the common case.
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [acct('a1', 'anthropic'), acct('a2', 'anthropic')], NOW);
+    expect(headings(t)).toEqual([]);
+    expect(order(t)).toEqual(['a1', 'a2']);
+  });
+
+  it('accounts keep their ORDER within a group — grouping re-associates, it does not re-rank', () => {
+    // Pool order carries meaning the dashboard cannot see (enrolment order, which
+    // account is default). Sorting would silently discard it.
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [acct('zeta', 'anthropic'), acct('alpha', 'anthropic')], NOW);
+    expect(order(t)).toEqual(['zeta', 'alpha']);
+  });
+
+  it('groups appear in FIRST-APPEARANCE order, not alphabetical', () => {
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [acct('c1', 'openai'), acct('a1', 'anthropic')], NOW);
+    expect(headings(t)).toEqual(['Codex', 'Claude']);
+  });
+
+  it('every account still renders exactly once — grouping must not drop or duplicate', () => {
+    const t = doc.createElement('div');
+    const accounts = [acct('a1', 'anthropic'), acct('c1', 'openai'), acct('g1', 'google'), acct('a2', 'anthropic')];
+    renderAccounts(doc, t, accounts, NOW);
+    const nicks = Array.from(t.querySelectorAll('.sub-account-nick')).map((n) => n.textContent);
+    expect(nicks.sort()).toEqual(['a1', 'a2', 'c1', 'g1']);
+    expect(t.querySelectorAll('.sub-account').length).toBe(4);
+  });
+
+  it('SECURITY: a hostile provider string is sanitized in the heading, never raw', () => {
+    // The heading is the one NEW dynamic string reaching the DOM, so it inherits the
+    // module's contract: textContent only, sanitized, no injected element survives.
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [
+      acct('x', '<img src=x onerror=alert(1)>'),
+      acct('a1', 'anthropic'),
+    ], NOW);
+    // The property is that the value arrives as TEXT, not that the characters vanish.
+    // Asserting innerHTML lacks the substring would be wrong: correctly-escaped text
+    // still reads "onerror" inside &lt;img …&gt;, so that assertion fails on working code.
+    expect(t.querySelector('img')).toBeNull();
+    for (const node of Array.from(t.querySelectorAll('*'))) {
+      expect(node.hasAttribute('onerror')).toBe(false);
+    }
+    const heading = t.querySelector('.sub-provider-heading')!;
+    expect(heading.children.length).toBe(0); // text only — no injected element survived
+  });
+
+  it('an account with no provider still renders under an honest heading', () => {
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [{ id: 'n', nickname: 'n', status: 'active' }, acct('a1', 'anthropic')], NOW);
+    // It is grouped rather than dropped, and the label does not invent a provider.
+    expect(t.querySelectorAll('.sub-account').length).toBe(2);
+    expect(headings(t)).toContain('Other');
+  });
+
+  it('the in-use marker survives grouping', () => {
+    const t = doc.createElement('div');
+    renderAccounts(doc, t, [acct('a1', 'anthropic'), acct('c1', 'openai')], NOW, 'c1');
+    const inUse = t.querySelector('.sub-account-inuse');
+    expect(inUse).not.toBeNull();
+    expect(inUse!.textContent).toContain('c1');
+  });
+});

--- a/upgrades/next/subscriptions-group-by-provider.md
+++ b/upgrades/next/subscriptions-group-by-provider.md
@@ -1,0 +1,54 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Subscriptions tab now groups your accounts by provider — Claude accounts together, Codex
+accounts together, each under a heading.
+
+Before, the list was one flat run of cards in enrolment order, so a Codex account could sit
+between two Claude ones. Each card names its provider, but in small text partway down, so
+telling them apart meant reading every card. With a single provider that was fine. With two it
+stopped being fine.
+
+The quota bars live inside the account cards, so grouping the accounts groups the quota view
+along with them.
+
+## What to Tell Your User
+
+- "Your accounts list is grouped by provider now, so your Codex account no longer sits in the
+  middle of your Claude ones."
+- "If you only have one provider, nothing changes at all."
+
+## Summary of New Capabilities
+
+None. This is a presentation change to an existing tab — no endpoint, no configuration.
+
+## Compatibility Notes
+
+**A single-provider install is untouched**: with one provider no heading is drawn, and the list
+renders exactly as before. That is deliberate — a heading reading "Claude" above a list of only
+Claude accounts is noise — and it is pinned by a test.
+
+Accounts keep their existing order within each group. Nothing is sorted alphabetically, because
+the order accounts arrive in carries meaning the dashboard cannot see (which was enrolled first,
+which is the default). The change re-associates without re-ranking.
+
+An account with no provider is still shown, under a heading reading "Other", rather than being
+dropped or filed under a provider it does not belong to.
+
+## Evidence
+
+8 tests in the existing jsdom suite, which exercises the shipped dashboard module against a real
+DOM. Shown capable of failing: restoring the flat list fails exactly the four grouping
+assertions while the four invariant tests keep passing.
+
+The controls carry the weight — a single-provider list is asserted unchanged, and order within a
+group is asserted preserved. Without them, "grouping works" would pass equally well against a
+change that sorted everything alphabetically and added a redundant heading to every
+single-provider install.
+
+The heading is the one new dynamic string reaching the page, so it rides the tab's existing
+sanitize-and-write-as-text contract; a test plants a hostile provider string and confirms no
+live element and no event-handler attribute survives.

--- a/upgrades/side-effects/subscriptions-group-by-provider.md
+++ b/upgrades/side-effects/subscriptions-group-by-provider.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — group the accounts list by provider
+
+## Summary
+
+`renderAccounts` drew accounts in a flat pool-ordered run, interleaving providers. It now draws
+each provider's accounts together under a heading, via a new pure `groupAccountsByProvider`.
+
+## Decision-point inventory
+
+None. This is presentation ordering. It gates nothing, grants nothing, and reads no state
+beyond the accounts array it is already handed.
+
+## 1. Over-block / 2. Under-block
+
+Not applicable — no admission decision. The nearest analogue is dropping an account from the
+list, which a test forbids explicitly (every account renders exactly once; count asserted).
+
+## 3. Level-of-abstraction fit
+
+Grouping belongs in the renderer, not the API. The pool's order is meaningful and the server
+should keep returning it as-is; how it is PRESENTED is a dashboard concern. Sorting server-side
+would have imposed one view on every consumer.
+
+## 4. Signal vs authority
+
+Not applicable — no decision logic.
+
+## 5. Interactions
+
+The in-use marker, quota bars, status, email and the no-quota fallback all render through the
+unchanged card path; grouping only reorders and interleaves headings. The heading marker is a
+sentinel object (`__providerHeading`) consumed at the top of the same loop, so there is one
+card-rendering path, not two. A test asserts the in-use marker survives grouping.
+
+## 6. Multi-machine posture
+
+Machine-local BY DESIGN — this is dashboard rendering of data the server already merged.
+Nothing replicates. The pool view's own machine tagging is untouched.
+
+## 7. Failure modes
+
+`groupAccountsByProvider` handles a non-array (returns []), a missing provider (grouped under
+`Other`), and a non-string provider (coerced to the empty key). It has no I/O and cannot throw
+for any accounts array the existing renderer would have accepted.
+
+**Security**: the heading is the only new dynamic string reaching the DOM. It goes through
+`friendlyProvider`, which maps known providers and sanitizes everything else, and is written
+via the module's `el()` textContent helper. A test plants `<img src=x onerror=...>` as a
+provider and asserts no live element and no `onerror` attribute survives.
+
+## 8. Rollback cost
+
+Change one call site back to `for (const a of accounts)`. No state, no migration, no config.
+
+## Evidence
+
+8 new tests in the existing jsdom suite, which drives the SHIPPED `dashboard/subscriptions.js`
+against a real DOM. Shown capable of failing: reverting the call site fails exactly the 4
+grouping assertions while the 4 invariant tests keep passing — the correct signature, since
+those describe behaviour that must hold either way.
+
+Controls carry the weight here: a single-provider list is asserted UNCHANGED (no heading), and
+account order within a group is asserted preserved. Without those, "grouping works" would pass
+equally well against a change that sorted everything alphabetically and added a redundant
+heading to every single-provider install.
+
+One test was WRONG on first run and the code was right: it asserted `innerHTML` lacks the
+substring "onerror", but correctly-escaped text still reads `&lt;img src=x onerror=...&gt;`.
+The assertion now tests the real property — no live element, no such attribute, heading has no
+element children — rather than the absence of characters.


### PR DESCRIPTION
## ELI16 — The accounts list mixed Claude and Codex together

The Subscriptions tab drew accounts in one flat pool-ordered run, so a Codex account could sit between two Claude ones. Each card does name its provider, but in small text partway down, so telling them apart meant reading every card. That was fine while every install had one provider; it stopped being fine as soon as a second one was enrolled, which is exactly when the operator hit it. Accounts are now drawn grouped, each provider under its own heading. Quota bars live inside the account cards, so grouping the accounts groups the quota view with them.

## UX Impact

Who sees this: any operator with more than one provider enrolled. Before, the Subscriptions tab rendered `Codex (sagemindai)` between `sagemind-justin` and `adriana` with nothing but a small `Codex · codex-cli` meta line to distinguish it. After, that account sits under a `CODEX` heading with the Claude accounts collected under `CLAUDE`.

Deliberately invisible to most installs: with a single provider **no heading is drawn at all** and the list renders exactly as before. A heading reading "Claude" above a list of only Claude accounts is noise, and most installs are single-provider — so the common case is untouched, and a test holds that line.

## Two choices that could have gone the other way

Both are pinned by controls, because both are ways this could silently do the wrong thing while still looking "grouped":

- **Order is preserved within a group.** Nothing is sorted alphabetically. Pool order carries meaning the dashboard cannot see — which account was enrolled first, which one is the default — so this re-associates without re-ranking.
- **Single-provider installs get nothing.** Without that control, a change described as "group everything" would naturally add a redundant heading to every one-provider install and pass its own tests.

## Evidence

8 tests in the existing jsdom suite, which drives the **shipped** `dashboard/subscriptions.js` against a real DOM rather than a copy of its logic.

Shown capable of failing: reverting the call site to the flat loop fails exactly the 4 grouping assertions while the 4 invariant tests (single-provider unchanged, order preserved, no drop/duplicate, in-use marker survives) keep passing — the correct signature, since those describe behaviour that must hold either way.

**Security**: the heading is the one new dynamic string reaching the DOM, so it rides the module's existing `friendlyProvider` + textContent contract. A test plants `<img src=x onerror=alert(1)>` as a provider and asserts no live element, no `onerror` attribute on any node, and no element children on the heading.

Worth recording: one test was wrong on first run while the code was right. It asserted `innerHTML` does not contain "onerror" — but correctly-escaped text still reads `&lt;img src=x onerror=...&gt;`, so that assertion fails against working code. It now tests the actual property rather than the absence of characters.

## Rollback

Change one call site back to `for (const a of accounts)`. No state, no migration, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013phcTXz9TFXwScQyXxnybm
