### PR TITLE
fix(init): never create a GitHub repository from a test run

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-16T09-53-56-171Z-init-no-remote-repo-under-test.json
+++ b/.instar/instar-dev-decisions/2026-08-16T09-53-56-171Z-init-no-remote-repo-under-test.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-16T09:53:56.171Z",
+  "slug": "init-no-remote-repo-under-test",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 33,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/init.ts"
+    ],
+    "addedLines": 33,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-16T09-56-21-668Z-init-no-remote-repo-under-test.json
+++ b/.instar/instar-dev-decisions/2026-08-16T09-56-21-668Z-init-no-remote-repo-under-test.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-16T09:56:21.668Z",
+  "slug": "init-no-remote-repo-under-test",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 33,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/init.ts"
+    ],
+    "addedLines": 33,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/init-no-remote-repo-under-test.eli16.md
+++ b/docs/specs/init-no-remote-repo-under-test.eli16.md
@@ -1,0 +1,39 @@
+# Tests must not create real GitHub repositories — Plain-English Overview
+
+> The one-line version: one test has been quietly creating three real repositories on the operator's GitHub account every time it runs, and it has done that 377 times.
+
+## The problem in one breath
+
+Setting up a new agent includes a "back this up to the cloud" step, which creates a private repository on your GitHub account. There is a test that checks new agents are set up correctly, and to do that it really does set one up. It gives the throwaway agent a random name, runs the real setup routine, and then deletes the temporary folder it made. What it never knew is that the setup routine also reached out to GitHub and made a real repository — and deleting a folder does not delete that. It has been doing this since the middle of June.
+
+## What already exists
+
+- **The setup routine** — the code that creates a new agent: writes its files, gives it an identity, and offers to back it up to the cloud. It is one routine, used by real installs and by tests alike.
+- **The cloud-backup step inside it** — starts a local repository, checks the GitHub command-line tool is present and signed in, then creates a private repository named after the agent. When nobody is at the keyboard to answer, it assumes yes, because that is the right default for a real person installing the software.
+- **The tests that call it** — seven files. They are careful about the filesystem: each redirects the agent's home to a temporary folder and deletes it afterwards. None of them were careful about the network, because nothing told them there was a network.
+
+## What this adds
+
+The setup routine now recognises when it is being run by a test, and skips the cloud-backup step entirely in that case. It says so on screen rather than skipping silently, so nobody is left wondering why their backup did not appear.
+
+That is the whole change. The important part is *where* it is: in the setup routine, not in the test.
+
+## The new pieces
+
+- **A "is this a test run?" check** — reads two well-known markers that testing tools set on the environment. It deliberately does **not** treat "this is running in CI" as a test, because someone's own automation might legitimately install an agent and would genuinely want the backup. Getting that distinction wrong would have quietly removed a real feature from real users.
+
+## The safeguards
+
+**Stops the leak at the only place it can happen.** Fixing the one test that was traced would have left the other six, and every test written afterwards, free to do exactly the same thing. There is one place in the code that reaches out to GitHub, so that is where the check goes. Nobody has to remember anything.
+
+**Does not take backups away from real people.** The check is false in any normal run, so a real installation behaves exactly as it did before, down to the same output. The one environment that might have looked like a test — continuous integration — is explicitly excluded, and there is a test holding that exclusion in place.
+
+**Proven to actually catch the problem.** The new test was deliberately run with the fix disabled to confirm it fails, and it does. That check was performed with the GitHub tool signed out, so the experiment itself could not create another repository — the account had 378 repositories before and 378 after.
+
+## What ships when
+
+One change, one pull request, no staged rollout and no setting to turn on. There is nothing to configure and nothing to migrate.
+
+## What you actually need to decide
+
+Two separate things. First: ship this fix, so no future test can create repositories on your account — yes or no. Second, and independently: whether to delete the 377 empty repositories that already exist. This change deliberately leaves them alone, because deleting repositories cannot be undone and the account is yours.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1204,6 +1204,29 @@ async function initStandaloneAgent(agentName: string, options: InitOptions): Pro
 // ── Cloud Backup Setup ──────────────────────────────────────────────
 
 /**
+ * True when this process is an automated test run.
+ *
+ * `initProject` is called by seven test files, and its cloud-backup step ends in
+ * `gh repo create` against whatever GitHub account the ambient CLI is authenticated
+ * as. Tests isolate the FILESYSTEM (they redirect HOME to a temp dir) but nothing
+ * isolated the NETWORK, so every run of those tests created real private repos on
+ * the operator's account and the temp-dir cleanup never knew they existed. That is
+ * how 377 empty `instar-*-test-<random>` repos accumulated on one account between
+ * 2026-06-14 and 2026-08-15 — three per run of a single unit test.
+ *
+ * The guard lives here rather than in the tests deliberately (Structure > Willpower):
+ * fixing the one test that happened to be noticed leaves the other six, and any test
+ * written later, free to do it again.
+ *
+ * Vitest sets `VITEST`; `NODE_ENV=test` covers other runners. `CI` is deliberately
+ * NOT a signal — a genuine `instar init` in someone's automation should still get
+ * its backup.
+ */
+export function isAutomatedTestRun(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !!env.VITEST || env.NODE_ENV === 'test';
+}
+
+/**
  * Set up cloud backup for a standalone agent.
  *
  * Philosophy: Users expect their data to be backed up. If the machine crashes,
@@ -1218,6 +1241,16 @@ async function initStandaloneAgent(agentName: string, options: InitOptions): Pro
  * 5. Create private repo automatically
  */
 async function setupCloudBackup(projectDir: string, stateDir: string, agentName: string): Promise<void> {
+  // A test run gets no cloud backup at all. Returning before the local git work as
+  // well as the remote call keeps the skip on one obvious line — no test asserts on
+  // backup artifacts, and a half-configured local repo with no remote would be a
+  // stranger state to reason about than none.
+  if (isAutomatedTestRun()) {
+    console.log();
+    console.log(pc.dim('  Cloud backup skipped — automated test run (no GitHub repository is created).'));
+    return;
+  }
+
   console.log();
   console.log(pc.bold('  Cloud Backup (recommended)'));
   console.log(pc.dim('  Backs up your agent data to the cloud so nothing is lost if this machine crashes.'));

--- a/tests/unit/init-cloud-backup-test-guard.test.ts
+++ b/tests/unit/init-cloud-backup-test-guard.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression guard: `instar init` must never create a real GitHub repository from a
+ * test run.
+ *
+ * `initProject`'s standalone path ends its cloud-backup step in `gh repo create`
+ * against whatever account the ambient `gh` CLI is authenticated as. Seven test files
+ * call `initProject`, and they isolate the FILESYSTEM (HOME is redirected to a temp
+ * dir) but nothing isolated the NETWORK — so each run created real private repos on
+ * the operator's account, and the temp-dir cleanup never knew they existed. 377 empty
+ * `instar-*-test-<random>` repos accumulated on one account between 2026-06-14 and
+ * 2026-08-15, three per run of a single unit test.
+ *
+ * The guard is in the setup routine rather than in the tests on purpose: patching the
+ * one test that was noticed leaves the other six, and every test written after it,
+ * free to do the same thing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { initProject, isAutomatedTestRun } from '../../src/commands/init.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('isAutomatedTestRun', () => {
+  it('detects vitest and NODE_ENV=test', () => {
+    expect(isAutomatedTestRun({ VITEST: 'true' })).toBe(true);
+    expect(isAutomatedTestRun({ NODE_ENV: 'test' })).toBe(true);
+  });
+
+  it('is false for an ordinary run', () => {
+    expect(isAutomatedTestRun({})).toBe(false);
+    expect(isAutomatedTestRun({ NODE_ENV: 'production' })).toBe(false);
+  });
+
+  // CI is deliberately not a signal: a genuine `instar init` inside someone's own
+  // automation should still get the backup it asked for.
+  it('does NOT treat CI alone as a test run', () => {
+    expect(isAutomatedTestRun({ CI: 'true' })).toBe(false);
+    expect(isAutomatedTestRun({ CI: '1', GITHUB_ACTIONS: 'true' })).toBe(false);
+  });
+
+  it('reads the live environment by default, which is a test run here', () => {
+    expect(isAutomatedTestRun()).toBe(true);
+  });
+});
+
+describe('standalone init under a test run', () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-backup-guard-'));
+    prevHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    SafeFsExecutor.safeRmSync(tmpHome, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/init-cloud-backup-test-guard.test.ts',
+    });
+  });
+
+  // The cloud-backup step is the ONLY thing that runs `git init` on the standalone
+  // path, so an absent `.git` is the observable proof that the step did not run —
+  // and therefore that `gh repo create` was never reached. Asserting on the absence
+  // of a local artifact keeps the test honest without stubbing the network, which
+  // would only prove the stub works.
+  it('creates the agent WITHOUT running the cloud-backup step', async () => {
+    const agentName = 'backup-guard-test-' + Math.random().toString(36).slice(2, 8);
+    await initProject({
+      name: agentName,
+      standalone: true,
+      port: 4098,
+      skipPrereqs: true,
+    });
+
+    const agentDir = path.join(tmpHome, '.instar', 'agents', agentName);
+    expect(fs.existsSync(agentDir)).toBe(true);
+    expect(fs.existsSync(path.join(agentDir, '.git'))).toBe(false);
+  });
+});

--- a/upgrades/next/init-no-remote-repo-under-test.md
+++ b/upgrades/next/init-no-remote-repo-under-test.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Setting up a new agent includes a cloud-backup step that creates a private GitHub repository on
+whatever account the `gh` CLI is signed in as. Seven test files call that same setup routine, and
+they were careful about the filesystem — each redirects the agent home to a temporary folder and
+deletes it afterwards — but nothing was careful about the network.
+
+So every run of those tests created real private repositories on the signed-in account, and the
+temp-folder cleanup never knew they existed. On the account where this was found: 378 repositories,
+377 of them auto-generated and empty, three per run of a single unit test, accumulating from
+2026-06-14 to 2026-08-15.
+
+The setup routine now recognises a test run and skips cloud backup entirely, saying so on screen
+rather than skipping silently. The guard lives in the setup routine rather than in the tests
+deliberately: fixing only the test that was traced would leave the other six, and every test written
+later, free to do the same thing.
+
+## What to Tell Your User
+
+- "If your GitHub account has filled up with empty repositories whose names start with instar and
+  end in test plus random letters, this was the cause. It stops now."
+- "This does not change anything about a real install — your backup still gets set up exactly as
+  before."
+- "The repositories already created are still there. Deleting them is your call, and I won't touch
+  them without you saying so."
+
+## Summary of New Capabilities
+
+None. This removes an unintended side effect — no new endpoint, no configuration, no permission.
+
+## Compatibility Notes
+
+**A real install is byte-identical.** The guard reads two markers that testing tools set (`VITEST`,
+`NODE_ENV=test`), neither of which is present in a normal run.
+
+**`CI` is deliberately not treated as a test run.** Someone whose own automation runs `instar init`
+inside CI genuinely wants the backup, and treating `CI` as "this is a test" would have silently
+taken a real feature away from them. A test pins that exclusion.
+
+**Existing repositories are untouched.** This change stops new ones being created; it does not
+delete anything. Removing repositories is irreversible and belongs to the account owner.
+
+## Evidence
+
+`tests/unit/init-cloud-backup-test-guard.test.ts` — both branches of the predicate, the explicit
+`CI` exclusion, and a standalone init leaving no `.git` directory, which is the observable proof
+that the backup step never ran.
+
+Shown capable of failing: with the guard forced off, the behavioural test fails on the `.git`
+assertion. That probe was run with `gh` deliberately signed out, so it provably stopped at the auth
+step and created no repository — the account count was 378 before and after.

--- a/upgrades/side-effects/init-no-remote-repo-under-test.md
+++ b/upgrades/side-effects/init-no-remote-repo-under-test.md
@@ -1,0 +1,142 @@
+# Side-Effects Review — init does not create a GitHub repository from a test run
+
+**Version / slug:** `init-no-remote-repo-under-test`
+**Date:** `2026-08-16`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required — see Phase 5 note below`
+
+## Summary of the change
+
+`initProject`'s standalone path calls `setupCloudBackup`, which runs `git init` and then `gh repo create instar-<agentName> --private` against whatever account the ambient `gh` CLI is authenticated as. Seven test files call `initProject`. They isolate the filesystem — HOME is redirected to a temp dir that is removed afterwards — but nothing isolated the network, so each run created a real private repository on the operator's GitHub account and the temp-dir cleanup never learned one existed.
+
+This adds an exported predicate `isAutomatedTestRun()` and makes `setupCloudBackup` return immediately when it is true. Files touched: `src/commands/init.ts`, plus `tests/unit/init-cloud-backup-test-guard.test.ts`.
+
+Measured on the affected account: 378 owned repositories, of which 377 are auto-generated — `instar-codex-only-test-*` (126), `instar-default-test-*` (126), `instar-both-test-*` (125), all 0 KB and private, accumulating from 2026-06-14 to 2026-08-15. Three per run of `tests/unit/init-claude-gating.test.ts`.
+
+## Decision-point inventory
+
+- `setupCloudBackup` entry (run / skip) — **add** — a test run skips cloud backup entirely.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Any genuine `instar init` that happens to run with `VITEST` set or `NODE_ENV=test` in its environment would silently lose its cloud backup. In practice `VITEST` is set only by the vitest runner in its own process, and `NODE_ENV=test` is a deliberate marker; neither is plausible in a real user install.
+
+`CI` is deliberately **not** a signal, and this is the case worth calling out because it was the tempting one. A user whose own automation runs `instar init` in GitHub Actions genuinely wants the backup, and treating `CI` as "this is a test" would have taken it away from them. Covered by a test asserting `CI=true` alone does not trip the guard.
+
+The skip is loud, not silent — it prints `Cloud backup skipped — automated test run (no GitHub repository is created).` so a surprised operator can see why.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **A test runner that sets neither marker.** A future test invoked by a runner that sets neither `VITEST` nor `NODE_ENV=test` would create repos again. The two markers cover every runner currently in the repo; a third runner would need adding here.
+- **Other external side effects on the init path are untouched.** This closes the GitHub-repo one, which is the one with a persistent, account-level, human-visible cost. If another step later reaches an external service, it needs its own guard — the predicate is exported so it can be reused rather than re-derived.
+- **The 377 repositories already created are not removed.** Deleting repositories is irreversible and they belong to the operator; the cleanup is theirs to authorize, and this change deliberately does not touch them. Tracked as an operator decision, not deferred work in the code: the code defect is fully closed here.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The guard sits at the top of `setupCloudBackup` rather than in the tests, and that is the whole point. Patching `tests/unit/init-claude-gating.test.ts` — the file that happened to be traced back — would have left the other six callers and every test written afterwards free to do the same thing. This is the *Structure > Willpower* choice: the one place that reaches GitHub refuses to do so under a test, so no test author has to remember.
+
+It could alternatively have been an `InitOptions` flag that tests pass. That was rejected for the same reason: an opt-in that a test author must remember to set is the willpower version of the same fix.
+
+Returning before `git init` rather than only before `gh repo create` is deliberate. No test asserts on backup artifacts, and a half-configured local repo with no remote would be a stranger state to reason about than no repo at all.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+There is no decision about agent behavior, information flow, or a user action here. It is an environment check that suppresses one of `init`'s own side effects during a test. It gates nothing an agent or user is trying to do, produces no verdict anything else consumes, and cannot block a message, action, or session.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. "Is this process a test run" is not a weighing of live signals — it is a two-value environment read with an enumerable domain (`VITEST`, `NODE_ENV=test`), and there are no competing signals to arbitrate between.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the guard runs before every other step in `setupCloudBackup`, so under a test it shadows all of them. That is the intent, and under a real run it is a no-op that changes nothing about the existing ordering.
+- **Double-fire:** none. `setupCloudBackup` has a single call site (`initStandaloneAgent`).
+- **Races:** none. Pure environment read, no shared state.
+- **Feedback loops:** this removes one. Each test run added repositories to the account the next test run authenticated against; nothing consumed or bounded that growth.
+- **Existing tests:** `tests/integration/fresh-install.test.ts` asserts a `.git` directory exists after init, but it uses the **non-standalone** path, which never calls `setupCloudBackup` and creates its git repo elsewhere. Verified by running it — unaffected.
+
+---
+
+## 6. External surfaces
+
+- **External systems:** this is the entire point — the GitHub API is no longer called during test runs. That is a removal of an unintended external effect, not a new one.
+- **Real users:** no change. A genuine `instar init` behaves byte-identically; the guard is false in every non-test process.
+- **Persistent state:** stops creating persistent state (repositories) on the operator's GitHub account. Creates none.
+- **Other agents / install base:** none.
+- **Timing:** none.
+- **Operator surface (Mobile-Complete):** no operator-facing action added or touched.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. No dashboard renderer, markup, approval page, or form is touched.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local BY DESIGN.** The check reads the environment of the single process running `instar init`. "Is this process a test run" is a fact about one process on one machine and has no meaning to replicate — a peer machine's answer would say nothing about this one's. There is no cross-machine question this could answer, so replication or a merged read would be noise, not coherence.
+
+- **User-facing notices:** one line on stdout during a test run. No messaging surface, so no one-voice gating.
+- **Durable state:** none held; the change only prevents durable state (repositories) being created. Nothing to strand on topic transfer.
+- **URLs:** none generated.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit, ship as a patch. Pure code change, one function plus a guard clause.
+- **Data migration:** none. Nothing persistent is written or read.
+- **Agent state repair:** none. No deployed agent's state depends on this.
+- **User visibility during rollback:** none for users. The visible consequence of a revert is that test runs would resume creating junk repositories on whichever account CI is authenticated as.
+
+---
+
+## Conclusion
+
+The review changed one thing: the first draft treated `CI` as a test signal, which would have silently removed cloud backup from any user running `instar init` inside their own CI. That was narrowed to the two markers that actually mean "a test runner is executing this", and the exclusion is now pinned by a test.
+
+The change is clear to ship. The residual is that the 377 repositories already on the operator's account still exist; that cleanup is an irreversible action on their property and belongs to them, not to this change.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required.
+
+The Phase 5 trigger list covers block/allow decisions on messaging or dispatch, session lifecycle, context exhaustion, coherence gates, idempotency checks, trust levels, and anything named sentinel/guard/gate/watchdog. This touches none: it suppresses one of `init`'s own external side effects during test runs and has no authority over any agent or user action.
+
+---
+
+## Evidence pointers
+
+- Account census: 378 owned repositories, 377 auto-generated across three `instar-*-test-<random>` families, all 0 KB, dated 2026-06-14 to 2026-08-15.
+- Origin traced to `tests/unit/init-claude-gating.test.ts` → `initProject({ standalone: true })` → `setupCloudBackup` → `execFileSync(gh, ['repo','create', 'instar-'+agentName, '--private', '--source', projectDir])`.
+- `tests/unit/init-cloud-backup-test-guard.test.ts` — predicate true/false branches, `CI` explicitly excluded, and a standalone init leaving no `.git` (the observable proof the backup step never ran).
+- **Shown capable of failing:** with the guard forced to `false`, the behavioural test fails with `expected true to be false` on the `.git` assertion. The probe was run with `gh` deliberately unauthenticated (`GH_CONFIG_DIR` pointed at an empty directory), so the run provably stopped at the auth step and created no repository — the account count was 378 before and after.


### PR DESCRIPTION
## ELI16 — one test has been quietly creating real GitHub repositories, 377 of them

Setting up a new agent includes a "back this up to the cloud" step, which creates a private repository on whatever GitHub account the machine is signed in as. There is a test that checks new agents get set up correctly, and to do that it really does set one up: it invents a random name, runs the real setup routine, and deletes the temporary folder afterwards.

What it never knew is that the setup routine also reached out to GitHub and made a real repository. Deleting a folder does not delete that. It has been doing this three times per run since the middle of June — 377 empty repositories on one account, alongside a single real one.

The fix is for the setup routine to recognise when a test is running it, and skip the cloud-backup step entirely — saying so on screen rather than skipping silently.

The important part is where the fix lives. Seven test files call that same setup routine. Fixing only the one that was traced would leave the other six, and every test written afterwards, free to do exactly the same thing. There is one place in the code that reaches out to GitHub, so that is where the check goes, and nobody has to remember anything.

One deliberate subtlety: "this is running in continuous integration" is *not* treated as a test. Someone's own automation might legitimately install an agent and would genuinely want the backup, so taking it away from them would have been a real regression. There is a test holding that exclusion in place.

The repositories that already exist are untouched. Deleting repositories cannot be undone, and the account belongs to the operator — that cleanup is their decision, not this change's.

## What was wrong

`initProject`'s standalone path calls `setupCloudBackup`, which runs `git init` and then `gh repo create instar-<agentName> --private` against whatever account the ambient `gh` CLI is signed in as.

Seven test files call `initProject`. They isolate the **filesystem** — HOME is redirected to a temp dir that is removed afterwards — but nothing isolated the **network**. So every run created a real private repository on the operator's account, and the temp-dir cleanup never knew one existed.

Measured on the affected account: **378 owned repositories, 377 of them auto-generated and empty** — `instar-codex-only-test-*` (126), `instar-default-test-*` (126), `instar-both-test-*` (125), all 0 KB and private, accumulating 2026-06-14 → 2026-08-15. Three per run of `tests/unit/init-claude-gating.test.ts`.

## The fix

`setupCloudBackup` returns immediately under a test run, and says so rather than skipping silently.

The guard is in the **setup routine**, not in the tests. That is the point: patching the one test that was traced leaves the other six — and every test written later — free to do the same thing. One place reaches GitHub, so that is where the check goes, and no test author has to remember (*Structure > Willpower*).

Returning before `git init` as well as before the remote call keeps the skip on one obvious line; no test asserts on backup artifacts, and a half-configured local repo with no remote would be a stranger state than none.

## `CI` is deliberately not a signal

Only `VITEST` and `NODE_ENV=test` count. Someone whose own automation runs `instar init` inside GitHub Actions genuinely wants their backup, and treating `CI` as "this is a test" would have silently taken a real feature from them. Pinned by a test.

## Tests

`tests/unit/init-cloud-backup-test-guard.test.ts` — both predicate branches, the explicit `CI` exclusion, and a standalone init leaving no `.git` directory (the observable proof the backup step never ran, without stubbing the network — which would only prove the stub works).

**Shown capable of failing:** with the guard forced to `false`, the behavioural test fails with `expected true to be false` on the `.git` assertion. That probe was run with `gh` deliberately signed out (`GH_CONFIG_DIR` pointed at an empty directory) so it provably stopped at the auth step and created no repository — the account count was 378 before and after.

## Not included, on purpose

The 377 repositories that already exist are untouched. Deleting repositories is irreversible and the account belongs to the operator; that cleanup is their decision, not this change's. The code defect is fully closed here.

`npx tsc --noEmit` clean. Side-effects review: `upgrades/side-effects/init-no-remote-repo-under-test.md`. Plain-English overview: `docs/specs/init-no-remote-repo-under-test.eli16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
