### PR TITLE
fix(enrollment): stop re-asking a Codex sign-in that already succeeded

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-16T09-51-29-312Z-codex-enrollment-reissue-race.json
+++ b/.instar/instar-dev-decisions/2026-08-16T09-51-29-312Z-codex-enrollment-reissue-race.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-08-16T09:51:29.312Z",
+  "slug": "codex-enrollment-reissue-race",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 177,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/EnrollmentWizard.ts",
+      "src/core/FrameworkLoginDriver.ts"
+    ],
+    "addedLines": 161,
+    "deletedLines": 16
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/codex-enrollment-reissue-race.eli16.md
+++ b/docs/specs/codex-enrollment-reissue-race.eli16.md
@@ -1,0 +1,86 @@
+# Codex sign-in kept asking forever — plain-English overview
+
+## The thing that went wrong
+
+Instar can sign you in to a Codex (OpenAI) subscription. It shows you a short code, you open a page,
+you approve it, and from then on that account is part of your pool.
+
+For one operator that never finished. Instar showed a code, the code expired about fifteen minutes
+later, instar showed a new one, and it did that **33 times between 1am and 9am** — still going when we
+found it. Approving a code correctly changed nothing.
+
+Worse, and not obvious from the outside: each of those attempts was quietly operating on the
+machine's **real** Codex account rather than a separate slot. That is almost certainly what signed the
+operator out of Codex earlier.
+
+## What already existed
+
+- Instar keeps a record of each sign-in that is still in progress, with the code and when it expires.
+- A background sweep every five minutes refreshes any record whose code has expired, so an operator
+  who wanders off does not come back to a dead code.
+- Each sign-in runs in its own terminal window, and instar is supposed to point it at a private
+  folder so two accounts cannot tread on each other.
+
+None of that is new. The problem was in the details of all three.
+
+## What is new
+
+Three fixes, because there were three separate bugs and any one of them alone would still have
+produced a loop.
+
+**1. Point Codex at the folder it actually reads.** Instar was setting the private-folder setting
+that *Claude* uses. Codex ignores it and uses a different one. We did not assume this — we tested it:
+told Codex to use an empty folder via the setting instar was using, and it happily reported it was
+still logged in to the real account; told it via the setting Codex actually reads, and it correctly
+said it was not logged in. Now each tool gets the setting it genuinely reads, and a tool with no
+setting we have verified gets none at all rather than a misleading one. Handing a program a setting
+it ignores is worse than handing it nothing, because everything downstream then believes the account
+is safely isolated when it is not.
+
+**2. Notice when a sign-in actually worked.** This was the real cause. There are two shapes of
+sign-in. Claude's ends with you pasting a code back into the dashboard — which tells instar, in so
+many words, "this one is done". Codex's does not: you approve it on OpenAI's site, the Codex program
+writes its own credential and closes, and nobody ever tells instar. So the record sat there marked
+"still waiting" forever. Now, before instar refreshes an expired sign-in, it checks whether that
+sign-in already succeeded — by looking for the credential in the folder it was supposed to land in —
+and if so marks it finished instead.
+
+**3. Stop destroying the thing waiting for your approval.** Every refresh closed the terminal window
+running the sign-in and opened a new one. That window was what was listening for your approval. Fix 2
+takes care of this: a sign-in that already worked is never refreshed, so its window is never closed.
+
+## The safeguards, in plain terms
+
+The obvious risk in fix 2 is deciding a sign-in worked when it did not — that would mark an account
+as connected when it never signed in, and leave you holding a dead code with no new one coming. Three
+things keep that from happening:
+
+- **The credential has to be newer than the sign-in attempt.** If you are re-connecting a slot that
+  still holds the previous account's credential, an old file does not count as this attempt
+  succeeding.
+- **Only the Codex-style sign-in is checked this way.** Claude's kind is left completely alone,
+  because a Claude folder's credential file gets rewritten during ordinary token refresh, and we did
+  not want a routine refresh mistaken for someone finishing a sign-in.
+- **Every uncertainty means "not finished".** Cannot read the folder, no credential there, the check
+  itself errors, the timestamps do not make sense — all of those fall back to exactly the old
+  behaviour of issuing a fresh code. The new check can only ever *prevent* instar from throwing away
+  a sign-in that worked; it can never leave you stranded on a dead code.
+
+## What is honestly still not covered
+
+- It confirms that *a* credential appeared, not *whose*. If you happened to sign in to a different
+  Codex account by hand in the same folder while an instar sign-in was pending, instar would credit
+  its own attempt. The account genuinely works and the pool entry points at a real credential, so the
+  outcome is harmless, but the record is not strictly accurate.
+- One error message still says "start a fresh sign-in" in a case where the sign-in has in fact
+  already finished. Slightly off, shared with a case where it is correct, and left alone rather than
+  reworded blind.
+
+## What you actually need to decide
+
+Nothing, to take the fix — it is a straight bug fix with no new settings and no new behaviour to opt
+into. Reverting it is a plain revert, but is worth pairing with turning Codex enrolment off, because
+going back also brings back the behaviour that signs you out of your real Codex account.
+
+The one thing worth your attention: if you have a Codex account that was enrolled *before* this fix,
+its credential may not be where the pool record claims. Worth checking rather than assuming.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13949,7 +13949,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // a 2nd account never clobbers the 1st.
     const { PendingLoginStore } = await import('../core/PendingLoginStore.js');
     const { EnrollmentWizard } = await import('../core/EnrollmentWizard.js');
-    const { FrameworkLoginDriver, enrollPaneSessionName, enrollmentBrowserEnv } = await import('../core/FrameworkLoginDriver.js');
+    const { FrameworkLoginDriver, enrollPaneSessionName, enrollmentBrowserEnv, enrollmentIsolationEnv, enrollmentCredentialPath } = await import('../core/FrameworkLoginDriver.js');
     const DEFAULT_ENROLL_LOGIN_COMMANDS: Record<string, string> = {
       'claude-code': 'claude auth login',
       'codex-cli': 'codex login',
@@ -13988,6 +13988,27 @@ export async function startServer(options: StartOptions): Promise<void> {
               sourceContext: 'account-follow-me-email-gate',
             })
         : undefined,
+      // A device-code sign-in (Codex, grok) completes inside the CLI and never
+      // tells instar, so the reissue sweep used to kill a SUCCEEDED login and
+      // mint a fresh code forever. Witness it on disk instead: the credential's
+      // mtime, which the wizard compares against the login's own start time.
+      // Any unreadable/absent slot answers null → the wizard re-drives exactly
+      // as before.
+      credentialWitness: (login) => {
+        const credentialPath = enrollmentCredentialPath(
+          login.framework,
+          login.configHome,
+          process.env,
+          os.homedir(),
+        );
+        if (!credentialPath) return null;
+        try {
+          return fs.statSync(credentialPath).mtimeMs;
+        } catch {
+          // @silent-fallback-ok: absent/unreadable credential is not success.
+          return null;
+        }
+      },
       driveLogin: new FrameworkLoginDriver({
         // Capture with `tmux capture-pane -J` so a hard-WRAPPED verification URL is
         // joined back into one line (the 2026-06-18 "code=t" truncation bug). Falls
@@ -14009,21 +14030,11 @@ export async function startServer(options: StartOptions): Promise<void> {
           // env-prefix sets the per-account config home for the login process so
           // the credential lands in its own slot.
           //
-          // Round-12 (security): the isolation var is PER-FRAMEWORK, and this
-          // set `CLAUDE_CONFIG_DIR` unconditionally — a variable grok ignores.
-          // With `xai` now an accepted pool provider that meant a grok login
-          // would land in the AMBIENT `~/.grok` while the account record claimed
-          // an isolated `configHome`: a second grok enrolment would silently
-          // overwrite the first account's session while the pool showed both
-          // active. grok reads `GROK_HOME`; a framework with no known isolation
-          // var gets NONE rather than a misleading one.
-          const isolationEnv = configHome
-            ? (framework === 'grok-build'
-                ? { GROK_HOME: configHome }
-                : framework === 'claude-code'
-                  ? { CLAUDE_CONFIG_DIR: configHome }
-                  : { CLAUDE_CONFIG_DIR: configHome })
-            : {};
+          // Round-12 (security): the isolation var is PER-FRAMEWORK. The mapping
+          // lives in `enrollmentIsolationEnv` (FrameworkLoginDriver) as the single
+          // source of truth — see there for why a framework with no verified
+          // isolation var gets NONE rather than a misleading one.
+          const isolationEnv = enrollmentIsolationEnv(framework, configHome);
           const env = { ...isolationEnv, ...enrollmentBrowserEnv(openBrowser) };
           const prefix = Object.entries(env).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(' ');
           const cmd = prefix ? `env ${prefix} ${baseCmd}` : baseCmd;

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -107,6 +107,24 @@ export interface EnrollmentWizardConfig {
    * is paged.
    */
   emitAttention?: (item: { id: string; title: string; body: string; priority: 'high'; source: 'agent' }) => void;
+  /**
+   * Witness for a login that completed WITHOUT telling instar.
+   *
+   * A `url-code-paste` flow (Claude) ends by the operator pasting a code back
+   * through the dashboard, which reaches a route that calls `complete()`. A
+   * `device-code` flow (Codex, grok) does not: the operator approves at the
+   * provider, the CLI writes its own credential and exits, and nothing informs
+   * instar. Without a witness that login stays `pending` forever, its TTL
+   * elapses, the reissue sweep kills the pane and mints a new code — so a
+   * SUCCESSFUL sign-in is destroyed and re-asked on a loop (33 reissues over 8h,
+   * observed 2026-08-16).
+   *
+   * Returns the epoch-ms mtime of the credential in the login's slot, or null
+   * when absent/unreadable. Compared against the login's `createdAt` so a
+   * credential that was ALREADY in the slot before this flow began cannot be
+   * mistaken for this flow succeeding. Absent ⇒ no witness ⇒ previous behaviour.
+   */
+  credentialWitness?: (login: PendingLogin) => Promise<number | null> | number | null;
 }
 
 export interface StartEnrollmentInput {
@@ -142,6 +160,7 @@ export class EnrollmentWizard {
   private readonly ensureReady: (configHome: string) => EnsureInteractiveReadyResult;
   private readonly oracle?: IdentityOracle;
   private readonly emitAttention?: (item: { id: string; title: string; body: string; priority: 'high'; source: 'agent' }) => void;
+  private readonly credentialWitness?: (login: PendingLogin) => Promise<number | null> | number | null;
 
   constructor(cfg: EnrollmentWizardConfig) {
     this.store = cfg.store;
@@ -150,6 +169,7 @@ export class EnrollmentWizard {
     this.ensureReady = cfg.ensureReady ?? ensureInteractiveReady;
     this.oracle = cfg.oracle;
     this.emitAttention = cfg.emitAttention;
+    this.credentialWitness = cfg.credentialWitness;
   }
 
   /** Default flow kind per provider: Codex/OpenAI and xAI/grok = device-code
@@ -274,6 +294,19 @@ export class EnrollmentWizard {
     const reissued: PendingLogin[] = [];
     for (const login of logins) {
       try {
+        // A device-code login can succeed without telling instar, and every
+        // re-drive KILLS the pane it would have succeeded in. Ask the witness
+        // BEFORE destroying anything: an already-succeeded flow is completed,
+        // never re-asked.
+        if (await this.completedWithoutTelling(login)) {
+          const completed = this.complete(login.id);
+          if (completed) {
+            this.logger.log(
+              `[EnrollmentWizard] ${login.id} already signed in — completing instead of ${reason} refresh`,
+            );
+            continue;
+          }
+        }
         const fresh = await this.driveLogin({
           provider: login.provider,
           framework: login.framework,
@@ -299,6 +332,37 @@ export class EnrollmentWizard {
       }
     }
     return reissued;
+  }
+
+  /**
+   * Did this login already succeed without instar being told?
+   *
+   * Only `device-code` flows can: a `url-code-paste` flow completes through the
+   * dashboard route that calls `complete()`, and its slot's credential is
+   * rewritten by ordinary token refresh, so witnessing it would risk marking a
+   * live re-enrolment "done" on an mtime bump that was never this flow.
+   *
+   * EVERY uncertainty answers false — no witness, unreadable slot, absent
+   * credential, unparseable timestamp, or a probe that throws. False is the
+   * previous behaviour (re-drive), so the witness can only ever PREVENT a
+   * destructive re-ask, never cause one, and can never strand an operator on a
+   * dead code by wrongly declaring success.
+   */
+  private async completedWithoutTelling(login: PendingLogin): Promise<boolean> {
+    if (!this.credentialWitness) return false;
+    if (login.kind !== 'device-code') return false;
+    try {
+      const credentialMs = await this.credentialWitness(login);
+      if (typeof credentialMs !== 'number' || !Number.isFinite(credentialMs)) return false;
+      const startedMs = Date.parse(login.createdAt);
+      if (!Number.isFinite(startedMs)) return false;
+      // A credential older than the flow was already there — a prior account in
+      // the slot, not this sign-in.
+      return credentialMs >= startedMs;
+    } catch {
+      // @silent-fallback-ok: an unreadable slot is not evidence of success.
+      return false;
+    }
   }
 
   /**

--- a/src/core/FrameworkLoginDriver.ts
+++ b/src/core/FrameworkLoginDriver.ts
@@ -39,6 +39,76 @@ export function enrollPaneSessionName(framework: string, configHome?: string): s
   return `instar-enroll-${framework}-${slug}`;
 }
 
+/**
+ * The environment that confines an enrollment login to its own credential slot.
+ * SINGLE SOURCE OF TRUTH — the spawn (server.ts) derives the env through this
+ * helper so the mapping can never drift from what each CLI actually reads.
+ *
+ * The isolation variable is PER-FRAMEWORK, and handing a CLI a variable it does
+ * not read is worse than handing it none: the login silently lands in the
+ * AMBIENT home while the pool records an isolated `configHome`, so a second
+ * enrolment overwrites the first account's session while the pool shows both
+ * active. Each framework therefore gets the variable it genuinely honours, and
+ * a framework with NO known isolation variable gets NONE rather than a
+ * misleading one.
+ *
+ * `codex-cli` reads `CODEX_HOME` (verified against the CLI: `CLAUDE_CONFIG_DIR`
+ * pointed at an empty directory still reported "Logged in using ChatGPT", while
+ * `CODEX_HOME` pointed at the same directory correctly reported "Not logged
+ * in"). It previously fell through to `CLAUDE_CONFIG_DIR`, so every
+ * instar-started Codex sign-in ran against the machine's real `~/.codex` —
+ * which is how an enrolment signed the operator out of their default Codex
+ * login. `gemini-cli` and `pi-cli` have no isolation variable instar has
+ * verified, so they get none.
+ */
+export function enrollmentIsolationEnv(
+  framework: string,
+  configHome?: string,
+): Record<string, string> {
+  if (!configHome) return {};
+  switch (framework) {
+    case 'claude-code':
+      return { CLAUDE_CONFIG_DIR: configHome };
+    case 'codex-cli':
+      return { CODEX_HOME: configHome };
+    case 'grok-build':
+      return { GROK_HOME: configHome };
+    default:
+      return {};
+  }
+}
+
+/**
+ * Where a framework's login writes its credential — the file whose appearance
+ * proves a `device-code` sign-in succeeded (see `EnrollmentWizard`'s
+ * `credentialWitness`). MIRRORS `enrollmentIsolationEnv` by construction: the
+ * credential lands wherever that env points, or in the CLI's ambient home when
+ * the framework has no isolation variable.
+ *
+ * Returns null for a framework whose credential location instar has not
+ * verified — a witness that guesses a path would read an absent file forever
+ * and silently degrade to the old re-ask loop while looking supported.
+ *
+ * `env`/`homedir` are parameters rather than direct `process`/`os` reads so the
+ * resolution stays pure and testable.
+ */
+export function enrollmentCredentialPath(
+  framework: string,
+  configHome: string | undefined,
+  env: Record<string, string | undefined>,
+  homedir: string,
+): string | null {
+  const join = (dir: string, file: string) => `${dir.replace(/\/+$/, '')}/${file}`;
+  switch (framework) {
+    case 'codex-cli':
+      return join(configHome ?? env['CODEX_HOME'] ?? join(homedir, '.codex'), 'auth.json');
+    case 'grok-build':
+      return join(configHome ?? env['GROK_HOME'] ?? join(homedir, '.grok'), 'auth.json');
+    default:
+      return null;
+  }
+}
+
 /** A login flow we know how to launch + scrape. */
 export interface FrameworkLoginRequest {
   provider: LoginProvider;

--- a/tests/integration/subscription-enrollment-routes.test.ts
+++ b/tests/integration/subscription-enrollment-routes.test.ts
@@ -19,6 +19,7 @@ import type { AddressInfo } from 'node:net';
 import { createRoutes } from '../../src/server/routes.js';
 import { PendingLoginStore } from '../../src/core/PendingLoginStore.js';
 import { EnrollmentWizard, type LoginArtifact } from '../../src/core/EnrollmentWizard.js';
+import { enrollmentCredentialPath } from '../../src/core/FrameworkLoginDriver.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 interface TestServer { url: string; close: () => Promise<void>; }
@@ -228,5 +229,92 @@ describe('/subscription-pool enrollment routes (integration)', () => {
   it('400 when required fields are missing', async () => {
     const res = await api('/subscription-pool/enroll', { method: 'POST', body: JSON.stringify({ id: 'x' }) });
     expect(res.status).toBe(400);
+  });
+});
+
+/**
+ * Integration — the credential witness composed EXACTLY as production composes it
+ * (`enrollmentCredentialPath` + a real `fs.statSync`), driven through the real
+ * reissue route against a real credential file on disk.
+ *
+ * The bug this guards: a Codex device-code sign-in completes inside the CLI and
+ * never tells instar, so the reissue sweep killed the succeeded pane and minted a
+ * fresh code on a loop (33 reissues over 8h, observed live 2026-08-16).
+ */
+describe('enrollment reissue — a device-code login that already signed in (integration)', () => {
+  let server: TestServer;
+  let dir: string;
+  let store: PendingLoginStore;
+  let clock: number;
+  let drives: number;
+  let slotHome: string;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-witness-int-'));
+    clock = Date.parse('2026-08-16T00:00:00Z');
+    store = new PendingLoginStore({ stateDir: dir, now: () => clock });
+    drives = 0;
+    slotHome = path.join(dir, 'codex-slot');
+    fs.mkdirSync(slotHome, { recursive: true });
+
+    const wizard = new EnrollmentWizard({
+      store,
+      now: () => clock,
+      driveLogin: async () => { drives++; return ARTIFACT; },
+      // The production composition, verbatim (src/commands/server.ts).
+      credentialWitness: (login) => {
+        const credentialPath = enrollmentCredentialPath(login.framework, login.configHome, process.env, os.homedir());
+        if (!credentialPath) return null;
+        try { return fs.statSync(credentialPath).mtimeMs; } catch { return null; }
+      },
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes({
+      config: { authToken: 't', stateDir: dir, port: 0 },
+      startTime: new Date(),
+      enrollmentWizard: wizard,
+    } as any));
+    server = await listen(app);
+  });
+  afterEach(async () => {
+    await server?.close();
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/subscription-enrollment-routes.test.ts:witness-cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  const api = (p: string, init?: RequestInit) =>
+    fetch(server.url + p, { headers: { 'Content-Type': 'application/json' }, ...init })
+      .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }));
+
+  async function startCodexLogin() {
+    return api('/subscription-pool/enroll', {
+      method: 'POST',
+      body: JSON.stringify({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli', configHome: slotHome }),
+    });
+  }
+
+  it('completes it instead of minting yet another code', async () => {
+    await startCodexLogin();
+    drives = 0;
+    // The operator approved at OpenAI; the CLI wrote its credential and exited.
+    fs.writeFileSync(path.join(slotHome, 'auth.json'), '{"tokens":{}}');
+
+    clock += 16 * 60_000; // TTL elapsed
+    const res = await api('/subscription-pool/enroll/reissue-expired', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(drives).toBe(0);
+    expect(store.get('codex-1')!.status).toBe('completed');
+  });
+
+  it('still reissues when the slot genuinely holds no credential', async () => {
+    await startCodexLogin();
+    drives = 0;
+
+    clock += 16 * 60_000;
+    await api('/subscription-pool/enroll/reissue-expired', { method: 'POST' });
+
+    expect(drives).toBe(1);
+    expect(store.get('codex-1')!.status).toBe('pending');
   });
 });

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -528,3 +528,134 @@ describe('EnrollmentWizard', () => {
     });
   });
 });
+
+/**
+ * A device-code sign-in (Codex, grok) completes INSIDE the CLI: the operator
+ * approves at the provider, the CLI writes its credential and exits, and nothing
+ * tells instar. Before the credential witness, that login stayed `pending`, its
+ * TTL elapsed, and the reissue sweep killed the pane and minted a new code — so a
+ * SUCCESSFUL sign-in was destroyed and re-asked forever (33 reissues over 8h,
+ * observed live 2026-08-16).
+ */
+describe('EnrollmentWizard — a login that succeeded without telling instar', () => {
+  const T0 = Date.parse('2026-08-16T00:00:00Z');
+  let dir: string;
+  let clock: number;
+  let store: PendingLoginStore;
+
+  function wizard(opts: {
+    credentialWitness?: (login: { framework: string; configHome?: string; createdAt: string; kind: string }) => number | null;
+    onDrive?: () => void;
+  } = {}) {
+    return new EnrollmentWizard({
+      store,
+      now: () => clock,
+      driveLogin: async () => {
+        opts.onDrive?.();
+        return { verificationUrl: 'https://auth.openai.com/codex/device', userCode: 'NEW-CODE1', ttlMs: 15 * 60_000 };
+      },
+      credentialWitness: opts.credentialWitness as never,
+    });
+  }
+
+  async function startCodexLogin(w: EnrollmentWizard) {
+    return w.start({
+      id: 'codex-justin', label: 'Codex', provider: 'openai',
+      framework: 'codex-cli', kind: 'device-code', configHome: '/slot/codex',
+    });
+  }
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-witness-'));
+    clock = T0;
+    store = new PendingLoginStore({ stateDir: dir, now: () => clock });
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/enrollment-wizard.test.ts:witness-cleanup' }); } catch { /* @silent-fallback-ok */ }
+  });
+
+  it('completes the login instead of killing its pane and minting a new code', async () => {
+    let drives = 0;
+    // The credential appears five minutes into the flow — the operator approved.
+    const w = wizard({ credentialWitness: () => T0 + 5 * 60_000, onDrive: () => { drives++; } });
+    await startCodexLogin(w);
+    drives = 0; // discount the initial drive; count only re-drives
+
+    clock = T0 + 16 * 60_000; // TTL elapsed
+    const reissued = await w.reissueExpired();
+
+    expect(reissued).toEqual([]);
+    expect(drives).toBe(0); // the succeeded pane was never destroyed
+    expect(store.get('codex-justin')!.status).toBe('completed');
+  });
+
+  it('does not mistake a credential that was already in the slot for this sign-in', async () => {
+    // Re-enrolling a slot that still holds the PREVIOUS account's credential must
+    // not read as instant success — otherwise the pool records an account that
+    // never signed in.
+    let drives = 0;
+    const w = wizard({ credentialWitness: () => T0 - 60 * 60_000, onDrive: () => { drives++; } });
+    await startCodexLogin(w);
+    drives = 0;
+
+    clock = T0 + 16 * 60_000;
+    const reissued = await w.reissueExpired();
+
+    expect(drives).toBe(1);
+    expect(reissued).toHaveLength(1);
+    expect(store.get('codex-justin')!.status).toBe('pending');
+  });
+
+  it('leaves a url-code-paste flow entirely alone', async () => {
+    // Claude completes through the dashboard paste-back route, and its slot's
+    // credential is rewritten by ordinary token refresh — witnessing it would risk
+    // marking a live re-enrolment "done" on an mtime bump that was never this flow.
+    let drives = 0;
+    const w = wizard({ credentialWitness: () => clock, onDrive: () => { drives++; } });
+    await w.start({
+      id: 'claude-1', label: 'Claude', provider: 'anthropic',
+      framework: 'claude-code', kind: 'url-code-paste', configHome: '/slot/claude',
+    });
+    drives = 0;
+
+    clock = T0 + 16 * 60_000;
+    await w.reissueExpired();
+
+    expect(drives).toBe(1);
+    expect(store.get('claude-1')!.status).toBe('pending');
+  });
+
+  it.each([
+    ['no witness is wired at all', undefined],
+    ['the slot holds no credential', () => null],
+    ['the probe throws', () => { throw new Error('EACCES'); }],
+  ])('re-drives exactly as before when %s', async (_label, witness) => {
+    let drives = 0;
+    const w = wizard({ credentialWitness: witness as never, onDrive: () => { drives++; } });
+    await startCodexLogin(w);
+    drives = 0;
+
+    clock = T0 + 16 * 60_000;
+    const reissued = await w.reissueExpired();
+
+    // Every uncertainty answers "not succeeded", so the witness can only ever
+    // PREVENT a destructive re-ask — never strand the operator on a dead code.
+    expect(drives).toBe(1);
+    expect(reissued).toHaveLength(1);
+  });
+
+  it('protects the restart-recovery and dead-pane paths too, not just TTL expiry', async () => {
+    let drives = 0;
+    const w = wizard({ credentialWitness: () => T0 + 5 * 60_000, onDrive: () => { drives++; } });
+    await startCodexLogin(w);
+    drives = 0;
+
+    // recoverAfterRestart() re-drives every non-terminal record at boot; a server
+    // bounce must not destroy a sign-in that already succeeded.
+    const recovered = await w.recoverAfterRestart();
+
+    expect(recovered).toEqual([]);
+    expect(drives).toBe(0);
+    expect(store.get('codex-justin')!.status).toBe('completed');
+  });
+});

--- a/tests/unit/framework-login-driver.test.ts
+++ b/tests/unit/framework-login-driver.test.ts
@@ -6,7 +6,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { FrameworkLoginDriver, enrollPaneSessionName, enrollmentBrowserEnv } from '../../src/core/FrameworkLoginDriver.js';
+import {
+  FrameworkLoginDriver,
+  enrollPaneSessionName,
+  enrollmentBrowserEnv,
+  enrollmentIsolationEnv,
+  enrollmentCredentialPath,
+} from '../../src/core/FrameworkLoginDriver.js';
 import { loadCapturedFixture } from '../helpers/loadCapturedFixture.js';
 
 describe('enrollPaneSessionName (shared pane-name source of truth — ws52-code-paste-back / codex #1)', () => {
@@ -203,5 +209,60 @@ describe('FrameworkLoginDriver.drive', () => {
     const driver = new FrameworkLoginDriver(deps);
     const a = await driver.drive({ provider: 'openai', framework: 'codex-cli', kind: 'device-code', scrapeTimeoutMs: 0 });
     expect(a.userCode).toBe('7DAU-W4XJA');
+  });
+});
+
+describe('enrollmentIsolationEnv — each CLI gets the variable it actually reads', () => {
+  const HOME = '/Users/x/.instar/agents/echo/.codex-followme-sagemindai';
+
+  it('confines a Codex login with CODEX_HOME, not CLAUDE_CONFIG_DIR', () => {
+    // The regression this exists for: codex-cli fell through to CLAUDE_CONFIG_DIR,
+    // a variable the Codex CLI ignores, so every instar-started Codex sign-in ran
+    // against the machine's real ~/.codex and signed the operator out of it.
+    expect(enrollmentIsolationEnv('codex-cli', HOME)).toEqual({ CODEX_HOME: HOME });
+    expect(enrollmentIsolationEnv('codex-cli', HOME)).not.toHaveProperty('CLAUDE_CONFIG_DIR');
+  });
+
+  it('keeps claude-code on CLAUDE_CONFIG_DIR and grok on GROK_HOME', () => {
+    expect(enrollmentIsolationEnv('claude-code', HOME)).toEqual({ CLAUDE_CONFIG_DIR: HOME });
+    expect(enrollmentIsolationEnv('grok-build', HOME)).toEqual({ GROK_HOME: HOME });
+  });
+
+  it('gives a framework with no verified isolation variable NONE, never a misleading one', () => {
+    // Handing a CLI a variable it ignores is worse than handing it none: the login
+    // lands in the ambient home while the pool records an isolated configHome.
+    expect(enrollmentIsolationEnv('gemini-cli', HOME)).toEqual({});
+    expect(enrollmentIsolationEnv('pi-cli', HOME)).toEqual({});
+  });
+
+  it('sets nothing when there is no slot to confine the login to', () => {
+    expect(enrollmentIsolationEnv('codex-cli', undefined)).toEqual({});
+    expect(enrollmentIsolationEnv('claude-code', undefined)).toEqual({});
+  });
+});
+
+describe('enrollmentCredentialPath — mirrors where the isolation env points', () => {
+  const ENV = { CODEX_HOME: '/env/codex', GROK_HOME: '/env/grok' };
+
+  it('points at the slot the login was confined to', () => {
+    expect(enrollmentCredentialPath('codex-cli', '/slot/codex', ENV, '/home/u')).toBe('/slot/codex/auth.json');
+    expect(enrollmentCredentialPath('grok-build', '/slot/grok', ENV, '/home/u')).toBe('/slot/grok/auth.json');
+  });
+
+  it('falls back to the ambient home the CLI would use when there is no slot', () => {
+    expect(enrollmentCredentialPath('codex-cli', undefined, ENV, '/home/u')).toBe('/env/codex/auth.json');
+    expect(enrollmentCredentialPath('codex-cli', undefined, {}, '/home/u')).toBe('/home/u/.codex/auth.json');
+    expect(enrollmentCredentialPath('grok-build', undefined, {}, '/home/u')).toBe('/home/u/.grok/auth.json');
+  });
+
+  it('tolerates a trailing slash on the slot rather than emitting a doubled separator', () => {
+    expect(enrollmentCredentialPath('codex-cli', '/slot/codex/', ENV, '/home/u')).toBe('/slot/codex/auth.json');
+  });
+
+  it('returns null for a framework whose credential location is unverified', () => {
+    // A guessed path would read an absent file forever — silently degrading to the
+    // old re-ask loop while looking supported.
+    expect(enrollmentCredentialPath('claude-code', '/slot/claude', ENV, '/home/u')).toBeNull();
+    expect(enrollmentCredentialPath('gemini-cli', '/slot/g', ENV, '/home/u')).toBeNull();
   });
 });

--- a/upgrades/next/codex-enrollment-reissue-race.md
+++ b/upgrades/next/codex-enrollment-reissue-race.md
@@ -1,0 +1,71 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+A Codex sign-in that you completed successfully is no longer thrown away and re-asked.
+
+Three defects compounded into one loop. A Codex sign-in was pointed at its private folder using
+`CLAUDE_CONFIG_DIR` — a variable the Codex CLI ignores — so the login actually ran against the
+machine's ambient `~/.codex` while the pool recorded an isolated `configHome`. Nothing ever detected
+that a sign-in had succeeded: `complete()` is only reached from an HTTP route, and a `device-code`
+flow (Codex, grok) has no paste-back step to trigger one, so the record stayed `pending`
+indefinitely. And every reissue killed the login's tmux pane before starting a new one — destroying
+the process that was waiting for the operator's approval.
+
+The result was a sign-in that could never finish: approve, nothing notices, the code expires, the
+listener is killed, a fresh code appears, repeat. Observed live at 33 reissues over eight hours on
+one account, still running when found — each iteration re-running `codex login` against the
+operator's real Codex account.
+
+Now the isolation variable is per-framework (`CODEX_HOME` for Codex, `GROK_HOME` for grok,
+`CLAUDE_CONFIG_DIR` for Claude, and **nothing** for a framework whose variable instar has not
+verified), and the reissue sweep checks whether a `device-code` login already succeeded — by looking
+for a credential in its slot newer than the login itself — and completes it instead of re-driving.
+
+## What to Tell Your User
+
+- "If a Codex sign-in kept handing you new codes, approve one and it will finish now."
+- "Signing in to Codex no longer disturbs the Codex account already on that machine."
+- "If you connected a Codex account before this fix, its credential may not be in the folder the
+  account list claims — worth a check."
+
+## Summary of New Capabilities
+
+None. This is a bug fix. No new endpoint, no new configuration key, no new behaviour to opt into.
+
+## Compatibility Notes
+
+**The Claude sign-in flow is deliberately untouched.** The success check applies only to
+`device-code` flows. Claude uses `url-code-paste`, which already completes through the dashboard
+route, and a Claude slot's credential file is rewritten by ordinary token refresh — so witnessing it
+could mistake a routine refresh for someone finishing a sign-in. Pinned by a test.
+
+**A credential that predates the sign-in does not count as success.** Re-connecting a slot that still
+holds the previous account's credential re-drives exactly as before, rather than being marked
+instantly complete. Also pinned by a test.
+
+**Every uncertainty preserves the old behaviour.** No witness wired, no credential present, an
+unreadable slot, a probe that throws, an unparseable timestamp — all fall back to issuing a fresh
+code. The check can only ever prevent instar from discarding a sign-in that worked; it cannot strand
+you on a dead code.
+
+**`gemini-cli` and `pi-cli` now get no isolation variable** instead of `CLAUDE_CONFIG_DIR`. Their
+actual behaviour is unchanged — they ignored that variable either way — but the spawned command no
+longer implies an isolation it never provided.
+
+## Evidence
+
+107 tests across the enrolment surface, including 26 in the login-driver unit suite, 44 in the
+enrolment-wizard unit suite, and 12 integration tests driving the real reissue route over a real
+credential file on disk with the witness composed exactly as production composes it.
+
+The isolation-variable defect was proven against the real CLI rather than reasoned about:
+`CLAUDE_CONFIG_DIR` pointed at an empty directory still reported "Logged in using ChatGPT", while
+`CODEX_HOME` pointed at the same directory correctly reported "Not logged in".
+
+Shown capable of failing: inverting the success comparison fails exactly the three behavioural tests
+— completion, the re-enrolment guard, and the restart-recovery path — while the uncertainty and
+flow-kind invariants keep passing. Without those controls, "it completes now" would pass equally well
+against a change that marked every pending login complete on sight.

--- a/upgrades/side-effects/codex-enrollment-reissue-race.md
+++ b/upgrades/side-effects/codex-enrollment-reissue-race.md
@@ -1,0 +1,319 @@
+# Side-Effects Review — Codex enrolment: stop re-asking a sign-in that already succeeded
+
+**Version / slug:** `codex-enrollment-reissue-race`
+**Date:** `2026-08-16`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `Echo — self-review, NOT independent (see "Second-pass review" below for why, and what that costs)`
+
+## Summary of the change
+
+A Codex subscription enrolment looped forever: 33 device codes issued for one sign-in between
+01:00Z and 09:21Z on 2026-08-16, still running when found. Three separate defects compound into
+that loop, and this change fixes all three.
+
+1. **The isolation variable was one the CLI does not read.** `src/commands/server.ts`'s enrolment
+   `spawn` gave every non-grok, non-claude framework `CLAUDE_CONFIG_DIR`. Codex reads `CODEX_HOME`.
+   Verified against the CLI rather than assumed: `CLAUDE_CONFIG_DIR=<empty dir> codex login status`
+   reported *"Logged in using ChatGPT"* (variable ignored, ambient home read), while
+   `CODEX_HOME=<empty dir> codex login status` reported *"Not logged in"*. So every instar-started
+   Codex sign-in ran against the machine's real `~/.codex` while the pool recorded an isolated
+   `configHome` — the mechanism behind the operator's earlier "enrolment signed me out of Codex".
+   The existing round-12 comment already stated the correct rule ("a framework with no known
+   isolation var gets NONE rather than a misleading one"); the code's final `else` branch handed out
+   `CLAUDE_CONFIG_DIR` anyway, and its two trailing ternary branches were identical — a dead branch
+   that is itself evidence the intent was never expressed.
+2. **Nothing detected success.** `complete()` is reached only from HTTP routes. A `url-code-paste`
+   flow (Claude) ends with the operator pasting a code back through the dashboard, which hits such a
+   route. A `device-code` flow (Codex, grok) does not: the operator approves at the provider, the CLI
+   writes its own credential and exits, and instar is never told. The record stayed `pending` forever.
+3. **Every re-drive destroys the pane.** The enrolment `spawn` does `tmux kill-session` on the
+   deterministic pane name before `new-session`, and all three reissue triggers (`reissueExpired`,
+   `recoverAfterRestart`, `refresh`) funnel through `driveLogin`. So the process waiting for the
+   operator's approval was killed on every sweep.
+
+Together: operator approves → nothing notices → TTL elapses → listener killed → new code → repeat.
+
+Files touched: `src/core/FrameworkLoginDriver.ts` (new pure `enrollmentIsolationEnv` +
+`enrollmentCredentialPath`), `src/core/EnrollmentWizard.ts` (new injected `credentialWitness` +
+`completedWithoutTelling` guard in `reissueLogins`), `src/commands/server.ts` (wire both), plus unit
+and integration tests.
+
+## Decision-point inventory
+
+- `EnrollmentWizard.reissueLogins()` — **modify** — gains a precondition: a login whose credential
+  already exists in its slot is completed instead of re-driven. This is the loop's missing
+  terminating condition.
+- `EnrollmentWizard.completedWithoutTelling()` — **add** — the detector answering "did this login
+  already succeed?". Detector only; it never blocks a user action.
+- enrolment `spawn` isolation env (`src/commands/server.ts`) — **modify** — per-framework mapping
+  moved to `enrollmentIsolationEnv`; `codex-cli` corrected to `CODEX_HOME`; frameworks with no
+  verified isolation variable now get none instead of a misleading one.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable** in the user-facing sense: this change rejects
+no input and blocks no message, action, or session.
+
+The nearest analogue is a *false completion*: wrongly deciding a sign-in succeeded would mark an
+account enrolled that never signed in, and leave the operator holding a dead code with no fresh one
+coming. Three properties bound it:
+
+- The credential must be **newer than the login's own `createdAt`**. A slot still holding the
+  previous account's credential — the re-enrolment case — reads as older and is not success. Pinned
+  by `does not mistake a credential that was already in the slot for this sign-in`.
+- Only `device-code` flows are witnessed. `url-code-paste` (Claude) is untouched, which matters
+  because a Claude slot's `.credentials.json` is rewritten by ordinary token refresh; an mtime bump
+  there could plausibly not be this flow. Pinned by `leaves a url-code-paste flow entirely alone`.
+- `enrollmentCredentialPath` returns null for any framework whose credential location instar has not
+  verified, so no guessed path can produce a false witness.
+
+---
+
+## 2. Under-block
+
+**What this still misses:**
+
+- **A credential written by something other than this flow, inside the flow's window.** If an
+  operator manually runs `codex login` in the same slot while an instar enrolment is pending, the
+  enrolment is marked completed on that credential. The outcome is benign — the slot genuinely holds
+  a working credential and the pool row points at it — but the enrolment is credited with a sign-in
+  it did not drive.
+- **Which account signed in is not checked.** The witness proves *a* credential appeared, not that
+  it belongs to the expected email. The follow-me path already has that gate (`completeFollowMe`'s
+  S7 email check via the identity oracle); the plain `complete()` path this change uses does not, and
+  this change deliberately does not add one — widening `complete()`'s contract is a larger change
+  than the loop fix, and the loop is actively burning the operator's real Codex login today.
+- **Timing granularity.** The comparison is `mtime >= createdAt` at whole-millisecond resolution. A
+  credential written in the same millisecond as the login record would read as success. Not
+  reachable in practice (a device-code flow takes seconds at minimum) and it fails toward the
+  *correct* answer anyway.
+- **The pane is still killed for a genuinely-expired login.** That is intended: an expired code has
+  nothing to preserve.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The witness is a **detector at the lowest layer that can answer the question**: one `stat` of a known
+file. It is deliberately not an authority — it does not decide whether an operator may enrol, and it
+does not gate a route.
+
+The layering choice worth defending is *where the framework knowledge lives*. Both the isolation
+variable and the credential path are per-framework facts, and instar already knew them in scattered
+places (`crossModelReviewer`, `codexHookArm`, `codexSpawn`, `ThreadlineBootstrap` all use
+`CODEX_HOME`; `OAuthRefresher` knows Claude's `.credentials.json`). The enrolment spawn was the one
+place that did not, which is exactly how it drifted. Putting both facts in
+`FrameworkLoginDriver.ts` next to the existing `enrollPaneSessionName` single-source-of-truth helper
+keeps the mapping in one testable place rather than inline in a 20k-line `server.ts`, and the two
+helpers are constructed to mirror each other: the credential lands where the isolation env points.
+
+A lower primitive was considered and rejected: reusing `readCodexSlotIdentity`
+(`src/providers/adapters/openai-codex/codexSlotIdentity.ts`), which parses `auth.json` and returns
+the account identity. It answers a richer question than the loop needs, costs a parse, and would
+couple the wizard to a provider adapter. Existence + mtime is the whole question here.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No — this change has no block/allow surface.** The witness is a detector whose only effect is
+  to *withhold a destructive self-action* (kill-pane + mint-new-code). It grants nothing, blocks no
+  operator action, and gates no message.
+
+The direction of failure is the load-bearing property. Every uncertainty — no witness wired, absent
+credential, unreadable slot, probe throws, unparseable timestamp, non-`device-code` flow — returns
+`false`, which is byte-for-byte the previous behaviour. A brittle detector holding block authority is
+the anti-pattern; here brittleness can only ever cause the *old* behaviour to persist, never a new
+refusal. The `it.each` case `re-drives exactly as before when …` pins all three uncertainty paths.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+**No new static heuristic at a competing-signals decision point.** "Does a credential exist in this
+slot, newer than this flow?" is an enumerable factual question with a filesystem answer, not a
+weighing of competing live signals. There is no scenario where evidence pulls both ways and a
+judgment call is needed: the file is there and newer, or it is not. The one genuinely ambiguous case
+(a credential written by a concurrent manual login) is documented under Under-block rather than
+papered over with a heuristic.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the guard runs *before* `driveLogin` inside `reissueLogins`, so on the success path
+  `driveLogin` and `store.reissue` never run. That is the point. Nothing downstream depends on a
+  re-drive having happened — `reissueLogins` returns the reissued list, and callers treat an empty
+  list as "nothing needed refreshing", which is now true in one more case. The three callers
+  (`reissueExpired`, `recoverAfterRestart`, `refresh`) all funnel through this one method, so the
+  fix covers the TTL sweep, the boot recovery, and the dead-pane path together — deliberately, since
+  a server bounce re-driving a succeeded login is the same defect wearing a different trigger
+  (pinned by `protects the restart-recovery and dead-pane paths too`).
+- **Double-fire:** `complete()` is idempotent at the store layer — `transition()` refuses to move a
+  record that is already `completed`/`abandoned`. If the paste-back route and the witness both fire
+  for the same login, the second is a no-op.
+- **Races:** the witness only reads the filesystem; it holds no state and mutates nothing. The
+  subsequent `complete()` goes through the store's existing transition path, unchanged. A login
+  cancelled concurrently is `abandoned` (terminal) and `expired()`/the non-terminal filters exclude
+  it, so it never reaches the witness.
+- **Feedback loops:** this **removes** one. The reissue sweep was a self-triggered controller with no
+  terminating condition reachable by the event it was waiting for. Completion is terminal, so a
+  completed login leaves the sweep's input set permanently. See the Class-Closure Declaration.
+- **`refresh()` and the submit-code route:** the route calls `refresh(id)` when it finds a dead pane
+  and returns `login-expired-fresh-ready`. A pane that died *because the login succeeded* now
+  completes instead, so `refresh()` returns null and the route answers `410 login-expired` rather
+  than handing the operator a fresh code for an account already signed in. That is the more honest of
+  the two answers, though the wording ("start a fresh sign-in") is now slightly off for that case —
+  noted for follow-up rather than silently reworded here, since the message is shared with the
+  genuinely-expired path.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / install base:** the isolation-variable correction changes the *environment of the
+  spawned login process* on every install that enrols a Codex account. This is the intended fix, and
+  it is strictly more correct: previously the credential landed in the ambient home regardless of
+  what the pool recorded.
+- **External systems:** no change to any provider API call, no new network traffic. The witness is
+  one local `stat`.
+- **Persistent state:** no schema change. A login that would previously have sat `pending` forever
+  now reaches `completed` — a status the store already defines and terminates on.
+- **Timing we do not control:** the witness depends on the CLI having flushed its credential to disk
+  before the sweep reads it. If it has not, the sweep re-drives exactly as before and the next sweep
+  catches it. Late is handled; wrong is not introduced.
+- **Operator surface (Mobile-Complete):** no operator-facing action added or changed. The operator's
+  path is unchanged — the enrolment card, its code, and its Cancel button all behave as before. What
+  changes is that a card stops re-issuing codes once its sign-in has landed, which is the behaviour
+  the surface already implied.
+
+---
+
+## 6b. Operator-surface quality
+
+**No operator surface — not applicable.** No dashboard renderer, markup file, approval page, or
+grant/revoke/secret-drop form is touched.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, and the reason is the whole point of the feature: a credential is a file
+on one machine's disk. A sign-in completed on the Mini writes the Mini's `~/.codex`; whether it
+happened is not a question another machine can answer, and must not be. Witnessing a peer's slot
+would be both wrong (the file is not there) and unsafe (it would let one machine mark another's
+enrolment complete).
+
+The enclosing pending-login record is likewise machine-local — it is created by, and drives, a tmux
+pane on one machine. The pool-wide question ("which accounts exist across my machines?") is already
+answered by the existing proxied-on-read `GET /subscription-pool?scope=pool` and the account×machine
+matrix, neither of which this change touches.
+
+- **User-facing notices:** none emitted. No one-voice gating needed.
+- **Durable state on topic transfer:** the pending-login record is not topic-scoped and does not ride
+  a topic move; unchanged by this work.
+- **Generated URLs:** none. The verification URL comes from the provider via the pane scrape, exactly
+  as before.
+
+Verified against the live pair while diagnosing: the laptop and the Mini each hold their own Codex
+slots at different paths, and the stuck login existed on exactly one of them.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the three source files and ship as a patch. Pure code change.
+- **Data migration:** none. No new fields, no schema change.
+- **Agent state repair:** none required. The one state effect is that some pending logins reach
+  `completed` — a pre-existing terminal status. A reverted build would simply stop detecting success
+  and resume re-driving, i.e. the old bug returns; nothing needs undoing.
+- **User visibility:** none during the rollback window. The Codex isolation variable would revert to
+  the wrong one, which is the status quo ante rather than a new regression — though it is worth
+  stating plainly that reverting *re-arms* the behaviour that signs an operator out of their default
+  Codex login, so a revert should be paired with disabling Codex enrolment rather than done blind.
+
+---
+
+## Conclusion
+
+The review changed the design twice. First, the witness was initially scoped by *framework*
+(codex-cli, grok-build); working question 1 surfaced that the real discriminator is the **flow kind**
+— `device-code` completes in the CLI with no paste-back, `url-code-paste` completes through a route
+that already calls `complete()` — so the guard is now keyed on `login.kind`, which is both narrower
+and framework-agnostic. Second, question 1 surfaced the re-enrolment false-positive (a slot still
+holding the previous account's credential), which produced the `mtime >= createdAt` comparison and
+its dedicated test; without that the fix would have marked stale slots enrolled on sight.
+
+Two honest residuals are recorded rather than resolved: the witness does not verify *which* account
+signed in (Under-block), and the `refresh()` route's shared "start a fresh sign-in" wording is now
+slightly off for the already-succeeded case (Interactions). Neither blocks shipping; both are
+narrower than the loop that is currently burning the operator's real Codex login every fifteen
+minutes.
+
+Clear to ship, with the second-pass caveat below stated plainly rather than waived.
+
+---
+
+## Second-pass review (if required)
+
+**Required?** Yes — this change touches session lifecycle (the enrolment pane's spawn/kill) and
+modifies a self-triggered controller, both of which the skill lists as second-pass triggers.
+
+**Reviewer:** Echo — **self-review, not an independent one.**
+
+**Why:** this session runs under a standing operator instruction not to spawn subagents unless
+explicitly requested. Rather than quietly record `not-required` (which would be false) or spawn one
+anyway, the constraint and its cost are stated here: the artifact has had no genuinely independent
+read, so the specific failure mode a second pass exists to catch — the author's own blind spot —
+remains uncovered. The PR is therefore the real review surface for this change, and a reviewer should
+weight questions 1, 2, and 5 accordingly.
+
+**Self-review findings** (applied above, not merely noted): the flow-kind rescope and the
+re-enrolment false-positive guard both came out of this pass. The residual I am least confident about
+is the concurrent-manual-login case in Under-block; I judged it benign, and a second reader should
+check that judgment rather than inherit it.
+
+---
+
+## Evidence pointers
+
+- Empirical proof of the isolation-variable defect (run against the real CLI on the laptop, 2026-08-16):
+  `CLAUDE_CONFIG_DIR=<empty dir> codex login status` → *"Logged in using ChatGPT"*;
+  `CODEX_HOME=<empty dir> codex login status` → *"Not logged in"*.
+- The live loop: pending login `codex-justin`, `reissueCount` 33, `createdAt` 01:00:19Z, still
+  `pending` at 09:21Z with a 15-minute TTL.
+- Negative check: inverting `completedWithoutTelling`'s comparison fails exactly the three
+  behavioural tests (completion, re-enrolment guard, restart path) and nothing else — the tests fail
+  for the reason they exist.
+- `tests/unit/framework-login-driver.test.ts` (26 passing), `tests/unit/enrollment-wizard.test.ts`
+  (44 passing), `tests/integration/subscription-enrollment-routes.test.ts` (12 passing); full
+  enrolment surface 107 passing.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `unbounded-self-action`
+- **`closure`** — `guard`
+- **`guardEvidence`** —
+  - **enforcementType:** `ratchet`
+  - **citation:** `tests/unit/self-action-convergence.test.ts`; guard implemented at
+    `src/core/EnrollmentWizard.ts#completedWithoutTelling`, applied in `reissueLogins`
+  - **howCaught / convergence argument:**
+    - **Control-loop edge:** the reissue sweep re-drives every non-terminal pending login whose TTL
+      has elapsed, on a 5-minute timer, plus once per server boot.
+    - **Steady-state bound:** previously **unbounded** — the loop waited on an event (the operator
+      approving) that it could observe no way, so the event's occurrence did not terminate it;
+      33 iterations were observed and it had no stopping state. The loop now has a terminating
+      condition reachable by the very event it waits for: the credential appearing moves the record
+      to `completed`, which is terminal, so it leaves `expired()` and the non-terminal recovery set
+      permanently. Steady state is one completion, then zero further iterations.
+    - **Settling brake:** completion is a terminal store transition (`PendingLoginStore.transition`
+      refuses to move a `completed`/`abandoned` record), so the login cannot re-enter the loop. The
+      brake engages only on positive evidence — every uncertainty returns `false` and preserves the
+      prior re-drive behaviour — so the brake can stall the loop's *destructive* action but can never
+      itself become a new unbounded action.


### PR DESCRIPTION
## ELI16 — a Codex sign-in you completed kept being thrown away and asked again

Instar can sign you in to a Codex subscription: it shows a short code, you approve it on OpenAI's site, and that account joins your pool.

For one operator that never finished. Instar showed a code, it expired about fifteen minutes later, instar showed another, and it did that **33 times between 1am and 9am** — still going when we found it. Approving correctly changed nothing. Worse, each attempt was quietly operating on the machine's **real** Codex account rather than a private slot, which is almost certainly what signed that operator out of Codex earlier.

Three bugs, all fixed here:

1. **Instar pointed Codex at the wrong folder setting.** It set the one Claude uses; Codex ignores it. Tested rather than assumed — pointed at an empty folder via instar's setting, Codex still reported being logged in; via the setting Codex actually reads, it correctly reported it was not.
2. **Nothing noticed a sign-in had worked.** Claude's flow ends with you pasting a code back, which tells instar it's done. Codex's does not — you approve on OpenAI's site, the Codex program writes its credential and closes, and instar is never told. So the record sat as "still waiting" forever.
3. **Each retry killed the thing waiting for your approval**, then started a fresh one.

Together: approve → nothing notices → it expires → the listener is killed → new code → repeat.

**Why it can't now strand you on a dead code.** Only the Codex-style flow is checked this way; Claude's is left alone, because a Claude folder's credential is rewritten during ordinary token refresh and we didn't want that mistaken for finishing a sign-in. Success needs a credential *newer* than the sign-in attempt, so re-connecting a slot holding the previous account's credential isn't read as instant success. And every way the check can be unsure — unreadable folder, no credential, the check itself erroring, nonsense timestamps — falls back to exactly the old behaviour of issuing a fresh code. It can only ever *prevent* instar discarding a sign-in that worked.

**Honestly still not covered:** it confirms *a* credential appeared, not *whose*. If you signed in to a different Codex account by hand in the same folder while an instar sign-in was pending, instar would credit its own attempt. The account works and the record points at a real credential, so it's harmless — but not strictly accurate.

---

A Codex enrolment looped forever — **33 device codes for one sign-in between 01:00Z and 09:21Z on 2026-08-16**, still running when found, each iteration re-running `codex login` against the operator's **real** Codex account. Three defects compound into that loop; all three are fixed here.

## The three defects

**1. The isolation variable was one the CLI does not read.** The enrolment spawn gave every non-grok, non-claude framework `CLAUDE_CONFIG_DIR`. Codex reads `CODEX_HOME`. Verified against the CLI rather than assumed:

| command | result |
|---|---|
| `CLAUDE_CONFIG_DIR=<empty dir> codex login status` | `Logged in using ChatGPT` — variable ignored, ambient home read |
| `CODEX_HOME=<empty dir> codex login status` | `Not logged in` — variable honoured |

So the login ran against the ambient `~/.codex` while the pool recorded an isolated `configHome`. That is the mechanism behind the operator's earlier "enrolment signed me out of Codex".

The round-12 review on #1905 diagnosed this exact class, wrote the correct rule into the comment — *"a framework with no known isolation var gets NONE rather than a misleading one"* — and fixed it **for grok only**, leaving `codex-cli` on the fallback that same comment forbids. The resulting ternary had two identical trailing branches (`claude-code → CLAUDE_CONFIG_DIR`, `else → CLAUDE_CONFIG_DIR`), a dead branch that is itself the tell: the intent was stated in prose and never expressed in code.

**2. Nothing detected success.** `complete()` is reached only from HTTP routes. A `url-code-paste` flow (Claude) ends with a dashboard paste-back that hits one. A `device-code` flow (Codex, grok) does not — the operator approves at the provider, the CLI writes its credential and exits, and instar is never told. The record stayed `pending` forever.

**3. Every re-drive destroys the pane.** The spawn `kill-session`s the deterministic pane before `new-session`, and all three reissue triggers (`reissueExpired`, `recoverAfterRestart`, `refresh`) funnel through `driveLogin` — so the process waiting for approval was killed on every sweep.

Together: approve → nothing notices → TTL elapses → listener killed → new code → repeat.

## The fix

The per-framework mapping moves into `enrollmentIsolationEnv` + `enrollmentCredentialPath` — pure, testable, beside the existing `enrollPaneSessionName` single-source-of-truth helper, and constructed to mirror each other (the credential lands where the isolation env points). `reissueLogins` gains a precondition: an already-succeeded `device-code` login is completed, never re-driven.

That gives the sweep the terminating condition it never had. It was a self-triggered controller waiting on an event it could observe no way, so the event's occurrence did not stop it. Completion is terminal, so a completed login leaves the loop's input set permanently.

## Why it cannot strand you on a dead code

Scoped by **flow kind, not framework**. `url-code-paste` is untouched — a Claude slot's credential is rewritten by ordinary token refresh, and an mtime bump there may not be this flow.

Success requires a credential **newer than the login's `createdAt`**, so re-enrolling a slot that still holds the previous account's credential is not mistaken for instant success.

Every uncertainty — no witness wired, absent credential, unreadable slot, probe throws, unparseable timestamp — returns `false`, which is the prior behaviour byte-for-byte. The guard can only ever **prevent** a destructive re-ask; it can never cause one.

## Reviewer note — please weight this

Second-pass review **was required** by the skill's criteria (session lifecycle + a self-triggered controller) and is recorded in the artifact as a **self-review, not waived**: this session runs under a standing instruction not to spawn subagents, so the artifact has had no independent read. **This PR is the real review surface.** The residual I am least confident about is the concurrent-manual-login case in the artifact's Under-block section — I judged it benign; please check that judgment rather than inherit it.

Two other honest residuals, recorded rather than resolved: the witness proves *a* credential appeared, not *whose* (the follow-me path has an email gate, the plain `complete()` path does not, and widening it is a larger change than this loop fix); and `refresh()`'s shared "start a fresh sign-in" wording is now slightly off for the already-succeeded case.

## Tests

107 across the enrolment surface — 26 login-driver unit, 44 enrolment-wizard unit, 12 integration driving the real reissue route over a real credential file with the witness composed exactly as production composes it.

**Shown capable of failing:** inverting the success comparison fails exactly the three behavioural tests (completion, re-enrolment guard, restart-recovery) while the uncertainty and flow-kind invariants keep passing. Without those controls, "it completes now" would pass equally well against a change that marked every pending login complete on sight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdrcAeB8zH2xQkQKgL2n6h
