### PR TITLE
fix: require independently ratified standards direction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,15 @@ jobs:
           else
             echo "required=0" >> "$GITHUB_OUTPUT"
           fi
+          git show "$BASE_SHA:docs/STANDARDS-REGISTRY.md" > "$RUNNER_TEMP/standards-registry-base.md"
+          git show "$BASE_SHA:.github/keyrings/telegram-principal-pub.pem" > "$RUNNER_TEMP/standards-direction-approver-base.pem"
       - run: node scripts/standards-coverage.mjs --check
         env:
           STANDARDS_AREA_AUDIT_BASE_FILE: ${{ runner.temp }}/standards-area-audits-base.json
           STANDARDS_AREA_AUDIT_BASE_REQUIRED: ${{ steps.area-audit-base.outputs.required }}
+          STANDARDS_DIRECTION_BASE_FILE: ${{ runner.temp }}/standards-registry-base.md
+          STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE: ${{ runner.temp }}/standards-direction-approver-base.pem
+          STANDARDS_DIRECTION_BASE_REVISION: ${{ github.event.pull_request.base.sha || github.event.before || format('{0}^', github.sha) }}
       - name: Migration consumer lockstep
         run: node scripts/lint-migration-consumer-completeness.js --diff-base "${{ github.event.pull_request.base.sha || github.event.before }}"
       - name: Upload coverage report

--- a/.instar/instar-dev-decisions/2026-08-17T17-48-53-053Z-phaseb-s5-rule-direction.json
+++ b/.instar/instar-dev-decisions/2026-08-17T17-48-53-053Z-phaseb-s5-rule-direction.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-08-17T17:48:53.053Z",
+  "slug": "phaseb-s5-rule-direction",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 551,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/standards-coverage.mjs",
+      "scripts/standards-direction-guard.mjs"
+    ],
+    "addedLines": 542,
+    "deletedLines": 9
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The existing coverage design bound candidate-authored review evidence to changed bytes but never modeled article continuity, amendment direction, or independent ratification."
+  },
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "gate",
+      "citation": "scripts/standards-direction-guard.mjs#evaluateStandardsDirection",
+      "howCaught": "The old family refresh is only candidate self-report; without an exact independently signed direction record, removals and weakenings remain refused, and candidate trust-root drift is separately blocked."
+    },
+    "component": "standards-coverage"
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-17T17-51-01-987Z-phaseb-s5-rule-direction.json
+++ b/.instar/instar-dev-decisions/2026-08-17T17-51-01-987Z-phaseb-s5-rule-direction.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-08-17T17:51:01.987Z",
+  "slug": "phaseb-s5-rule-direction",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 551,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/standards-coverage.mjs",
+      "scripts/standards-direction-guard.mjs"
+    ],
+    "addedLines": 542,
+    "deletedLines": 9
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The existing coverage design bound candidate-authored review evidence to changed bytes but never modeled article continuity, amendment direction, or independent ratification."
+  },
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "gate",
+      "citation": "scripts/standards-direction-guard.mjs#evaluateStandardsDirection",
+      "howCaught": "The old family refresh is only candidate self-report; without an exact independently signed direction record, removals and weakenings remain refused, and candidate trust-root drift is separately blocked."
+    },
+    "component": "standards-coverage"
+  },
+  "verdict": "pass"
+}

--- a/docs/STANDARDS-DIRECTION-GUARD.md
+++ b/docs/STANDARDS-DIRECTION-GUARD.md
@@ -1,0 +1,45 @@
+# Standards direction guard
+
+The standards pipeline compares every Rule-bearing article with the protected-base
+registry. Additions, removals, and edits require a direction ratification bound to
+the exact base revision, registry hashes, article identity, and before/after article
+hashes. An edit declares `strengthen`, `neutral`, or `weaken`; the declaration has no
+authority until its Ed25519 signature verifies.
+
+## Trust boundary
+
+The approver public key is read from the protected-base revision at
+`.github/keyrings/telegram-principal-pub.pem`. CI extracts that exact file from the
+base SHA before running the check. The candidate checkout's copy is never a trust
+source, so replacing the candidate key and signing with the replacement does not
+authorize a change. Candidate pin bytes are also compared with protected base and
+any drift is refused even when the registry itself is unchanged. This closes a
+two-step attack where a pin-only change lands first and authorizes a later weakening.
+
+Bootstrap and rotation are consequently not self-service repository changes. They
+require an explicitly separate protected-main control-plane authorization that can
+bypass this one immutable-pin check; ordinary PR CI always refuses the drift. Once a
+real pin exists, changing it through an ordinary candidate is never accepted merely
+because that candidate supplies a matching signature.
+
+The corresponding private key must remain outside the repository, agent-readable
+credential stores, and build environment. The current fleet file is a comments-only
+placeholder: no production approver key is configured, and therefore every standards
+change fails closed until an independently controlled key is deliberately installed
+in protected main. The test suite uses ephemeral fixture keys only; none are reusable
+approval credentials.
+
+## Identity and rename cost
+
+An explicit `Article ID` is authoritative. Existing articles that predate explicit IDs
+receive a deterministic legacy identity derived from family and heading. Renaming one
+of those headings is deliberately conservative: it appears as one removal plus one
+addition, and both require independent ratification. That review friction is the cost
+of preventing a rename from resetting constitutional identity.
+
+## Approval ledger
+
+Candidate ratifications live in `docs/standards-direction-approvals.json`. The ledger
+is declarative evidence, not a trust root. A stale, forged, self-signed, wrong-base,
+wrong-article, or replayed record is rejected. A legitimate strengthening follows the
+same signed path as a weakening; the guard does not use keywords to infer prose meaning.

--- a/docs/specs/phaseb-s5-rule-direction.eli16.md
+++ b/docs/specs/phaseb-s5-rule-direction.eli16.md
@@ -1,0 +1,68 @@
+# Standards direction guard — plain-English overview
+
+> The one-line version: changing Instar's rulebook must say whether the change
+> strengthens, preserves, weakens, adds, or removes an obligation, and a second
+> trusted principal must ratify the exact change.
+
+## The problem in one breath
+
+The standards checker noticed that rulebook text changed, but it did not know
+whether the change made a rule stronger or weaker. Worse, deleting an unguarded
+rule improved the score because the deleted rule disappeared from the number
+being measured. In both cases the person making the change could write a fresh
+"I reviewed this" record and clear the only objection.
+
+## What already exists
+
+- **A standards registry** — 88 articles, each with a normative Rule field.
+- **A coverage ratchet** — CI measures how many articles name real enforcement
+  and refuses numerical regressions.
+- **Family audit records** — exact content hashes reveal an unacknowledged edit,
+  but the changer can refresh those records without independent authority.
+
+## What this adds
+
+Every Rule-bearing article now has a stable identity. Additions and removals are
+mechanical facts, while edits carry an explicit direction. A ratification is
+valid only when a separately held Ed25519 key signs the exact base revision,
+the before and after article hashes, the declared direction, and the approver's
+identity and time. Replaying the signature after changing one byte fails.
+
+The score's denominator also keeps the union of the old and new article sets.
+Deleting an article therefore cannot make a smaller constitution look better.
+The candidate-only score is still reported for visibility but cannot satisfy the
+floor.
+
+## The safeguards
+
+**The changer cannot move the goalposts.** The approver public key is read from
+protected main, alongside the protected article inventory. Replacing the public
+key in the proposed change and signing with the matching attacker key is refused.
+A pin-only change is refused too, closing the two-commit version of that attack.
+Installing or rotating the real pin therefore needs a separately authorized
+protected-main control-plane action, never an ordinary self-authorizing change.
+
+**The checker does not pretend to understand prose.** Code does not guess that
+"should" is weaker than "must." A human declares the semantic direction and an
+independent principal ratifies the exact bytes. Mechanical facts stay mechanical;
+judgment stays with an accountable principal.
+
+**Unknown never means clean.** Missing base input, an empty article population,
+malformed evidence, candidate pin drift, or an unavailable file produces
+`not-proven` and makes CI fail. A comments-only or malformed protected key can
+pass an unchanged registry, but it cannot validate any amendment signature, so
+every rulebook change remains blocked.
+
+## What ships when
+
+The direction guard, continuity denominator, CI protected-base extraction,
+approval ledger, documentation, and tests ship as one change. The repository's
+current public-key file contains no operational key, so rulebook amendments are
+blocked until an independently controlled public key is installed on protected
+main. Its private half must never be available to repository-changing agents or
+the build environment.
+
+## What you actually need to decide
+
+Approve the hybrid boundary: code determines identity and population changes,
+while independently signed declarations carry semantic direction.

--- a/docs/specs/phaseb-s5-rule-direction.md
+++ b/docs/specs/phaseb-s5-rule-direction.md
@@ -1,0 +1,118 @@
+---
+title: "A Standards Change Must Carry Its Direction"
+slug: "phaseb-s5-rule-direction"
+author: "instar-codey"
+parent-principle: "Structure beats Willpower"
+eli16-overview: "phaseb-s5-rule-direction.eli16.md"
+lessons-engaged: "Structure beats Willpower; Honest Denominators; Verify the State, Not Its Symbol; Signal vs Authority"
+approved: true
+approved-by: "Pathway, Phase B orchestrator (topic 29723)"
+approved-date: "2026-08-17"
+review-convergence: "2026-08-17T17:30:00.000Z"
+review-iterations: 3
+review-completed-at: "2026-08-17T17:30:00.000Z"
+review-report: "docs/specs/reports/phaseb-s5-rule-direction-convergence.md"
+single-run-completable: true
+frontloaded-decisions: 4
+cheap-to-change-tags: 0
+contested-then-cleared: 3
+---
+
+# A standards change must carry its direction
+
+## Operator intent
+
+Phase B lane S5 reproduced two ways the live standards-coverage ratchet could
+be made to approve a weaker constitution. Deleting an unguarded article raised
+the aggregate score because the item left its own denominator. Rewriting the
+foundational obligation as optional kept every score unchanged. In both cases,
+the changer could refresh the existing content attestation and make CI green.
+
+The guard must distinguish a mechanical removal from an edit, keep removed
+articles in the continuity denominator, and require direction-bearing
+ratification that the changer cannot author alone. It must run through the
+existing standards-coverage pipeline and fail closed when either the protected
+base or the approval trust root cannot be read.
+
+## Grounded current state
+
+The existing script parses 88 Rule-bearing articles, grades named enforcement
+references, and binds each family audit to its current digest. It does not give
+articles immutable identities, preserve a population after deletion, or bind a
+review to an edit direction. Its existing family evidence is written in the
+candidate tree by the same principal making the change.
+
+The repository's approver key file is presently a comments-only placeholder.
+This change therefore ships fail-closed for constitutional amendments until an
+independently controlled Ed25519 public key is committed to protected main. The
+matching private key must remain outside the repository, agent-readable
+credential stores, and build environments.
+
+## Decisions
+
+### 1. Hybrid direction model
+
+Addition and removal are computed mechanically from stable article identity.
+Edits declare one of `strengthen`, `neutral`, or `weaken`; the declaration is
+accepted only when an independent Ed25519 signature covers the exact protected
+base revision, both registry hashes, article identity, before/after summaries,
+direction, approver identity, and timestamp. The guard does not infer semantic
+strength from prose or keywords.
+
+### 2. Article identity and rename cost
+
+An explicit Article ID is immutable. Existing articles without one receive a
+deterministic legacy identity derived from family and heading. A legacy heading
+rename is consequently remove-plus-add and requires independent ratification.
+That friction is deliberate and documented: identity changes cannot silently
+erase continuity.
+
+### 3. Protected-base trust root
+
+Both the article inventory and approver public key are read from the protected
+base, never from candidate bytes. Replacing the candidate key and signing with
+its matching private key must still fail. Candidate pin drift itself must fail,
+including a pin-only change with no registry delta, so an attacker cannot move
+the goalposts in one commit and weaken the rulebook in the next. Bootstrap or
+rotation requires an explicitly separate protected-main control-plane action;
+an ordinary candidate cannot authorize its own future authority. The CI workflow
+extracts both protected inputs from the base revision before invoking the guard.
+
+### 4. Honest continuity denominator
+
+The aggregate and family ratios use the union of protected-base and candidate
+article identities as their denominator. A removal remains represented and can
+never improve a headline ratio merely by leaving the candidate population. The
+current-population ratio remains separately visible and holds no floor authority.
+
+## Decision points touched
+
+- Standards-change acceptance is a deterministic policy authority over a closed
+  domain: exact identities, hashes, signature validity, and declared direction.
+- Semantic direction remains human judgment. The code verifies the declaration
+  and its independent ratification; it does not classify prose.
+- Unknown input, missing base material, empty population, malformed approval,
+  or unreadable trust root yields `not-proven` and a failing pipeline exit.
+
+## Acceptance criteria
+
+1. The real standards-coverage entry point passes on the pristine registry.
+2. An article deletion fails as `REMOVAL`, keeps the continuity denominator at
+   88, and cannot be cleared by refreshing the old family attestation.
+3. A foundational weakening fails as `WEAKENING` and cannot be cleared by the
+   old self-authored attestation.
+4. A valid strengthening signed by an independent fixture principal passes.
+5. Replacing the candidate trust pin with an attacker key and signing with its
+   private key fails because verification uses the protected-base pin.
+6. A pin-only candidate change fails before it can become the next protected
+   base authority.
+7. The five-property battery and all four negative controls bite with the
+   type-preserving hollow producing executed assertion failures.
+8. CI extracts the registry and approver pin from its protected base and invokes
+   the wired guard through `scripts/standards-coverage.mjs --check`.
+
+## Rollback
+
+Revert the guard module, coverage-script integration, CI extraction steps,
+approval ledger, documentation, and tests together. No migration or runtime
+state repair is required. The old coverage behavior returns immediately.

--- a/docs/specs/reports/phaseb-s5-rule-direction-convergence.md
+++ b/docs/specs/reports/phaseb-s5-rule-direction-convergence.md
@@ -1,0 +1,36 @@
+# Phase B S5 direction guard — convergence record
+
+**Date:** 2026-08-17
+**Reviewer / authority:** Pathway, Phase B orchestrator, topic 29723
+**Builder:** instar-codey, lane S5
+
+## Review sequence
+
+1. Pathway accepted the hybrid design: immutable article identity and continuity
+   denominators for mechanical deletion facts; explicit independently ratified
+   direction for semantic edits. It confirmed that refreshing the old
+   self-attestation left the new objection standing.
+2. Pathway raised the candidate-pin replacement attack. The design was corrected
+   so the approver public key is resolved from the protected base exactly like
+   the article inventory. A live attacker-key mutation and a regression test now
+   show candidate pin replacement is ignored and refused.
+3. Pathway added the adapter requirement and separated authorship from verdict.
+   The S5 adapter describes the real mutations, while the independent acceptance
+   lane owns the machine verdict. Pathway then froze verifier-core edits during
+   its audit; S5 changes only its own adapter and manifest entry.
+4. The independent instar-dev second pass found the two-step pin attack: a
+   pin-only candidate could become the next protected-base authority. The guard
+   now refuses any candidate pin drift, including changes with no registry delta.
+   It also corrected an ELI16 overclaim: malformed protected key bytes block an
+   amendment signature, but do not make an unchanged registry fail.
+
+## Converged result
+
+No semantic prose classifier is introduced. The guard verifies closed mechanical
+facts and an external signature over a declared judgment. The protected-base
+trust root closes goalpost replacement; the private key is not stored in the
+repository or build environment; missing key material fails closed. Legacy
+heading renames are explicitly documented as remove-plus-add and therefore
+require approval. Bootstrap and rotation are separate protected-main control-plane
+actions; an ordinary candidate cannot establish its own future authority. The
+implementation and tests match the reviewed shape.

--- a/docs/standards-direction-approvals.json
+++ b/docs/standards-direction-approvals.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "approvals": []
+}

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -54,6 +54,13 @@ import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import { articleIds, parseRegistryStructure } from './standards-registry-article-core.mjs';
+import {
+  evaluateStandardsDirection,
+  readCandidateApproverKey,
+  readDirectionApprovalLedger,
+  resolveProtectedApproverKey,
+  resolveProtectedBaseRegistry,
+} from './standards-direction-guard.mjs';
 import { parseFrontmatter, validateAuditReport } from './write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -105,6 +112,8 @@ const AREA_AUDITS_PATH = path.join(ROOT, 'docs', 'standards-registry-area-audits
 const AREA_MODEL_AUDIT_PATH = path.join(ROOT, 'docs', 'standards-registry-area-model-audit.json');
 const CI_WORKFLOW_PATH = path.join(ROOT, '.github', 'workflows', 'ci.yml');
 const OUT_PATH = path.join(ROOT, '.instar', 'standards-coverage.json');
+const DIRECTION_APPROVALS_PATH = path.join(ROOT, 'docs', 'standards-direction-approvals.json');
+const DIRECTION_APPROVER_KEY_PATH = path.join(ROOT, '.github', 'keyrings', 'telegram-principal-pub.pem');
 
 // ── Hardcoded committed floors (the read baseline; output file is never it) ──
 const numEnv = (env, def) => {
@@ -575,6 +584,9 @@ function validateRootSelfWiring() {
   const checkEnv = {
     STANDARDS_AREA_AUDIT_BASE_FILE: '${{ runner.temp }}/standards-area-audits-base.json',
     STANDARDS_AREA_AUDIT_BASE_REQUIRED: '${{ steps.area-audit-base.outputs.required }}',
+    STANDARDS_DIRECTION_BASE_FILE: '${{ runner.temp }}/standards-registry-base.md',
+    STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE: '${{ runner.temp }}/standards-direction-approver-base.pem',
+    STANDARDS_DIRECTION_BASE_REVISION: "${{ github.event.pull_request.base.sha || github.event.before || format('{0}^', github.sha) }}",
   };
   if (!exactKeys(job, ['name', 'runs-on', 'steps']) ||
     job.name !== 'Standards Enforcement Coverage' || job['runs-on'] !== 'ubuntu-latest' ||
@@ -595,6 +607,8 @@ function validateRootSelfWiring() {
     'else',
     '  echo "required=0" >> "$GITHUB_OUTPUT"',
     'fi',
+    'git show "$BASE_SHA:docs/STANDARDS-REGISTRY.md" > "$RUNNER_TEMP/standards-registry-base.md"',
+    'git show "$BASE_SHA:.github/keyrings/telegram-principal-pub.pem" > "$RUNNER_TEMP/standards-direction-approver-base.pem"',
     '',
   ].join('\n');
   const expectedBaseSha = "${{ github.event.pull_request.base.sha || github.event.before || format('{0}^', github.sha) }}";
@@ -1237,8 +1251,69 @@ function compute() {
         capturedSections: 0,
         unrecognizedSections: [],
       },
+      directionGuard: {
+        status: ALLOW_PARTIAL_REGISTRY ? 'not-assessed' : 'not-proven',
+        errors: ALLOW_PARTIAL_REGISTRY ? [] : ['candidate standards registry is unavailable'],
+        changes: [],
+        trustRoot: { origin: 'protected-base', source: null, revision: null, candidateTreeIgnored: true },
+        population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+      },
     };
   }
+
+  const directionGuard = (() => {
+    if (ALLOW_PARTIAL_REGISTRY) {
+      return {
+        status: 'not-assessed', errors: [], changes: [],
+        trustRoot: { origin: 'not-assessed', source: null, revision: null, candidateTreeIgnored: true },
+        population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+      };
+    }
+    const base = resolveProtectedBaseRegistry({
+      root: ROOT,
+      explicitFile: Object.hasOwn(process.env, 'STANDARDS_DIRECTION_BASE_FILE')
+        ? process.env.STANDARDS_DIRECTION_BASE_FILE
+        : undefined,
+      explicitRevision: process.env.STANDARDS_DIRECTION_BASE_REVISION,
+    });
+    if (base.errors.length > 0 || base.markdown === null) {
+      return {
+        status: 'not-proven', errors: base.errors, changes: [],
+        trustRoot: { origin: 'protected-base', source: null, revision: null, candidateTreeIgnored: true },
+        population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+      };
+    }
+    const approvals = readDirectionApprovalLedger(DIRECTION_APPROVALS_PATH);
+    const candidateKey = readCandidateApproverKey(DIRECTION_APPROVER_KEY_PATH);
+    const key = resolveProtectedApproverKey({
+      root: ROOT,
+      explicitFile: Object.hasOwn(process.env, 'STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE')
+        ? process.env.STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE
+        : undefined,
+      explicitRevision: process.env.STANDARDS_DIRECTION_BASE_REVISION,
+    });
+    if (key.revision !== base.revision) {
+      key.errors.push('protected-base registry and approver trust root resolved from different revisions');
+    }
+    const assessed = evaluateStandardsDirection({
+      baseMarkdown: base.markdown,
+      candidateMarkdown: markdown,
+      approvalLedger: approvals.value,
+      approverPublicKeyPem: key.pem,
+      candidateApproverPublicKeyPem: candidateKey.pem,
+      baseRevision: base.revision ?? 'unknown-protected-base',
+    });
+    assessed.errors.unshift(...approvals.errors, ...candidateKey.errors, ...key.errors);
+    if (assessed.errors.length > 0) assessed.status = 'not-proven';
+    assessed.trustRoot = {
+      origin: 'protected-base',
+      source: key.source,
+      revision: key.revision,
+      candidateTreeIgnored: true,
+      candidateTreeDriftBlocked: true,
+    };
+    return assessed;
+  })();
 
   const { articles, enforcementScope, areaSha256, areaSectionCounts } = parseRegistry(canonicalText(markdown));
   const routeTable = loadRouteTable();
@@ -1297,7 +1372,9 @@ function compute() {
 
   const total = articles.length;
   const enforced = byKind.ratchet + byKind.gate + byKind.lint;
-  const enforcedRatio = total === 0 ? 1 : Number((enforced / total).toFixed(4));
+  const continuityTotal = directionGuard.population?.continuity || total;
+  const currentPopulationEnforcedRatio = total === 0 ? 1 : Number((enforced / total).toFixed(4));
+  const enforcedRatio = continuityTotal === 0 ? 1 : Number((enforced / continuityTotal).toFixed(4));
   const areaNames = [...areaTallies.keys()].sort();
   const loadedAreaAudits = loadAreaAuditLedger(areaNames);
   const loadedAreaModelAudit = loadAreaModelAudit(areaNames);
@@ -1323,7 +1400,9 @@ function compute() {
     const audit = isPlainObject(loadedAreaAudits.ledger?.areas?.[areaName])
       ? loadedAreaAudits.ledger.areas[areaName]
       : null;
-    const ratio = tally.total === 0 ? 1 : Number((tally.enforced / tally.total).toFixed(4));
+    const areaContinuityTotal = directionGuard.population?.byFamily?.[areaName]?.continuity || tally.total;
+    const currentPopulationRatio = tally.total === 0 ? 1 : Number((tally.enforced / tally.total).toFixed(4));
+    const ratio = areaContinuityTotal === 0 ? 1 : Number((tally.enforced / areaContinuityTotal).toFixed(4));
     const auditCurrent = typeof audit?.areaSha256 === 'string' && audit.areaSha256 === areaSha256[areaName];
     if (audit && !auditCurrent) {
       areaAuditErrors.push(
@@ -1333,9 +1412,11 @@ function compute() {
     if (auditCurrent) currentAreaAudits += 1;
     areas[areaName] = {
       total: tally.total,
+      continuityTotal: areaContinuityTotal,
       enforced: tally.enforced,
       byKind: tally.byKind,
       refResolutionRatio: ratio,
+      currentPopulationRefResolutionRatio: currentPopulationRatio,
       gaps: tally.gaps,
       currentAreaSha256: areaSha256[areaName],
       lastAuditedAt: typeof audit?.lastAuditedAt === 'string' ? audit.lastAuditedAt : null,
@@ -1365,7 +1446,8 @@ function compute() {
     generatedAt: new Date().toISOString(),
     registryFound: true,
     rootSelfWiring,
-    total, byKind, enforcedRatio, gaps, enforcementScope, areas,
+    total, continuityTotal, byKind, enforcedRatio, currentPopulationEnforcedRatio,
+    gaps, enforcementScope, areas, directionGuard,
     areaAudit: {
       status: areaAuditErrors.length === 0 ? 'current' : 'invalid',
       path: path.relative(ROOT, AREA_AUDITS_PATH),
@@ -1470,7 +1552,7 @@ function recordAreaAudit(report, selection, auditRef) {
     if (canonicalTimestamp(oldTimestamp) && Date.parse(lastAuditedAt) < Date.parse(oldTimestamp)) {
       throw new Error(`lastAuditedAt for ${area} may not move backward`);
     }
-    const measuredFloor = { enforced: measurement.enforced, total: measurement.total };
+    const measuredFloor = { enforced: measurement.enforced, total: measurement.continuityTotal ?? measurement.total };
     const oldFloor = existing.areas?.[area]?.refResolutionFloor;
     const rebaselining = typeof REBASELINE_REASON === 'string' && REBASELINE_REASON.trim().length > 0;
     const refResolutionFloor = !rebaselining
@@ -1600,15 +1682,21 @@ function main() {
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');
   } else if (!QUIET) {
     console.error(`[standards-coverage] registry=${report.registryFound} total=${report.total} ` +
+      `continuity-total=${report.continuityTotal ?? report.total} ` +
       `enforced-ratio=${report.enforcedRatio} (ratchet ${report.byKind.ratchet} / gate ${report.byKind.gate} / ` +
       `lint ${report.byKind.lint} / spec-only ${report.byKind['spec-only']} / gap ${report.byKind['documented-only']}) ` +
       `false-claims=${report.falseClaimCount} ` +
       `dangling=${report.danglingCount} ` +
       `unrecognized-sections=${report.enforcementScope.unrecognizedSections.length}`);
     console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling} unrecognized-sections<=${FLOORS.unrecognizedSectionCeiling}`);
+    console.error(`[standards-coverage] direction-guard=${report.directionGuard.status} ` +
+      `base=${report.directionGuard.baseRevision ?? 'not-assessed'} ` +
+      `trust-root=${report.directionGuard.trustRoot?.origin ?? 'unknown'} ` +
+      `candidate-pin-ignored-as-authority=${report.directionGuard.trustRoot?.candidateTreeIgnored === true} ` +
+      `candidate-pin-drift-blocked=${report.directionGuard.trustRoot?.candidateTreeDriftBlocked === true}`);
     for (const [area, measurement] of Object.entries(report.areas)) {
       console.error(
-        `[standards-coverage] area="${area}" total=${measurement.total} ` +
+        `[standards-coverage] area="${area}" total=${measurement.total} continuity-total=${measurement.continuityTotal ?? measurement.total} ` +
         `ref-resolution-ratio=${measurement.refResolutionRatio} ` +
         `floor=${measurement.refResolutionFloor ? `${measurement.refResolutionFloor.enforced}/${measurement.refResolutionFloor.total}` : 'missing'} ` +
         `last-audited=${measurement.lastAuditedAt ?? 'missing'} audit-ref=${measurement.auditRef ?? 'missing'} ` +
@@ -1621,6 +1709,9 @@ function main() {
     for (const error of report.areaModelAudit.errors) {
       console.error(`[standards-coverage] AREA MODEL AUDIT — ${error}`);
     }
+    for (const error of report.directionGuard.errors) {
+      console.error(`[standards-coverage] DIRECTION GUARD — ${error}`);
+    }
     for (const fc of report.falseClaims) {
       console.error(`[standards-coverage] FALSE CLAIM — "${fc.standard}" asserts running machinery (${fc.claims.map((c) => `"${c}"`).join(', ')}) but names no resolvable guard.`);
     }
@@ -1629,15 +1720,18 @@ function main() {
   if (CHECK) {
     const failures = [];
     const aggregateEnforced = report.byKind.ratchet + report.byKind.gate + report.byKind.lint;
-    if (report.total > 0 && ratioBelowNumericFloor(aggregateEnforced, report.total, FLOORS.enforcedRatio)) {
-      failures.push(`enforced ratio ${aggregateEnforced}/${report.total} (${report.enforcedRatio}) < floor ${FLOORS.enforcedRatio}`);
+    const continuityDenominator = report.continuityTotal ?? report.total;
+    if (continuityDenominator > 0 && ratioBelowNumericFloor(aggregateEnforced, continuityDenominator, FLOORS.enforcedRatio)) {
+      failures.push(`enforced ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < floor ${FLOORS.enforcedRatio}`);
     }
+    for (const error of report.directionGuard.errors) failures.push(`direction guard: ${error}`);
     for (const error of report.areaAudit.errors) failures.push(error);
     for (const error of report.areaModelAudit.errors) failures.push(error);
     for (const [area, measurement] of Object.entries(report.areas)) {
-      if (ratioBelowFloor(measurement.enforced, measurement.total, measurement.refResolutionFloor)) {
+      const areaContinuityDenominator = measurement.continuityTotal ?? measurement.total;
+      if (ratioBelowFloor(measurement.enforced, areaContinuityDenominator, measurement.refResolutionFloor)) {
         failures.push(
-          `area "${area}" ref-resolution ratio ${measurement.enforced}/${measurement.total} < floor ` +
+          `area "${area}" ref-resolution ratio ${measurement.enforced}/${areaContinuityDenominator} < floor ` +
           `${measurement.refResolutionFloor.enforced}/${measurement.refResolutionFloor.total}`,
         );
       }

--- a/scripts/standards-direction-guard.mjs
+++ b/scripts/standards-direction-guard.mjs
@@ -1,0 +1,439 @@
+// safe-git-allow: CI bootstrap uses read-only merge-base/show before TypeScript is compiled.
+/**
+ * Direction-aware constitutional amendment guard.
+ *
+ * Mechanical facts (article identity, addition, removal, population) come from
+ * the protected base and candidate registries. Semantic direction for an edit
+ * is declared, then independently ratified with an Ed25519 signature over the
+ * exact before/after bytes. A repository file written by the changer is never
+ * authority by itself.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { ARTICLE_ID_RE, articleIds, parseRegistryStructure } from './standards-registry-article-core.mjs';
+
+export const DIRECTION_APPROVAL_SCHEMA_VERSION = 1;
+export const DIRECTION_GUARD_SYMBOL = 'evaluateStandardsDirection';
+const FIELD_RE = /^\*\*(.+?)\.\*\*\s*(.*)$/;
+const DIRECTIONS = new Set(['add', 'remove', 'strengthen', 'neutral', 'weaken']);
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const RFC3339_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const canonicalText = (value) => String(value).replace(/\r\n?/g, '\n');
+const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const exactKeys = (value, keys) => isObject(value) &&
+  JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+const familyName = (heading) => heading.split(/\s+[—–-]\s+/)[0].trim();
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isObject(value)) return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+}
+
+export function canonicalDirectionPayload(payload) {
+  return `standards-direction-ratification-v1\0${JSON.stringify(stableValue(payload))}`;
+}
+
+function slug(value) {
+  return value.normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function fieldsFor(block) {
+  const fields = [];
+  let current = null;
+  const flush = () => {
+    if (!current) return;
+    fields.push({ heading: current.heading, text: current.lines.join('\n').trim() });
+    current = null;
+  };
+  for (const line of block.visibleLines) {
+    if (line === null) continue;
+    const match = line.match(FIELD_RE);
+    if (match) {
+      flush();
+      current = { heading: match[1].trim(), lines: [match[2]] };
+    } else if (current) current.lines.push(line);
+  }
+  flush();
+  return fields;
+}
+
+/** Resolve every Rule-bearing article to a closed, unique identity set. */
+export function inventoryStandardsArticles(markdown) {
+  const text = canonicalText(markdown);
+  const articles = [];
+  const errors = [];
+  const identities = new Set();
+  let parsedRuleMarkers = 0;
+
+  for (const section of parseRegistryStructure(text)) {
+    const family = familyName(section.heading);
+    for (const block of section.blocks) {
+      const fields = fieldsFor(block);
+      const rules = fields.filter((field) => field.heading === 'Rule');
+      if (rules.length === 0) continue;
+      parsedRuleMarkers += rules.length;
+      if (rules.length !== 1) {
+        errors.push(`article "${block.name}" must contain exactly one Rule field (found ${rules.length})`);
+        continue;
+      }
+      const explicitIds = articleIds(block);
+      if (explicitIds.length > 1) {
+        errors.push(`article "${block.name}" has duplicate Article ID declarations`);
+        continue;
+      }
+      if (explicitIds.length === 1 && !ARTICLE_ID_RE.test(explicitIds[0])) {
+        errors.push(`article "${block.name}" has invalid Article ID "${explicitIds[0]}"`);
+        continue;
+      }
+      const id = explicitIds[0] ?? `legacy/${slug(family)}/${slug(block.name)}`;
+      if (identities.has(id)) {
+        errors.push(`article identity collision for "${id}"`);
+        continue;
+      }
+      identities.add(id);
+      const rule = rules[0].text;
+      articles.push({
+        id,
+        family,
+        name: block.name,
+        rule,
+        ruleSha256: sha256(`standards-rule-v1\0${rule}`),
+        articleSha256: sha256(`standards-article-v1\0${canonicalText(block.raw)}`),
+      });
+    }
+  }
+
+  const rawRuleMarkers = text.split('\n').filter((line) => /^\*\*Rule\.\*\*/.test(line)).length;
+  if (rawRuleMarkers !== parsedRuleMarkers || parsedRuleMarkers !== articles.length) {
+    errors.push(
+      `article enumeration is open: raw Rule fields=${rawRuleMarkers}, parsed Rule fields=${parsedRuleMarkers}, identities=${articles.length}`,
+    );
+  }
+  if (articles.length === 0) errors.push('standards article population is empty (NOT-PROVEN, never 0/0 clean)');
+  return { articles, errors };
+}
+
+function articleSummary(article) {
+  if (!article) return null;
+  return {
+    id: article.id,
+    family: article.family,
+    name: article.name,
+    ruleSha256: article.ruleSha256,
+    articleSha256: article.articleSha256,
+  };
+}
+
+function changeKind(before, after) {
+  if (!before) return 'add';
+  if (!after) return 'remove';
+  return 'edit';
+}
+
+function directionLabel(direction, kind) {
+  if (kind === 'remove') return 'REMOVAL';
+  if (kind === 'add') return 'ADDITION';
+  if (direction === 'weaken') return 'WEAKENING';
+  if (direction === 'strengthen') return 'STRENGTHENING';
+  if (direction === 'neutral') return 'NEUTRAL EDIT';
+  return 'DIRECTION UNDECLARED';
+}
+
+function validTimestamp(value) {
+  if (typeof value !== 'string' || !RFC3339_UTC_RE.test(value)) return false;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+}
+
+function verifyApprovalSignature(payload, signature, publicKeyPem) {
+  if (typeof signature !== 'string' || signature.length < 40 || typeof publicKeyPem !== 'string') return false;
+  try {
+    const key = crypto.createPublicKey(publicKeyPem);
+    return crypto.verify(
+      null,
+      Buffer.from(canonicalDirectionPayload(payload), 'utf8'),
+      key,
+      Buffer.from(signature, 'base64'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function validateApprovalShape(entry) {
+  if (!exactKeys(entry, ['payload', 'signature'])) return 'must contain exactly payload and signature';
+  const payload = entry.payload;
+  if (!exactKeys(payload, [
+    'schemaVersion', 'baseRevision', 'baseRegistrySha256', 'candidateRegistrySha256',
+    'articleId', 'change', 'direction', 'before', 'after', 'approvedBy', 'approvedAt',
+  ])) return 'payload has unknown or missing fields';
+  if (payload.schemaVersion !== DIRECTION_APPROVAL_SCHEMA_VERSION) return 'payload schemaVersion is unsupported';
+  if (!['add', 'remove', 'edit'].includes(payload.change) || !DIRECTIONS.has(payload.direction)) return 'payload change/direction is invalid';
+  if (typeof payload.baseRevision !== 'string' || payload.baseRevision.length < 1 || payload.baseRevision.length > 160) return 'payload baseRevision is invalid';
+  if (!SHA256_RE.test(payload.baseRegistrySha256) || !SHA256_RE.test(payload.candidateRegistrySha256)) return 'payload registry digest is invalid';
+  if (typeof payload.articleId !== 'string' || payload.articleId.length < 3 || payload.articleId.length > 180) return 'payload articleId is invalid';
+  if (typeof payload.approvedBy !== 'string' || payload.approvedBy.trim().length < 2 || payload.approvedBy.length > 120) return 'payload approvedBy is invalid';
+  if (!validTimestamp(payload.approvedAt) || Date.parse(payload.approvedAt) > Date.now() + 5 * 60_000) return 'payload approvedAt is invalid';
+  for (const [which, summary] of [['before', payload.before], ['after', payload.after]]) {
+    if (summary === null) continue;
+    if (!exactKeys(summary, ['id', 'family', 'name', 'ruleSha256', 'articleSha256']) ||
+      typeof summary.id !== 'string' || typeof summary.family !== 'string' || typeof summary.name !== 'string' ||
+      !SHA256_RE.test(summary.ruleSha256) || !SHA256_RE.test(summary.articleSha256)) {
+      return `payload ${which} summary is invalid`;
+    }
+  }
+  return null;
+}
+
+function parseApprovalLedger(value) {
+  const errors = [];
+  if (!exactKeys(value, ['schemaVersion', 'approvals']) ||
+    value.schemaVersion !== DIRECTION_APPROVAL_SCHEMA_VERSION || !Array.isArray(value.approvals)) {
+    return { approvals: [], errors: ['direction approval ledger must contain exactly schemaVersion: 1 and approvals[]'] };
+  }
+  const approvals = [];
+  for (const [index, entry] of value.approvals.entries()) {
+    const error = validateApprovalShape(entry);
+    if (error) errors.push(`direction approval ${index} ${error}`);
+    else approvals.push(entry);
+  }
+  return { approvals, errors };
+}
+
+function familyPopulation(articles) {
+  const map = new Map();
+  for (const article of articles) {
+    if (!map.has(article.family)) map.set(article.family, new Set());
+    map.get(article.family).add(article.id);
+  }
+  return map;
+}
+
+/**
+ * Evaluate candidate constitutional direction against a protected base.
+ * This exact export is imported by the pipeline and its negative-control test.
+ */
+export function evaluateStandardsDirection({
+  baseMarkdown,
+  candidateMarkdown,
+  approvalLedger = { schemaVersion: 1, approvals: [] },
+  approverPublicKeyPem = '',
+  candidateApproverPublicKeyPem = null,
+  baseRevision = 'unknown-protected-base',
+}) {
+  const base = inventoryStandardsArticles(baseMarkdown);
+  const candidate = inventoryStandardsArticles(candidateMarkdown);
+  const ledger = parseApprovalLedger(approvalLedger);
+  const errors = [
+    ...base.errors.map((error) => `protected base: ${error}`),
+    ...candidate.errors.map((error) => `candidate: ${error}`),
+    ...ledger.errors,
+  ];
+  if (candidateApproverPublicKeyPem !== null && candidateApproverPublicKeyPem !== approverPublicKeyPem) {
+    errors.push(
+      'APPROVER TRUST ROOT CHANGE is not self-authorizable: candidate pin differs from protected base; ' +
+      'bootstrap or rotation requires external protected-main control-plane authorization',
+    );
+  }
+  const baseRegistrySha256 = sha256(canonicalText(baseMarkdown));
+  const candidateRegistrySha256 = sha256(canonicalText(candidateMarkdown));
+  const baseById = new Map(base.articles.map((article) => [article.id, article]));
+  const candidateById = new Map(candidate.articles.map((article) => [article.id, article]));
+  const ids = [...new Set([...baseById.keys(), ...candidateById.keys()])].sort();
+  const changes = [];
+
+  for (const id of ids) {
+    const before = baseById.get(id) ?? null;
+    const after = candidateById.get(id) ?? null;
+    if (before && after && before.articleSha256 === after.articleSha256 &&
+      before.family === after.family && before.name === after.name) continue;
+    changes.push({ id, kind: changeKind(before, after), before, after });
+  }
+
+  const basePopulation = familyPopulation(base.articles);
+  const candidatePopulation = familyPopulation(candidate.articles);
+  const families = [...new Set([...basePopulation.keys(), ...candidatePopulation.keys()])].sort();
+  const byFamily = {};
+  for (const family of families) {
+    const baseIds = basePopulation.get(family) ?? new Set();
+    const candidateIds = candidatePopulation.get(family) ?? new Set();
+    byFamily[family] = {
+      protectedBase: baseIds.size,
+      candidate: candidateIds.size,
+      continuity: new Set([...baseIds, ...candidateIds]).size,
+    };
+  }
+
+  for (const change of changes) {
+    const matching = ledger.approvals.filter(({ payload }) =>
+      payload.baseRegistrySha256 === baseRegistrySha256 &&
+      payload.candidateRegistrySha256 === candidateRegistrySha256 &&
+      payload.articleId === change.id);
+    const displayName = change.after?.name ?? change.before?.name ?? change.id;
+    if (matching.length === 0) {
+      errors.push(
+        `${directionLabel(null, change.kind)} "${displayName}" (${change.id}) requires an independently signed direction ratification`,
+      );
+      continue;
+    }
+    if (matching.length > 1) {
+      errors.push(`article "${displayName}" has multiple ratifications for the same protected-base/candidate pair`);
+      continue;
+    }
+    const approval = matching[0];
+    const direction = approval.payload.direction;
+    const expectedDirection = change.kind === 'add' ? 'add' : change.kind === 'remove' ? 'remove' : direction;
+    const expectedPayload = {
+      schemaVersion: DIRECTION_APPROVAL_SCHEMA_VERSION,
+      baseRevision,
+      baseRegistrySha256,
+      candidateRegistrySha256,
+      articleId: change.id,
+      change: change.kind,
+      direction: expectedDirection,
+      before: articleSummary(change.before),
+      after: articleSummary(change.after),
+      approvedBy: approval.payload.approvedBy,
+      approvedAt: approval.payload.approvedAt,
+    };
+    const label = directionLabel(direction, change.kind);
+    if (change.kind === 'edit' && !['strengthen', 'neutral', 'weaken'].includes(direction)) {
+      errors.push(`${label} "${displayName}" has invalid edit direction "${direction}"`);
+      continue;
+    }
+    if (JSON.stringify(stableValue(approval.payload)) !== JSON.stringify(stableValue(expectedPayload))) {
+      errors.push(`${label} "${displayName}" ratification does not bind the exact protected-base/candidate article bytes`);
+      continue;
+    }
+    if (!verifyApprovalSignature(approval.payload, approval.signature, approverPublicKeyPem)) {
+      errors.push(`${label} "${displayName}" lacks a valid different-principal signature`);
+      continue;
+    }
+    change.direction = direction;
+    change.approvedBy = approval.payload.approvedBy;
+  }
+
+  return {
+    status: errors.length === 0 ? 'passed' : 'not-proven',
+    errors,
+    baseRevision,
+    baseRegistrySha256,
+    candidateRegistrySha256,
+    changes: changes.map((change) => ({
+      articleId: change.id,
+      name: change.after?.name ?? change.before?.name ?? change.id,
+      familyBefore: change.before?.family ?? null,
+      familyAfter: change.after?.family ?? null,
+      change: change.kind,
+      direction: change.direction ?? null,
+      approvedBy: change.approvedBy ?? null,
+    })),
+    population: {
+      protectedBase: base.articles.length,
+      candidate: candidate.articles.length,
+      continuity: new Set([...baseById.keys(), ...candidateById.keys()]).size,
+      additions: changes.filter((change) => change.kind === 'add').map((change) => change.id),
+      removals: changes.filter((change) => change.kind === 'remove').map((change) => change.id),
+      byFamily,
+    },
+  };
+}
+
+function resolveProtectedBaseText({ root, explicitFile, explicitRevision, repoPath, noun, envHint }) {
+  if (explicitFile !== undefined) {
+    if (typeof explicitFile !== 'string' || explicitFile.length === 0) {
+      return { text: null, revision: null, source: 'explicit', errors: [`protected-base ${noun} path is empty`] };
+    }
+    try {
+      const stat = fs.lstatSync(explicitFile);
+      if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('not a regular file');
+      return {
+        text: fs.readFileSync(explicitFile, 'utf8'),
+        revision: explicitRevision || 'explicit-protected-base',
+        source: explicitFile,
+        errors: [],
+      };
+    } catch (error) {
+      return { text: null, revision: null, source: explicitFile, errors: [`protected-base ${noun} is unavailable: ${error instanceof Error ? error.message : String(error)}`] };
+    }
+  }
+
+  for (const ref of ['refs/remotes/upstream/main', 'refs/remotes/origin/main']) {
+    try {
+      const revision = execFileSync('git', ['merge-base', 'HEAD', ref], { cwd: root, encoding: 'utf8' }).trim();
+      if (!revision) continue;
+      const text = execFileSync('git', ['show', `${revision}:${repoPath}`], { cwd: root, encoding: 'utf8' });
+      return { text, revision, source: ref, errors: [] };
+    } catch {
+      // Try the next protected main ref. Failure of all candidates is loud below.
+    }
+  }
+  return {
+    text: null,
+    revision: null,
+    source: null,
+    errors: [`protected-base ${noun} is unavailable (set ${envHint} or fetch upstream/main/origin/main)`],
+  };
+}
+
+/** Fail-closed protected-base registry acquisition for the real pipeline. */
+export function resolveProtectedBaseRegistry({ root, explicitFile, explicitRevision }) {
+  const result = resolveProtectedBaseText({
+    root,
+    explicitFile,
+    explicitRevision,
+    repoPath: 'docs/STANDARDS-REGISTRY.md',
+    noun: 'registry',
+    envHint: 'STANDARDS_DIRECTION_BASE_FILE',
+  });
+  return { ...result, markdown: result.text };
+}
+
+/** The approver pin is always read from the same protected base as the registry. */
+export function resolveProtectedApproverKey({ root, explicitFile, explicitRevision }) {
+  const result = resolveProtectedBaseText({
+    root,
+    explicitFile,
+    explicitRevision,
+    repoPath: '.github/keyrings/telegram-principal-pub.pem',
+    noun: 'approver trust root',
+    envHint: 'STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE',
+  });
+  return { ...result, pem: result.text };
+}
+
+/** Candidate pin bytes are observed only to refuse drift; they never verify a signature. */
+export function readCandidateApproverKey(file) {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('not a regular file');
+    return { pem: fs.readFileSync(file, 'utf8'), errors: [] };
+  } catch (error) {
+    return {
+      pem: null,
+      errors: [`candidate approver trust root is unavailable: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+}
+
+export function readDirectionApprovalLedger(file) {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('not a regular file');
+    return { value: JSON.parse(fs.readFileSync(file, 'utf8')), errors: [] };
+  } catch (error) {
+    return {
+      value: { schemaVersion: 1, approvals: [] },
+      errors: [`direction approval ledger is unavailable or malformed: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+}

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -208,11 +208,27 @@ function runCheck(env: Record<string, string> = {}): { code: number; out: string
 }
 
 function runFullCheck(): { code: number; out: string } {
+  const registryPath = path.join(repo, 'docs', 'STANDARDS-REGISTRY.md');
+  const basePath = path.join(repo, '.standards-direction-base.md');
+  const baseApproverPath = path.join(repo, '.standards-direction-approver-base.pem');
+  fs.writeFileSync(basePath, fs.existsSync(registryPath) ? fs.readFileSync(registryPath) : '# missing registry\n');
+  const fixtureApproverPin = 'fixture trust root; no signature is required for an unchanged registry\n';
+  fs.writeFileSync(baseApproverPath, fixtureApproverPin);
+  write('docs/standards-direction-approvals.json', '{\n  "schemaVersion": 1,\n  "approvals": []\n}\n');
+  write('.github/keyrings/telegram-principal-pub.pem', fixtureApproverPin);
   try {
     return {
       code: 0,
       out: execFileSync('node', [SCRIPT, '--check'], {
-        cwd: repo, encoding: 'utf8', env: { ...process.env, STANDARDS_COVERAGE_ROOT: repo },
+        cwd: repo,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          STANDARDS_COVERAGE_ROOT: repo,
+          STANDARDS_DIRECTION_BASE_FILE: basePath,
+          STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE: baseApproverPath,
+          STANDARDS_DIRECTION_BASE_REVISION: 'fixture-protected-base',
+        },
       }),
     };
   } catch (error) {
@@ -273,10 +289,15 @@ describe('standards-coverage ratchet script', () => {
       '          else',
       '            echo "required=0" >> "$GITHUB_OUTPUT"',
       '          fi',
+      '          git show "$BASE_SHA:docs/STANDARDS-REGISTRY.md" > "$RUNNER_TEMP/standards-registry-base.md"',
+      '          git show "$BASE_SHA:.github/keyrings/telegram-principal-pub.pem" > "$RUNNER_TEMP/standards-direction-approver-base.pem"',
       '      - run: node scripts/standards-coverage.mjs --check',
       '        env:',
       '          STANDARDS_AREA_AUDIT_BASE_FILE: ${{ runner.temp }}/standards-area-audits-base.json',
       '          STANDARDS_AREA_AUDIT_BASE_REQUIRED: ${{ steps.area-audit-base.outputs.required }}',
+      '          STANDARDS_DIRECTION_BASE_FILE: ${{ runner.temp }}/standards-registry-base.md',
+      '          STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE: ${{ runner.temp }}/standards-direction-approver-base.pem',
+      "          STANDARDS_DIRECTION_BASE_REVISION: ${{ github.event.pull_request.base.sha || github.event.before || format('{0}^', github.sha) }}",
     ].join('\n'));
     fs.rmSync(path.join(repo, 'docs', 'standards-registry-area-audits.json'));
     refreshAreaAudits();

--- a/tests/unit/standards-direction-guard-contract.test.ts
+++ b/tests/unit/standards-direction-guard-contract.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const guardPath = process.env.STANDARDS_DIRECTION_GUARD_UNDER_TEST ??
+  path.resolve(__dirname, '../../scripts/standards-direction-guard.mjs');
+const guard = await import(/* @vite-ignore */ pathToFileURL(guardPath).href);
+
+const baseRegistry = [
+  '# Standards',
+  '',
+  '## The Root',
+  '',
+  '### Structure beats Willpower',
+  '**Article ID.** `structure-beats-willpower`',
+  '**Rule.** Enforce behavior in architecture.',
+  '',
+  '## Building',
+  '',
+  '### Honest Gap',
+  '**Article ID.** `honest-gap`',
+  '**Rule.** Preserve this obligation.',
+  '',
+].join('\n');
+
+describe('standards direction guard behavioral contract', () => {
+  it('passes a pristine non-vacuous registry', () => {
+    const result = guard.evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: baseRegistry,
+      baseRevision: 'contract-base',
+    });
+    expect(result.status).toBe('passed');
+    expect(result.errors).toEqual([]);
+    expect(result.population.continuity).toBe(2);
+  });
+
+  it('refuses and names a real removal without shrinking continuity', () => {
+    const candidate = baseRegistry.replace([
+      '### Honest Gap',
+      '**Article ID.** `honest-gap`',
+      '**Rule.** Preserve this obligation.',
+      '',
+    ].join('\n'), '');
+    expect(candidate).not.toContain('### Honest Gap');
+    const result = guard.evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: candidate,
+      baseRevision: 'contract-base',
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('REMOVAL "Honest Gap"');
+    expect(result.population).toEqual(expect.objectContaining({
+      protectedBase: 2,
+      candidate: 1,
+      continuity: 2,
+    }));
+  });
+
+  it('refuses an empty candidate rather than passing 0/0', () => {
+    const result = guard.evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: '# Standards\n',
+      baseRevision: 'contract-base',
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('standards article population is empty');
+  });
+});

--- a/tests/unit/standards-direction-guard.test.ts
+++ b/tests/unit/standards-direction-guard.test.ts
@@ -1,0 +1,447 @@
+// safe-git-allow: isolated tmpdir mutations are the guard's P3 negative controls.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  canonicalDirectionPayload,
+  evaluateStandardsDirection,
+  inventoryStandardsArticles,
+  resolveProtectedApproverKey,
+  resolveProtectedBaseRegistry,
+} from '../../scripts/standards-direction-guard.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GUARD = path.resolve(__dirname, '../../scripts/standards-direction-guard.mjs');
+const CORE = path.resolve(__dirname, '../../scripts/standards-registry-article-core.mjs');
+const CONTRACT = path.resolve(__dirname, 'standards-direction-guard-contract.test.ts');
+const VITEST = path.resolve(__dirname, '../../node_modules/vitest/vitest.mjs');
+const BASE_REVISION = 'protected-base-fixture';
+
+const baseRegistry = [
+  '# Standards',
+  '',
+  '## The Root',
+  '',
+  '### Structure beats Willpower',
+  '**Article ID.** `structure-beats-willpower`',
+  '**Rule.** If behavior matters, enforce it in architecture and never rely on remembering.',
+  '**Applied through.** `scripts/standards-direction-guard.mjs`.',
+  '',
+  '## Building',
+  '',
+  '### Honest Gap',
+  '**Article ID.** `honest-gap`',
+  '**Rule.** Preserve this obligation.',
+  '**In practice.** Use judgment.',
+  '',
+].join('\n');
+
+function replaceRootRule(markdown: string, rule: string): string {
+  return markdown.replace(
+    '**Rule.** If behavior matters, enforce it in architecture and never rely on remembering.',
+    `**Rule.** ${rule}`,
+  );
+}
+
+function removeGap(markdown: string): string {
+  return markdown.replace([
+    '### Honest Gap',
+    '**Article ID.** `honest-gap`',
+    '**Rule.** Preserve this obligation.',
+    '**In practice.** Use judgment.',
+    '',
+  ].join('\n'), '');
+}
+
+function summary(article: ReturnType<typeof inventoryStandardsArticles>['articles'][number] | undefined) {
+  if (!article) return null;
+  return {
+    id: article.id,
+    family: article.family,
+    name: article.name,
+    ruleSha256: article.ruleSha256,
+    articleSha256: article.articleSha256,
+  };
+}
+
+function approvalFor(input: {
+  base: string;
+  candidate: string;
+  articleId: string;
+  direction: 'add' | 'remove' | 'strengthen' | 'neutral' | 'weaken';
+  privateKey: crypto.KeyObject;
+  approvedBy?: string;
+}) {
+  const probe = evaluateStandardsDirection({
+    baseMarkdown: input.base,
+    candidateMarkdown: input.candidate,
+    baseRevision: BASE_REVISION,
+  });
+  const before = inventoryStandardsArticles(input.base).articles.find((article) => article.id === input.articleId);
+  const after = inventoryStandardsArticles(input.candidate).articles.find((article) => article.id === input.articleId);
+  const change = before && after ? 'edit' : before ? 'remove' : 'add';
+  const payload = {
+    schemaVersion: 1,
+    baseRevision: BASE_REVISION,
+    baseRegistrySha256: probe.baseRegistrySha256,
+    candidateRegistrySha256: probe.candidateRegistrySha256,
+    articleId: input.articleId,
+    change,
+    direction: input.direction,
+    before: summary(before),
+    after: summary(after),
+    approvedBy: input.approvedBy ?? 'fixture-independent-operator',
+    approvedAt: '2026-08-17T16:00:00.000Z',
+  };
+  return {
+    payload,
+    signature: crypto.sign(
+      null,
+      Buffer.from(canonicalDirectionPayload(payload), 'utf8'),
+      input.privateKey,
+    ).toString('base64'),
+  };
+}
+
+describe('standards direction guard', () => {
+  let keyPair: ReturnType<typeof crypto.generateKeyPairSync>;
+
+  beforeEach(() => {
+    keyPair = crypto.generateKeyPairSync('ed25519');
+  });
+
+  it('C1 passes the pristine registry and exposes a non-vacuous denominator', () => {
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: baseRegistry,
+      baseRevision: BASE_REVISION,
+    });
+    expect(result.status).toBe('passed');
+    expect(result.errors).toEqual([]);
+    expect(result.population).toEqual(expect.objectContaining({ protectedBase: 2, candidate: 2, continuity: 2 }));
+  });
+
+  it('P1/P4b names a real article REMOVAL and keeps the protected-base denominator', () => {
+    const candidate = removeGap(baseRegistry);
+    expect(candidate).not.toContain('### Honest Gap'); // C2 mutation-applied control
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: candidate,
+      baseRevision: BASE_REVISION,
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('REMOVAL "Honest Gap"');
+    expect(result.population).toEqual(expect.objectContaining({ protectedBase: 2, candidate: 1, continuity: 2 }));
+    expect(result.population.removals).toEqual(['honest-gap']);
+  });
+
+  it('P2 refuses a self-authored removal attestation signed by the wrong principal', () => {
+    const candidate = removeGap(baseRegistry);
+    const attacker = crypto.generateKeyPairSync('ed25519');
+    const approval = approvalFor({
+      base: baseRegistry,
+      candidate,
+      articleId: 'honest-gap',
+      direction: 'remove',
+      privateKey: attacker.privateKey,
+      approvedBy: 'fixture-changer',
+    });
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: candidate,
+      baseRevision: BASE_REVISION,
+      approvalLedger: { schemaVersion: 1, approvals: [approval] },
+      approverPublicKeyPem: keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('REMOVAL "Honest Gap" lacks a valid different-principal signature');
+  });
+
+  it('names a declared WEAKENING and refuses the changer\'s signature', () => {
+    const candidate = replaceRootRule(
+      baseRegistry,
+      'We should prefer architecture where practical; remembering is an acceptable alternative.',
+    );
+    expect(candidate).toContain('remembering is an acceptable alternative'); // C2
+    const attacker = crypto.generateKeyPairSync('ed25519');
+    const approval = approvalFor({
+      base: baseRegistry,
+      candidate,
+      articleId: 'structure-beats-willpower',
+      direction: 'weaken',
+      privateKey: attacker.privateKey,
+      approvedBy: 'fixture-changer',
+    });
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: candidate,
+      baseRevision: BASE_REVISION,
+      approvalLedger: { schemaVersion: 1, approvals: [approval] },
+      approverPublicKeyPem: keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain(
+      'WEAKENING "Structure beats Willpower" lacks a valid different-principal signature',
+    );
+  });
+
+  it('refuses a candidate-tree pin replacement signed by the changer', () => {
+    const candidate = replaceRootRule(
+      baseRegistry,
+      'We should prefer architecture where practical; remembering is an acceptable alternative.',
+    );
+    const attacker = crypto.generateKeyPairSync('ed25519');
+    const protectedKeyFile = path.join(os.tmpdir(), `s5-protected-key-${crypto.randomUUID()}.pem`);
+    const candidateKeyFile = path.join(os.tmpdir(), `s5-candidate-key-${crypto.randomUUID()}.pem`);
+    fs.writeFileSync(
+      protectedKeyFile,
+      keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    );
+    fs.writeFileSync(
+      candidateKeyFile,
+      attacker.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    );
+    try {
+      const protectedPin = resolveProtectedApproverKey({
+        root: os.tmpdir(),
+        explicitFile: protectedKeyFile,
+        explicitRevision: BASE_REVISION,
+      });
+      expect(protectedPin.pem).not.toBe(fs.readFileSync(candidateKeyFile, 'utf8')); // attack applied
+      const approval = approvalFor({
+        base: baseRegistry,
+        candidate,
+        articleId: 'structure-beats-willpower',
+        direction: 'weaken',
+        privateKey: attacker.privateKey,
+        approvedBy: 'fixture-changer-after-pin-swap',
+      });
+      const result = evaluateStandardsDirection({
+        baseMarkdown: baseRegistry,
+        candidateMarkdown: candidate,
+        baseRevision: BASE_REVISION,
+        approvalLedger: { schemaVersion: 1, approvals: [approval] },
+        approverPublicKeyPem: protectedPin.pem,
+        candidateApproverPublicKeyPem: fs.readFileSync(candidateKeyFile, 'utf8'),
+      });
+      expect(result.status).toBe('not-proven');
+      expect(result.errors.join('\n')).toContain('APPROVER TRUST ROOT CHANGE is not self-authorizable');
+      expect(result.errors.join('\n')).toContain(
+        'WEAKENING "Structure beats Willpower" lacks a valid different-principal signature',
+      );
+    } finally {
+      fs.rmSync(protectedKeyFile, { force: true });
+      fs.rmSync(candidateKeyFile, { force: true });
+    }
+  });
+
+  it('refuses a pin-only goalpost move before it can become the next protected base', () => {
+    const protectedPin = keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    const attacker = crypto.generateKeyPairSync('ed25519');
+    const attackerPin = attacker.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    expect(attackerPin).not.toBe(protectedPin); // C2 mutation-applied control
+
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: baseRegistry,
+      baseRevision: BASE_REVISION,
+      approvalLedger: { schemaVersion: 1, approvals: [] },
+      approverPublicKeyPem: protectedPin,
+      candidateApproverPublicKeyPem: attackerPin,
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.changes).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.stringContaining('APPROVER TRUST ROOT CHANGE is not self-authorizable'),
+    ]);
+  });
+
+  it('allows a legitimate strengthening independently ratified over the exact bytes', () => {
+    const candidate = replaceRootRule(
+      baseRegistry,
+      'If behavior matters, enforce it in architecture, exercise the guard, and preserve the negative control.',
+    );
+    const approval = approvalFor({
+      base: baseRegistry,
+      candidate,
+      articleId: 'structure-beats-willpower',
+      direction: 'strengthen',
+      privateKey: keyPair.privateKey,
+    });
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: candidate,
+      baseRevision: BASE_REVISION,
+      approvalLedger: { schemaVersion: 1, approvals: [approval] },
+      approverPublicKeyPem: keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    });
+    expect(result.status).toBe('passed');
+    expect(result.errors).toEqual([]);
+    expect(result.changes).toEqual([
+      expect.objectContaining({ articleId: 'structure-beats-willpower', direction: 'strengthen' }),
+    ]);
+  });
+
+  it('rejects a signature replay after any candidate byte changes', () => {
+    const candidate = replaceRootRule(baseRegistry, 'If behavior matters, enforce it twice.');
+    const approval = approvalFor({
+      base: baseRegistry,
+      candidate,
+      articleId: 'structure-beats-willpower',
+      direction: 'strengthen',
+      privateKey: keyPair.privateKey,
+    });
+    const changedAgain = `${candidate}\n<!-- one more byte -->\n`;
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: changedAgain,
+      baseRevision: BASE_REVISION,
+      approvalLedger: { schemaVersion: 1, approvals: [approval] },
+      approverPublicKeyPem: keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('DIRECTION UNDECLARED "Structure beats Willpower"');
+  });
+
+  it('P4a rejects an empty population instead of scoring 0/0 clean', () => {
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: '# Standards\n',
+      baseRevision: BASE_REVISION,
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('candidate: standards article population is empty');
+  });
+
+  it('P4b rejects a Rule field planted outside the structural article enumeration', () => {
+    const candidate = `${baseRegistry}\n**Rule.** Hidden outside every article heading.\n`;
+    const result = evaluateStandardsDirection({
+      baseMarkdown: baseRegistry,
+      candidateMarkdown: candidate,
+      baseRevision: BASE_REVISION,
+    });
+    expect(result.status).toBe('not-proven');
+    expect(result.errors.join('\n')).toContain('candidate: article enumeration is open');
+  });
+
+  it('P5 reports NOT-PROVEN when the protected base is absent', () => {
+    const missing = path.join(os.tmpdir(), `s5-missing-${crypto.randomUUID()}.md`);
+    const result = resolveProtectedBaseRegistry({ root: os.tmpdir(), explicitFile: missing });
+    expect(result.markdown).toBeNull();
+    expect(result.errors.join('\n')).toContain('protected-base registry is unavailable');
+  });
+});
+
+describe('standards direction guard P3 negative controls', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'standards-direction-p3-'));
+    fs.copyFileSync(CORE, path.join(tmp, 'standards-registry-article-core.mjs'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function contractRun() {
+    const run = spawnSync(process.execPath, [VITEST, 'run', CONTRACT], {
+      cwd: path.resolve(__dirname, '../..'),
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        STANDARDS_DIRECTION_GUARD_UNDER_TEST: path.join(tmp, 'standards-direction-guard.mjs'),
+      },
+      encoding: 'utf8',
+    });
+    return {
+      exitCode: run.status ?? 1,
+      output: `${run.stdout}${run.stderr}`,
+    };
+  }
+
+  function reportP3(label: string, run: ReturnType<typeof contractRun>) {
+    if (process.env.S5_REPORT_P3 !== '1') return;
+    const deciding = run.output.split('\n').filter((line) =>
+      /Failed to load|Cannot find|is not a function|AssertionError|expected |Test Files|Tests\s+\d+/.test(line),
+    );
+    process.stderr.write(`\n[S5-P3 ${label}] exit=${run.exitCode}\n${deciding.slice(-18).join('\n')}\n`);
+  }
+
+  it('3a DELETE makes the exact-symbol contract fail', () => {
+    expect(fs.existsSync(path.join(tmp, 'standards-direction-guard.mjs'))).toBe(false); // mutation applied
+    const run = contractRun();
+    reportP3('3a-delete', run);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.output).toMatch(/Failed to load|Cannot find module|does not exist/);
+  });
+
+  it('3b COMMENT OUT makes the exact-symbol contract fail', () => {
+    const source = fs.readFileSync(GUARD, 'utf8');
+    const sabotaged = source.split('\n').map((line) => `// ${line}`).join('\n');
+    fs.writeFileSync(path.join(tmp, 'standards-direction-guard.mjs'), sabotaged);
+    const commented = fs.readFileSync(path.join(tmp, 'standards-direction-guard.mjs'), 'utf8');
+    expect(commented.split('\n').filter(Boolean).every((line) => line.startsWith('// '))).toBe(true); // mutation applied
+    const run = contractRun();
+    reportP3('3b-comment-out', run);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.output).toContain('guard.evaluateStandardsDirection is not a function');
+  });
+
+  it('3c SUPERSTRING RENAME makes the exact-symbol contract fail', () => {
+    const source = fs.readFileSync(GUARD, 'utf8');
+    const sabotaged = source.replaceAll('evaluateStandardsDirection', 'evaluateStandardsDirectionDisabled');
+    fs.writeFileSync(path.join(tmp, 'standards-direction-guard.mjs'), sabotaged);
+    expect(sabotaged).toContain('evaluateStandardsDirectionDisabled'); // mutation applied
+    expect(sabotaged).not.toMatch(/\bevaluateStandardsDirection\b/);
+    const run = contractRun();
+    reportP3('3c-superstring-rename', run);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.output).toContain('guard.evaluateStandardsDirection is not a function');
+  });
+
+  it('3d TYPE-PRESERVING HOLLOW compiles and loses on behavioral assertions', () => {
+    const source = fs.readFileSync(GUARD, 'utf8');
+    const bodyStart = source.indexOf('export function evaluateStandardsDirection({');
+    const bodyEnd = source.indexOf('\n}\n\n/** Fail-closed protected-base registry acquisition', bodyStart);
+    expect(bodyStart).toBeGreaterThanOrEqual(0);
+    expect(bodyEnd).toBeGreaterThan(bodyStart);
+    const signatureEnd = source.indexOf('}) {', bodyStart) + 4;
+    const passingBody = `
+  // P3d TYPE-PRESERVING HOLLOW: fabricated all-clear with the real API intact.
+  return {
+    status: 'passed',
+    errors: [],
+    baseRevision,
+    baseRegistrySha256: '0'.repeat(64),
+    candidateRegistrySha256: '0'.repeat(64),
+    changes: [],
+    population: {
+      protectedBase: 1,
+      candidate: 1,
+      continuity: 1,
+      additions: [],
+      removals: [],
+      byFamily: {},
+    },
+  };
+`;
+    const sabotaged = `${source.slice(0, signatureEnd)}${passingBody}${source.slice(bodyEnd)}`;
+    fs.writeFileSync(path.join(tmp, 'standards-direction-guard.mjs'), sabotaged);
+    const applied = fs.readFileSync(path.join(tmp, 'standards-direction-guard.mjs'), 'utf8');
+    expect(applied).toContain('export function evaluateStandardsDirection({');
+    expect(applied).toContain('P3d TYPE-PRESERVING HOLLOW');
+    expect(applied).not.toContain('const base = inventoryStandardsArticles(baseMarkdown);');
+
+    const run = contractRun();
+    reportP3('3d-type-preserving-hollow', run);
+    expect(run.exitCode).not.toBe(0);
+    expect(run.output).toContain('Tests  3 failed (3)');
+    expect(run.output).toMatch(/expected 'passed' to be 'not-proven'/);
+  });
+});

--- a/upgrades/next/phaseb-s5-rule-direction.md
+++ b/upgrades/next/phaseb-s5-rule-direction.md
@@ -1,0 +1,52 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The standards-coverage pipeline now treats every Rule-bearing article as a
+stable identity across protected main and a candidate change. Additions and
+removals are mechanical facts; edits carry an explicit direction ratified by an
+independently held Ed25519 key over the exact before/after bytes. Aggregate and
+family floors retain removed identities in their continuity denominator, so a
+smaller constitution cannot improve its score.
+
+The approver public key is read from protected main. Candidate key replacement
+is never signature authority, and candidate pin drift is refused even when the
+registry is unchanged, closing both one-change and two-change goalpost moves.
+Legacy heading renames intentionally appear as remove-plus-add and require the
+same independent review.
+
+## What to Tell Your User
+
+This is an internal governance hardening change. It does not add or alter an
+end-user action. It makes changes to Instar's own rulebook accountable: removing
+or weakening a rule can no longer make the score look better or pass on the
+changer's word alone.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Direction-aware rulebook review | Automatic in fleet pull-request checks |
+| Removal-safe standards scoring | Automatic in the standards coverage report |
+| Protected approver-key continuity | Automatic; candidate key drift is refused |
+
+## Evidence
+
+On the live release baseline, deleting one article raised coverage from 0.7386
+to 0.7471 and a foundational weakening passed after the changer refreshed its
+own family attestation. Through the wired pipeline after this change, deletion
+reports REMOVAL while retaining 65/88, weakening reports WEAKENING after the old
+refresh, candidate key/signature replacement is refused, and a pin-only change
+is refused before it can become the next trust root. The pristine pipeline
+passes; the focused suites pass 53/53, including all four negative controls. The
+type-preserving hollow compiles, runs all three behavioral contracts, and loses
+on three assertion mismatches.
+
+## Known Limits
+
+The repository currently carries a comments-only approver-key placeholder, so
+standards amendments fail closed until a separately authorized protected-main
+control-plane action installs a real public key. Its private key must remain
+outside the repository, agent-readable credential stores, and build environments.
+Cryptography proves who ratified exact bytes; it does not prove that the human
+semantic judgment was wise.

--- a/upgrades/side-effects/phaseb-s5-rule-direction.md
+++ b/upgrades/side-effects/phaseb-s5-rule-direction.md
@@ -1,0 +1,154 @@
+# Side-Effects Review — Standards Direction Guard
+
+**Version / slug:** `phaseb-s5-rule-direction`
+**Date:** `2026-08-17`
+**Author:** Instar-codey
+**Second-pass reviewer:** pending independent reviewer entry below
+
+## Summary of the change
+
+This change adds `scripts/standards-direction-guard.mjs`, integrates it into
+`scripts/standards-coverage.mjs` and CI, stores direction approvals in
+`docs/standards-direction-approvals.json`, and adds focused behavioral and
+negative-control tests. Standards-change acceptance now compares stable article
+identity against protected main, preserves removed identities in coverage
+denominators, and requires exact independently signed direction ratification.
+
+## Decision-point inventory
+
+- `evaluateStandardsDirection` — **add** — accepts or refuses additions,
+  removals, and edits against protected-base identities and signatures.
+- `standards-coverage --check` — **modify** — consumes the direction result and
+  uses continuity denominators for aggregate and family floors.
+- CI standards job — **modify** — extracts protected-base registry and approver
+  pin before invoking the existing check entry point.
+
+---
+
+## 1. Over-block
+
+An ordinary heading rename on one of the 86 legacy articles changes its derived
+identity and is treated as remove-plus-add, so it needs independent ratification.
+Formatting anywhere inside an article also changes its article hash and needs a
+declared, signed direction. These are known conservative costs: permissive rename
+inference would reopen the identity-erasure path. With the repository's current
+comments-only key placeholder, every standards amendment fails closed until a
+real independently controlled public key is installed on protected main.
+
+## 2. Under-block
+
+A legitimate approver can ratify a direction declaration that is semantically
+wrong; cryptography proves principal and bytes, not judgment quality. If the
+approver private key becomes readable to the changer, the principal separation
+collapses. The operational requirement is explicit: keep the private key outside
+the repository, agent credential stores, and build environments. Candidate key
+replacement is closed because the pin is read from protected main and all
+candidate pin drift is refused, including a pin-only first step.
+
+## 3. Level-of-abstraction fit
+
+The guard operates at the correct split. Stable identity, before/after hashes,
+population union, signature validity, and protected-base acquisition are closed
+mechanical facts. Semantic direction remains a human declaration. The code does
+not build a brittle prose classifier and does not compete with an LLM authority.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [x] Deterministic hard-invariant authority over a closed governance protocol.
+
+The generic template's first three safe boxes do not describe this case. The
+guard has blocking authority, but it does not judge prose with brittle logic.
+It verifies enumerable invariants: exact identities and hashes, allowed direction
+tokens, signature validity, and protected-base provenance. Human semantic judgment
+arrives as a signed declaration. This is the principle document's deterministic
+policy-evaluator / hard-invariant exception, not a message-meaning heuristic.
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals judgment point. The only
+semantic choice, direction, is explicitly made and signed by an independent
+principal. Code checks the declaration's closed protocol and never infers the
+choice from competing evidence.
+
+## 5. Interactions
+
+- **Shadowing:** the direction guard runs alongside the existing area-audit and
+  coverage floors. It adds errors; it does not prevent their evaluation or logs.
+- **Double-fire:** a standards edit can produce both a stale area-audit objection
+  and a direction objection. This is intentional: one binds review freshness,
+  the other binds amendment direction and independent authority. Refreshing the
+  first does not clear the second.
+- **Races:** all inputs are immutable Git bytes or a candidate JSON file during a
+  single CI process. There is no shared mutable runtime state.
+- **Feedback loops:** none. The check never writes its approval ledger or registry.
+
+## 6. External surfaces
+
+CI output gains direction status, protected-base revision, trust-root provenance,
+an explicit candidate-pin-not-authoritative fact, and a pin-drift-blocked fact.
+Standards authors gain a signed JSON approval record. No Telegram, Slack,
+Cloudflare, database, conversation, timing, or user data surface changes. No
+operator-facing action is added; key custody and protected-main pin installation
+remain repository governance operations.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Replicated through Git.** The registry, candidate ledger, public trust pin,
+guard, CI wiring, and tests are committed bytes. Every machine on the same commit
+derives the same canonical hashes and verdict. The signing private key is
+deliberately not replicated to agent machines. The feature emits no user-facing
+notices, holds no runtime durable state that can strand on topic transfer, and
+generates no URLs.
+
+## 8. Rollback cost
+
+Revert the guard, coverage integration, workflow extraction, ledger, docs, and
+tests as one patch and ship the next release. No data migration, agent-state
+repair, secret rotation, or runtime cleanup is required. During rollback the old
+self-attestation weakness returns, so rulebook amendments should remain paused.
+
+## Conclusion
+
+The review found two deliberate friction points and no accidental runtime side
+effect: legacy renames require ratification, and the comments-only protected pin
+blocks amendments until independent custody is provisioned. The candidate-pin
+goalpost attack is closed in both one-change and two-change forms by protected-base
+verification plus an unconditional candidate-drift refusal. Normal CI can never
+bootstrap or rotate the pin; that requires separate protected-main control-plane
+authority. The change is ready for normal CI.
+
+## Second-pass review
+
+**Reviewer:** independent Codex second-pass lane
+**Independent read of the artifact:** concern resolved. The first review found
+that protected-base verification stopped a same-change pin swap but allowed a
+pin-only first step to become the next base. It also found the ELI16 overstated
+malformed-placeholder behavior. Candidate pin drift is now always refused, the
+pin-only regression is tested, bootstrap/rotation authority is stated explicitly,
+and the malformed-key wording now matches the live pipeline. With those changes,
+the review concurs on authority separation, denominators, rename friction,
+multi-machine posture, and rollback.
+
+## Evidence pointers
+
+- `scratchpad/phaseB/REPORT-S5.md`
+- `tests/unit/standards-direction-guard.test.ts`
+- `tests/unit/standards-direction-guard-contract.test.ts`
+- `tests/unit/standards-coverage-ratchet.test.ts`
+
+## Class-Closure Declaration
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence:
+{ enforcementType: gate, citation: scripts/standards-direction-guard.mjs#evaluateStandardsDirection,
+howCaught: the exact old self-authored family refresh has no independently signed
+direction record, so deletion and weakening remain refused even after that claim
+is refreshed }`.


### PR DESCRIPTION
## Summary

- assigns stable per-article identities and measures the enforcement ratio over the protected-base/candidate identity union, so deletion cannot improve the score
- requires independently signed direction attestations for edits and removals
- reads the approver trust root from the protected base and vetoes every candidate-tree pin change, including pin-only two-step goalpost movement
- wires the guard into the existing standards coverage CI check
## ELI16 — a smaller rulebook must not look safer

Instar has a rulebook and a check that scores how much of it is enforced. Before this change, someone could delete a rule and make the score rise because the deleted rule vanished from the total. They could also turn a requirement into its opposite and refresh their own review record, leaving the check green.

This change keeps removed rules in the comparison, so deletion cannot improve the score. Any removal or weakening must also be approved by a different trusted signer for the exact old and new text. The trusted public key is read from protected main, so the proposer cannot replace it with their own key inside the same change. Ordinary heading renames count as remove-plus-add and therefore carry the same approval cost.

## Trust boundary

The repository contains no approver private key. The present pinned file is a comments-only placeholder, so an unchanged registry passes but every amendment fails closed until an authorized external control-plane action bootstraps a real protected-main key. Rotation also requires that separate protected-main action. A legacy heading rename is conservatively remove-plus-add and therefore requires approval.

## Evidence

- reproduced both live defects before implementation: deletion improved 65/88 to 65/87 and digest refresh cleared the only objection; weakening also cleared after self-authored refresh
- after the guard, deletion remains 65/88 and both changes stay blocked after the old refresh
- attacker-controlled candidate key plus matching signature is refused; pin-only candidate change is refused
- independently signed strengthening passes; replay after a one-byte change fails
- P3 ran all four sabotages, including the type-preserving constant-pass body; all three contract tests executed and failed on assertion mismatches
- focused suite: 3 files, 53 tests passed
- build and lint passed; commit and pre-push hooks passed
- side-effects review recorded in upgrades/side-effects/phaseb-s5-rule-direction.md
## Landing note — verification state and immediate refusal

**BUILT WITH HAND EVIDENCE; NOT MACHINE-VERIFIED.** The independent instrument has not graded this guard and is on its fourth repair cycle. This change must not be described as FIXED or EFFECTIVE unless that independent measurement later establishes it.

**The fail-closed consequence is immediate and real.** Until an authorized protected-main control-plane action bootstraps a genuine approver public key, **every standards-registry amendment will be refused**. That refusal is the intended safe behavior. This landing does not bootstrap, generate, rotate, install, default, or self-sign any approver key; establishing the trust root remains a separate operator action outside this change.

## Phase B status

**BUILT with hand evidence; not yet FIXED.** The S5 verifier adapter exists, but machine verification remains pending independent acceptance after the shared verifier core is repaired. This PR does not claim that the instrument has blessed the guard. The lane changed only its adapter/manifest entry and did not edit verifier core, verifier tests, or shared schema.