### PR TITLE
feat(dashboard): build the paid-door arming screen that was never there

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3541,8 +3541,8 @@
         What the internal AI calls cost, and where the paid-door caps sit. The dollar figures are a
         <b>reporting</b> view — immutable token counts priced against a reviewed price list on read, so a
         price correction reflows automatically. <b>No paid door is live yet</b>, so metered spend is $0;
-        subscription/CLI doors are <b>$0 (not per-token billed)</b>. This is read-only — money caps and the
-        go-live control are a later increment.
+        subscription/CLI doors are <b>$0 (not per-token billed)</b>. The spend figures above are a report;
+        the controls below set a door's ceilings and take it live, and each of those takes your PIN.
       </div>
 
       <!-- Glance floors F10/F11 (topic 29836, Phase 3): the shared component renders
@@ -3550,6 +3550,12 @@
            became plain words at the glance ("pay-per-use"); the per-model math and the
            paid-door caps moved one drill down. -->
       <div id="spendGlance" class="glance-root"></div>
+
+      <!-- Paid-door arming (Increment B UI). Two PIN-committed steps: set both ceilings,
+           then take the door live. The server renders the exact wording of each step and
+           the commit sends back only the plan id + nonce, so a field the operator never
+           saw rendered cannot land. Freeze needs no PIN — halting money is always cheap. -->
+      <div id="spendArming" class="spend-arm-root"></div>
     </div>
 
     <!-- Evidence Tab (WikiClaim Phase 4) — per-entity evidence + reverse "what cites this?" view.
@@ -3634,6 +3640,28 @@
 
     <!-- subscriptions tab (Subscription & Auth Standard P2.2 — live quota + pending logins) -->
     <style>
+      /* Paid-door arming controls (Spend tab). Mobile-first: full-width stacked fields
+         and 44px touch targets, since the operator reaches this from their phone. */
+      .spend-arm-root { display:flex; flex-direction:column; gap:12px; margin-top:8px;
+        border-top:1px solid var(--border,#2a2a2a); padding-top:16px; }
+      .spend-arm-h { margin:0; font-size:16px; }
+      .spend-arm-field { display:flex; flex-direction:column; gap:6px; font-size:13px; opacity:.9; }
+      .spend-arm-input { width:100%; box-sizing:border-box; min-height:44px; padding:10px 12px;
+        font-size:16px; /* 16px stops iOS zooming the page on focus */
+        border:1px solid var(--border,#2a2a2a); border-radius:8px; background:transparent; color:inherit; }
+      .spend-arm-hint { font-size:12px; opacity:.6; }
+      .spend-arm-btns { display:flex; flex-wrap:wrap; gap:8px; }
+      .spend-arm-btn { min-height:44px; padding:10px 14px; font-size:14px; border-radius:8px;
+        border:1px solid var(--border,#2a2a2a); background:transparent; color:inherit; cursor:pointer; flex:1 1 auto; }
+      .spend-arm-btn-freeze { border-color:#b45309; color:#f59e0b; }
+      .spend-arm-btn-commit { border-color:#16a34a; color:#22c55e; width:100%; margin-top:10px; }
+      .spend-arm-plan { display:flex; flex-direction:column; gap:8px; }
+      .spend-arm-plan-label { font-size:12px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; opacity:.6; }
+      .spend-arm-plan-text { font-size:14px; line-height:1.5; padding:12px; border-radius:8px;
+        border:1px solid var(--border,#2a2a2a); white-space:pre-wrap; word-break:break-word; }
+      .spend-arm-plan-expiry, .spend-arm-note { font-size:12px; opacity:.7; }
+      @media (max-width:520px) { .spend-arm-btn { flex:1 1 100%; } }
+
       /* Provider group heading — only rendered when more than one provider is
          enrolled, so a single-provider install looks exactly as it did before. */
       .sub-provider-heading { font-size:12px; font-weight:700; letter-spacing:.06em; text-transform:uppercase;
@@ -6010,6 +6038,10 @@
 
       const spec = glance.spendGlanceSpec(document, summary, caps);
       glance.renderGlance(document, glanceRoot, spec);
+      // The arming controls sit below the read-only glance. Rendered from the SAME caps
+      // payload, so the door list and its live/frozen wording cannot drift from the view
+      // above it.
+      renderSpendArming(caps);
     }
 
     async function loadResources() {
@@ -8633,6 +8665,217 @@
         catch (e) { console.error('[glance] module load failed', e); return null; }
       }
       return __glanceModule;
+    }
+
+    // ── Spend tab — paid-door arming (Increment B UI) ──
+    // Two PIN-committed steps (set both ceilings, then go live), each previewed as the
+    // SERVER's rendered wording before the PIN box appears. The commit posts only the
+    // plan id + nonce + PIN, never the form fields.
+    let __spendArmModule = null;
+    async function loadSpendArmModule() {
+      if (!__spendArmModule) {
+        try { __spendArmModule = await import('/dashboard/spend-arming.js'); }
+        catch (e) { console.error('[spend-arming] module load failed', e); return null; }
+      }
+      return __spendArmModule;
+    }
+
+    // The plan currently awaiting approval. Cleared whenever inputs change, so a PIN can
+    // never be applied to a plan the operator has since edited away from.
+    let __spendPendingPlan = null;
+
+    async function renderSpendArming(caps) {
+      const root = document.getElementById('spendArming');
+      if (!root) return;
+      const M = await loadSpendArmModule();
+      if (!M) { root.textContent = 'Loading the money controls failed — refresh to retry.'; return; }
+      root.replaceChildren();
+
+      const h = document.createElement('h3');
+      h.textContent = 'Paid doors';
+      h.className = 'spend-arm-h';
+      root.appendChild(h);
+
+      const rows = M.armableDoors(caps);
+      if (rows.length === 0) {
+        const n = document.createElement('div');
+        n.className = 'spend-arm-note';
+        n.textContent = 'No pay-per-use doors are configured on this agent.';
+        root.appendChild(n);
+        return;
+      }
+
+      const sel = document.createElement('select');
+      sel.id = 'spendArmKey';
+      sel.className = 'spend-arm-input';
+      for (const r of rows) {
+        const o = document.createElement('option');
+        o.value = r.keyRef;
+        // textContent — keyRef/provider are server data, never markup.
+        o.textContent = `${r.provider} · ${r.door} — ${M.doorStateWords(r)}`;
+        sel.appendChild(o);
+      }
+      const selWrap = document.createElement('label');
+      selWrap.className = 'spend-arm-field';
+      selWrap.appendChild(document.createTextNode('Which door'));
+      selWrap.appendChild(sel);
+      root.appendChild(selWrap);
+
+      const mkNum = (id, label, hint) => {
+        const w = document.createElement('label');
+        w.className = 'spend-arm-field';
+        w.appendChild(document.createTextNode(label));
+        const i = document.createElement('input');
+        i.id = id; i.type = 'number'; i.min = '0'; i.step = '0.01';
+        i.className = 'spend-arm-input'; i.inputMode = 'decimal';
+        i.addEventListener('input', () => { __spendPendingPlan = null; renderSpendPlan(null); });
+        w.appendChild(i);
+        const hn = document.createElement('div');
+        hn.className = 'spend-arm-hint'; hn.textContent = hint;
+        w.appendChild(hn);
+        return w;
+      };
+      root.appendChild(mkNum('spendArmLifetime', 'Lifetime ceiling (USD)',
+        'The total this door may ever spend. It stops permanently here.'));
+      root.appendChild(mkNum('spendArmDaily', 'Daily ceiling (USD)',
+        'The most it may spend in one day. Both ceilings are required.'));
+      sel.addEventListener('change', () => { __spendPendingPlan = null; renderSpendPlan(null); });
+
+      const btns = document.createElement('div');
+      btns.className = 'spend-arm-btns';
+      const mkBtn = (text, cls, fn) => {
+        const b = document.createElement('button');
+        b.textContent = text; b.className = cls; b.onclick = fn; return b;
+      };
+      btns.appendChild(mkBtn('Preview cap change', 'spend-arm-btn', () => previewSpendPlan('caps-adjust')));
+      btns.appendChild(mkBtn('Preview go live', 'spend-arm-btn', () => previewSpendPlan('go-live')));
+      btns.appendChild(mkBtn('Freeze this door', 'spend-arm-btn spend-arm-btn-freeze', freezeSpendDoor));
+      root.appendChild(btns);
+
+      const planBox = document.createElement('div');
+      planBox.id = 'spendArmPlan'; planBox.className = 'spend-arm-plan';
+      root.appendChild(planBox);
+
+      const status = document.createElement('div');
+      status.id = 'spendArmStatus'; status.className = 'spend-arm-note';
+      root.appendChild(status);
+    }
+
+    function selectedSpendRow(caps, M) {
+      const key = (document.getElementById('spendArmKey') || {}).value;
+      return M.armableDoors(caps).find((r) => r.keyRef === key) || null;
+    }
+
+    function renderSpendPlan(plan) {
+      const box = document.getElementById('spendArmPlan');
+      if (!box) return;
+      loadSpendArmModule().then((M) => {
+        if (!M) return;
+        M.renderPlanPreview(document, box, plan);
+        if (!plan) return;
+        // The PIN box appears ONLY once there is a rendered plan to approve, so the
+        // operator never types a secret against something they have not read.
+        const w = document.createElement('label');
+        w.className = 'spend-arm-field';
+        w.appendChild(document.createTextNode('Dashboard PIN'));
+        const p = document.createElement('input');
+        p.type = 'password'; p.id = 'spendArmPin'; p.className = 'spend-arm-input';
+        p.autocomplete = 'off'; p.inputMode = 'numeric';
+        w.appendChild(p);
+        box.appendChild(w);
+        const b = document.createElement('button');
+        b.className = 'spend-arm-btn spend-arm-btn-commit';
+        b.textContent = 'Approve with PIN';
+        b.onclick = commitSpendPlan;
+        box.appendChild(b);
+      });
+    }
+
+    function setSpendArmStatus(text) {
+      const s = document.getElementById('spendArmStatus');
+      if (s) s.textContent = text;
+    }
+
+    async function previewSpendPlan(action) {
+      const M = await loadSpendArmModule();
+      if (!M) return;
+      const caps = await apiFetch('/routing-spend/caps').catch(() => null);
+      const row = selectedSpendRow(caps, M);
+      if (!row) { setSpendArmStatus('Pick a door first.'); return; }
+
+      let fields;
+      if (action === 'caps-adjust') {
+        const num = (id) => {
+          const raw = (document.getElementById(id) || {}).value;
+          return raw === '' || raw === undefined ? '' : Number(raw);
+        };
+        const lifetimeCapUsd = num('spendArmLifetime');
+        const dailyCapUsd = num('spendArmDaily');
+        const v = M.validateCaps({ lifetimeCapUsd, dailyCapUsd });
+        if (!v.ok) { setSpendArmStatus(v.error); return; }
+        fields = { keyRef: row.keyRef, provider: row.provider, lifetimeCapUsd, dailyCapUsd };
+      } else {
+        fields = { door: row.door, keyRef: row.keyRef, enabled: true };
+      }
+
+      try {
+        const plan = await apiFetch('/routing-spend/plan', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(M.planRequest(action, fields)),
+        });
+        __spendPendingPlan = plan;
+        setSpendArmStatus('');
+        renderSpendPlan(plan);
+      } catch (err) {
+        __spendPendingPlan = null;
+        renderSpendPlan(null);
+        setSpendArmStatus(M.moneyLayerNote(err && err.message));
+      }
+    }
+
+    async function commitSpendPlan() {
+      const M = await loadSpendArmModule();
+      if (!M || !__spendPendingPlan) { setSpendArmStatus('Preview a change first.'); return; }
+      const pinEl = document.getElementById('spendArmPin');
+      const pin = pinEl ? pinEl.value : '';
+      if (!pin) { setSpendArmStatus('Enter your dashboard PIN to approve.'); return; }
+      try {
+        await apiFetch('/routing-spend/caps/adjust', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(M.commitRequest(__spendPendingPlan, pin)),
+        });
+        if (pinEl) pinEl.value = '';
+        __spendPendingPlan = null;
+        renderSpendPlan(null);
+        setSpendArmStatus('Applied.');
+        loadRoutingSpend();
+      } catch (err) {
+        if (pinEl) pinEl.value = '';
+        setSpendArmStatus(M.moneyLayerNote(err && err.message));
+      }
+    }
+
+    async function freezeSpendDoor() {
+      const M = await loadSpendArmModule();
+      if (!M) return;
+      const caps = await apiFetch('/routing-spend/caps').catch(() => null);
+      const row = selectedSpendRow(caps, M);
+      if (!row) { setSpendArmStatus('Pick a door first.'); return; }
+      try {
+        // No PIN: halting money is always cheap and always available. UNfreezing is the
+        // PIN-gated direction.
+        await apiFetch('/routing-spend/freeze', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ keyRef: row.keyRef }),
+        });
+        setSpendArmStatus('Frozen. Spending on that door is halted.');
+        loadRoutingSpend();
+      } catch (err) {
+        setSpendArmStatus(M.moneyLayerNote(err && err.message));
+      }
     }
 
     async function loadCommitments() {

--- a/dashboard/spend-arming.js
+++ b/dashboard/spend-arming.js
@@ -1,0 +1,170 @@
+/**
+ * Spend tab — the paid-door arming controls (Routing Control Room, Increment B UI).
+ *
+ * The money layer's routes existed but had no screen, while the Spend tab told the
+ * operator that caps and go-live were "a later increment". So an operator told the
+ * arming was "one tap in the Spend tab, enter your PIN" went looking for a PIN box
+ * that had never been built. This is that screen.
+ *
+ * Three things this module refuses to do, because each one caused or repeated that
+ * failure:
+ *
+ * 1. It never claims a control is available when the server says the money layer is
+ *    off. A 503 renders the REASON — that enabling it is the operator's own switch,
+ *    reserved to them by design — not a generic "something went wrong".
+ * 2. It never sends the PIN anywhere except the commit call. The plan/preview call
+ *    is deliberately PIN-free, so the operator sees exactly what they are approving
+ *    BEFORE any secret leaves the page.
+ * 3. It never derives what will be committed from the form. The server renders the
+ *    plan text; the commit sends back only the plan id and nonce. A field the
+ *    operator never saw rendered cannot land.
+ *
+ * Every dynamic value is written with textContent (same contract as subscriptions.js).
+ */
+
+/** Element helper — textContent ONLY, never innerHTML. */
+function el(doc, tag, cls, text) {
+  const n = doc.createElement(tag);
+  if (cls) n.className = cls;
+  if (text !== undefined && text !== null) n.textContent = String(text);
+  return n;
+}
+
+/**
+ * What to tell the operator when a money-layer call fails.
+ *
+ * The 503 case is the one that matters. "Money controls are unavailable" would repeat
+ * the original confusion — the operator would go looking for what they did wrong. The
+ * money layer being off is not a fault and not something they can fix from this screen;
+ * it is a switch deliberately reserved to them, and saying so is the whole point.
+ */
+export function moneyLayerNote(message) {
+  const m = message === undefined || message === null ? '' : String(message);
+  if (/503|not enabled|money layer/i.test(m)) {
+    return 'Money controls are switched off on this agent. Turning them on is your decision — ' +
+      'it is deliberately not something an agent or a developer can flip. Once it is on, these ' +
+      'controls work; until then nothing here can arm a door.';
+  }
+  if (/caps store unreadable/i.test(m)) {
+    return 'The caps record could not be read, so money controls are refusing to act rather ' +
+      'than guess. Nothing has changed.';
+  }
+  if (/pin/i.test(m)) {
+    return 'That PIN was not accepted. Nothing has changed.';
+  }
+  return 'Could not reach the money controls just now. Nothing has changed — try again.';
+}
+
+/**
+ * Validate the two ceilings before asking the server for a plan.
+ *
+ * BOTH are required: the server takes a lifetime ceiling and a daily ceiling, and there
+ * is no monthly figure to fall back on. A monthly intent has to be expressed as both, and
+ * leaving one blank silently produces a very different product — a daily rate with no
+ * lifetime bound is a tap left running, not a budget.
+ */
+export function validateCaps(input) {
+  const { lifetimeCapUsd, dailyCapUsd } = input || {};
+  for (const [name, label] of [['lifetimeCapUsd', 'lifetime'], ['dailyCapUsd', 'daily']]) {
+    const v = (input || {})[name];
+    if (v === '' || v === null || v === undefined) {
+      return { ok: false, error: `Enter a ${label} ceiling — the server requires both.` };
+    }
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      return { ok: false, error: `The ${label} ceiling must be a number.` };
+    }
+    if (v <= 0) {
+      return { ok: false, error: `The ${label} ceiling must be greater than zero.` };
+    }
+  }
+  if (dailyCapUsd > lifetimeCapUsd) {
+    return {
+      ok: false,
+      error: 'The daily ceiling is above the lifetime ceiling, so the daily one could never ' +
+        'bind. Lower the daily figure or raise the lifetime one.',
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * The request body for a plan preview. Deliberately a pure function so a test can prove
+ * the PIN is NOT in it — a preview that carried the secret would defeat the point of
+ * showing the operator what they are approving first.
+ */
+export function planRequest(action, fields) {
+  const f = fields || {};
+  if (action === 'caps-adjust') {
+    return {
+      action: 'caps-adjust',
+      keyRef: f.keyRef,
+      provider: f.provider,
+      lifetimeCapUsd: f.lifetimeCapUsd,
+      dailyCapUsd: f.dailyCapUsd,
+    };
+  }
+  if (action === 'go-live') {
+    return { action: 'go-live', door: f.door, keyRef: f.keyRef, enabled: f.enabled === true };
+  }
+  if (action === 'unfreeze') {
+    return { action: 'unfreeze', keyRef: f.keyRef };
+  }
+  return null;
+}
+
+/**
+ * The commit body. Carries ONLY the plan identity and the PIN — never the form fields.
+ *
+ * This is the load-bearing security shape: the server derives what to apply solely from
+ * the plan it rendered, so a value the operator never saw on screen cannot be committed
+ * by editing the form after previewing.
+ */
+export function commitRequest(plan, pin) {
+  return { planId: (plan || {}).planId, nonce: (plan || {}).nonce, pin };
+}
+
+/** Render the server's plan text for approval. The text is the server's, shown verbatim. */
+export function renderPlanPreview(doc, target, plan) {
+  if (!target) return;
+  target.replaceChildren();
+  if (!plan || !plan.renderedText) {
+    target.appendChild(el(doc, 'div', 'spend-arm-note', 'No plan to approve yet.'));
+    return;
+  }
+  target.appendChild(el(doc, 'div', 'spend-arm-plan-label', 'Approve exactly this:'));
+  target.appendChild(el(doc, 'div', 'spend-arm-plan-text', plan.renderedText));
+  if (plan.expiresAt) {
+    target.appendChild(el(doc, 'div', 'spend-arm-plan-expiry', `This approval expires at ${plan.expiresAt}.`));
+  }
+}
+
+/**
+ * The per-door rows the arming panel offers.
+ *
+ * Only METERED (paid) doors can be armed, so subscription doors are excluded rather than
+ * rendered as inert rows — an unarmable row invites the same "where do I tap?" confusion
+ * this screen exists to remove.
+ */
+export function armableDoors(caps) {
+  const keys = (caps && Array.isArray(caps.keys)) ? caps.keys : [];
+  return keys
+    .filter((k) => k && typeof k.keyRef === 'string' && k.keyRef.length > 0)
+    .map((k) => ({
+      keyRef: k.keyRef,
+      provider: k.provider,
+      door: k.door,
+      lifetimeCapUsd: k.lifetimeCapUsd,
+      dailyCapUsd: k.dailyCapUsd,
+      frozen: k.frozen === true,
+      goLiveState: k.goLiveState,
+      live: k.goLiveState === 'live',
+    }));
+}
+
+/** Plain-language state for a door, so the operator can tell armed from not-armed. */
+export function doorStateWords(row) {
+  if (!row) return '';
+  if (row.frozen) return 'Frozen — spending is halted';
+  if (row.live) return 'Live — this door can spend';
+  return 'Not live — this door cannot spend';
+}

--- a/docs/specs/spend-arming-ui.eli16.md
+++ b/docs/specs/spend-arming-ui.eli16.md
@@ -1,0 +1,52 @@
+# The arming screen that was never built
+
+## What this is
+
+The screen where you set a paid door's spending limits and turn it on. It did not exist,
+which is why you could not find anywhere to enter your PIN.
+
+## What was actually wrong
+
+The machinery behind arming a paid door was built a while ago and works. The screen for it
+was not. Worse, the Spend tab told you so in small print — it said caps and the go-live
+control were "a later increment" — while you had been told it was one tap away. So you went
+looking for a PIN box that had never been drawn, which is the most confusing possible state:
+being told to do something the interface cannot do.
+
+## What the screen does
+
+You pick a door, set two limits, preview, and approve with your PIN.
+
+**Two limits, both required.** Every paid door has a lifetime ceiling and a daily ceiling.
+There is no monthly setting to choose instead, so a monthly intention has to be expressed as
+both. A hundred lifetime with three thirty a day is a hard hundred-dollar budget that also
+cannot be burned in one afternoon. Three thirty a day with a large lifetime is a tap you leave
+running. Those are different things, so the screen refuses to let you leave one blank rather
+than quietly picking one for you.
+
+**Arming is two approvals, not one.** Setting the limits is one step and taking the door live
+is another, each with its own PIN entry. That is how the machinery already worked; the screen
+does not collapse them, because approving "set these limits" and approving "start spending"
+are genuinely different decisions.
+
+**You approve words, not a button.** Before the PIN box appears, the server writes out exactly
+what it is about to do and the screen shows you that sentence. What gets committed is that
+plan — not whatever is in the form. So if you preview, then change a number, the old approval
+stops applying. A figure you never read cannot be the figure that lands.
+
+**Freezing needs no PIN.** Stopping money should always be cheap, so the freeze button works
+immediately. Unfreezing is the direction that asks for your PIN.
+
+## The honest part
+
+The screen cannot arm anything until you switch the money layer on, and that switch is
+deliberately reserved to you — not something an agent or a developer can flip. If you use the
+controls while it is off, the screen says exactly that: that it is your switch, and that
+nothing here can arm a door until you turn it on. It does not show a generic error, because a
+generic error would send you hunting for what you did wrong when the answer is simply that you
+have not turned it on yet.
+
+## What you would notice
+
+The Spend tab gains a "Paid doors" section under the figures, and its small print no longer
+claims the controls do not exist.

--- a/tests/unit/spend-arming.test.ts
+++ b/tests/unit/spend-arming.test.ts
@@ -1,0 +1,242 @@
+/**
+ * The Spend tab's paid-door arming controls.
+ *
+ * The failure this screen exists to fix: the money routes existed with no UI, while the
+ * tab said caps and go-live were "a later increment". An operator told arming was "one
+ * tap, enter your PIN" went looking for a PIN box that had never been built.
+ *
+ * So the tests that matter most are not "the form works". They are:
+ *   - a switched-off money layer is explained honestly, not as a generic error
+ *   - the PIN never travels with the preview
+ *   - the commit carries the PLAN, never the form fields
+ */
+// @ts-nocheck — browser-native ESM module, no types.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  moneyLayerNote,
+  validateCaps,
+  planRequest,
+  commitRequest,
+  renderPlanPreview,
+  armableDoors,
+  doorStateWords,
+} from '../../dashboard/spend-arming.js';
+
+let doc: Document;
+beforeEach(() => {
+  doc = new JSDOM('<!doctype html><body></body>').window.document;
+});
+
+describe('moneyLayerNote — the message that caused the original confusion', () => {
+  it('THE POINT: a switched-off money layer names WHOSE switch it is', () => {
+    const note = moneyLayerNote('routing-spend money layer not enabled (routingSpend.money.enabled)');
+    expect(note).toMatch(/your decision/i);
+    // The operator must not be left hunting for what they did wrong.
+    expect(note).not.toMatch(/something went wrong|unexpected error/i);
+  });
+
+  it('says plainly that nothing here can arm while it is off', () => {
+    expect(moneyLayerNote('HTTP 503')).toMatch(/nothing here can arm/i);
+  });
+
+  it('CONTROL: an ordinary failure does NOT claim the money layer is off', () => {
+    // Without this, every failure would read as "your switch is off", which would send
+    // the operator to flip a switch that is already on.
+    const note = moneyLayerNote('network timeout');
+    expect(note).not.toMatch(/your decision/i);
+    expect(note).toMatch(/nothing has changed/i);
+  });
+
+  it('an unreadable caps store reports refusing-to-guess, not a wrong cap', () => {
+    expect(moneyLayerNote('caps store unreadable — money surfaces fail closed'))
+      .toMatch(/refusing to act rather than guess/i);
+  });
+
+  it('a rejected PIN says nothing changed', () => {
+    expect(moneyLayerNote('bad pin')).toMatch(/not accepted[\s\S]*nothing has changed/i);
+  });
+
+  it('never throws on a missing or non-string message', () => {
+    expect(typeof moneyLayerNote(undefined)).toBe('string');
+    expect(typeof moneyLayerNote(null)).toBe('string');
+    expect(typeof moneyLayerNote({} as unknown as string)).toBe('string');
+  });
+});
+
+describe('validateCaps — both ceilings are required', () => {
+  it('accepts a lifetime and a daily ceiling', () => {
+    expect(validateCaps({ lifetimeCapUsd: 100, dailyCapUsd: 3.3 })).toEqual({ ok: true });
+  });
+
+  it('THE ONE THAT MATTERS: a missing ceiling is refused, not defaulted', () => {
+    // A monthly intent has to be expressed as BOTH. Silently defaulting one produces a
+    // different product: a daily rate with no lifetime bound is a tap left running.
+    expect(validateCaps({ lifetimeCapUsd: 100 }).ok).toBe(false);
+    expect(validateCaps({ dailyCapUsd: 3.3 }).ok).toBe(false);
+    expect(validateCaps({ lifetimeCapUsd: 100, dailyCapUsd: '' }).error).toMatch(/requires both/i);
+  });
+
+  it('refuses a daily ceiling above the lifetime ceiling, and says why', () => {
+    const r = validateCaps({ lifetimeCapUsd: 50, dailyCapUsd: 80 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/could never bind/i);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -5],
+    ['NaN', NaN],
+    ['a numeric string', '100'],
+  ])('refuses %s rather than coercing it', (_label, bad) => {
+    expect(validateCaps({ lifetimeCapUsd: bad, dailyCapUsd: 3 }).ok).toBe(false);
+  });
+
+  it('never throws on junk input', () => {
+    expect(validateCaps(undefined).ok).toBe(false);
+    expect(validateCaps(null).ok).toBe(false);
+  });
+});
+
+describe('the PIN boundary', () => {
+  it('THE SECURITY PROPERTY: a plan preview carries NO pin', () => {
+    // The operator must see what they are approving before any secret leaves the page.
+    const body = planRequest('caps-adjust', {
+      keyRef: 'metered_openrouter_bench', provider: 'openrouter',
+      lifetimeCapUsd: 100, dailyCapUsd: 3.3, pin: '123456',
+    });
+    expect(JSON.stringify(body)).not.toContain('123456');
+    expect('pin' in body).toBe(false);
+  });
+
+  it('the go-live preview carries no pin either', () => {
+    const body = planRequest('go-live', { door: 'openrouter-api', keyRef: 'k', enabled: true, pin: '999999' });
+    expect(JSON.stringify(body)).not.toContain('999999');
+  });
+
+  it('the COMMIT carries the plan identity and the pin — and NOT the form fields', () => {
+    // The server derives what to apply solely from the plan it rendered, so a value the
+    // operator never saw on screen cannot be committed by editing the form afterwards.
+    const body = commitRequest(
+      { planId: 'PLAN-1', nonce: 'n-1', renderedText: 'set caps to ...' },
+      '123456',
+    );
+    expect(body).toEqual({ planId: 'PLAN-1', nonce: 'n-1', pin: '123456' });
+    expect('lifetimeCapUsd' in body).toBe(false);
+    expect('keyRef' in body).toBe(false);
+  });
+
+  it('go-live must be explicit — enabled is never truthy by accident', () => {
+    expect(planRequest('go-live', { keyRef: 'k' }).enabled).toBe(false);
+    expect(planRequest('go-live', { keyRef: 'k', enabled: 'yes' }).enabled).toBe(false);
+    expect(planRequest('go-live', { keyRef: 'k', enabled: true }).enabled).toBe(true);
+  });
+
+  it('an unknown action produces no request at all', () => {
+    expect(planRequest('delete-everything', { keyRef: 'k' })).toBeNull();
+  });
+});
+
+describe('renderPlanPreview', () => {
+  it('shows the SERVER text verbatim, as text', () => {
+    const t = doc.createElement('div');
+    renderPlanPreview(doc, t, { renderedText: 'Set metered_openrouter_bench to $100 lifetime.', expiresAt: '2026-08-16T04:00:00Z' });
+    expect(t.textContent).toContain('Set metered_openrouter_bench to $100 lifetime.');
+    expect(t.textContent).toContain('expires');
+  });
+
+  it('a hostile plan text cannot become markup', () => {
+    // The plan text is server-authored, but it is still rendered as text — the module's
+    // contract is textContent everywhere, with no exception for "trusted" strings.
+    const t = doc.createElement('div');
+    renderPlanPreview(doc, t, { renderedText: '<img src=x onerror=alert(1)>' });
+    expect(t.querySelector('img')).toBeNull();
+    for (const n of Array.from(t.querySelectorAll('*'))) {
+      expect(n.hasAttribute('onerror')).toBe(false);
+    }
+  });
+
+  it('with no plan it says so rather than showing a stale one', () => {
+    const t = doc.createElement('div');
+    renderPlanPreview(doc, t, { renderedText: 'old plan' });
+    renderPlanPreview(doc, t, null);
+    expect(t.textContent).not.toContain('old plan');
+    expect(t.textContent).toMatch(/no plan/i);
+  });
+});
+
+describe('armableDoors + doorStateWords', () => {
+  const caps = {
+    keys: [
+      { keyRef: 'metered_gemini_bench', provider: 'google', door: 'gemini-api', lifetimeCapUsd: 40, dailyCapUsd: 15, frozen: false, goLiveState: 'not-live' },
+      { keyRef: 'metered_openrouter_bench', provider: 'openrouter', door: 'openrouter-api', lifetimeCapUsd: 60, dailyCapUsd: 25, frozen: true, goLiveState: 'not-live' },
+      { keyRef: '', provider: 'broken' },
+    ],
+  };
+
+  it('lists the real metered doors and drops a malformed row', () => {
+    const rows = armableDoors(caps);
+    expect(rows.map((r) => r.keyRef)).toEqual(['metered_gemini_bench', 'metered_openrouter_bench']);
+  });
+
+  it('survives an empty or missing caps payload', () => {
+    expect(armableDoors(null)).toEqual([]);
+    expect(armableDoors({})).toEqual([]);
+  });
+
+  it('states live/not-live/frozen in words the operator can act on', () => {
+    const rows = armableDoors(caps);
+    expect(doorStateWords(rows[0])).toMatch(/not live/i);
+    expect(doorStateWords(rows[1])).toMatch(/frozen/i);
+    expect(doorStateWords({ live: true })).toMatch(/can spend/i);
+  });
+
+  it('CONTROL: frozen takes precedence over live — a frozen door must never read as spendable', () => {
+    expect(doorStateWords({ live: true, frozen: true })).toMatch(/frozen/i);
+  });
+});
+
+/**
+ * Wiring — the layer that has burned this feature repeatedly tonight.
+ *
+ * A module the page imports but that does not exist on disk, or a control the page
+ * never calls, is the exact "built but unreachable" shape that made an operator hunt
+ * for a PIN box that was never there. These are cheap and they close that gap.
+ */
+describe('spend arming — production wiring', () => {
+  const html = fs.readFileSync('dashboard/index.html', 'utf8');
+
+  it('every dashboard module the page imports EXISTS on disk', () => {
+    // Serving is express.static over the whole dashboard dir, so presence is the
+    // only thing standing between an import and a 404 at runtime.
+    const refs = [...html.matchAll(/import\(['"]\/dashboard\/([\w.-]+)['"]\)/g)].map((m) => m[1]);
+    expect(refs).toContain('spend-arming.js');
+    for (const r of refs) {
+      expect(fs.existsSync(path.join('dashboard', r)), `${r} is imported but missing`).toBe(true);
+    }
+  });
+
+  it('the arming panel is rendered from the spend loader, not orphaned', () => {
+    expect(html).toContain('renderSpendArming(caps)');
+    expect(html).toContain('id="spendArming"');
+  });
+
+  it('the tab no longer tells the operator that money controls do not exist', () => {
+    // The old copy said caps and go-live were "a later increment". Leaving that while
+    // shipping the controls would reproduce the original confusion exactly.
+    expect(html).not.toContain('money caps and the\n        go-live control are a later increment');
+    expect(html).not.toMatch(/go-live control are a later increment/);
+  });
+
+  it('the commit posts to the PIN-gated route, and the preview does not', () => {
+    expect(html).toContain("apiFetch('/routing-spend/caps/adjust'");
+    expect(html).toContain("apiFetch('/routing-spend/plan'");
+  });
+
+  it('the PIN field is a password input and is cleared after use', () => {
+    expect(html).toContain("p.type = 'password'");
+    expect(html).toMatch(/pinEl\.value = ''/);
+  });
+});

--- a/upgrades/next/spend-arming-ui.md
+++ b/upgrades/next/spend-arming-ui.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Spend tab gains the screen for arming a paid door — setting its spending limits and taking
+it live. The machinery for this existed and worked; the screen did not, and the tab's own small
+print said caps and go-live were "a later increment". So an operator told arming was "one tap,
+enter your PIN" went looking for a PIN box that had never been drawn. That copy is corrected too.
+
+## What to Tell Your User
+
+- "You can now set a paid door's limits and turn it on from the Spend tab, on your phone."
+- "It asks for your PIN twice on purpose — once to set the limits, once to start spending."
+- "The freeze button needs no PIN. Stopping money should always be immediate."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Set a paid door's ceilings | Spend tab → Paid doors → enter both ceilings → Preview → PIN |
+| Take a paid door live | Spend tab → Paid doors → Preview go live → PIN |
+| Freeze a door immediately | Spend tab → Paid doors → Freeze (no PIN) |
+
+## Compatibility Notes
+
+**The controls cannot arm anything until the money layer is switched on, and that switch is
+reserved to the operator** — deliberately not something an agent or a developer can flip. Used
+while it is off, the screen says exactly that, rather than showing a generic error that would
+send someone hunting for a mistake they did not make.
+
+**Both ceilings are required.** A door has a lifetime ceiling and a daily ceiling, and there is
+no monthly setting, so a monthly intention must be expressed as both. The screen refuses a blank
+rather than choosing one silently: $100 lifetime with $3.30/day is a hard budget that also cannot
+burn in an afternoon, while $3.30/day with a large lifetime is a tap left running.
+
+**You approve rendered words, not a button.** The server writes out what it is about to do and
+the screen shows that sentence before the PIN box appears. What commits is that plan, not the
+form — so editing a number after previewing invalidates the approval, and a figure never read
+cannot land.
+
+## Evidence
+
+31 unit tests against the shipped module in a real DOM, plus wiring tests asserting that every
+dashboard module the page imports exists on disk — the guard against the "built but unreachable"
+shape this feature is fixing.
+
+Shown capable of failing, independently: leaking the PIN into the preview request fails exactly
+the security test; replacing the honest switched-off message with a generic one fails exactly the
+two tests pinning it. A control asserts an ordinary network failure does not claim the money layer
+is off.
+
+Not yet proven live: the money layer is off on this agent, so the end-to-end arming path cannot be
+exercised until an operator enables it. That is stated rather than implied away.

--- a/upgrades/side-effects/spend-arming-ui.md
+++ b/upgrades/side-effects/spend-arming-ui.md
@@ -1,0 +1,86 @@
+# Side-Effects Review — paid-door arming UI
+
+## Summary
+
+The routing-spend money layer's routes (`/routing-spend/plan`, `/caps/adjust`, `/freeze`) had no
+screen, while the Spend tab's own copy said caps and go-live were "a later increment". This adds
+the two-step arming flow and corrects that copy.
+
+## How this arose
+
+An operator was told arming was "one tap in the Spend tab, enter your PIN". It was not — the tab
+was read-only and said so. They went looking for a PIN box that had never been drawn. That is the
+same class as the enrolment failures earlier tonight: a capability described as reachable that
+had no reachable surface.
+
+## Decision-point inventory
+
+None added. The screen holds no authority: it renders a plan the SERVER composed and posts back
+the plan identity plus the operator's PIN. The server verifies the PIN and derives what to apply
+from its own rendered plan. The UI cannot arm, adjust, or unfreeze anything on its own.
+
+## 1. Over-block
+
+`validateCaps` refuses client-side before asking for a plan: a missing ceiling, a non-number, a
+non-positive value, or a daily ceiling above the lifetime ceiling. The last could arguably be
+allowed (the server may accept it), but a daily ceiling that can never bind is almost certainly a
+typo, and the message says why rather than just refusing.
+
+## 2. Under-block
+
+The client does no authorization at all — deliberately. Every real refusal (bad PIN, money layer
+off, unreadable caps store, expired plan) is the server's, and the UI only renders the reason.
+
+## 3. Level-of-abstraction fit
+
+Plan rendering stays server-side; the client never composes the sentence the operator approves.
+That is what makes "a field you never saw cannot land" true, and it would be false if the UI
+built its own summary text.
+
+## 4. Signal vs authority
+
+The UI is pure presentation plus transport. The PIN gate is unchanged and remains server-side.
+
+## 5. Interactions
+
+The panel renders from the SAME `/routing-spend/caps` payload the read-only glance above it uses,
+so the door list and its live/frozen wording cannot drift from the figures. Editing any input or
+changing the door clears the pending plan, so a PIN can never be applied to a plan the operator
+has since edited away from.
+
+## 6. Multi-machine posture
+
+Machine-local BY DESIGN — the dashboard is served per machine and the PIN is a per-machine
+secret. Go-live already carries a `designatedMachineId` server-side; the UI does not touch it.
+
+## 7. Failure modes
+
+Every money-layer failure routes through `moneyLayerNote`, which distinguishes: money layer off
+(names it as the operator's own switch), caps store unreadable (refusing to guess), rejected PIN,
+and everything else. The default says "nothing has changed", which is true on every path because
+the server fails closed. The module has no I/O and every exported function is total (tested
+against undefined/null/junk).
+
+**Security**: the PIN never appears in a preview request (pure-function test asserts it), is a
+`type=password` field, is cleared on both success and failure, and is never placed in a URL. All
+rendering is textContent; a hostile plan text is tested for.
+
+## 8. Rollback cost
+
+Delete the `spendArming` div and the `renderSpendArming(caps)` call. The module is inert without
+them. No state, no migration, no config.
+
+## Evidence
+
+31 unit tests against the shipped module in a real DOM, plus wiring tests that assert every
+`/dashboard/*.js` the page imports exists on disk — the guard against the "wired but unreachable"
+shape that caused this whole thread.
+
+Shown capable of failing, independently: leaking the PIN into the preview request fails exactly
+the security test; replacing the honest 503 message with a generic one fails exactly the two
+tests that pin it. A CONTROL asserts an ordinary network failure does NOT claim the money layer
+is off — without it, every failure would send the operator to flip a switch that is already on.
+
+**Not yet proven live.** The money layer is off on this agent, so the arming path cannot be
+driven end-to-end until the operator enables it. That is stated rather than papered over: this
+review does not claim live-channel proof it does not have.


### PR DESCRIPTION
## ELI16 — The arming screen an operator was told existed, and didn't

The routing-spend money layer's routes (`/routing-spend/plan`, `/caps/adjust`, `/freeze`) were built and work. The screen for them was not — and the Spend tab's own copy told the operator so, in small print, saying caps and go-live were "a later increment". Meanwhile they'd been told arming was "one tap in the Spend tab, enter your PIN". So they went looking for a PIN box that had never been drawn: told to do something the interface could not do. This builds the two-step arming flow and corrects that copy, because shipping controls while the page still denies they exist would reproduce the confusion exactly.

## UX Impact

Who sees this: an operator arming a pay-per-use door from their phone. Before: the Spend tab rendered figures and the sentence *"This is read-only — money caps and the go-live control are a later increment."* — no door list, no cap inputs, no PIN field. After: a **Paid doors** section with a door picker, both ceilings, a preview of the server's own wording, a PIN field, and a freeze button. Mobile-first — 44px touch targets, 16px inputs so iOS doesn't zoom on focus, buttons going full-width under 520px.

## Three refusals, each traced to a real failure

- **A switched-off money layer is never reported as a generic error.** `routingSpend.money.enabled` is an explicit operator enable, reserved from agents and developers by design. The screen says that. A generic error would send the operator hunting for a mistake they did not make. A **control** asserts an ordinary network failure does *not* claim the layer is off — otherwise every failure would send them to flip a switch that's already on.
- **The PIN never travels with a preview.** The plan request is PIN-free, so the operator reads what they're approving before any secret leaves the page.
- **What commits is the plan, not the form.** The server renders the sentence; the commit posts back only `planId` + `nonce` + PIN. A value the operator never saw rendered cannot land. Editing any input clears the pending plan, so a PIN can't be applied to a plan they've since edited away from.

Both ceilings are required rather than defaulted. A door has a lifetime and a daily ceiling and there is no monthly field, so a monthly intent must be expressed as both — `$100` lifetime + `$3.30`/day is a hard budget that also can't burn in an afternoon; `$3.30`/day with a large lifetime is a tap left running. Silently picking one ships a different product.

Freeze needs no PIN — halting money is always cheap. Unfreezing is the gated direction.

## Evidence

31 unit tests against the shipped module in a real DOM, plus wiring tests asserting every `/dashboard/*.js` the page imports exists on disk — the guard against the built-but-unreachable shape this fixes.

Shown capable of failing, **independently**: leaking the PIN into the preview request fails exactly the security test; genericising the switched-off message fails exactly the two tests pinning it.

## Not claimed

**Live-channel proof is NOT claimed.** The money layer is off on this agent, so the end-to-end arming path cannot be driven until an operator enables it. That's stated in the side-effects artifact and the release note rather than implied away — a "one tap" that doesn't exist is precisely what that standard is for.

## Rollback

Delete the `spendArming` div and the `renderSpendArming(caps)` call; the module is inert without them. No state, no migration, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013phcTXz9TFXwScQyXxnybm
