### PR TITLE
H1: authenticate execution receipts in memory

### DIFF
--- a/scratchpad/phaseB/REPORT-H3.md
+++ b/scratchpad/phaseB/REPORT-H3.md
@@ -1,0 +1,44 @@
+# H3 — hardened verification-core conformance repair
+
+## 2026-08-18 05:57:55 -0700 (PDT)
+
+Subject: PR #1924, starting head `3f47621dbeb3eca0f26523f713ad4c2120f13cf1`.
+
+### Fault 1 — corrected authority-location claim
+
+H3 corrects the documentation rather than changing the trusted core. The HMAC key is generated on the main instrument thread by `crypto.randomBytes(32)`, then its buffer ownership is transferred to the Worker over `MessagePort`. The Worker holds and uses it, zeroes it on close, and no key file is written. Moving key generation merely to preserve the earlier inaccurate sentence would have changed trusted-core behavior outside H3's boundary.
+
+### Fault 2 — standalone post-pinning rejection fixtures
+
+Each fixture pins a legitimate observer session as setup, submits one attacked candidate, verifies the existing authority returns false, verifies the candidate is not in the live authenticated-event set, and emits an UNKNOWN verdict. `authenticatedEvents` counts attacked candidates, not the legitimate setup event.
+
+```text
+H3_DUPLICATE_READY setupPinned=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN
+H3_UNSIGNED_EVENT setupPinned=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN
+H3_REPLAYED_EVENT setupPinned=true setupSequence2=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN
+H3_OUT_OF_ORDER_EVENT setupPinned=true attemptedSequence=3 expectedSequence=2 authenticatedEvents=0 verdict=UNKNOWN
+H3_IDENTITY_MISMATCH setupPinned=true mismatchedField=guardId authenticatedEvents=0 verdict=UNKNOWN
+```
+
+Focused verification:
+
+```text
+$ node --test scratchpad/phaseB/authenticated-execution-receipt.test.mjs scratchpad/phaseB/fix-verifier.test.mjs
+tests 24
+pass 24
+fail 0
+exit 0
+```
+
+Repository gates:
+
+```text
+$ npx tsc --noEmit
+exit 0
+$ npm run lint
+exit 0
+```
+
+Boundary verification: only the authority test file and this report were changed. The signing algorithm, sequence and identity checks, receipt binding, `authenticated-execution-receipt.mjs`, and `fix-verifier.mjs` are unchanged.
+
+State: BUILT WITH HAND EVIDENCE; independent re-judgement pending. Pull request only; no merge.

--- a/scratchpad/phaseB/authenticated-execution-receipt.test.mjs
+++ b/scratchpad/phaseB/authenticated-execution-receipt.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -6,9 +7,65 @@ import { spawn } from 'node:child_process';
 import test from 'node:test';
 
 import {
+  AUTHENTICATED_OBSERVER_EVENT_SCHEMA,
   createAuthenticatedReceiptAuthority,
+  isLiveAuthenticatedObserverEvent,
   isLiveAuthenticatedReceipt,
 } from './authenticated-execution-receipt.mjs';
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function signObserverEvent(keyPair, fields) {
+  const event = {
+    eventSchema: AUTHENTICATED_OBSERVER_EVENT_SCHEMA,
+    source: 'fix-verifier-observer',
+    ...fields,
+  };
+  return {
+    ...event,
+    signature: crypto.sign(null, Buffer.from(canonical(event)), keyPair.privateKey).toString('base64'),
+  };
+}
+
+async function pinObserverFixture(authority) {
+  const keyPair = crypto.generateKeyPairSync('ed25519');
+  const publicKey = keyPair.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+  const identity = {
+    observerSession: crypto.randomUUID(),
+    guardId: 'H3-fixture-guard',
+    nodeEntry: 'guard.mjs',
+    observerPid: process.pid,
+    argv: ['guard.mjs'],
+  };
+  const readyFields = {
+    ...identity,
+    sequence: 1,
+    kind: 'observer-ready',
+    publicKey,
+  };
+  const ready = signObserverEvent(keyPair, readyFields);
+  assert.equal(await authority.pinObserverEvent(ready, {
+    kind: 'observer-ready',
+    guardId: identity.guardId,
+    nodeEntry: identity.nodeEntry,
+    observerPid: identity.observerPid,
+  }), true);
+  assert.equal(isLiveAuthenticatedObserverEvent(ready), true);
+  return { keyPair, identity, readyFields };
+}
+
+function rejectedEventResult(authenticated) {
+  return {
+    authenticatedEvents: authenticated ? 1 : 0,
+    verdict: authenticated ? 'PROVEN' : 'UNKNOWN',
+  };
+}
 
 function runChild(argv) {
   return new Promise((resolve, reject) => {
@@ -88,4 +145,109 @@ test('unavailable private authority never authenticates evidence', async () => {
   await authority.close();
   assert.equal(await authority.authenticate({}, {}), false);
   await assert.rejects(() => authority.issue({}), /unavailable/);
+});
+
+test('H3 duplicate observer-ready fixture fails closed after the session is pinned', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H3-duplicate-ready' });
+  try {
+    const { keyPair, readyFields } = await pinObserverFixture(authority);
+    const duplicate = signObserverEvent(keyPair, readyFields);
+    const result = rejectedEventResult(await authority.pinObserverEvent(duplicate, {
+      kind: 'observer-ready',
+      guardId: readyFields.guardId,
+      nodeEntry: readyFields.nodeEntry,
+      observerPid: readyFields.observerPid,
+    }));
+    assert.equal(isLiveAuthenticatedObserverEvent(duplicate), false);
+    assert.deepEqual(result, { authenticatedEvents: 0, verdict: 'UNKNOWN' });
+    console.log('H3_DUPLICATE_READY setupPinned=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN');
+  } finally {
+    await authority.close();
+  }
+});
+
+test('H3 unsigned post-pinning observer event fixture fails closed', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H3-unsigned' });
+  try {
+    const { identity } = await pinObserverFixture(authority);
+    const unsigned = {
+      eventSchema: AUTHENTICATED_OBSERVER_EVENT_SCHEMA,
+      source: 'fix-verifier-observer',
+      ...identity,
+      sequence: 2,
+      kind: 'child-start',
+      childPid: process.pid,
+      startedAt: new Date().toISOString(),
+    };
+    const result = rejectedEventResult(await authority.authenticateObserverEvent(unsigned, identity));
+    assert.equal(isLiveAuthenticatedObserverEvent(unsigned), false);
+    assert.deepEqual(result, { authenticatedEvents: 0, verdict: 'UNKNOWN' });
+    console.log('H3_UNSIGNED_EVENT setupPinned=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN');
+  } finally {
+    await authority.close();
+  }
+});
+
+test('H3 replayed post-pinning observer event fixture fails closed', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H3-replay' });
+  try {
+    const { keyPair, identity } = await pinObserverFixture(authority);
+    const first = signObserverEvent(keyPair, {
+      ...identity,
+      sequence: 2,
+      kind: 'child-start',
+      childPid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
+    assert.equal(await authority.authenticateObserverEvent(first, identity), true);
+    const replay = JSON.parse(JSON.stringify(first));
+    const result = rejectedEventResult(await authority.authenticateObserverEvent(replay, identity));
+    assert.equal(isLiveAuthenticatedObserverEvent(replay), false);
+    assert.deepEqual(result, { authenticatedEvents: 0, verdict: 'UNKNOWN' });
+    console.log('H3_REPLAYED_EVENT setupPinned=true setupSequence2=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN');
+  } finally {
+    await authority.close();
+  }
+});
+
+test('H3 out-of-order post-pinning observer event fixture fails closed', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H3-out-of-order' });
+  try {
+    const { keyPair, identity } = await pinObserverFixture(authority);
+    const outOfOrder = signObserverEvent(keyPair, {
+      ...identity,
+      sequence: 3,
+      kind: 'child-exit',
+      childPid: process.pid,
+      childExitCode: 0,
+      emittedAfterChildExit: true,
+    });
+    const result = rejectedEventResult(await authority.authenticateObserverEvent(outOfOrder, identity));
+    assert.equal(isLiveAuthenticatedObserverEvent(outOfOrder), false);
+    assert.deepEqual(result, { authenticatedEvents: 0, verdict: 'UNKNOWN' });
+    console.log('H3_OUT_OF_ORDER_EVENT setupPinned=true attemptedSequence=3 expectedSequence=2 authenticatedEvents=0 verdict=UNKNOWN');
+  } finally {
+    await authority.close();
+  }
+});
+
+test('H3 identity-mismatched post-pinning observer event fixture fails closed', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H3-identity-mismatch' });
+  try {
+    const { keyPair, identity } = await pinObserverFixture(authority);
+    const mismatch = signObserverEvent(keyPair, {
+      ...identity,
+      guardId: 'candidate-replaced-guard',
+      sequence: 2,
+      kind: 'child-start',
+      childPid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
+    const result = rejectedEventResult(await authority.authenticateObserverEvent(mismatch, identity));
+    assert.equal(isLiveAuthenticatedObserverEvent(mismatch), false);
+    assert.deepEqual(result, { authenticatedEvents: 0, verdict: 'UNKNOWN' });
+    console.log('H3_IDENTITY_MISMATCH setupPinned=true mismatchedField=guardId authenticatedEvents=0 verdict=UNKNOWN');
+  } finally {
+    await authority.close();
+  }
 });


### PR DESCRIPTION
## Status

BUILT WITH HAND EVIDENCE; NOT MACHINE-VERIFIED. This change must not be described as FIXED or EFFECTIVE until the independently certified instrument grades it.

## Dependency

This branch is conceptually stacked on W1 PR #1923. GitHub cannot use its fork-owned head branch as an upstream base branch, so this PR targets `main` and includes the W1 commits plus H1 hardening. H1 does not modify or force-push the W1-owned branch.

## What changed

- replaces disk-readable tokens and writable receipt files with an ephemeral HMAC receipt authority held in memory
- each generated pipeline observer creates an ephemeral Ed25519 key in its own sanitized process; `NODE_OPTIONS` is removed before that process starts
- the authority pins the signed `observer-ready` event only after validating the live wrapper process, then verifies every later event against the pinned session and strict sequence
- aggregate stdout is transport only: unsigned, self-signed stand-in, replayed, duplicate-ready, or out-of-order event text receives no authority
- the final HMAC receipt is issued by the same authority only when its observer session, event sequence, observer pid, event kind, and signature hash match the last authenticated event
- receipt MAC binds real child pid, exit status, signal, argv hash, observer session, signed-event sequence, nonce, and timestamps
- authenticated receipts and argv are frozen before credit

## Controls

- C1 live S5 wiring: exact signed observer-ready, child-start, and child-exit sequence authenticated; child `76405` exited 0; receipt bound to event sequence 3; wiring WIRED
- prior C3 disk forgery: real child false, forged receipt rejected, wiring UNKNOWN
- new C4 stdout injection: stand-in emitted three correctly shaped, self-signed `FIX_VERIFIER_OBSERVER_EVENT` lines without running the declared child; authenticated events 0, authenticated receipts 0, verdict UNKNOWN
- focused suite: 19 passed, 0 failed

## Integration

S4 and S5 consume the hardened path through the W1 verifier. F1 directly observes its child through ChildProcess APIs and is not on the aggregate-stdout event path.

No approver key, CI configuration, model registry, or staleness gate was changed. This PR is open for independent review and must not be merged by this lane.
## H3 conformance repair

The independent J7 judgement found two evidence faults; H3 addresses both without changing the trusted verifier core.

**Authority-location correction:** the HMAC key is generated on the main instrument thread by `crypto.randomBytes(32)`, then its buffer ownership is transferred to the Worker over `MessagePort`. The Worker holds and uses it, zeroes it on close, and no key file is written. I corrected the claim instead of moving generation because changing trusted-core behavior merely to preserve an inaccurate sentence would exceed H3's demonstration-only boundary.

**Standalone post-pinning fixtures:** each fixture pins a legitimate observer session as setup, submits one attacked candidate, verifies the existing authority returns false, and verifies that candidate never enters the live authenticated-event set. The deciding lines are:

```text
H3_DUPLICATE_READY setupPinned=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN
H3_UNSIGNED_EVENT setupPinned=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN
H3_REPLAYED_EVENT setupPinned=true setupSequence2=true candidateEvents=1 authenticatedEvents=0 verdict=UNKNOWN
H3_OUT_OF_ORDER_EVENT setupPinned=true attemptedSequence=3 expectedSequence=2 authenticatedEvents=0 verdict=UNKNOWN
H3_IDENTITY_MISMATCH setupPinned=true mismatchedField=guardId authenticatedEvents=0 verdict=UNKNOWN
```

Focused suite after synchronizing with current upstream main: 24 tests passed, 0 failed. Type-check and the repository's full lint entry point passed. The normal pre-commit and pre-push hooks passed; no hook was bypassed.

Boundary proof: `authenticated-execution-receipt.mjs` remains SHA-256 `6534ed0983b733311d343c23b60bc70d13648ca9d911a136875504d20d6e4817`, and `fix-verifier.mjs` remains SHA-256 `584a0a0b7248c4bede3f99e58f369db2183ca298fc5c1209862a6e3dc41edd72`, matching the J7-reviewed source. No signing algorithm, sequence check, identity check, or receipt binding changed.

H3 remains pull-request-only. No merge is requested or authorized.

## ELI16 — Make execution receipts difficult to fake

Several safety checks rely on a child process reporting what it ran and how it ended. Plain output lines or writable receipt files can be copied, edited, or replayed, so they are weak evidence. This change gives each live observer a short-lived identity held in memory, accepts its events only in the expected order, and creates a final signed receipt tied to the real child process and exit result. Forged, repeated, unsigned, or out-of-order messages remain unknown instead of receiving credit. This strengthens the evidence for later independent review; it does not by itself declare the larger feature fixed.
