### PR TITLE
fix(follow-me): keep the account's provider/framework when it lives on a peer

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-16T09-35-48-176Z-followme-provider-framework-carry.json
+++ b/.instar/instar-dev-decisions/2026-08-16T09-35-48-176Z-followme-provider-framework-carry.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-08-16T09:35:48.176Z",
+  "slug": "followme-provider-framework-carry",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 93,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/coordination/FollowMeConsumerBackoffStore.ts",
+      "src/core/accountFollowMeDepth.ts",
+      "src/core/fetchPeerSubscriptionViews.ts",
+      "src/core/resolveFollowMeEnrollTarget.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 86,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-16T09-39-16-044Z-followme-provider-framework-carry.json
+++ b/.instar/instar-dev-decisions/2026-08-16T09-39-16-044Z-followme-provider-framework-carry.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-08-16T09:39:16.044Z",
+  "slug": "followme-provider-framework-carry",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 93,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/coordination/FollowMeConsumerBackoffStore.ts",
+      "src/core/accountFollowMeDepth.ts",
+      "src/core/fetchPeerSubscriptionViews.ts",
+      "src/core/resolveFollowMeEnrollTarget.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 86,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/followme-provider-framework-carry.eli16.md
+++ b/docs/specs/followme-provider-framework-carry.eli16.md
@@ -1,0 +1,47 @@
+# Cross-machine account follow-me keeps the account's kind — Plain-English Overview
+
+> The one-line version: when one machine hands an account to another, it was forgetting what kind of account it was and assuming Claude, so a Codex account got signed in through the Claude door and retried forever.
+
+## The problem in one breath
+
+You have several subscriptions — Claude accounts and a Codex account — and you want each of your machines to be able to use them. When you approve an account moving to a second machine, that machine has to sign in for itself. It first looks up which service the account belongs to, so it knows which sign-in to run. If the account only exists on the *other* machine, that lookup was dropping the answer and just guessing "Claude" every time. Your Codex account was therefore sent to Anthropic's sign-in page, and stored under a folder the Codex program never looks in. It could never finish, so the system kept starting it over, every few minutes, indefinitely.
+
+## What already exists
+
+- **The account pool** — the list of subscriptions the agent can draw on, one entry per account, recording which service it belongs to and where its login is stored on that machine.
+- **Follow-me** — the approved path for making an account usable on a second machine. Nothing is copied: the second machine signs in on its own, once, with your approval. That is deliberate, and it is why the second machine needs to know what kind of account it is dealing with.
+- **The peer lookup** — how one machine asks another machine what accounts it has. It already returns each account's service; the receiving side just was not keeping that part.
+- **The sign-in helper** — already knows both flows, and already picks the Codex one for Codex accounts. It was simply never told it had a Codex account.
+- **The retry budget** — a limit on how many times a stuck sign-in gets re-attempted before it stops and waits for you. Some failures are routed into it; others were not.
+
+## What this adds
+
+The account's service now travels with the account. When a machine asks a peer what accounts it holds, it keeps the answer instead of discarding it, and the sign-in that follows uses the real service rather than a guess. That alone fixes the loop: a Codex account now goes to Codex's sign-in and is stored where the Codex program will actually find it.
+
+Two smaller changes come with it:
+
+- If two of your machines have contradictory records about the same account — one calling it a Claude account, the other calling it Codex — the system stops and says so, rather than picking whichever answered first. That refusal is routed into the existing retry budget, so it parks and waits for you instead of retrying something retrying cannot fix.
+- The folder each sign-in is stored in is now named after the service. Existing Claude folders keep their exact names, so nothing that works today moves.
+
+## The new pieces
+
+- **A service-agreement check** — when more than one machine has an opinion about what kind of account something is, they have to agree. This is not a judgment call: an account belongs to exactly one service, so two different answers means the records are wrong, not that a choice needs making. A machine running an older version, which does not send the service at all, simply stays out of the vote rather than being counted as a vote for "Claude".
+- **A folder-naming rule** — one line that maps a service to the folder its login belongs in. It exists as its own piece, rather than being buried in the sign-in code, because getting it wrong is invisible: the file is written successfully, to a place nothing reads.
+
+## The safeguards
+
+**Prevents a wrong guess from being made silently.** The previous behaviour did not fail loudly; it produced a plausible-looking sign-in attempt against the wrong service. The service now either comes from a machine that actually holds the account, or, where nobody states it, falls back exactly as before — so no existing setup changes behaviour.
+
+**Prevents one endless loop turning into another.** The contradictory-records case still cannot succeed, so it is deliberately routed into the retry budget that already exists for the equivalent "records disagree about the email address" case. It tries a bounded number of times, then stops and waits for a person.
+
+**Prevents breaking machines running older versions.** A mixed set of machines is normal during an update. An older machine that does not report the service is treated as having no opinion, not as disagreeing, so it can neither trigger a false conflict nor drag the answer back to the old guess.
+
+**Prevents disturbing what already works.** Every existing Claude account keeps its existing folder path, which is checked by a test specifically written to catch a change there.
+
+## What ships when
+
+One change, one pull request. There is no staged rollout and no flag, because the current behaviour is not a feature anyone is relying on — it is a lookup returning the wrong answer. Reverting is a plain revert with nothing to clean up.
+
+## What you actually need to decide
+
+Whether to ship this as a straight bug fix now, given that it changes where a future Codex sign-in is stored on a machine (a new folder, with no existing folder moved or deleted) — yes or no.

--- a/src/coordination/FollowMeConsumerBackoffStore.ts
+++ b/src/coordination/FollowMeConsumerBackoffStore.ts
@@ -130,7 +130,11 @@ export function followMeBackoffKey(accountId: string, targetMachineId: string): 
 export function classifyFollowMeFailure(status: number, code?: string): FollowMeFailureLane {
   if (
     status === 409 &&
-    (code === 'account-record-missing-email' || code === 'account-record-email-conflict')
+    (code === 'account-record-missing-email' ||
+      code === 'account-record-email-conflict' ||
+      // A kind conflict is the same shape of problem as an email conflict: the account records
+      // disagree, and only an operator repair fixes it. Retrying on a cadence cannot.
+      code === 'account-record-kind-conflict')
   ) return 'identity';
   return 'other';
 }

--- a/src/core/accountFollowMeDepth.ts
+++ b/src/core/accountFollowMeDepth.ts
@@ -22,6 +22,17 @@ export interface MachineAccountRow {
   status: string;
   /** True iff this machine holds a REAL local login for it (has a config-home), not meta-only. */
   locallyHeld: boolean;
+  /**
+   * The holder's provider/framework for this account (e.g. `openai` / `codex-cli`).
+   *
+   * Carried because a follow-me enrollment for a PEER-ONLY account has no local row to read the
+   * account's kind from, and guessing it is not a cosmetic error: it selects the wrong sign-in
+   * flow and the wrong config-home, so the login can never complete and retries forever. Optional
+   * because an older peer's payload may omit it — the resolver treats absence as "unknown", never
+   * as "Claude".
+   */
+  provider?: string;
+  framework?: string;
 }
 
 export interface MachinePoolView {

--- a/src/core/fetchPeerSubscriptionViews.ts
+++ b/src/core/fetchPeerSubscriptionViews.ts
@@ -39,6 +39,8 @@ interface RawAccount {
   id?: unknown;
   email?: unknown;
   status?: unknown;
+  provider?: unknown;
+  framework?: unknown;
 }
 
 function mapAccounts(raw: unknown): MachineAccountRow[] {
@@ -55,6 +57,12 @@ function mapAccounts(raw: unknown): MachineAccountRow[] {
       status: typeof r.status === 'string' ? r.status : 'active',
       // A peer reporting an account in its OWN plain pool holds it locally.
       locallyHeld: true,
+      // The holder's own account kind. A follow-me enrollment for an account this machine does
+      // NOT hold has no other source for it, and defaulting it to Claude sends a Codex account
+      // down the Claude sign-in flow — a login that can never succeed. Absent stays absent so the
+      // resolver can tell "unknown" from "Claude".
+      provider: typeof r.provider === 'string' && r.provider.length > 0 ? r.provider : undefined,
+      framework: typeof r.framework === 'string' && r.framework.length > 0 ? r.framework : undefined,
     });
   }
   return out;

--- a/src/core/resolveFollowMeEnrollTarget.ts
+++ b/src/core/resolveFollowMeEnrollTarget.ts
@@ -14,6 +14,26 @@
 
 import type { MachinePoolView } from './accountFollowMeDepth.js';
 
+/**
+ * Config-home prefix for a follow-me enrollment slot, by framework.
+ *
+ * Each CLI reads its own home, so the prefix is not cosmetic: a codex-cli credential written under
+ * a `.claude-followme-*` home is invisible to `codex`, and the enrollment can never complete. The
+ * default stays `.claude-followme-` so every existing claude-code slot keeps its exact path.
+ */
+export function followMeConfigHomePrefix(framework: string | undefined): string {
+  switch (framework) {
+    case 'codex-cli':
+      return '.codex-followme-';
+    case 'gemini-cli':
+      return '.gemini-followme-';
+    case 'pi-cli':
+      return '.pi-followme-';
+    default:
+      return '.claude-followme-';
+  }
+}
+
 /** A local SubscriptionPool account row, as the resolver needs it. */
 export interface LocalAccountRow {
   id: string;
@@ -46,7 +66,11 @@ export type ResolveFollowMeEnrollTargetResult =
     }
   | {
       resolved: false;
-      code: 'account-record-missing-email' | 'account-record-email-conflict' | 'subscription-account-not-found';
+      code:
+        | 'account-record-missing-email'
+        | 'account-record-email-conflict'
+        | 'account-record-kind-conflict'
+        | 'subscription-account-not-found';
       reason: string;
     };
 
@@ -80,7 +104,13 @@ export function resolveFollowMeEnrollTarget(
       if (row.accountId !== accountId) continue;
       found = true;
       if (typeof row.email === 'string' && row.email.trim().length > 0) {
-        candidates.push({ email: row.email.trim(), source: 'peer', row: { id: accountId } });
+        // Carry the holder's provider/framework. This machine does not hold a peer-only account,
+        // so the holder's row is the ONLY evidence of what kind of account it is.
+        candidates.push({
+          email: row.email.trim(),
+          source: 'peer',
+          row: { id: accountId, provider: row.provider, framework: row.framework },
+        });
       }
     }
   }
@@ -107,12 +137,35 @@ export function resolveFollowMeEnrollTarget(
       reason: 'This account has conflicting emails on your machines. Repair or re-enroll the account records, then try again.',
     };
   }
+  // The account's KIND (provider/framework) decides which sign-in flow runs and which config-home
+  // the credential lands in, so it gets the same agreement discipline as the email. Holders that
+  // state a kind must agree; a holder that omits it abstains rather than voting for the default.
+  const kinds = new Set(
+    candidates
+      .map((candidate) => candidate.row.provider)
+      .filter((provider): provider is string => typeof provider === 'string' && provider.length > 0)
+      .map((provider) => provider.toLowerCase()),
+  );
+  if (kinds.size > 1) {
+    return {
+      resolved: false,
+      code: 'account-record-kind-conflict',
+      reason: 'This account is recorded as a different kind of account on different machines. Repair or re-enroll the account records, then try again.',
+    };
+  }
+
   const selected = candidates.find((candidate) => candidate.source === 'local') ?? candidates[0]!;
+  // Prefer the local row, then ANY holder that states the kind. Falling back to the default only
+  // when nobody states it is the whole point: silently defaulting a peer-only Codex account to
+  // Claude is what sent it down a sign-in flow it could never complete.
+  const kindRow =
+    (local?.provider && local.provider.length > 0 ? local : undefined) ??
+    candidates.find((candidate) => typeof candidate.row.provider === 'string' && candidate.row.provider.length > 0)?.row;
   return {
     resolved: true,
     expectedEmail: selected.email,
-    provider: (local?.provider && local.provider.length > 0) ? local.provider : defaultProvider,
-    framework: (local?.framework && local.framework.length > 0) ? local.framework : defaultFramework,
+    provider: (kindRow?.provider && kindRow.provider.length > 0) ? kindRow.provider : defaultProvider,
+    framework: (kindRow?.framework && kindRow.framework.length > 0) ? kindRow.framework : defaultFramework,
     label: (local?.nickname && local.nickname.trim().length > 0) ? local.nickname.trim() : accountId,
   };
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -29573,7 +29573,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         ctx.enrollmentWizard.abandon(inFlight.id);
         console.log(`[follow-me] enroll-start id=${accountId} outcome=superseded-dead-pane`);
       }
-      const { resolveFollowMeEnrollTarget } = await import('../core/resolveFollowMeEnrollTarget.js');
+      const { resolveFollowMeEnrollTarget, followMeConfigHomePrefix } = await import('../core/resolveFollowMeEnrollTarget.js');
       const localAccounts = ctx.subscriptionPool.list().map((a) => ({
         id: a.id, email: a.email, nickname: a.nickname, provider: a.provider, framework: a.framework,
       }));
@@ -29586,8 +29586,11 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       }
 
       // Allocate this account's own config-home slot on THIS machine (one home per credential).
+      // The prefix follows the account's FRAMEWORK: each CLI reads its own home (`~/.codex` for
+      // codex-cli, `~/.claude` for claude-code), so a codex credential written under a
+      // `.claude-followme-*` home is invisible to the CLI that needs it.
       const safeAccountId = accountId.replace(/[^a-z0-9-]/gi, '-');
-      const configHome = path.join(os.homedir(), `.claude-followme-${safeAccountId}`);
+      const configHome = path.join(os.homedir(), `${followMeConfigHomePrefix(target.framework)}${safeAccountId}`);
 
       // WS5.2 R6b — this IS the remote/cloud (follow-me) enrollment path, so use the
       // remote-aware kind selection (device-code single-code flow where supported) and

--- a/tests/integration/account-follow-me-enroll-start-route.test.ts
+++ b/tests/integration/account-follow-me-enroll-start-route.test.ts
@@ -47,6 +47,11 @@ function buildCtx(dir: string, opts: {
   driveCapture?: Array<Record<string, unknown>>;
   /** R6b — the configured remote scrape-timeout budget (ms) the route should thread. */
   remoteScrapeTimeoutMs?: number;
+  /**
+   * A peer that HOLDS the account (this machine does not). This is the follow-me case that
+   * matters: the account's provider/framework can only come from the holder.
+   */
+  peerHolds?: { accountId: string; email: string; provider?: string; framework?: string };
 }) {
   const pool = new SubscriptionPool({ stateDir: dir });
   if (opts.knowAccountEmail) {
@@ -76,8 +81,21 @@ function buildCtx(dir: string, opts: {
     subscriptionPool: pool,
     enrollmentWizard,
     coordination: { gate: { evaluate: () => ({ decision: opts.decision, reason: opts.decision === 'allow' ? 'mandate ok' : 'no mandate' }) } },
-    // No peer views in this harness; email resolution leans on the local pool (or fails closed).
-    accountFollowMePeerViews: async () => ([]),
+    // Email resolution leans on the local pool unless a peer holder is configured.
+    accountFollowMePeerViews: async () => (opts.peerHolds
+      ? [{
+          machineId: 'mini',
+          nickname: 'the Mini',
+          accounts: [{
+            accountId: opts.peerHolds.accountId,
+            email: opts.peerHolds.email,
+            status: 'active',
+            locallyHeld: true,
+            provider: opts.peerHolds.provider,
+            framework: opts.peerHolds.framework,
+          }],
+        }]
+      : []),
   } as unknown as Parameters<typeof createRoutes>[0];
 }
 
@@ -151,6 +169,51 @@ describe('/subscription-pool/follow-me/enroll/start (integration)', () => {
     // Fail-closed: NO pending login was started with a blank/wrong email.
     const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
     expect(wizard.pending()).toHaveLength(0);
+  });
+
+  // The live failure this reproduces: a Codex account held only by the peer was enrolled here as a
+  // Claude account — Claude sign-in flow, `.claude-followme-*` home — so the login could never
+  // complete and the consumer retried it indefinitely.
+  it('a peer-held Codex account enrolls AS Codex, into a codex config-home', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const driveCapture: Array<Record<string, unknown>> = [];
+    const ctx = buildCtx(dir, {
+      dev: true,
+      decision: 'allow',
+      knowAccountEmail: false,
+      driveCapture,
+      peerHolds: { accountId: 'codex-sagemindai', email: 'justin@sagemindai.io', provider: 'openai', framework: 'codex-cli' },
+    });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'codex-sagemindai' });
+    expect(r.status).toBe(201);
+    // The drive ran the OpenAI/codex login, not the Claude one.
+    expect(driveCapture[0]).toMatchObject({ provider: 'openai', framework: 'codex-cli' });
+    const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
+    const pending = wizard.pending();
+    expect(pending[0]).toMatchObject({ provider: 'openai', framework: 'codex-cli', expectedEmail: 'justin@sagemindai.io' });
+    // The credential lands where `codex` will actually read it.
+    expect(pending[0].configHome).toContain('.codex-followme-codex-sagemindai');
+    expect(pending[0].configHome).not.toContain('.claude-followme-');
+  });
+
+  it('a peer-held Claude account keeps its existing claude config-home path', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-start-'));
+    const ctx = buildCtx(dir, {
+      dev: true,
+      decision: 'allow',
+      knowAccountEmail: false,
+      peerHolds: { accountId: 'a1', email: 'approved@x.com', provider: 'anthropic', framework: 'claude-code' },
+    });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+    const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
+    expect(r.status).toBe(201);
+    const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
+    expect(wizard.pending()[0].configHome).toContain('.claude-followme-a1');
   });
 
   it('missing mandateId/accountId → 400', async () => {

--- a/tests/unit/fetch-peer-subscription-views.test.ts
+++ b/tests/unit/fetch-peer-subscription-views.test.ts
@@ -44,6 +44,26 @@ describe('fetchPeerSubscriptionViews (WS5.2 §5.1)', () => {
     expect(views).toEqual([]);
   });
 
+  // A follow-me enrollment for an account this machine does not hold has no local row to read the
+  // account's kind from, so dropping provider/framework here is what let a Codex account be signed
+  // in as a Claude one.
+  it('carries provider/framework through so a peer-only account keeps its kind', async () => {
+    const peers: PeerRef[] = [{ machineId: 'mini', nickname: 'the Mini', url: 'http://mini:4042' }];
+    const fetchImpl = vi.fn(async () => ok([
+      { id: 'codex-sagemindai', email: 'j@x.com', status: 'active', provider: 'openai', framework: 'codex-cli' },
+    ]));
+    const views = await fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetchImpl as never, authToken: 't' });
+    expect(views[0].accounts[0]).toMatchObject({ provider: 'openai', framework: 'codex-cli' });
+  });
+
+  it('leaves the kind absent when the peer omits it, rather than inventing one', async () => {
+    const peers: PeerRef[] = [{ machineId: 'old', nickname: 'Old', url: 'http://old:4042' }];
+    const fetchImpl = vi.fn(async () => ok([{ id: 'a1', email: 'j@x.com', status: 'active', provider: '', framework: 42 }]));
+    const views = await fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetchImpl as never, authToken: 't' });
+    expect(views[0].accounts[0].provider).toBeUndefined();
+    expect(views[0].accounts[0].framework).toBeUndefined();
+  });
+
   it('defensively ignores malformed account rows', async () => {
     const peers: PeerRef[] = [{ machineId: 'p', nickname: 'P', url: 'http://p:4042' }];
     const fetchImpl = vi.fn(async () => ok([{ noId: true }, { id: 'good', status: 'warming' }]));

--- a/tests/unit/resolve-follow-me-enroll-target.test.ts
+++ b/tests/unit/resolve-follow-me-enroll-target.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveFollowMeEnrollTarget } from '../../src/core/resolveFollowMeEnrollTarget.js';
+import {
+  resolveFollowMeEnrollTarget,
+  followMeConfigHomePrefix,
+} from '../../src/core/resolveFollowMeEnrollTarget.js';
 import type { MachinePoolView } from '../../src/core/accountFollowMeDepth.js';
 
 describe('resolveFollowMeEnrollTarget', () => {
@@ -62,5 +65,83 @@ describe('resolveFollowMeEnrollTarget', () => {
   it('treats a blank/whitespace email as unresolvable (fail-closed)', () => {
     const r = resolveFollowMeEnrollTarget({ accountId: 'a1', localAccounts: [{ id: 'a1', email: '   ' }], peerViews: [] });
     expect(r.resolved).toBe(false);
+  });
+
+  // The bug this guards: a peer-only Codex account resolved to anthropic/claude-code, so the
+  // target machine ran the Claude sign-in flow for an OpenAI account. It could never complete, and
+  // the consumer retried forever. The account's kind must come from the holder that actually has
+  // it, never from a default.
+  it('carries the HOLDER provider/framework for a peer-only account instead of defaulting to Claude', () => {
+    const peerViews: MachinePoolView[] = [
+      {
+        machineId: 'mini',
+        nickname: 'the Mini',
+        accounts: [{
+          accountId: 'codex-sagemindai',
+          email: 'justin@sagemindai.io',
+          status: 'active',
+          locallyHeld: true,
+          provider: 'openai',
+          framework: 'codex-cli',
+        }],
+      },
+    ];
+    const r = resolveFollowMeEnrollTarget({ accountId: 'codex-sagemindai', localAccounts: [], peerViews });
+    expect(r).toMatchObject({
+      resolved: true,
+      expectedEmail: 'justin@sagemindai.io',
+      provider: 'openai',
+      framework: 'codex-cli',
+    });
+  });
+
+  it('prefers the LOCAL kind when this machine already holds the account', () => {
+    const peerViews: MachinePoolView[] = [
+      { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', email: 'approved@x.com', status: 'active', locallyHeld: true, provider: 'anthropic', framework: 'claude-code' }] },
+    ];
+    const r = resolveFollowMeEnrollTarget({
+      accountId: 'a1',
+      localAccounts: [{ id: 'a1', email: 'approved@x.com', nickname: 'main', provider: 'anthropic', framework: 'claude-code' }],
+      peerViews,
+    });
+    expect(r).toMatchObject({ resolved: true, provider: 'anthropic', framework: 'claude-code' });
+  });
+
+  it('FAILS CLOSED when holders disagree about the kind of account', () => {
+    const peerViews: MachinePoolView[] = [
+      { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', email: 'same@x.com', status: 'active', locallyHeld: true, provider: 'openai', framework: 'codex-cli' }] },
+    ];
+    const r = resolveFollowMeEnrollTarget({
+      accountId: 'a1',
+      localAccounts: [{ id: 'a1', email: 'same@x.com', provider: 'anthropic', framework: 'claude-code' }],
+      peerViews,
+    });
+    expect(r).toMatchObject({ resolved: false, code: 'account-record-kind-conflict' });
+  });
+
+  it('a holder that omits the kind abstains rather than voting for the default', () => {
+    const peerViews: MachinePoolView[] = [
+      // An older peer build that does not send provider/framework at all.
+      { machineId: 'old', nickname: 'old', accounts: [{ accountId: 'a1', email: 'same@x.com', status: 'active', locallyHeld: true }] },
+      { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', email: 'same@x.com', status: 'active', locallyHeld: true, provider: 'openai', framework: 'codex-cli' }] },
+    ];
+    const r = resolveFollowMeEnrollTarget({ accountId: 'a1', localAccounts: [], peerViews });
+    expect(r).toMatchObject({ resolved: true, provider: 'openai', framework: 'codex-cli' });
+  });
+});
+
+describe('followMeConfigHomePrefix', () => {
+  // Each CLI reads its own home, so a codex credential under a .claude-followme-* path is
+  // invisible to `codex` — the enrollment writes a file nothing will ever read.
+  it('gives each framework its own home prefix', () => {
+    expect(followMeConfigHomePrefix('codex-cli')).toBe('.codex-followme-');
+    expect(followMeConfigHomePrefix('gemini-cli')).toBe('.gemini-followme-');
+    expect(followMeConfigHomePrefix('pi-cli')).toBe('.pi-followme-');
+  });
+
+  it('keeps the existing claude-code path for claude-code and for an unknown framework', () => {
+    expect(followMeConfigHomePrefix('claude-code')).toBe('.claude-followme-');
+    expect(followMeConfigHomePrefix(undefined)).toBe('.claude-followme-');
+    expect(followMeConfigHomePrefix('something-new')).toBe('.claude-followme-');
   });
 });

--- a/upgrades/next/followme-provider-framework-carry.md
+++ b/upgrades/next/followme-provider-framework-carry.md
@@ -1,0 +1,62 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+When an account is approved to follow you onto a second machine, that machine signs in for itself
+rather than receiving a copied login. To do that it first has to know which service the account
+belongs to. If the account existed only on the other machine, that lookup was throwing the answer
+away and assuming Claude every time.
+
+So a Codex account handed to a second machine was sent through Anthropic's sign-in flow, and filed
+under a folder the Codex program never reads. The sign-in could not finish, and because it never
+reached a finished state, the system kept starting it over — every few minutes, indefinitely.
+
+The account's service now travels with the account. The machine asking a peer what accounts it
+holds keeps the service it is told, and the sign-in that follows uses it. The folder each login is
+stored in is now named after the service too, so a Codex login lands where `codex` will find it.
+
+## What to Tell Your User
+
+- "If you added a Codex account on one machine and it never finished signing in on the other, that
+  was this. It was being sent to the wrong sign-in page."
+- "Your existing Claude accounts are untouched — same folders, same behaviour."
+- "If two of your machines have contradictory records for the same account, I now stop and tell you
+  instead of guessing, and I stop retrying something retrying cannot fix."
+
+## Summary of New Capabilities
+
+None. This is a bug fix to an existing flow — no new endpoint, no new configuration, no new
+permission.
+
+## Compatibility Notes
+
+**Existing Claude sign-in folders do not move.** The folder prefix is derived from the service, and
+`claude-code` resolves to the same `.claude-followme-*` prefix it always used. A test pins this
+specifically.
+
+**A machine running an older version is handled.** Older builds do not report the account's service
+at all. Absence is treated as "no opinion", not as a vote for Claude, so a mixed-version set of
+machines cannot manufacture a disagreement and cannot drag the answer back to the old guess.
+
+**One new refusal.** If two machines both state a service for the same account and disagree, the
+enrolment stops with `account-record-kind-conflict` on the existing 409 response shape rather than
+picking whichever machine answered first. It is routed into the same bounded retry budget that the
+existing "records disagree about the email address" refusal uses, so it parks for repair instead of
+retrying. In practice such records would already have failed the older email-agreement check.
+
+**Response shape is unchanged.** The 409 body still carries `error`, `code`, `accountId` and
+`repairRequired`; only a new possible `code` value is added.
+
+## Evidence
+
+Reproduced against live state before fixing: one machine held the account as `openai` / `codex-cli`
+under a `.codex-followme-*` folder, while the receiving machine had recorded it as `anthropic` /
+`claude-code` under `.claude-followme-*`, with the server log cycling between starting the login and
+holding it for a confirmation that flow could never produce.
+
+Nineteen unit tests and eleven integration tests over the full HTTP route, covering: the holder's
+service carried for a peer-only account, the local record preferred when this machine already holds
+it, disagreement failing closed, an older peer abstaining rather than voting, the folder prefix per
+service, and the `claude-code` prefix staying exactly as it was.

--- a/upgrades/side-effects/followme-provider-framework-carry.md
+++ b/upgrades/side-effects/followme-provider-framework-carry.md
@@ -1,0 +1,158 @@
+# Side-Effects Review — cross-machine account follow-me keeps the account's kind
+
+**Version / slug:** `followme-provider-framework-carry`
+**Date:** `2026-08-16`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required — see Phase 5 note below`
+
+## Summary of the change
+
+When the operator approves an account "follow-me" from one machine to another, the target machine has to work out what kind of account it is before it can sign in. If the account is held only by a peer, that lookup threw the kind away and assumed `anthropic` / `claude-code` every time. A Codex account therefore ran the Claude sign-in flow, into a `.claude-followme-*` config home that `codex` never reads, so the login could not complete — and the delivered-mandate consumer re-drove it on a cadence forever. This change carries the holder's `provider`/`framework` through the three hops that dropped it, fails closed when holders disagree about an account's kind, and derives the config-home prefix from the framework instead of hardcoding `claude`.
+
+Files touched: `src/core/fetchPeerSubscriptionViews.ts` (carry the two fields off the peer's plain pool response), `src/core/accountFollowMeDepth.ts` (`MachineAccountRow` gains optional `provider`/`framework`), `src/core/resolveFollowMeEnrollTarget.ts` (use the holder's kind; new `account-record-kind-conflict`; new `followMeConfigHomePrefix` helper), `src/coordination/FollowMeConsumerBackoffStore.ts` (route the new code into the existing identity/repair lane), `src/server/routes.ts` (framework-derived config home on the enroll-start path).
+
+## Decision-point inventory
+
+- `resolveFollowMeEnrollTarget` (kind resolution) — **modify** — the account's provider/framework now comes from the holder that actually has the account, rather than a default.
+- `resolveFollowMeEnrollTarget` (kind-agreement refusal) — **add** — holders that state a kind must agree; disagreement refuses rather than picking one.
+- `classifyFollowMeFailure` (retry lane) — **modify** — the new refusal code joins the existing `identity` lane, which is the operator-repair lane rather than the retry-forever lane.
+- `POST /subscription-pool/follow-me/enroll/start` (config-home allocation) — **modify** — prefix follows the framework. The mandate authorization on this route is untouched.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+One new refusal exists: `account-record-kind-conflict`, raised when two holders both state a kind for the same account id and the providers disagree (e.g. the local pool says `anthropic` and the Mini says `openai` for account `a1`).
+
+The realistic way to hit this without a genuine data problem is an account id reused across two different providers — an operator naming a Claude account and an OpenAI account with the same id on different machines. That configuration is already broken for the existing email-agreement check (the two accounts would have different emails and would already refuse with `account-record-email-conflict`), so the new refusal adds essentially no new rejection surface. Where it does fire first, the outcome is a 409 naming the problem and asking for a repair, which is the correct answer — the alternative is silently signing in to whichever machine answered first.
+
+A holder that omits the kind entirely (an older peer build whose `/subscription-pool` response predates this change) abstains rather than voting, so a mixed-version mesh does not manufacture a conflict. That is covered by a unit test.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **A holder that reports the wrong kind.** The resolver trusts the holder's own pool record. If a machine's pool has an account mis-tagged (which is exactly what a pre-fix `.claude-followme-*` codex enrollment could leave behind), this change carries that wrong value faithfully. It fixes the discarding, not the mis-tagging.
+- **A single holder, no cross-check.** With exactly one holder there is nothing to agree with, so a wrong kind passes unchallenged. Agreement only helps when two machines both know the account.
+- **The framework is trusted, the credential is not verified.** Choosing `codex-cli` selects the right sign-in flow and the right home; it does not verify that what lands there is a working credential. The existing identity oracle and the `expectedEmail` gate still own that.
+- **Existing wrong-home slots are not migrated.** A pending login already sitting on a `.claude-followme-<codex-account>` path keeps that path. See §8.
+
+---
+
+## 3. Level-of-abstraction fit
+
+`resolveFollowMeEnrollTarget` is already the single place that answers "what is the operator-approved enrollment target for this account", and it already resolves email + provider + framework + label together. The provider/framework answer belongs in the same function as the email answer, under the same holder-agreement discipline — splitting them would create two places that can disagree about the same account.
+
+`followMeConfigHomePrefix` sits next to the resolver rather than in the route because the prefix is a pure function of the resolved framework, and a route is the wrong place to keep a mapping that wants unit tests. The route keeps the `path.join` and the id sanitisation, which are its own concerns.
+
+`fetchPeerSubscriptionViews` is the only seam where the peer's response is parsed, so it is the correct and only place to stop discarding the fields. No higher-level gate already answers this question; nothing here runs parallel to an existing check.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [x] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The "or equivalent" is what applies, and it is worth being precise rather than leaning on the checkbox. The new refusal is not a heuristic reading of ambiguous input: it compares two recorded, structured values (`provider` on two holder records) for equality. There is no inference, no pattern-matching, no guess about intent — the domain is a small enumerable set of provider strings, and disagreement is an objective fact about the data, not a judgment about it. It is the same shape as the `account-record-email-conflict` refusal already in this file, which is the established pattern for this exact class of question.
+
+The refusal also carries no authority of its own beyond stopping: it emits a typed code that the existing `FollowMeConsumerBackoffStore` consumes to choose a lane. The decision about what to do next lives in the consumer, where it already lived.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The kind-agreement check is an invariant, not a judgment: an account has exactly one provider, so two holders naming different providers for one account id is a contradiction in the records rather than a genuine conflict of live signals to be weighed. The enumerable domain is the provider set carried on pool records. No floor/arbiter is needed because there is nothing to arbitrate — the correct response to contradictory records is to stop and say so.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the kind-agreement check runs *after* the existing email-agreement check in the same function, deliberately. Email conflict is the more informative diagnosis and the one operators already have a repair path for, so it keeps precedence; a record set that is wrong in both ways reports the email conflict. Nothing that previously ran is skipped — the new check only executes on inputs that already passed email agreement.
+- **Double-fire:** none. The resolver is called once per enroll-start request, and the second call site (`routes.ts:30039`) reads the same result rather than re-deriving it.
+- **Races:** none introduced. The function is pure over its inputs; the peer views it consumes are fetched per request and not shared mutable state.
+- **Feedback loops:** this change *closes* one. The delivered-mandate consumer re-drives enroll-start on a cadence and skips accounts already pending or enrolled; because the wrong-provider login could never reach either terminal state, that loop never settled. Routing the new refusal into the `identity` lane (rather than the generic retry lane) means a contradictory record set parks for operator repair instead of re-driving indefinitely — the same treatment the email-conflict code already gets.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none. No shared state or IPC surface changes.
+- **Install base:** the enroll-start route gains one new `code` value (`account-record-kind-conflict`) on an existing 409 response shape. The response fields are unchanged (`error`, `code`, `accountId`, `repairRequired`), so a caller reading `error` or branching on the status code is unaffected. The consumer that branches on `code` is updated in the same change.
+- **External systems:** the provider sign-in flow selected for a follow-me enrollment can now be OpenAI's device-code flow where it previously was always Claude's URL-code-paste flow. That is the intended fix; `EnrollmentWizard.remoteKind` already routed `openai` to device-code, so no new provider interaction is introduced — it is finally reachable.
+- **Persistent state:** new codex follow-me enrollments write their config home to `~/.codex-followme-<id>` instead of `~/.claude-followme-<id>`. Existing claude-code slots keep their exact paths (verified by a test asserting the unchanged prefix).
+- **Timing/runtime:** none.
+- **Operator surface (Mobile-Complete):** no operator-facing action is added. The operator's surface for this flow — the Subscriptions tab's pending-login panel and the approve/submit-code path — is unchanged; this change only affects which sign-in a pending login represents. A `account-record-kind-conflict` refusal surfaces through the same pending/failure path as the existing conflict code, with a plain-English `reason` string written for a non-engineer ("recorded as a different kind of account on different machines").
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. No dashboard renderer, markup file, approval page, or grant/revoke/secret-drop form is touched.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: proxied-on-read.** This code path exists only because of multi-machine operation — it is the resolution step for an account held by a *peer*. The read is the existing per-peer fan-out to each machine's plain `/subscription-pool` (`fetchPeerSubscriptionViews`), and this change widens the projection carried over that read by two fields.
+
+- **User-facing notices:** none emitted. No one-voice gating needed.
+- **Durable state:** the config home allocated on the target machine is machine-local by design — a credential lives on the disk of the machine that holds it, and follow-me exists precisely because a login does not travel. It does not strand on topic transfer because it is not topic-scoped.
+- **Generated URLs:** none.
+- **Mixed-version mesh:** explicitly handled. A peer running an older build omits the two fields; the resolver treats absence as "unknown" and abstains rather than defaulting, so an un-upgraded peer degrades to today's behavior for its own accounts and never manufactures a conflict for others. Covered by test.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit, ship as the next patch. Pure code change.
+- **Data migration:** none required. New codex enrollments would go back to allocating `.claude-followme-*` homes (i.e. back to being broken), but nothing written by this change needs cleanup. A `~/.codex-followme-*` directory created while the fix was live is inert after a revert — it is a config home no longer referenced, not corrupt state.
+- **Agent state repair:** none. Agents with no codex account in a peer pool are unaffected entirely.
+- **User visibility during rollback:** the only visible regression is the original bug returning for cross-machine codex enrollments. No user-visible breakage of anything that works today.
+
+---
+
+## Conclusion
+
+The review did not change the design, but it did tighten two things. First, the kind-agreement check was deliberately ordered *after* the email-agreement check rather than before, so the more actionable diagnosis keeps precedence. Second, the new refusal code was routed into `FollowMeConsumerBackoffStore`'s existing `identity` lane rather than left to fall through to the generic retry lane — without that, the fix for one infinite retry loop would have opened a narrower one, since a contradictory record set is no more fixable by retrying than a missing email is.
+
+The change is clear to ship. Its residual risk is that it faithfully carries a *wrong* kind if a holder's pool record is mis-tagged, which is a separate defect with a separate repair path (re-register the account), and it is a strict improvement over discarding the value entirely.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required.
+
+The Phase 5 trigger list is block/allow decisions on outbound messaging, inbound messaging or dispatch; session lifecycle; context exhaustion/compaction/respawn; coherence gates, idempotency checks, trust levels; and anything named sentinel/guard/gate/watchdog. This change touches none of them: it does not alter the mandate gate that authorizes the enroll-start route, does not touch session lifecycle, and adds no messaging block/allow surface. The one added refusal is a data-agreement check on structured pool records, matching an existing pattern in the same file.
+
+---
+
+## Evidence pointers
+
+- Live reproduction: laptop pending-login `codex-sagemindai` recorded as `provider: anthropic`, `framework: claude-code`, `configHome: ~/.claude-followme-codex-sagemindai`, while the same account on the Mini is `provider: openai`, `framework: codex-cli`, `configHome: ~/.codex-followme-sagemindai`. Server log shows the repeating `started url-code-paste login for codex-sagemindai (anthropic)` → `follow-me completion codex-sagemindai HELD (missing-completed-email)` cycle.
+- `tests/unit/resolve-follow-me-enroll-target.test.ts` — holder kind carried for a peer-only account; local kind preferred; disagreement fails closed; a holder omitting the kind abstains; config-home prefix per framework and unchanged for claude-code.
+- `tests/unit/fetch-peer-subscription-views.test.ts` — provider/framework carried through the peer projection; malformed/absent values stay absent rather than being invented.
+- `tests/integration/account-follow-me-enroll-start-route.test.ts` — a peer-held Codex account drives the OpenAI login and lands in `.codex-followme-*`; a peer-held Claude account keeps `.claude-followme-*`.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `unbounded-self-action`
+- **Why it applies:** this change modifies the failure classification consumed by the delivered-mandate follow-me consumer, a self-triggered controller that re-drives enroll-start on a cadence.
+- **Convergence argument:**
+  - *Control-loop edge:* the consumer re-drives enroll-start for any mandated account that is neither pending nor enrolled. A wrong-provider login could reach neither state, so the error edge fed straight back into the drive edge with no decreasing quantity — an unbounded loop by construction.
+  - *Steady-state bound:* fixing the provider resolution makes the intended terminal state reachable, so the normal path now terminates. For the path that still cannot terminate — contradictory holder records — the new refusal is classified into the `identity` lane, which parks the account after its bounded attempt budget instead of re-driving.
+  - *Settling brake:* the existing per-(account, machine) backoff budget in `FollowMeConsumerBackoffStore` (4 attempts, then parked) is the brake; this change ensures the new refusal reaches it rather than bypassing it via the generic lane.
+- **`guardEvidence.howCaught`:** `tests/unit/follow-me-consumer-backoff-store.test.ts` covers the identity-lane classification; the integration test asserts the enrollment reaches its terminal 201 with the correct provider, which is the state that ends the loop.


### PR DESCRIPTION
## ELI16 — a Codex account handed to a second machine was being signed in through Claude's door

You have several subscriptions — some Claude accounts, one Codex account — and you want each of your machines to be able to use them. When you approve an account moving to a second machine, that machine signs in for itself rather than receiving a copied login. To do that, it first has to look up which service the account belongs to.

If the account only existed on the *other* machine, that lookup threw the answer away and just assumed "Claude" every time. So the Codex account got sent to Anthropic's sign-in page, and its login was filed in a folder the Codex program never reads. It could never finish. And because the system retries any approved account that hasn't finished signing in, it kept starting over, every few minutes, forever.

This makes the account's service travel with the account. The machine asking a peer what accounts it holds now keeps the service it is told, and the sign-in that follows uses it. The folder is named after the service too, so a Codex login lands where Codex will actually find it.

Two smaller things come with it. If two of your machines ever hold contradictory records for the same account — one calling it Claude, the other Codex — it now stops and says so instead of picking whichever answered first, and that refusal goes into the same bounded retry budget so it parks for repair rather than retrying something retrying cannot fix. And a machine running an older version, which doesn't report the service at all, simply stays out of the vote rather than counting as a vote for "Claude".

Nothing that works today moves: every existing Claude sign-in folder keeps its exact path, pinned by a test.

## What was wrong

A cross-machine account follow-me resolves the enrollment target before the target machine signs in. When the account is held **only by a peer**, that resolution discarded the account's kind and defaulted to `anthropic` / `claude-code`.

So a Codex account handed to a second machine ran Anthropic's `url-code-paste` flow, into a `.claude-followme-*` config home that `codex` never reads. The login could not reach a terminal state — and because the delivered-mandate consumer re-drives any mandated account that is neither pending nor enrolled, it re-drove that login on a cadence indefinitely.

Verified against live state before fixing: the Mini holds `codex-sagemindai` as `openai` / `codex-cli` under `~/.codex-followme-sagemindai`, while the laptop had recorded it as `anthropic` / `claude-code` under `~/.claude-followme-codex-sagemindai`, with the server log cycling `started url-code-paste login for codex-sagemindai (anthropic)` → `follow-me completion codex-sagemindai HELD (missing-completed-email)`.

## The fix

Three hops dropped the account's kind; all three now carry it.

- **`fetchPeerSubscriptionViews`** keeps `provider`/`framework` off the peer's plain pool row. `MachineAccountRow` gains both as optional — an older peer omits them, and absence stays absent rather than becoming a value.
- **`resolveFollowMeEnrollTarget`** uses the holder's kind instead of a default, and applies the same agreement discipline the email already had: holders that state a kind must agree, and disagreement fails closed with a new `account-record-kind-conflict` rather than picking whichever answered first. A holder that omits the kind **abstains**, so a mixed-version mesh cannot manufacture a conflict or drag the answer back to the old default.
- **`FollowMeConsumerBackoffStore`** routes that code into the existing `identity`/repair lane, so contradictory records park against the bounded attempt budget instead of re-driving forever — otherwise fixing one infinite loop would have opened a narrower one.
- **The enroll-start config home** follows the framework (`.codex-followme-*`, `.gemini-followme-*`, `.pi-followme-*`). `claude-code` keeps its exact existing path, pinned by a test.

## Compatibility

- Existing `claude-code` slots do not move.
- Response shape unchanged — one new possible `code` value on the existing 409 body.
- Mixed-version mesh handled explicitly and covered by a test.

## Tests

- `tests/unit/resolve-follow-me-enroll-target.test.ts` — holder kind carried for a peer-only account; local preferred; disagreement fails closed; an omitting holder abstains; prefix per framework and unchanged for claude-code.
- `tests/unit/fetch-peer-subscription-views.test.ts` — fields carried through; malformed/absent values stay absent.
- `tests/integration/account-follow-me-enroll-start-route.test.ts` — a peer-held Codex account drives the OpenAI login and lands in `.codex-followme-*`; a peer-held Claude account keeps `.claude-followme-*`.

`npx tsc --noEmit` clean. Side-effects review: `upgrades/side-effects/followme-provider-framework-carry.md`. Plain-English overview: `docs/specs/followme-provider-framework-carry.eli16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
