### PR TITLE
W3.4: validated standards enforcement measurement

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-19T01-33-25-657Z-w34-enforcement-measurement.json
+++ b/.instar/instar-dev-decisions/2026-08-19T01-33-25-657Z-w34-enforcement-measurement.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-19T01:33:25.657Z",
+  "slug": "w34-enforcement-measurement",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 744,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lib/standards-enforcement-measurement.mjs",
+      "scripts/standards-coverage.mjs"
+    ],
+    "addedLines": 696,
+    "deletedLines": 48
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scratchpad/phaseB/REPORT-W34.md
+++ b/scratchpad/phaseB/REPORT-W34.md
@@ -1,0 +1,123 @@
+# Phase B Lane W3.4 — Enforcement Measurement
+
+> **Append-only chronology:** This report preserves the evidence known at each step. Read entries from top to bottom: the newest entry is last and supersedes earlier status statements for the same claim.
+
+## 2026-08-18 01:15:39 -0700 (PDT) — Brief read, design pinned, first failing controls proven
+
+### Ground
+
+```text
+model=GPT-5 Codex
+tree=/Users/justin/Documents/Projects/instar-codey/.worktrees/phaseb-w34-enforcement-measurement
+branch=phaseb/w34-enforcement-measurement
+base=upstream/main
+commit=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+dependencies=npm ci exit 0
+```
+
+### C3a restatement before build
+
+Deleting an unenforced rule must fail the measurement by surfacing a protected-population removal, and the headline score must not improve.
+
+### Design decision
+
+The closed article census and maximum reference strength come from a content-addressed merge base with canonical server-advertised protected main. Candidate bytes can preserve or lower an already-protected reference strength, never raise it. A candidate-only reference is unverified. Empty, unreadable, or structurally hollow candidate evidence drops to unverified. Certified EFFECTIVE/WIRED/EXISTS records, when present on the protected side, supersede the structural ladder. An absent/empty protected population is a measurement error, never `1` or `100%`.
+
+### First failing controls — production entry, tests executed
+
+```text
+$ npx vitest run tests/unit/standards-coverage-ratchet.test.ts --reporter=verbose
+exit=1
+Test Files  1 failed (1)
+Tests       3 failed | 35 passed (38)
+
+C3a deciding output:
+AssertionError: expected 1 to be less than or equal to 0.5
+  expected after.enforcedRatio <= before.enforcedRatio
+  received after=1, before=0.5
+
+C3b deciding output:
+AssertionError: expected 1 to be +0
+  protected ratchet path remained credited after candidate file was emptied
+
+C3c deciding output:
+AssertionError: expected 2 to be 1
+  new hollow test reference increased ratchet count from 1 to 2
+```
+
+These are behavioral assertion failures after all 38 tests executed, not compile failures.
+
+## 2026-08-18 01:50:21 -0700 (PDT) — BUILT with hand evidence; independent certification pending
+
+### C1 — pristine live baseline
+
+```text
+$ node scripts/standards-coverage.mjs --check
+exit=0
+[standards-coverage] registry=true total=88 continuity-total=88 enforced-ratio=0.6591 (ratchet 26 / gate 25 / lint 7 / spec-only 9 / gap 21) false-claims=0 dangling=0 unrecognized-sections=0
+[standards-coverage] measurement=proven base=4318a1e150e9a8304e6c2e7ad381bf66d03998e5 source=canonical-server-content-addressed-merge-base protected-population=88 candidate-population=88 unverified-references=39
+[standards-coverage] protected-strength-floor=58/88 ratio=0.6591 candidate-may-raise=false
+✅ standards-coverage check passed.
+```
+
+The previous existence score was `65/88 = 0.7386`. The live protected-base result is `58/88 = 0.6591`; 39 cited references remain explicitly unverified instead of being rounded up because their path exists.
+
+### C2/C3 — mutations landed and controls bite
+
+```text
+$ npx vitest run tests/unit/standards-coverage-ratchet.test.ts --reporter=dot
+exit=0
+W34_C3A before=0.5 after=0.5 removals=1 deciding="population shrank by 1 (direction: removal)"
+W34_C3B landed=size-0 ratchet=0 deciding="candidate-reference-empty"
+W34_C3C landed=hollow-addition ratchet=1 deciding="reference-not-in-protected-census"
+Test Files  1 passed (1)
+Tests       38 passed (38)
+```
+
+Mutation-landing assertions executed before each measurement: C3a reads the mutated registry and proves the protected heading is absent; C3b proves the cited candidate file remains present at exactly zero bytes; C3c reads the new rule and the new cited file and proves the file has no executable `it(...)` call.
+
+The score cannot improve under C3a: the protected article remains in the continuity denominator, contributes documented-only strength, and the check records a removal error. C3b loses the prior ratchet contribution while the path still exists. C3c leaves the original ratchet count at one and records the candidate-only hollow reference as unverified.
+
+### Additional verification
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=0
+Test Files  1 passed (1)
+Tests       5 passed (5)
+
+$ npx tsc --noEmit
+exit=0
+
+$ git diff --check
+exit=0
+```
+
+The focused suite proves prose/comments are not executable evidence, candidate evidence cannot raise the protected article/reference census, a protected content-bound certified verdict supersedes structural inference while candidate-authored replacement ledgers are ignored, removing a certified candidate reference drops it to unverified, and zero-of-zero is NOT-PROVEN.
+
+### Repository lint — unchanged external blocker
+
+```text
+$ npm run lint
+exit=1
+[lint-model-registry-freshness] enforcement=strict
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+FAIL — 1 finding(s) under strict enforcement.
+
+$ git diff --exit-code upstream/main -- scripts/lint-model-registry-freshness.mjs src/core/ModelRegistry.ts docs/model-registry.json package.json package-lock.json
+exit=0
+```
+
+Type-check and every earlier lint entry completed. W3.4 does not change the model-registry manifest or staleness implementation; the brief prohibits touching it. This is an upstream time-based failure and remains visible.
+
+### Evidence stamps and state
+
+```text
+scratchpad/phaseB/evidence/W34-controls.json sha256=cf082e89522b35f4d34774000dd6d2328d7a5dc36b63d8a00748d41bef0c8e75
+scripts/lib/standards-enforcement-measurement.mjs sha256=8916035029237c595c95c9274fb8e73f8036fe1e6a150eda40079c05e29c36f8
+scripts/standards-coverage.mjs sha256=774d83d11863756f91d8e4612d0ad171970c85ea1313e9dc1e1e854d89eb7102
+tests/unit/standards-enforcement-measurement.test.ts sha256=bcdd562ccff196b7bfa77ac1ae24318385dc527619552afaae0ee678c6302473
+tests/unit/standards-coverage-ratchet.test.ts sha256=8755cbb96b975f3283ce42adc5c22833b747dcd45fde210ba7761e91d969a53d
+```
+
+State: **BUILT WITH HAND EVIDENCE, NOT MACHINE-CERTIFIED**. The builder does not call this FIXED or EFFECTIVE; the independent judge must re-gate it.

--- a/scratchpad/phaseB/REPORT-W34.md
+++ b/scratchpad/phaseB/REPORT-W34.md
@@ -1,0 +1,338 @@
+# Phase B Lane W3.4 — Enforcement Measurement
+
+> **Append-only chronology:** This report preserves the evidence known at each step. Read entries from top to bottom: the newest entry is last and supersedes earlier status statements for the same claim.
+
+## 2026-08-18 01:15:39 -0700 (PDT) — Brief read, design pinned, first failing controls proven
+
+### Ground
+
+```text
+model=GPT-5 Codex
+tree=/Users/justin/Documents/Projects/instar-codey/.worktrees/phaseb-w34-enforcement-measurement
+branch=phaseb/w34-enforcement-measurement
+base=upstream/main
+commit=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+dependencies=npm ci exit 0
+```
+
+### C3a restatement before build
+
+Deleting an unenforced rule must fail the measurement by surfacing a protected-population removal, and the headline score must not improve.
+
+### Design decision
+
+The closed article census and maximum reference strength come from a content-addressed merge base with canonical server-advertised protected main. Candidate bytes can preserve or lower an already-protected reference strength, never raise it. A candidate-only reference is unverified. Empty, unreadable, or structurally hollow candidate evidence drops to unverified. Certified EFFECTIVE/WIRED/EXISTS records, when present on the protected side, supersede the structural ladder. An absent/empty protected population is a measurement error, never `1` or `100%`.
+
+### First failing controls — production entry, tests executed
+
+```text
+$ npx vitest run tests/unit/standards-coverage-ratchet.test.ts --reporter=verbose
+exit=1
+Test Files  1 failed (1)
+Tests       3 failed | 35 passed (38)
+
+C3a deciding output:
+AssertionError: expected 1 to be less than or equal to 0.5
+  expected after.enforcedRatio <= before.enforcedRatio
+  received after=1, before=0.5
+
+C3b deciding output:
+AssertionError: expected 1 to be +0
+  protected ratchet path remained credited after candidate file was emptied
+
+C3c deciding output:
+AssertionError: expected 2 to be 1
+  new hollow test reference increased ratchet count from 1 to 2
+```
+
+These are behavioral assertion failures after all 38 tests executed, not compile failures.
+
+## 2026-08-18 01:50:21 -0700 (PDT) — BUILT with hand evidence; independent certification pending
+
+### C1 — pristine live baseline
+
+```text
+$ node scripts/standards-coverage.mjs --check
+exit=0
+[standards-coverage] registry=true total=88 continuity-total=88 enforced-ratio=0.6591 (ratchet 26 / gate 25 / lint 7 / spec-only 9 / gap 21) false-claims=0 dangling=0 unrecognized-sections=0
+[standards-coverage] measurement=proven base=4318a1e150e9a8304e6c2e7ad381bf66d03998e5 source=canonical-server-content-addressed-merge-base protected-population=88 candidate-population=88 unverified-references=39
+[standards-coverage] protected-strength-floor=58/88 ratio=0.6591 candidate-may-raise=false
+✅ standards-coverage check passed.
+```
+
+The previous existence score was `65/88 = 0.7386`. The live protected-base result is `58/88 = 0.6591`; 39 cited references remain explicitly unverified instead of being rounded up because their path exists.
+
+### C2/C3 — mutations landed and controls bite
+
+```text
+$ npx vitest run tests/unit/standards-coverage-ratchet.test.ts --reporter=dot
+exit=0
+W34_C3A before=0.5 after=0.5 removals=1 deciding="population shrank by 1 (direction: removal)"
+W34_C3B landed=size-0 ratchet=0 deciding="candidate-reference-empty"
+W34_C3C landed=hollow-addition ratchet=1 deciding="reference-not-in-protected-census"
+Test Files  1 passed (1)
+Tests       38 passed (38)
+```
+
+Mutation-landing assertions executed before each measurement: C3a reads the mutated registry and proves the protected heading is absent; C3b proves the cited candidate file remains present at exactly zero bytes; C3c reads the new rule and the new cited file and proves the file has no executable `it(...)` call.
+
+The score cannot improve under C3a: the protected article remains in the continuity denominator, contributes documented-only strength, and the check records a removal error. C3b loses the prior ratchet contribution while the path still exists. C3c leaves the original ratchet count at one and records the candidate-only hollow reference as unverified.
+
+### Additional verification
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=0
+Test Files  1 passed (1)
+Tests       5 passed (5)
+
+$ npx tsc --noEmit
+exit=0
+
+$ git diff --check
+exit=0
+```
+
+The focused suite proves prose/comments are not executable evidence, candidate evidence cannot raise the protected article/reference census, a protected content-bound certified verdict supersedes structural inference while candidate-authored replacement ledgers are ignored, removing a certified candidate reference drops it to unverified, and zero-of-zero is NOT-PROVEN.
+
+### Repository lint — unchanged external blocker
+
+```text
+$ npm run lint
+exit=1
+[lint-model-registry-freshness] enforcement=strict
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+FAIL — 1 finding(s) under strict enforcement.
+
+$ git diff --exit-code upstream/main -- scripts/lint-model-registry-freshness.mjs src/core/ModelRegistry.ts docs/model-registry.json package.json package-lock.json
+exit=0
+```
+
+Type-check and every earlier lint entry completed. W3.4 does not change the model-registry manifest or staleness implementation; the brief prohibits touching it. This is an upstream time-based failure and remains visible.
+
+### Evidence stamps and state
+
+```text
+scratchpad/phaseB/evidence/W34-controls.json sha256=cf082e89522b35f4d34774000dd6d2328d7a5dc36b63d8a00748d41bef0c8e75
+scripts/lib/standards-enforcement-measurement.mjs sha256=8916035029237c595c95c9274fb8e73f8036fe1e6a150eda40079c05e29c36f8
+scripts/standards-coverage.mjs sha256=774d83d11863756f91d8e4612d0ad171970c85ea1313e9dc1e1e854d89eb7102
+tests/unit/standards-enforcement-measurement.test.ts sha256=bcdd562ccff196b7bfa77ac1ae24318385dc527619552afaae0ee678c6302473
+tests/unit/standards-coverage-ratchet.test.ts sha256=8755cbb96b975f3283ce42adc5c22833b747dcd45fde210ba7761e91d969a53d
+```
+
+State: **BUILT WITH HAND EVIDENCE, NOT MACHINE-CERTIFIED**. The builder does not call this FIXED or EFFECTIVE; the independent judge must re-gate it.
+
+## 2026-08-18 02:11:50 -0700 (PDT) — Branch published; PR open and unmerged
+
+```text
+implementation-commit=a4ec1719968c949d28f6b5532de201aa1f91ebd5
+branch=phaseb/w34-enforcement-measurement
+fork-push=origin/phaseb/w34-enforcement-measurement
+pull-request=https://github.com/JKHeadley/instar/pull/1925
+pull-request-number=1925
+pull-request-state=OPEN
+base=JKHeadley/instar main
+merge=NOT PERFORMED
+```
+
+First normal push attempt, deciding output:
+
+```text
+Test Files  no tests
+Tests       no tests
+TestRunnerCapacityTimeoutError: [test-runner-bound] could not START within budget (600000ms, suite lane) — this is NOT a test failure; 1 holder(s): [pid 61347]
+Serialized Error: { code: 'INSTAR_TEST_CAPACITY_TIMEOUT', exitCode: 75 }
+```
+
+The holder was a live Vitest process in another agent worktree. The limit was not raised, disabled, or reclaimed. Because the exact affected set had already passed as 38/38 plus 5/5 on the current source, the unchanged retry used the repository-documented `INSTAR_PRE_PUSH_SKIP=1` test-only opt-out. The pre-push release and fixture-pollution gates still ran and passed; CI remains authoritative.
+
+PR body states **BUILT WITH HAND EVIDENCE, NOT MACHINE-CERTIFIED**, records the unrelated model-registry staleness finding and capacity-only push result, and reserves FIXED/EFFECTIVE for the independent judge.
+
+## 2026-08-18 02:15:10 -0700 (PDT) — FINAL PR pointer (supersedes the preceding PR-state entry)
+
+The cross-repository PR above was closed by GitHub-side activity and could not be reopened even though its fork head still existed. Its only automation diagnostic was a Vercel comment saying the cross-repository branch/commit reference could not be resolved. No merge occurred. The identical commit was therefore published as a review branch in the upstream repository and a same-repository PR was opened.
+
+```text
+superseded-pull-request=https://github.com/JKHeadley/instar/pull/1925
+superseded-state=CLOSED
+superseded-merged=false
+
+current-pull-request=https://github.com/JKHeadley/instar/pull/1926
+current-pull-request-number=1926
+current-state=OPEN
+current-draft=false
+current-base=JKHeadley/instar:main
+current-head=JKHeadley/instar:phaseb/w34-enforcement-measurement
+current-head-sha=aefb9d2a5123738724a9d78ba14e942245e9055b
+current-merged=false
+```
+
+The current upstream PR was read twice after creation and returned `state=open`, `merged=false`, and the exact local head SHA both times. Nothing was merged.
+
+## 2026-08-18 03:23:26 -0700 (PDT) — J5 F1 reproduced; first C3d control fails before repair
+
+Independent verdict read first: `scratchpad/phaseB/REPORT-J5.md` reports **NOT YET** because assertion execution was incorrectly sufficient for proven ratchet strength. The denominator, protected reference boundary, empty-file behavior, and zero-of-zero behavior remain accepted and are not reopened.
+
+Required repaired boundary: a reference may earn proven-strength only from protected, content-bound evidence that ties it to the specific cited article and records a landed violation mutation that flips the real check from a clean control to a failing result.
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=1
+Test Files  1 failed (1)
+Tests       1 failed | 5 passed (6)
+
+FAIL C3d refuses proven strength to an already-censused executable but vacuous assertion
+AssertionError: expected 'ratchet' to be 'documented-only'
+Expected: "documented-only"
+Received: "ratchet"
+```
+
+C2 landed evidence: the protected and candidate snapshots both contain the already-censused file `tests/unit/vacuous.test.ts` with the executable body `it('does not observe the rule', () => expect(true).toBe(true))`; the test reads it back and asserts that exact vacuous assertion is present before measurement. All six tests executed, so this is a behavioral numerator failure rather than a compile/reference failure.
+
+## 2026-08-18 03:48:34 -0700 (PDT) — J5 repair built; vacuous executable assertion refused proven strength
+
+Supersedes the W3.4 strength result above that reported `58/88`: those 58 were structurally executable references, not references with rule-specific relevance and fail-direction evidence. The protected live baseline has no schema-v2 proof ledger, so its honest proven-strength numerator is now zero.
+
+### Required proof boundary
+
+A reference earns proven strength only when the protected evidence binds the exact article/rule and observer digests to an independent subject, records a clean run with tests executed, and records a landed subject mutation that violates that rule and makes the same test population fail by assertion. The candidate verdict ledger is still ignored. The candidate observer and subject must still match the protected digests.
+
+Rejected evidence:
+
+```text
+executable assertion without protected proof -> documented-only / protected-relevance-proof-missing
+subjectRef == observerRef -> protected verdict ledger invalid (subject/oracle boundary)
+failureKind=compile or testsRun=0 -> protected verdict ledger invalid (no assertion-level fail direction)
+```
+
+### C3d must-fail control — red before repair
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=1
+Test Files  1 failed (1)
+Tests       1 failed | 5 passed (6)
+
+FAIL C3d refuses proven strength to an already-censused executable but vacuous assertion
+AssertionError: expected 'ratchet' to be 'documented-only'
+Expected: "documented-only"
+Received: "ratchet"
+```
+
+Landing evidence executed before measurement: both protected and candidate snapshots contained the already-censused executable test body `it('does not observe the rule', () => expect(true).toBe(true))`, and the control read that body back before asserting the result. All six tests ran; this was the vacuous behavior receiving numerator credit, not a compile or reference failure.
+
+### C3d after repair — same landed fixture, now refused
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=0
+Test Files  1 passed (1)
+Tests       8 passed (8)
+
+W34_C3D landed=already-censused-expect-true strength=documented-only deciding="protected-relevance-proof-missing"
+```
+
+The eight tests also prove that a valid protected relevance + fail-direction record can confer its certified rung, a record that mutates its observer is rejected, compile-only red evidence is rejected, candidate-authored replacement records cannot raise strength, changed/missing candidate evidence loses credit, and zero-of-zero remains NOT-PROVEN.
+
+### Live result and regression verification
+
+```text
+$ node scripts/standards-coverage.mjs --check
+exit=0
+[standards-coverage] registry=true total=88 continuity-total=88 enforced-ratio=0 (ratchet 0 / gate 0 / lint 0 / spec-only 0 / gap 88) false-claims=0 dangling=0 unrecognized-sections=0
+[standards-coverage] measurement=proven base=4318a1e150e9a8304e6c2e7ad381bf66d03998e5 source=canonical-server-content-addressed-merge-base protected-population=88 candidate-population=88 unverified-references=254
+[standards-coverage] protected-strength-floor=0/88 ratio=0 candidate-may-raise=false
+✅ standards-coverage check passed.
+
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts tests/unit/standards-coverage-ratchet.test.ts --reporter=verbose
+exit=0
+Test Files  2 passed (2)
+Tests       46 passed (46)
+
+$ npx tsc --noEmit
+exit=0
+
+$ git diff --check
+exit=0
+```
+
+False-claim detection remains its own question: it asks whether the standard names resolvable machinery, while proven-strength asks whether that machinery has behavioral proof. Separating them prevents the stricter numerator from relabeling every resolvable-but-unverified citation as “no guard named.”
+
+### Full repository lint — unchanged external blocker
+
+```text
+$ npm run lint
+exit=1
+[lint-model-registry-freshness] enforcement=strict
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+FAIL — 1 finding(s) under strict enforcement.
+```
+
+TypeScript and every earlier lint entry passed. W3.4 still does not touch the model registry, per scope.
+
+### Content-addressed evidence
+
+```text
+scratchpad/phaseB/evidence/W34-J5-repair-controls.json sha256=19b0b2ae66f2923445221772bd09a9c28300401b62c7f486cccbd051dafb3c05
+scripts/lib/standards-enforcement-measurement.mjs sha256=7df6898a4a530bc6ce43dabd994a85c376ab3e19333724367000f6afd0c6a932
+scripts/standards-coverage.mjs sha256=c46737e5f248711fe3d0746c58f363a533716795a9d51fbd371770a7c7e7f754
+tests/unit/standards-enforcement-measurement.test.ts sha256=eb4564507ec5bcc56dd0db9c858422017277369b6eca546647262a151a94bfe4
+tests/unit/standards-coverage-ratchet.test.ts sha256=45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3
+upgrades/next/enforcement-measurement.md sha256=a33b792831b83902d4f68105767fa45dedc9484ac965ad33a67f3657f240b8cd
+```
+
+State: **BUILT WITH HAND EVIDENCE, PENDING INDEPENDENT JUDGE RE-CERTIFICATION**. PR #1926 remains open and unmerged.
+
+## 2026-08-18 03:56:48 -0700 (PDT) — Rule-continuity hardening (supersedes preceding test counts and hashes)
+
+The relevance binding now also checks the candidate `ruleSha256` against the protected proof. Keeping the same article identity and observer while rewriting the cited rule loses proven strength with `candidate-cited-rule-changed`; protected proof cannot slide onto a different candidate obligation. Full-article whitespace is deliberately not the boundary—the exact Rule text digest is—so deleting an adjacent unguarded article does not spuriously invalidate an unchanged proved rule.
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=dot
+exit=0
+Test Files  1 passed (1)
+Tests       9 passed (9)
+
+$ npx vitest run tests/unit/standards-coverage-ratchet.test.ts --reporter=dot
+exit=0
+W34_C3A before=0.5 after=0.5 removals=1 deciding="population shrank by 1 (direction: removal)"
+W34_C3B landed=size-0 ratchet=0 deciding="candidate-reference-empty"
+W34_C3C landed=hollow-addition ratchet=1 deciding="reference-not-in-protected-census"
+Test Files  1 passed (1)
+Tests       38 passed (38)
+```
+
+Current evidence hashes (the hashes in the preceding section are superseded):
+
+```text
+scratchpad/phaseB/evidence/W34-J5-repair-controls.json sha256=1f09210204346e133b76110997b8c56880864a04e9eb8bd6cf33a1af95ff028d
+scripts/lib/standards-enforcement-measurement.mjs sha256=c7046545033b6f08db019284cc81a37f795472646b39f382c4029bf6a90ea069
+scripts/standards-coverage.mjs sha256=c46737e5f248711fe3d0746c58f363a533716795a9d51fbd371770a7c7e7f754
+tests/unit/standards-enforcement-measurement.test.ts sha256=f4e48bd25cf330a26b609ee18747a6bccdf289fe00685ba8d01c21e497d6ece0
+tests/unit/standards-coverage-ratchet.test.ts sha256=45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3
+upgrades/next/enforcement-measurement.md sha256=758c42ef17d28ccb88528a17739892257147df98df83c9271356b3863f9cfde8
+```
+
+## 2026-08-18 04:06:27 -0700 (PDT) — Repair published to PR #1926; open and unmerged
+
+```text
+implementation-commit=9112c99142520cb0c70e1f670ec4930882b672a6
+branch=phaseb/w34-enforcement-measurement
+remote=upstream (https://github.com/JKHeadley/instar.git)
+push=481c5bd0010ab693b8998c1c946b978ff49d25f9..9112c99142520cb0c70e1f670ec4930882b672a6
+pull-request=https://github.com/JKHeadley/instar/pull/1926
+pull-request-state=OPEN
+pull-request-head=9112c99142520cb0c70e1f670ec4930882b672a6
+merged=false
+```
+
+The normal pre-push gate ran rather than being skipped:
+
+```text
+Smoke affected set: 4 test files / 65 test cases.
+Test Files  4 passed (4)
+Tests       65 passed (65)
+exit=0
+```
+
+The PR body now states the repaired relevance + fail-direction boundary, the behavioral vacuity control, the honest live `0/88`, the unchanged model-registry lint blocker, and **BUILT WITH HAND EVIDENCE, PENDING INDEPENDENT JUDGE RE-CERTIFICATION**. No merge or approval was performed.

--- a/scratchpad/phaseB/REPORT-W34.md
+++ b/scratchpad/phaseB/REPORT-W34.md
@@ -147,3 +147,24 @@ Serialized Error: { code: 'INSTAR_TEST_CAPACITY_TIMEOUT', exitCode: 75 }
 The holder was a live Vitest process in another agent worktree. The limit was not raised, disabled, or reclaimed. Because the exact affected set had already passed as 38/38 plus 5/5 on the current source, the unchanged retry used the repository-documented `INSTAR_PRE_PUSH_SKIP=1` test-only opt-out. The pre-push release and fixture-pollution gates still ran and passed; CI remains authoritative.
 
 PR body states **BUILT WITH HAND EVIDENCE, NOT MACHINE-CERTIFIED**, records the unrelated model-registry staleness finding and capacity-only push result, and reserves FIXED/EFFECTIVE for the independent judge.
+
+## 2026-08-18 02:15:10 -0700 (PDT) — FINAL PR pointer (supersedes the preceding PR-state entry)
+
+The cross-repository PR above was closed by GitHub-side activity and could not be reopened even though its fork head still existed. Its only automation diagnostic was a Vercel comment saying the cross-repository branch/commit reference could not be resolved. No merge occurred. The identical commit was therefore published as a review branch in the upstream repository and a same-repository PR was opened.
+
+```text
+superseded-pull-request=https://github.com/JKHeadley/instar/pull/1925
+superseded-state=CLOSED
+superseded-merged=false
+
+current-pull-request=https://github.com/JKHeadley/instar/pull/1926
+current-pull-request-number=1926
+current-state=OPEN
+current-draft=false
+current-base=JKHeadley/instar:main
+current-head=JKHeadley/instar:phaseb/w34-enforcement-measurement
+current-head-sha=aefb9d2a5123738724a9d78ba14e942245e9055b
+current-merged=false
+```
+
+The current upstream PR was read twice after creation and returned `state=open`, `merged=false`, and the exact local head SHA both times. Nothing was merged.

--- a/scratchpad/phaseB/REPORT-W34.md
+++ b/scratchpad/phaseB/REPORT-W34.md
@@ -312,3 +312,27 @@ tests/unit/standards-enforcement-measurement.test.ts sha256=f4e48bd25cf330a26b60
 tests/unit/standards-coverage-ratchet.test.ts sha256=45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3
 upgrades/next/enforcement-measurement.md sha256=758c42ef17d28ccb88528a17739892257147df98df83c9271356b3863f9cfde8
 ```
+
+## 2026-08-18 04:06:27 -0700 (PDT) — Repair published to PR #1926; open and unmerged
+
+```text
+implementation-commit=9112c99142520cb0c70e1f670ec4930882b672a6
+branch=phaseb/w34-enforcement-measurement
+remote=upstream (https://github.com/JKHeadley/instar.git)
+push=481c5bd0010ab693b8998c1c946b978ff49d25f9..9112c99142520cb0c70e1f670ec4930882b672a6
+pull-request=https://github.com/JKHeadley/instar/pull/1926
+pull-request-state=OPEN
+pull-request-head=9112c99142520cb0c70e1f670ec4930882b672a6
+merged=false
+```
+
+The normal pre-push gate ran rather than being skipped:
+
+```text
+Smoke affected set: 4 test files / 65 test cases.
+Test Files  4 passed (4)
+Tests       65 passed (65)
+exit=0
+```
+
+The PR body now states the repaired relevance + fail-direction boundary, the behavioral vacuity control, the honest live `0/88`, the unchanged model-registry lint blocker, and **BUILT WITH HAND EVIDENCE, PENDING INDEPENDENT JUDGE RE-CERTIFICATION**. No merge or approval was performed.

--- a/scratchpad/phaseB/REPORT-W34.md
+++ b/scratchpad/phaseB/REPORT-W34.md
@@ -168,3 +168,147 @@ current-merged=false
 ```
 
 The current upstream PR was read twice after creation and returned `state=open`, `merged=false`, and the exact local head SHA both times. Nothing was merged.
+
+## 2026-08-18 03:23:26 -0700 (PDT) — J5 F1 reproduced; first C3d control fails before repair
+
+Independent verdict read first: `scratchpad/phaseB/REPORT-J5.md` reports **NOT YET** because assertion execution was incorrectly sufficient for proven ratchet strength. The denominator, protected reference boundary, empty-file behavior, and zero-of-zero behavior remain accepted and are not reopened.
+
+Required repaired boundary: a reference may earn proven-strength only from protected, content-bound evidence that ties it to the specific cited article and records a landed violation mutation that flips the real check from a clean control to a failing result.
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=1
+Test Files  1 failed (1)
+Tests       1 failed | 5 passed (6)
+
+FAIL C3d refuses proven strength to an already-censused executable but vacuous assertion
+AssertionError: expected 'ratchet' to be 'documented-only'
+Expected: "documented-only"
+Received: "ratchet"
+```
+
+C2 landed evidence: the protected and candidate snapshots both contain the already-censused file `tests/unit/vacuous.test.ts` with the executable body `it('does not observe the rule', () => expect(true).toBe(true))`; the test reads it back and asserts that exact vacuous assertion is present before measurement. All six tests executed, so this is a behavioral numerator failure rather than a compile/reference failure.
+
+## 2026-08-18 03:48:34 -0700 (PDT) — J5 repair built; vacuous executable assertion refused proven strength
+
+Supersedes the W3.4 strength result above that reported `58/88`: those 58 were structurally executable references, not references with rule-specific relevance and fail-direction evidence. The protected live baseline has no schema-v2 proof ledger, so its honest proven-strength numerator is now zero.
+
+### Required proof boundary
+
+A reference earns proven strength only when the protected evidence binds the exact article/rule and observer digests to an independent subject, records a clean run with tests executed, and records a landed subject mutation that violates that rule and makes the same test population fail by assertion. The candidate verdict ledger is still ignored. The candidate observer and subject must still match the protected digests.
+
+Rejected evidence:
+
+```text
+executable assertion without protected proof -> documented-only / protected-relevance-proof-missing
+subjectRef == observerRef -> protected verdict ledger invalid (subject/oracle boundary)
+failureKind=compile or testsRun=0 -> protected verdict ledger invalid (no assertion-level fail direction)
+```
+
+### C3d must-fail control — red before repair
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=1
+Test Files  1 failed (1)
+Tests       1 failed | 5 passed (6)
+
+FAIL C3d refuses proven strength to an already-censused executable but vacuous assertion
+AssertionError: expected 'ratchet' to be 'documented-only'
+Expected: "documented-only"
+Received: "ratchet"
+```
+
+Landing evidence executed before measurement: both protected and candidate snapshots contained the already-censused executable test body `it('does not observe the rule', () => expect(true).toBe(true))`, and the control read that body back before asserting the result. All six tests ran; this was the vacuous behavior receiving numerator credit, not a compile or reference failure.
+
+### C3d after repair — same landed fixture, now refused
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose
+exit=0
+Test Files  1 passed (1)
+Tests       8 passed (8)
+
+W34_C3D landed=already-censused-expect-true strength=documented-only deciding="protected-relevance-proof-missing"
+```
+
+The eight tests also prove that a valid protected relevance + fail-direction record can confer its certified rung, a record that mutates its observer is rejected, compile-only red evidence is rejected, candidate-authored replacement records cannot raise strength, changed/missing candidate evidence loses credit, and zero-of-zero remains NOT-PROVEN.
+
+### Live result and regression verification
+
+```text
+$ node scripts/standards-coverage.mjs --check
+exit=0
+[standards-coverage] registry=true total=88 continuity-total=88 enforced-ratio=0 (ratchet 0 / gate 0 / lint 0 / spec-only 0 / gap 88) false-claims=0 dangling=0 unrecognized-sections=0
+[standards-coverage] measurement=proven base=4318a1e150e9a8304e6c2e7ad381bf66d03998e5 source=canonical-server-content-addressed-merge-base protected-population=88 candidate-population=88 unverified-references=254
+[standards-coverage] protected-strength-floor=0/88 ratio=0 candidate-may-raise=false
+✅ standards-coverage check passed.
+
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts tests/unit/standards-coverage-ratchet.test.ts --reporter=verbose
+exit=0
+Test Files  2 passed (2)
+Tests       46 passed (46)
+
+$ npx tsc --noEmit
+exit=0
+
+$ git diff --check
+exit=0
+```
+
+False-claim detection remains its own question: it asks whether the standard names resolvable machinery, while proven-strength asks whether that machinery has behavioral proof. Separating them prevents the stricter numerator from relabeling every resolvable-but-unverified citation as “no guard named.”
+
+### Full repository lint — unchanged external blocker
+
+```text
+$ npm run lint
+exit=1
+[lint-model-registry-freshness] enforcement=strict
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+FAIL — 1 finding(s) under strict enforcement.
+```
+
+TypeScript and every earlier lint entry passed. W3.4 still does not touch the model registry, per scope.
+
+### Content-addressed evidence
+
+```text
+scratchpad/phaseB/evidence/W34-J5-repair-controls.json sha256=19b0b2ae66f2923445221772bd09a9c28300401b62c7f486cccbd051dafb3c05
+scripts/lib/standards-enforcement-measurement.mjs sha256=7df6898a4a530bc6ce43dabd994a85c376ab3e19333724367000f6afd0c6a932
+scripts/standards-coverage.mjs sha256=c46737e5f248711fe3d0746c58f363a533716795a9d51fbd371770a7c7e7f754
+tests/unit/standards-enforcement-measurement.test.ts sha256=eb4564507ec5bcc56dd0db9c858422017277369b6eca546647262a151a94bfe4
+tests/unit/standards-coverage-ratchet.test.ts sha256=45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3
+upgrades/next/enforcement-measurement.md sha256=a33b792831b83902d4f68105767fa45dedc9484ac965ad33a67f3657f240b8cd
+```
+
+State: **BUILT WITH HAND EVIDENCE, PENDING INDEPENDENT JUDGE RE-CERTIFICATION**. PR #1926 remains open and unmerged.
+
+## 2026-08-18 03:56:48 -0700 (PDT) — Rule-continuity hardening (supersedes preceding test counts and hashes)
+
+The relevance binding now also checks the candidate `ruleSha256` against the protected proof. Keeping the same article identity and observer while rewriting the cited rule loses proven strength with `candidate-cited-rule-changed`; protected proof cannot slide onto a different candidate obligation. Full-article whitespace is deliberately not the boundary—the exact Rule text digest is—so deleting an adjacent unguarded article does not spuriously invalidate an unchanged proved rule.
+
+```text
+$ npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=dot
+exit=0
+Test Files  1 passed (1)
+Tests       9 passed (9)
+
+$ npx vitest run tests/unit/standards-coverage-ratchet.test.ts --reporter=dot
+exit=0
+W34_C3A before=0.5 after=0.5 removals=1 deciding="population shrank by 1 (direction: removal)"
+W34_C3B landed=size-0 ratchet=0 deciding="candidate-reference-empty"
+W34_C3C landed=hollow-addition ratchet=1 deciding="reference-not-in-protected-census"
+Test Files  1 passed (1)
+Tests       38 passed (38)
+```
+
+Current evidence hashes (the hashes in the preceding section are superseded):
+
+```text
+scratchpad/phaseB/evidence/W34-J5-repair-controls.json sha256=1f09210204346e133b76110997b8c56880864a04e9eb8bd6cf33a1af95ff028d
+scripts/lib/standards-enforcement-measurement.mjs sha256=c7046545033b6f08db019284cc81a37f795472646b39f382c4029bf6a90ea069
+scripts/standards-coverage.mjs sha256=c46737e5f248711fe3d0746c58f363a533716795a9d51fbd371770a7c7e7f754
+tests/unit/standards-enforcement-measurement.test.ts sha256=f4e48bd25cf330a26b609ee18747a6bccdf289fe00685ba8d01c21e497d6ece0
+tests/unit/standards-coverage-ratchet.test.ts sha256=45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3
+upgrades/next/enforcement-measurement.md sha256=758c42ef17d28ccb88528a17739892257147df98df83c9271356b3863f9cfde8
+```

--- a/scratchpad/phaseB/REPORT-W34.md
+++ b/scratchpad/phaseB/REPORT-W34.md
@@ -121,3 +121,29 @@ tests/unit/standards-coverage-ratchet.test.ts sha256=8755cbb96b975f3283ce42adc5c
 ```
 
 State: **BUILT WITH HAND EVIDENCE, NOT MACHINE-CERTIFIED**. The builder does not call this FIXED or EFFECTIVE; the independent judge must re-gate it.
+
+## 2026-08-18 02:11:50 -0700 (PDT) — Branch published; PR open and unmerged
+
+```text
+implementation-commit=a4ec1719968c949d28f6b5532de201aa1f91ebd5
+branch=phaseb/w34-enforcement-measurement
+fork-push=origin/phaseb/w34-enforcement-measurement
+pull-request=https://github.com/JKHeadley/instar/pull/1925
+pull-request-number=1925
+pull-request-state=OPEN
+base=JKHeadley/instar main
+merge=NOT PERFORMED
+```
+
+First normal push attempt, deciding output:
+
+```text
+Test Files  no tests
+Tests       no tests
+TestRunnerCapacityTimeoutError: [test-runner-bound] could not START within budget (600000ms, suite lane) — this is NOT a test failure; 1 holder(s): [pid 61347]
+Serialized Error: { code: 'INSTAR_TEST_CAPACITY_TIMEOUT', exitCode: 75 }
+```
+
+The holder was a live Vitest process in another agent worktree. The limit was not raised, disabled, or reclaimed. Because the exact affected set had already passed as 38/38 plus 5/5 on the current source, the unchanged retry used the repository-documented `INSTAR_PRE_PUSH_SKIP=1` test-only opt-out. The pre-push release and fixture-pollution gates still ran and passed; CI remains authoritative.
+
+PR body states **BUILT WITH HAND EVIDENCE, NOT MACHINE-CERTIFIED**, records the unrelated model-registry staleness finding and capacity-only push result, and reserves FIXED/EFFECTIVE for the independent judge.

--- a/scratchpad/phaseB/evidence/W34-J5-repair-controls.json
+++ b/scratchpad/phaseB/evidence/W34-J5-repair-controls.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T03:48:34-07:00",
+  "status": "built-with-hand-evidence-pending-independent-recertification",
+  "protectedBase": {
+    "remote": "https://github.com/JKHeadley/instar.git",
+    "ref": "refs/heads/main",
+    "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "source": "canonical-server-content-addressed-merge-base",
+    "candidateMayRaiseStrength": false
+  },
+  "requiredProof": {
+    "articleBinding": "articleId + articleSha256 + ruleSha256",
+    "observerBinding": "observerRef + observerSha256",
+    "subjectBoundary": "subjectRef differs from observerRef and the verdict ledger",
+    "cleanControl": "exitCode=0 and testsRun>=1",
+    "failDirection": "landed independent-subject mutation, same testsRun, nonzero exit, assertion failure, distinct output digest"
+  },
+  "c3dRedBeforeRepair": {
+    "command": "npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose",
+    "exitCode": 1,
+    "tests": "1 failed | 5 passed (6)",
+    "mutationLanded": "protected and candidate snapshots contained an already-censused executable expect(true).toBe(true) assertion",
+    "decidingOutput": "AssertionError: expected 'ratchet' to be 'documented-only'"
+  },
+  "c3dGreenAfterRepair": {
+    "command": "npx vitest run tests/unit/standards-enforcement-measurement.test.ts --reporter=verbose",
+    "exitCode": 0,
+    "tests": "9 passed (9)",
+    "decidingOutput": "W34_C3D landed=already-censused-expect-true strength=documented-only deciding=\"protected-relevance-proof-missing\""
+  },
+  "negativeProofControls": {
+    "subjectOracleBoundary": "proof mutating its observer is rejected and measurement is not-proven",
+    "compileOnlyRed": "testsRun=0/failureKind=compile is rejected; only same-test assertion failure qualifies",
+    "candidateRuleContinuity": "changing the candidate rule digest while retaining identity and observer loses proven strength"
+  },
+  "liveMeasurement": {
+    "command": "node scripts/standards-coverage.mjs --check",
+    "exitCode": 0,
+    "population": {
+      "protected": 88,
+      "candidate": 88,
+      "continuity": 88
+    },
+    "provenStrength": {
+      "enforced": 0,
+      "total": 88,
+      "ratio": 0,
+      "byKind": {
+        "ratchet": 0,
+        "gate": 0,
+        "lint": 0,
+        "spec-only": 0,
+        "documented-only": 88
+      }
+    },
+    "unverifiedReferenceCount": 254,
+    "decidingOutput": "measurement=proven base=4318a1e150e9a8304e6c2e7ad381bf66d03998e5 source=canonical-server-content-addressed-merge-base protected-population=88 candidate-population=88 unverified-references=254"
+  },
+  "verification": {
+    "affectedSuites": "47/47 passed across 2 files",
+    "typeCheck": "passed",
+    "diffCheck": "passed",
+    "repositoryLint": {
+      "outcome": "blocked-by-unchanged-upstream-state",
+      "decidingOutput": "STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window"
+    }
+  },
+  "certification": "pending-independent-judge-recertification"
+}

--- a/scratchpad/phaseB/evidence/W34-controls.json
+++ b/scratchpad/phaseB/evidence/W34-controls.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T01:50:21-07:00",
+  "status": "built-with-hand-evidence",
+  "protectedBase": {
+    "remote": "https://github.com/JKHeadley/instar.git",
+    "ref": "refs/heads/main",
+    "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "source": "canonical-server-content-addressed-merge-base",
+    "candidateMayRaiseStrength": false
+  },
+  "c1": {
+    "command": "node scripts/standards-coverage.mjs --check",
+    "exitCode": 0,
+    "protectedPopulation": 88,
+    "candidatePopulation": 88,
+    "provenStrength": {
+      "enforced": 58,
+      "total": 88,
+      "ratio": 0.6591,
+      "byKind": {
+        "ratchet": 26,
+        "gate": 25,
+        "lint": 7,
+        "spec-only": 9,
+        "documented-only": 21
+      }
+    },
+    "unverifiedReferenceCount": 39,
+    "decidingOutput": "measurement=proven base=4318a1e150e9a8304e6c2e7ad381bf66d03998e5 source=canonical-server-content-addressed-merge-base protected-population=88 candidate-population=88 unverified-references=39"
+  },
+  "c2": {
+    "outcome": "proven-landed",
+    "evidence": [
+      "C3a test reads the candidate registry after mutation and asserts that the Protected Gap heading is absent",
+      "C3b test stats the cited candidate file and asserts an exact size of zero",
+      "C3c test reads both the added rule and its cited file and asserts the file contains no it(...) call"
+    ]
+  },
+  "c3a": {
+    "mutation": "delete one unenforced protected rule",
+    "beforeRatio": 0.5,
+    "afterRatio": 0.5,
+    "removals": 1,
+    "measurementStatus": "not-proven",
+    "decidingOutput": "W34_C3A before=0.5 after=0.5 removals=1 deciding=\"population shrank by 1 (direction: removal)\""
+  },
+  "c3b": {
+    "mutation": "empty a cited ratchet file while preserving its path",
+    "ratchetCountAfter": 0,
+    "decidingOutput": "W34_C3B landed=size-0 ratchet=0 deciding=\"candidate-reference-empty\""
+  },
+  "c3c": {
+    "mutation": "add a new rule citing a new prose-only test file",
+    "ratchetCountAfter": 1,
+    "decidingOutput": "W34_C3C landed=hollow-addition ratchet=1 deciding=\"reference-not-in-protected-census\""
+  },
+  "verification": {
+    "standardsCoverageSuite": "38/38 passed",
+    "measurementUnitSuite": "5/5 passed",
+    "typeCheck": "passed",
+    "diffCheck": "passed",
+    "repositoryLint": {
+      "outcome": "blocked-by-unchanged-upstream-state",
+      "decidingOutput": "STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window",
+      "relevantFilesDifferFromUpstream": false
+    }
+  },
+  "certification": "pending-independent-judge"
+}

--- a/scratchpad/phaseB/evidence/W34-evidence-stamps.json
+++ b/scratchpad/phaseB/evidence/W34-evidence-stamps.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-18T03:56:48-07:00",
+  "sha256": {
+    "scripts/lib/standards-enforcement-measurement.mjs": "c7046545033b6f08db019284cc81a37f795472646b39f382c4029bf6a90ea069",
+    "scripts/standards-coverage.mjs": "c46737e5f248711fe3d0746c58f363a533716795a9d51fbd371770a7c7e7f754",
+    "tests/unit/standards-enforcement-measurement.test.ts": "f4e48bd25cf330a26b609ee18747a6bccdf289fe00685ba8d01c21e497d6ece0",
+    "tests/unit/standards-coverage-ratchet.test.ts": "45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3",
+    "scratchpad/phaseB/evidence/W34-controls.json": "cf082e89522b35f4d34774000dd6d2328d7a5dc36b63d8a00748d41bef0c8e75",
+    "scratchpad/phaseB/evidence/W34-J5-repair-controls.json": "1f09210204346e133b76110997b8c56880864a04e9eb8bd6cf33a1af95ff028d",
+    "upgrades/next/enforcement-measurement.md": "758c42ef17d28ccb88528a17739892257147df98df83c9271356b3863f9cfde8"
+  }
+}

--- a/scratchpad/phaseB/evidence/W34-evidence-stamps.json
+++ b/scratchpad/phaseB/evidence/W34-evidence-stamps.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-18T01:50:21-07:00",
+  "sha256": {
+    "scripts/lib/standards-enforcement-measurement.mjs": "8916035029237c595c95c9274fb8e73f8036fe1e6a150eda40079c05e29c36f8",
+    "scripts/standards-coverage.mjs": "774d83d11863756f91d8e4612d0ad171970c85ea1313e9dc1e1e854d89eb7102",
+    "tests/unit/standards-enforcement-measurement.test.ts": "bcdd562ccff196b7bfa77ac1ae24318385dc527619552afaae0ee678c6302473",
+    "tests/unit/standards-coverage-ratchet.test.ts": "8755cbb96b975f3283ce42adc5c22833b747dcd45fde210ba7761e91d969a53d",
+    "scratchpad/phaseB/evidence/W34-controls.json": "cf082e89522b35f4d34774000dd6d2328d7a5dc36b63d8a00748d41bef0c8e75",
+    "upgrades/next/enforcement-measurement.md": "bf82188a3b23ad42c129dcd399e07cfb79b4dc675ae71c801e0dacf5c4e76183"
+  }
+}

--- a/scratchpad/phaseB/evidence/W34-evidence-stamps.json
+++ b/scratchpad/phaseB/evidence/W34-evidence-stamps.json
@@ -1,12 +1,13 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-18T01:50:21-07:00",
+  "generatedAt": "2026-08-18T03:56:48-07:00",
   "sha256": {
-    "scripts/lib/standards-enforcement-measurement.mjs": "8916035029237c595c95c9274fb8e73f8036fe1e6a150eda40079c05e29c36f8",
-    "scripts/standards-coverage.mjs": "774d83d11863756f91d8e4612d0ad171970c85ea1313e9dc1e1e854d89eb7102",
-    "tests/unit/standards-enforcement-measurement.test.ts": "bcdd562ccff196b7bfa77ac1ae24318385dc527619552afaae0ee678c6302473",
-    "tests/unit/standards-coverage-ratchet.test.ts": "8755cbb96b975f3283ce42adc5c22833b747dcd45fde210ba7761e91d969a53d",
+    "scripts/lib/standards-enforcement-measurement.mjs": "c7046545033b6f08db019284cc81a37f795472646b39f382c4029bf6a90ea069",
+    "scripts/standards-coverage.mjs": "c46737e5f248711fe3d0746c58f363a533716795a9d51fbd371770a7c7e7f754",
+    "tests/unit/standards-enforcement-measurement.test.ts": "f4e48bd25cf330a26b609ee18747a6bccdf289fe00685ba8d01c21e497d6ece0",
+    "tests/unit/standards-coverage-ratchet.test.ts": "45cd195bd50ac1263bface56fcdde3aaedc0ff705a2008bb54285f540ee34aa3",
     "scratchpad/phaseB/evidence/W34-controls.json": "cf082e89522b35f4d34774000dd6d2328d7a5dc36b63d8a00748d41bef0c8e75",
-    "upgrades/next/enforcement-measurement.md": "bf82188a3b23ad42c129dcd399e07cfb79b4dc675ae71c801e0dacf5c4e76183"
+    "scratchpad/phaseB/evidence/W34-J5-repair-controls.json": "1f09210204346e133b76110997b8c56880864a04e9eb8bd6cf33a1af95ff028d",
+    "upgrades/next/enforcement-measurement.md": "758c42ef17d28ccb88528a17739892257147df98df83c9271356b3863f9cfde8"
   }
 }

--- a/scripts/lib/standards-enforcement-measurement.mjs
+++ b/scripts/lib/standards-enforcement-measurement.mjs
@@ -1,0 +1,503 @@
+// safe-git-allow: protected measurement uses only content-addressed read operations through /usr/bin/git.
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import ts from 'typescript';
+
+export const CANONICAL_PROTECTED_REMOTE = 'https://github.com/JKHeadley/instar.git';
+export const PROTECTED_MAIN_REF = 'refs/heads/main';
+export const PROTECTED_VERDICTS_PATH = 'docs/standards-enforcement-verdicts.json';
+export const PROTECTED_VERDICT_SCHEMA_VERSION = 2;
+const SYSTEM_GIT = '/usr/bin/git';
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const STRENGTH_RANK = {
+  'documented-only': 0,
+  'spec-only': 1,
+  lint: 2,
+  gate: 3,
+  ratchet: 4,
+};
+
+const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const exactKeys = (value, keys) => isObject(value) &&
+  JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+const weaker = (left, right) => STRENGTH_RANK[left] <= STRENGTH_RANK[right] ? left : right;
+
+function safeRepoPath(rel) {
+  return typeof rel === 'string' && rel.length > 0 && !path.isAbsolute(rel) &&
+    !rel.includes('\0') && !rel.split(/[\\/]/).includes('..');
+}
+
+function scrubbedGitEnv(root) {
+  const {
+    GIT_ALTERNATE_OBJECT_DIRECTORIES: _alternateObjects,
+    GIT_CONFIG_COUNT: _configCount,
+    GIT_CONFIG_PARAMETERS: _configParameters,
+    GIT_DIR: _gitDir,
+    GIT_OBJECT_DIRECTORY: _objectDirectory,
+    GIT_WORK_TREE: _workTree,
+    ...ambient
+  } = process.env;
+  return { ...ambient, HOME: path.parse(root).root, GIT_NO_REPLACE_OBJECTS: '1' };
+}
+
+function git(root, args, timeout = 20_000) {
+  const child = spawnSync(SYSTEM_GIT, args, {
+    cwd: root,
+    encoding: 'utf8',
+    timeout,
+    maxBuffer: 64 * 1024 * 1024,
+    env: scrubbedGitEnv(root),
+  });
+  if (child.error || child.status !== 0) return null;
+  return child.stdout;
+}
+
+function canonicalRemoteMain(root) {
+  const child = spawnSync(SYSTEM_GIT, [
+    'ls-remote', '--refs', CANONICAL_PROTECTED_REMOTE, PROTECTED_MAIN_REF,
+  ], {
+    cwd: path.parse(root).root,
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: {
+      PATH: '/usr/bin:/bin',
+      HOME: path.parse(root).root,
+      LANG: 'C',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_COUNT: '0',
+      GIT_NO_REPLACE_OBJECTS: '1',
+      GIT_TERMINAL_PROMPT: '0',
+    },
+  });
+  if (child.error || child.status !== 0) return null;
+  const fields = child.stdout.trim().split(/\s+/);
+  if (fields.length !== 2 || fields[1] !== PROTECTED_MAIN_REF || !/^[a-f0-9]{40}$/.test(fields[0])) return null;
+  return fields[0];
+}
+
+function directorySnapshot(root) {
+  const absolute = path.resolve(root);
+  const listFiles = (prefix) => {
+    const start = path.resolve(absolute, prefix);
+    const out = [];
+    const walk = (dir) => {
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.isFile()) out.push(path.relative(absolute, full).split(path.sep).join('/'));
+      }
+    };
+    walk(start);
+    return out.sort();
+  };
+  return {
+    source: 'explicit-test-fixture',
+    protectedMainSha: null,
+    baseRevision: `fixture:${sha256(absolute).slice(0, 12)}`,
+    readFile(rel) {
+      if (!safeRepoPath(rel)) return null;
+      const full = path.resolve(absolute, rel);
+      if (full !== absolute && !full.startsWith(`${absolute}${path.sep}`)) return null;
+      try {
+        const stat = fs.lstatSync(full);
+        if (!stat.isFile() || stat.isSymbolicLink()) return null;
+        return fs.readFileSync(full, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    listFiles,
+    hasMarker(marker) {
+      if (typeof marker !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(marker)) return false;
+      const re = new RegExp(`\\b${marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
+      return listFiles('src').some((rel) => {
+        if (!/\.(?:ts|js|mjs|cjs)$/.test(rel)) return false;
+        const content = this.readFile(rel);
+        return content !== null && re.test(content);
+      });
+    },
+  };
+}
+
+/**
+ * Resolve the measurement oracle. Production ignores candidate remotes and tracking refs:
+ * the server-advertised main SHA is reduced to a content-addressed merge base. An explicit
+ * directory exists only for `--allow-partial-registry` test fixtures; the caller controls
+ * that boundary and never passes it in a real check.
+ */
+export function resolveProtectedMeasurementSnapshot({ root, fixtureRoot = null }) {
+  if (fixtureRoot !== null) return directorySnapshot(fixtureRoot);
+  const protectedMainSha = canonicalRemoteMain(root);
+  if (!protectedMainSha) throw new Error('protected main unavailable from canonical server');
+  const baseRevision = git(root, ['merge-base', 'HEAD', protectedMainSha])?.trim() ?? '';
+  if (!/^[a-f0-9]{40}$/.test(baseRevision)) {
+    throw new Error(`protected merge base unavailable for canonical main ${protectedMainSha.slice(0, 12)}`);
+  }
+  return {
+    source: 'canonical-server-content-addressed-merge-base',
+    protectedMainSha,
+    baseRevision,
+    readFile(rel) {
+      if (!safeRepoPath(rel)) return null;
+      return git(root, ['show', `${baseRevision}:${rel}`]);
+    },
+    listFiles(prefix) {
+      if (!safeRepoPath(prefix)) return [];
+      const output = git(root, ['ls-tree', '-r', '--name-only', baseRevision, '--', prefix]);
+      return output === null ? [] : output.trim().split('\n').filter(Boolean).sort();
+    },
+    hasMarker(marker) {
+      if (typeof marker !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(marker)) return false;
+      return git(root, ['grep', '-q', '-w', '--fixed-strings', marker, baseRevision, '--', 'src']) !== null;
+    },
+  };
+}
+
+export function routeTableFromSnapshot(snapshot) {
+  const out = new Set();
+  const re = /router\.(get|post|put|delete|patch)\s*\(\s*['"`]([^'"`]+)['"`]/g;
+  for (const rel of snapshot.listFiles('src/server')) {
+    if (!rel.endsWith('.ts') || rel.endsWith('.test.ts')) continue;
+    const content = snapshot.readFile(rel);
+    if (content === null) continue;
+    for (const match of content.matchAll(re)) out.add(`${match[1].toUpperCase()} ${match[2]}`);
+  }
+  return out;
+}
+
+function candidateReader(root) {
+  return (rel) => {
+    if (!safeRepoPath(rel)) return null;
+    const full = path.resolve(root, rel);
+    if (full !== root && !full.startsWith(`${root}${path.sep}`)) return null;
+    try {
+      const stat = fs.lstatSync(full);
+      if (!stat.isFile() || stat.isSymbolicLink()) return null;
+      return fs.readFileSync(full, 'utf8');
+    } catch {
+      return null;
+    }
+  };
+}
+
+function calleeName(node) {
+  if (ts.isIdentifier(node)) return node.text;
+  if (ts.isPropertyAccessExpression(node)) return node.name.text;
+  return '';
+}
+
+function analyzeProgram(content, rel) {
+  const kind = /\.(?:ts|tsx)$/.test(rel) ? ts.ScriptKind.TS : ts.ScriptKind.JS;
+  const source = ts.createSourceFile(rel, content, ts.ScriptTarget.Latest, true, kind);
+  const facts = {
+    test: false,
+    assertion: false,
+    conditional: false,
+    failure: false,
+    diagnostic: false,
+  };
+  const visit = (node) => {
+    if (ts.isIfStatement(node) || ts.isSwitchStatement(node) || ts.isConditionalExpression(node)) facts.conditional = true;
+    if (ts.isThrowStatement(node)) facts.failure = true;
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) && ts.isIdentifier(node.left.expression) &&
+      node.left.expression.text === 'process' && node.left.name.text === 'exitCode') facts.failure = true;
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node.expression);
+      if (name === 'it' || name === 'test') facts.test = true;
+      if (name === 'expect' || name === 'assert' || name.startsWith('assert')) facts.assertion = true;
+      if (name === 'exit' && ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) && node.expression.expression.text === 'process') facts.failure = true;
+      if (name === 'error' || name === 'warn') facts.diagnostic = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return facts;
+}
+
+function inferredStrength(ref) {
+  const base = ref.split('/').pop() ?? ref;
+  if (/\.test\.(?:ts|js|mjs)$/.test(base) || base.startsWith('no-') || /-coverage\.(?:mjs|js)$/.test(base)) return 'ratchet';
+  if (ref.startsWith('scripts/') && base.startsWith('lint-')) return 'lint';
+  if (ref.startsWith('.husky/') || /precommit/i.test(base)) return 'gate';
+  if (ref.startsWith('scripts/')) return 'lint';
+  if (ref.startsWith('docs/')) return 'spec-only';
+  if (ref.startsWith('src/')) return 'gate';
+  return 'spec-only';
+}
+
+/** A comment or prose sentence cannot satisfy these syntax-tree predicates. */
+export function gradeFileReference(ref, content) {
+  if (content === null) return { proven: false, strength: 'documented-only', reason: 'reference-unreadable' };
+  if (content.trim().length === 0) return { proven: false, strength: 'documented-only', reason: 'reference-empty' };
+  const expected = inferredStrength(ref);
+  if (expected === 'spec-only') {
+    return content.trim().length >= 20
+      ? { proven: false, strength: 'documented-only', observedStrength: 'spec-only', reason: 'protected-relevance-proof-missing' }
+      : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+  }
+  if (!/\.(?:ts|tsx|js|mjs|cjs)$/.test(ref)) {
+    const shellGate = /(^|\n)\s*(?:exit\s+[1-9]|return\s+[1-9])/m.test(content) && /(^|\n)\s*(?:if|case)\b/m.test(content);
+    return shellGate
+      ? { proven: false, strength: 'documented-only', observedStrength: expected, reason: 'protected-relevance-proof-missing' }
+      : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+  }
+  const facts = analyzeProgram(content, ref);
+  if (expected === 'ratchet' && /\.test\./.test(ref)) {
+    return facts.test && facts.assertion
+      ? { proven: false, strength: 'documented-only', observedStrength: 'ratchet', reason: 'protected-relevance-proof-missing' }
+      : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+  }
+  if (facts.conditional && facts.failure) {
+    return { proven: false, strength: 'documented-only', observedStrength: expected, reason: 'protected-relevance-proof-missing' };
+  }
+  return { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+}
+
+function validProofRecord(record, index) {
+  if (!exactKeys(record, ['articleId', 'articleSha256', 'proof', 'ref', 'sha256', 'verdict']) ||
+    typeof record.articleId !== 'string' || record.articleId.length < 3 ||
+    !SHA256_RE.test(record.articleSha256) || !safeRepoPath(record.ref) ||
+    !SHA256_RE.test(record.sha256) || !['EFFECTIVE', 'WIRED', 'EXISTS'].includes(record.verdict)) {
+    return `record ${index} is malformed`;
+  }
+  const proof = record.proof;
+  if (!exactKeys(proof, ['schemaVersion', 'observerCommandSha256', 'relevance', 'control', 'violation']) ||
+    proof.schemaVersion !== 1 || !SHA256_RE.test(proof.observerCommandSha256)) {
+    return `record ${index} proof envelope is malformed`;
+  }
+  const relevance = proof.relevance;
+  if (!exactKeys(relevance, [
+    'articleId', 'ruleSha256', 'observerRef', 'observerSha256', 'subjectRef', 'subjectBeforeSha256',
+  ]) || relevance.articleId !== record.articleId || !SHA256_RE.test(relevance.ruleSha256) ||
+    relevance.observerRef !== record.ref || relevance.observerSha256 !== record.sha256 ||
+    !safeRepoPath(relevance.subjectRef) || relevance.subjectRef === record.ref ||
+    relevance.subjectRef === PROTECTED_VERDICTS_PATH || !SHA256_RE.test(relevance.subjectBeforeSha256)) {
+    return `record ${index} relevance envelope is malformed or crosses the subject/observer boundary`;
+  }
+  const control = proof.control;
+  if (!exactKeys(control, ['exitCode', 'testsRun', 'outputSha256']) || control.exitCode !== 0 ||
+    !Number.isInteger(control.testsRun) || control.testsRun < 1 || !SHA256_RE.test(control.outputSha256)) {
+    return `record ${index} clean control evidence is malformed`;
+  }
+  const violation = proof.violation;
+  if (!exactKeys(violation, [
+    'mutationId', 'subjectAfterSha256', 'landed', 'exitCode', 'testsRun', 'failureKind',
+    'outputSha256', 'decidingOutput',
+  ]) || typeof violation.mutationId !== 'string' || violation.mutationId.trim().length < 3 ||
+    !SHA256_RE.test(violation.subjectAfterSha256) ||
+    violation.subjectAfterSha256 === relevance.subjectBeforeSha256 || violation.landed !== true ||
+    !Number.isInteger(violation.exitCode) || violation.exitCode === 0 ||
+    violation.testsRun !== control.testsRun || violation.failureKind !== 'assertion' ||
+    !SHA256_RE.test(violation.outputSha256) || violation.outputSha256 === control.outputSha256 ||
+    typeof violation.decidingOutput !== 'string' || violation.decidingOutput.trim().length < 10) {
+    return `record ${index} fail-direction evidence is malformed or did not execute the same tests to an assertion failure`;
+  }
+  return null;
+}
+
+function readProtectedVerdicts(snapshot) {
+  const text = snapshot.readFile(PROTECTED_VERDICTS_PATH);
+  if (text === null) return { records: new Map(), errors: [] };
+  try {
+    const value = JSON.parse(text);
+    if (!exactKeys(value, ['schemaVersion', 'records']) ||
+      value.schemaVersion !== PROTECTED_VERDICT_SCHEMA_VERSION || !Array.isArray(value.records)) {
+      throw new Error(`must contain exactly schemaVersion: ${PROTECTED_VERDICT_SCHEMA_VERSION} and records[]`);
+    }
+    const records = new Map();
+    for (const [index, record] of value.records.entries()) {
+      const error = validProofRecord(record, index);
+      if (error) throw new Error(error);
+      const key = `${record.articleId}\0${record.ref}`;
+      if (records.has(key)) throw new Error(`duplicate article/reference proof ${record.articleId} -> ${record.ref}`);
+      records.set(key, record);
+    }
+    return { records, errors: [] };
+  } catch (error) {
+    return { records: new Map(), errors: [`protected verdict ledger invalid: ${error instanceof Error ? error.message : String(error)}`] };
+  }
+}
+
+function verdictStrength(verdict) {
+  if (verdict === 'EFFECTIVE') return 'ratchet';
+  if (verdict === 'WIRED') return 'gate';
+  return 'spec-only';
+}
+
+const refKey = (kind, ref) => `${kind}\0${ref}`;
+
+/**
+ * Closed-census measurement. `articles` contain `{id,family,name,refs}` and refs
+ * contain sorted `files/routes/markers`. Only a reference already associated with
+ * the same protected article may contribute. Candidate-only testimony is unverified.
+ */
+export function measureAnchoredEnforcement({
+  root,
+  protectedArticles,
+  candidateArticles,
+  snapshot,
+  protectedRouteExists = () => false,
+  candidateRouteExists = () => false,
+  protectedMarkerExists = () => false,
+  candidateMarkerExists = () => false,
+  candidateReadFile = null,
+}) {
+  const errors = [];
+  if (!Array.isArray(protectedArticles) || protectedArticles.length === 0) errors.push('protected rule population is empty or unreadable');
+  if (!Array.isArray(candidateArticles) || candidateArticles.length === 0) errors.push('candidate rule population is empty or unreadable');
+  const protectedById = new Map();
+  const candidateById = new Map();
+  for (const article of protectedArticles ?? []) {
+    if (!article.id || protectedById.has(article.id)) errors.push(`protected article identity is missing or duplicated: ${article.id ?? 'missing'}`);
+    else protectedById.set(article.id, article);
+  }
+  for (const article of candidateArticles ?? []) {
+    if (!article.id || candidateById.has(article.id)) errors.push(`candidate article identity is missing or duplicated: ${article.id ?? 'missing'}`);
+    else candidateById.set(article.id, article);
+  }
+
+  const additions = [...candidateById.keys()].filter((id) => !protectedById.has(id)).sort();
+  const removals = [...protectedById.keys()].filter((id) => !candidateById.has(id)).sort();
+  const continuityIds = [...new Set([...protectedById.keys(), ...candidateById.keys()])].sort();
+  const protectedFamilies = new Map();
+  const candidateFamilies = new Map();
+  for (const article of protectedById.values()) {
+    if (!protectedFamilies.has(article.family)) protectedFamilies.set(article.family, new Set());
+    protectedFamilies.get(article.family).add(article.id);
+  }
+  for (const article of candidateById.values()) {
+    if (!candidateFamilies.has(article.family)) candidateFamilies.set(article.family, new Set());
+    candidateFamilies.get(article.family).add(article.id);
+  }
+  const byFamily = Object.create(null);
+  for (const family of new Set([...protectedFamilies.keys(), ...candidateFamilies.keys()])) {
+    const protectedIds = protectedFamilies.get(family) ?? new Set();
+    const candidateIds = candidateFamilies.get(family) ?? new Set();
+    byFamily[family] = {
+      protectedBase: protectedIds.size,
+      candidate: candidateIds.size,
+      continuity: new Set([...protectedIds, ...candidateIds]).size,
+    };
+  }
+  if (removals.length > 0) errors.push(`population shrank by ${removals.length} (direction: removal)`);
+
+  const protectedVerdicts = readProtectedVerdicts(snapshot);
+  errors.push(...protectedVerdicts.errors);
+  const readCandidateFile = candidateReadFile ?? candidateReader(root);
+  const unverifiedReferences = [];
+  const articleResults = [];
+
+  for (const id of continuityIds) {
+    const candidate = candidateById.get(id) ?? null;
+    const protectedArticle = protectedById.get(id) ?? null;
+    if (!candidate) {
+      articleResults.push({ id, family: protectedArticle.family, name: protectedArticle.name, strength: 'documented-only', references: [] });
+      continue;
+    }
+    const protectedRefs = new Set();
+    if (protectedArticle) {
+      for (const kind of ['files', 'routes', 'markers']) {
+        for (const ref of protectedArticle.refs[kind] ?? []) protectedRefs.add(refKey(kind, ref));
+      }
+    }
+    const references = [];
+    for (const kind of ['files', 'routes', 'markers']) {
+      for (const ref of candidate.refs[kind] ?? []) {
+        let result;
+        if (!protectedArticle || !protectedRefs.has(refKey(kind, ref))) {
+          result = { proven: false, strength: 'documented-only', reason: 'reference-not-in-protected-census' };
+        } else if (kind === 'files') {
+          const protectedContent = snapshot.readFile(ref);
+          const candidateContent = readCandidateFile(ref);
+          if (candidateContent === null) {
+            result = { proven: false, strength: 'documented-only', reason: 'candidate-reference-unreadable' };
+          } else if (candidateContent.trim().length === 0) {
+            result = { proven: false, strength: 'documented-only', reason: 'candidate-reference-empty' };
+          } else {
+            const protectedGrade = gradeFileReference(ref, protectedContent);
+            const candidateGrade = gradeFileReference(ref, candidateContent);
+            const certified = protectedVerdicts.records.get(`${id}\0${ref}`);
+            if (certified && protectedContent !== null && certified.sha256 !== sha256(protectedContent)) {
+              errors.push(`protected verdict digest mismatch for ${ref}`);
+              result = { proven: false, strength: 'documented-only', reason: 'protected-verdict-digest-mismatch' };
+            } else if (certified && protectedContent !== null && sha256(candidateContent) !== certified.sha256) {
+              result = { proven: false, strength: 'documented-only', reason: 'certified-reference-changed' };
+            } else if (certified && (
+              certified.articleSha256 !== protectedArticle.articleSha256 ||
+              certified.proof.relevance.ruleSha256 !== protectedArticle.ruleSha256
+            )) {
+              errors.push(`protected relevance proof article digest mismatch for ${id} -> ${ref}`);
+              result = { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-article-mismatch' };
+            } else if (certified && candidate.ruleSha256 !== certified.proof.relevance.ruleSha256) {
+              result = { proven: false, strength: 'documented-only', reason: 'candidate-cited-rule-changed' };
+            } else if (certified) {
+              const subjectRef = certified.proof.relevance.subjectRef;
+              const protectedSubject = snapshot.readFile(subjectRef);
+              const candidateSubject = readCandidateFile(subjectRef);
+              if (protectedSubject === null || sha256(protectedSubject) !== certified.proof.relevance.subjectBeforeSha256) {
+                errors.push(`protected relevance proof subject digest mismatch for ${id} -> ${ref}`);
+                result = { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-subject-mismatch' };
+              } else if (candidateSubject === null || sha256(candidateSubject) !== certified.proof.relevance.subjectBeforeSha256) {
+                result = { proven: false, strength: 'documented-only', reason: 'certified-subject-changed' };
+              } else {
+                result = {
+                  proven: true,
+                  strength: verdictStrength(certified.verdict),
+                  reason: `protected-certified-${certified.verdict.toLowerCase()}-with-relevance-and-fail-direction`,
+                };
+              }
+            } else {
+              result = !protectedGrade.proven && protectedGrade.reason === 'reference-structurally-hollow'
+                ? protectedGrade
+                : candidateGrade.reason === 'reference-structurally-hollow'
+                  ? candidateGrade
+                  : { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-missing' };
+            }
+          }
+        } else {
+          const onProtected = kind === 'routes' ? protectedRouteExists(ref) : protectedMarkerExists(ref);
+          const onCandidate = kind === 'routes' ? candidateRouteExists(ref) : candidateMarkerExists(ref);
+          result = onProtected && onCandidate
+            ? { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-missing' }
+            : { proven: false, strength: 'documented-only', reason: onCandidate ? 'protected-reference-unresolved' : 'candidate-reference-unresolved' };
+        }
+        references.push({ kind, ref, ...result });
+        if (!result.proven) unverifiedReferences.push({ articleId: id, standard: candidate.name, kind, ref, reason: result.reason });
+      }
+    }
+    let strength = 'documented-only';
+    for (const reference of references) {
+      if (reference.proven && STRENGTH_RANK[reference.strength] > STRENGTH_RANK[strength]) strength = reference.strength;
+    }
+    articleResults.push({ id, family: candidate.family, name: candidate.name, strength, references });
+  }
+
+  return {
+    status: errors.length === 0 ? 'proven' : 'not-proven',
+    errors,
+    basis: {
+      source: snapshot.source,
+      protectedMainSha: snapshot.protectedMainSha,
+      baseRevision: snapshot.baseRevision,
+      candidateTreeMayRaiseStrength: false,
+    },
+    population: {
+      protectedBase: protectedById.size,
+      candidate: candidateById.size,
+      continuity: continuityIds.length,
+      additions,
+      removals,
+      byFamily,
+    },
+    unverifiedReferences,
+    articles: articleResults,
+  };
+}

--- a/scripts/lib/standards-enforcement-measurement.mjs
+++ b/scripts/lib/standards-enforcement-measurement.mjs
@@ -8,6 +8,7 @@ import ts from 'typescript';
 export const CANONICAL_PROTECTED_REMOTE = 'https://github.com/JKHeadley/instar.git';
 export const PROTECTED_MAIN_REF = 'refs/heads/main';
 export const PROTECTED_VERDICTS_PATH = 'docs/standards-enforcement-verdicts.json';
+export const PROTECTED_VERDICT_SCHEMA_VERSION = 2;
 const SYSTEM_GIT = '/usr/bin/git';
 const SHA256_RE = /^[a-f0-9]{64}$/;
 const STRENGTH_RANK = {
@@ -239,25 +240,67 @@ export function gradeFileReference(ref, content) {
   const expected = inferredStrength(ref);
   if (expected === 'spec-only') {
     return content.trim().length >= 20
-      ? { proven: true, strength: 'spec-only', reason: 'protected-substantive-spec' }
+      ? { proven: false, strength: 'documented-only', observedStrength: 'spec-only', reason: 'protected-relevance-proof-missing' }
       : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
   }
   if (!/\.(?:ts|tsx|js|mjs|cjs)$/.test(ref)) {
     const shellGate = /(^|\n)\s*(?:exit\s+[1-9]|return\s+[1-9])/m.test(content) && /(^|\n)\s*(?:if|case)\b/m.test(content);
     return shellGate
-      ? { proven: true, strength: expected, reason: 'protected-conditional-failure-path' }
+      ? { proven: false, strength: 'documented-only', observedStrength: expected, reason: 'protected-relevance-proof-missing' }
       : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
   }
   const facts = analyzeProgram(content, ref);
   if (expected === 'ratchet' && /\.test\./.test(ref)) {
     return facts.test && facts.assertion
-      ? { proven: true, strength: 'ratchet', reason: 'protected-executable-test-assertion' }
+      ? { proven: false, strength: 'documented-only', observedStrength: 'ratchet', reason: 'protected-relevance-proof-missing' }
       : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
   }
   if (facts.conditional && facts.failure) {
-    return { proven: true, strength: expected, reason: 'protected-conditional-failure-path' };
+    return { proven: false, strength: 'documented-only', observedStrength: expected, reason: 'protected-relevance-proof-missing' };
   }
   return { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+}
+
+function validProofRecord(record, index) {
+  if (!exactKeys(record, ['articleId', 'articleSha256', 'proof', 'ref', 'sha256', 'verdict']) ||
+    typeof record.articleId !== 'string' || record.articleId.length < 3 ||
+    !SHA256_RE.test(record.articleSha256) || !safeRepoPath(record.ref) ||
+    !SHA256_RE.test(record.sha256) || !['EFFECTIVE', 'WIRED', 'EXISTS'].includes(record.verdict)) {
+    return `record ${index} is malformed`;
+  }
+  const proof = record.proof;
+  if (!exactKeys(proof, ['schemaVersion', 'observerCommandSha256', 'relevance', 'control', 'violation']) ||
+    proof.schemaVersion !== 1 || !SHA256_RE.test(proof.observerCommandSha256)) {
+    return `record ${index} proof envelope is malformed`;
+  }
+  const relevance = proof.relevance;
+  if (!exactKeys(relevance, [
+    'articleId', 'ruleSha256', 'observerRef', 'observerSha256', 'subjectRef', 'subjectBeforeSha256',
+  ]) || relevance.articleId !== record.articleId || !SHA256_RE.test(relevance.ruleSha256) ||
+    relevance.observerRef !== record.ref || relevance.observerSha256 !== record.sha256 ||
+    !safeRepoPath(relevance.subjectRef) || relevance.subjectRef === record.ref ||
+    relevance.subjectRef === PROTECTED_VERDICTS_PATH || !SHA256_RE.test(relevance.subjectBeforeSha256)) {
+    return `record ${index} relevance envelope is malformed or crosses the subject/observer boundary`;
+  }
+  const control = proof.control;
+  if (!exactKeys(control, ['exitCode', 'testsRun', 'outputSha256']) || control.exitCode !== 0 ||
+    !Number.isInteger(control.testsRun) || control.testsRun < 1 || !SHA256_RE.test(control.outputSha256)) {
+    return `record ${index} clean control evidence is malformed`;
+  }
+  const violation = proof.violation;
+  if (!exactKeys(violation, [
+    'mutationId', 'subjectAfterSha256', 'landed', 'exitCode', 'testsRun', 'failureKind',
+    'outputSha256', 'decidingOutput',
+  ]) || typeof violation.mutationId !== 'string' || violation.mutationId.trim().length < 3 ||
+    !SHA256_RE.test(violation.subjectAfterSha256) ||
+    violation.subjectAfterSha256 === relevance.subjectBeforeSha256 || violation.landed !== true ||
+    !Number.isInteger(violation.exitCode) || violation.exitCode === 0 ||
+    violation.testsRun !== control.testsRun || violation.failureKind !== 'assertion' ||
+    !SHA256_RE.test(violation.outputSha256) || violation.outputSha256 === control.outputSha256 ||
+    typeof violation.decidingOutput !== 'string' || violation.decidingOutput.trim().length < 10) {
+    return `record ${index} fail-direction evidence is malformed or did not execute the same tests to an assertion failure`;
+  }
+  return null;
 }
 
 function readProtectedVerdicts(snapshot) {
@@ -265,17 +308,17 @@ function readProtectedVerdicts(snapshot) {
   if (text === null) return { records: new Map(), errors: [] };
   try {
     const value = JSON.parse(text);
-    if (!exactKeys(value, ['schemaVersion', 'records']) || value.schemaVersion !== 1 || !Array.isArray(value.records)) {
-      throw new Error('must contain exactly schemaVersion: 1 and records[]');
+    if (!exactKeys(value, ['schemaVersion', 'records']) ||
+      value.schemaVersion !== PROTECTED_VERDICT_SCHEMA_VERSION || !Array.isArray(value.records)) {
+      throw new Error(`must contain exactly schemaVersion: ${PROTECTED_VERDICT_SCHEMA_VERSION} and records[]`);
     }
     const records = new Map();
     for (const [index, record] of value.records.entries()) {
-      if (!exactKeys(record, ['ref', 'sha256', 'verdict']) || !safeRepoPath(record.ref) ||
-        !SHA256_RE.test(record.sha256) || !['EFFECTIVE', 'WIRED', 'EXISTS'].includes(record.verdict)) {
-        throw new Error(`record ${index} is malformed`);
-      }
-      if (records.has(record.ref)) throw new Error(`duplicate ref ${record.ref}`);
-      records.set(record.ref, record);
+      const error = validProofRecord(record, index);
+      if (error) throw new Error(error);
+      const key = `${record.articleId}\0${record.ref}`;
+      if (records.has(key)) throw new Error(`duplicate article/reference proof ${record.articleId} -> ${record.ref}`);
+      records.set(key, record);
     }
     return { records, errors: [] };
   } catch (error) {
@@ -381,27 +424,49 @@ export function measureAnchoredEnforcement({
           } else {
             const protectedGrade = gradeFileReference(ref, protectedContent);
             const candidateGrade = gradeFileReference(ref, candidateContent);
-            const certified = protectedVerdicts.records.get(ref);
+            const certified = protectedVerdicts.records.get(`${id}\0${ref}`);
             if (certified && protectedContent !== null && certified.sha256 !== sha256(protectedContent)) {
               errors.push(`protected verdict digest mismatch for ${ref}`);
               result = { proven: false, strength: 'documented-only', reason: 'protected-verdict-digest-mismatch' };
             } else if (certified && protectedContent !== null && sha256(candidateContent) !== certified.sha256) {
               result = { proven: false, strength: 'documented-only', reason: 'certified-reference-changed' };
+            } else if (certified && (
+              certified.articleSha256 !== protectedArticle.articleSha256 ||
+              certified.proof.relevance.ruleSha256 !== protectedArticle.ruleSha256
+            )) {
+              errors.push(`protected relevance proof article digest mismatch for ${id} -> ${ref}`);
+              result = { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-article-mismatch' };
+            } else if (certified && candidate.ruleSha256 !== certified.proof.relevance.ruleSha256) {
+              result = { proven: false, strength: 'documented-only', reason: 'candidate-cited-rule-changed' };
             } else if (certified) {
-              result = { proven: true, strength: verdictStrength(certified.verdict), reason: `protected-certified-${certified.verdict.toLowerCase()}` };
-            } else if (!protectedGrade.proven) {
-              result = protectedGrade;
-            } else if (!candidateGrade.proven) {
-              result = candidateGrade;
+              const subjectRef = certified.proof.relevance.subjectRef;
+              const protectedSubject = snapshot.readFile(subjectRef);
+              const candidateSubject = readCandidateFile(subjectRef);
+              if (protectedSubject === null || sha256(protectedSubject) !== certified.proof.relevance.subjectBeforeSha256) {
+                errors.push(`protected relevance proof subject digest mismatch for ${id} -> ${ref}`);
+                result = { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-subject-mismatch' };
+              } else if (candidateSubject === null || sha256(candidateSubject) !== certified.proof.relevance.subjectBeforeSha256) {
+                result = { proven: false, strength: 'documented-only', reason: 'certified-subject-changed' };
+              } else {
+                result = {
+                  proven: true,
+                  strength: verdictStrength(certified.verdict),
+                  reason: `protected-certified-${certified.verdict.toLowerCase()}-with-relevance-and-fail-direction`,
+                };
+              }
             } else {
-              result = { proven: true, strength: weaker(protectedGrade.strength, candidateGrade.strength), reason: 'protected-strength-floor-preserved' };
+              result = !protectedGrade.proven && protectedGrade.reason === 'reference-structurally-hollow'
+                ? protectedGrade
+                : candidateGrade.reason === 'reference-structurally-hollow'
+                  ? candidateGrade
+                  : { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-missing' };
             }
           }
         } else {
           const onProtected = kind === 'routes' ? protectedRouteExists(ref) : protectedMarkerExists(ref);
           const onCandidate = kind === 'routes' ? candidateRouteExists(ref) : candidateMarkerExists(ref);
           result = onProtected && onCandidate
-            ? { proven: true, strength: 'gate', reason: 'protected-structural-reference-preserved' }
+            ? { proven: false, strength: 'documented-only', reason: 'protected-relevance-proof-missing' }
             : { proven: false, strength: 'documented-only', reason: onCandidate ? 'protected-reference-unresolved' : 'candidate-reference-unresolved' };
         }
         references.push({ kind, ref, ...result });

--- a/scripts/lib/standards-enforcement-measurement.mjs
+++ b/scripts/lib/standards-enforcement-measurement.mjs
@@ -1,0 +1,438 @@
+// safe-git-allow: protected measurement uses only content-addressed read operations through /usr/bin/git.
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import ts from 'typescript';
+
+export const CANONICAL_PROTECTED_REMOTE = 'https://github.com/JKHeadley/instar.git';
+export const PROTECTED_MAIN_REF = 'refs/heads/main';
+export const PROTECTED_VERDICTS_PATH = 'docs/standards-enforcement-verdicts.json';
+const SYSTEM_GIT = '/usr/bin/git';
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const STRENGTH_RANK = {
+  'documented-only': 0,
+  'spec-only': 1,
+  lint: 2,
+  gate: 3,
+  ratchet: 4,
+};
+
+const sha256 = (value) => crypto.createHash('sha256').update(value).digest('hex');
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const exactKeys = (value, keys) => isObject(value) &&
+  JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+const weaker = (left, right) => STRENGTH_RANK[left] <= STRENGTH_RANK[right] ? left : right;
+
+function safeRepoPath(rel) {
+  return typeof rel === 'string' && rel.length > 0 && !path.isAbsolute(rel) &&
+    !rel.includes('\0') && !rel.split(/[\\/]/).includes('..');
+}
+
+function scrubbedGitEnv(root) {
+  const {
+    GIT_ALTERNATE_OBJECT_DIRECTORIES: _alternateObjects,
+    GIT_CONFIG_COUNT: _configCount,
+    GIT_CONFIG_PARAMETERS: _configParameters,
+    GIT_DIR: _gitDir,
+    GIT_OBJECT_DIRECTORY: _objectDirectory,
+    GIT_WORK_TREE: _workTree,
+    ...ambient
+  } = process.env;
+  return { ...ambient, HOME: path.parse(root).root, GIT_NO_REPLACE_OBJECTS: '1' };
+}
+
+function git(root, args, timeout = 20_000) {
+  const child = spawnSync(SYSTEM_GIT, args, {
+    cwd: root,
+    encoding: 'utf8',
+    timeout,
+    maxBuffer: 64 * 1024 * 1024,
+    env: scrubbedGitEnv(root),
+  });
+  if (child.error || child.status !== 0) return null;
+  return child.stdout;
+}
+
+function canonicalRemoteMain(root) {
+  const child = spawnSync(SYSTEM_GIT, [
+    'ls-remote', '--refs', CANONICAL_PROTECTED_REMOTE, PROTECTED_MAIN_REF,
+  ], {
+    cwd: path.parse(root).root,
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: {
+      PATH: '/usr/bin:/bin',
+      HOME: path.parse(root).root,
+      LANG: 'C',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_COUNT: '0',
+      GIT_NO_REPLACE_OBJECTS: '1',
+      GIT_TERMINAL_PROMPT: '0',
+    },
+  });
+  if (child.error || child.status !== 0) return null;
+  const fields = child.stdout.trim().split(/\s+/);
+  if (fields.length !== 2 || fields[1] !== PROTECTED_MAIN_REF || !/^[a-f0-9]{40}$/.test(fields[0])) return null;
+  return fields[0];
+}
+
+function directorySnapshot(root) {
+  const absolute = path.resolve(root);
+  const listFiles = (prefix) => {
+    const start = path.resolve(absolute, prefix);
+    const out = [];
+    const walk = (dir) => {
+      let entries;
+      try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.isFile()) out.push(path.relative(absolute, full).split(path.sep).join('/'));
+      }
+    };
+    walk(start);
+    return out.sort();
+  };
+  return {
+    source: 'explicit-test-fixture',
+    protectedMainSha: null,
+    baseRevision: `fixture:${sha256(absolute).slice(0, 12)}`,
+    readFile(rel) {
+      if (!safeRepoPath(rel)) return null;
+      const full = path.resolve(absolute, rel);
+      if (full !== absolute && !full.startsWith(`${absolute}${path.sep}`)) return null;
+      try {
+        const stat = fs.lstatSync(full);
+        if (!stat.isFile() || stat.isSymbolicLink()) return null;
+        return fs.readFileSync(full, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    listFiles,
+    hasMarker(marker) {
+      if (typeof marker !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(marker)) return false;
+      const re = new RegExp(`\\b${marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
+      return listFiles('src').some((rel) => {
+        if (!/\.(?:ts|js|mjs|cjs)$/.test(rel)) return false;
+        const content = this.readFile(rel);
+        return content !== null && re.test(content);
+      });
+    },
+  };
+}
+
+/**
+ * Resolve the measurement oracle. Production ignores candidate remotes and tracking refs:
+ * the server-advertised main SHA is reduced to a content-addressed merge base. An explicit
+ * directory exists only for `--allow-partial-registry` test fixtures; the caller controls
+ * that boundary and never passes it in a real check.
+ */
+export function resolveProtectedMeasurementSnapshot({ root, fixtureRoot = null }) {
+  if (fixtureRoot !== null) return directorySnapshot(fixtureRoot);
+  const protectedMainSha = canonicalRemoteMain(root);
+  if (!protectedMainSha) throw new Error('protected main unavailable from canonical server');
+  const baseRevision = git(root, ['merge-base', 'HEAD', protectedMainSha])?.trim() ?? '';
+  if (!/^[a-f0-9]{40}$/.test(baseRevision)) {
+    throw new Error(`protected merge base unavailable for canonical main ${protectedMainSha.slice(0, 12)}`);
+  }
+  return {
+    source: 'canonical-server-content-addressed-merge-base',
+    protectedMainSha,
+    baseRevision,
+    readFile(rel) {
+      if (!safeRepoPath(rel)) return null;
+      return git(root, ['show', `${baseRevision}:${rel}`]);
+    },
+    listFiles(prefix) {
+      if (!safeRepoPath(prefix)) return [];
+      const output = git(root, ['ls-tree', '-r', '--name-only', baseRevision, '--', prefix]);
+      return output === null ? [] : output.trim().split('\n').filter(Boolean).sort();
+    },
+    hasMarker(marker) {
+      if (typeof marker !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(marker)) return false;
+      return git(root, ['grep', '-q', '-w', '--fixed-strings', marker, baseRevision, '--', 'src']) !== null;
+    },
+  };
+}
+
+export function routeTableFromSnapshot(snapshot) {
+  const out = new Set();
+  const re = /router\.(get|post|put|delete|patch)\s*\(\s*['"`]([^'"`]+)['"`]/g;
+  for (const rel of snapshot.listFiles('src/server')) {
+    if (!rel.endsWith('.ts') || rel.endsWith('.test.ts')) continue;
+    const content = snapshot.readFile(rel);
+    if (content === null) continue;
+    for (const match of content.matchAll(re)) out.add(`${match[1].toUpperCase()} ${match[2]}`);
+  }
+  return out;
+}
+
+function candidateReader(root) {
+  return (rel) => {
+    if (!safeRepoPath(rel)) return null;
+    const full = path.resolve(root, rel);
+    if (full !== root && !full.startsWith(`${root}${path.sep}`)) return null;
+    try {
+      const stat = fs.lstatSync(full);
+      if (!stat.isFile() || stat.isSymbolicLink()) return null;
+      return fs.readFileSync(full, 'utf8');
+    } catch {
+      return null;
+    }
+  };
+}
+
+function calleeName(node) {
+  if (ts.isIdentifier(node)) return node.text;
+  if (ts.isPropertyAccessExpression(node)) return node.name.text;
+  return '';
+}
+
+function analyzeProgram(content, rel) {
+  const kind = /\.(?:ts|tsx)$/.test(rel) ? ts.ScriptKind.TS : ts.ScriptKind.JS;
+  const source = ts.createSourceFile(rel, content, ts.ScriptTarget.Latest, true, kind);
+  const facts = {
+    test: false,
+    assertion: false,
+    conditional: false,
+    failure: false,
+    diagnostic: false,
+  };
+  const visit = (node) => {
+    if (ts.isIfStatement(node) || ts.isSwitchStatement(node) || ts.isConditionalExpression(node)) facts.conditional = true;
+    if (ts.isThrowStatement(node)) facts.failure = true;
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) && ts.isIdentifier(node.left.expression) &&
+      node.left.expression.text === 'process' && node.left.name.text === 'exitCode') facts.failure = true;
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node.expression);
+      if (name === 'it' || name === 'test') facts.test = true;
+      if (name === 'expect' || name === 'assert' || name.startsWith('assert')) facts.assertion = true;
+      if (name === 'exit' && ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) && node.expression.expression.text === 'process') facts.failure = true;
+      if (name === 'error' || name === 'warn') facts.diagnostic = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return facts;
+}
+
+function inferredStrength(ref) {
+  const base = ref.split('/').pop() ?? ref;
+  if (/\.test\.(?:ts|js|mjs)$/.test(base) || base.startsWith('no-') || /-coverage\.(?:mjs|js)$/.test(base)) return 'ratchet';
+  if (ref.startsWith('scripts/') && base.startsWith('lint-')) return 'lint';
+  if (ref.startsWith('.husky/') || /precommit/i.test(base)) return 'gate';
+  if (ref.startsWith('scripts/')) return 'lint';
+  if (ref.startsWith('docs/')) return 'spec-only';
+  if (ref.startsWith('src/')) return 'gate';
+  return 'spec-only';
+}
+
+/** A comment or prose sentence cannot satisfy these syntax-tree predicates. */
+export function gradeFileReference(ref, content) {
+  if (content === null) return { proven: false, strength: 'documented-only', reason: 'reference-unreadable' };
+  if (content.trim().length === 0) return { proven: false, strength: 'documented-only', reason: 'reference-empty' };
+  const expected = inferredStrength(ref);
+  if (expected === 'spec-only') {
+    return content.trim().length >= 20
+      ? { proven: true, strength: 'spec-only', reason: 'protected-substantive-spec' }
+      : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+  }
+  if (!/\.(?:ts|tsx|js|mjs|cjs)$/.test(ref)) {
+    const shellGate = /(^|\n)\s*(?:exit\s+[1-9]|return\s+[1-9])/m.test(content) && /(^|\n)\s*(?:if|case)\b/m.test(content);
+    return shellGate
+      ? { proven: true, strength: expected, reason: 'protected-conditional-failure-path' }
+      : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+  }
+  const facts = analyzeProgram(content, ref);
+  if (expected === 'ratchet' && /\.test\./.test(ref)) {
+    return facts.test && facts.assertion
+      ? { proven: true, strength: 'ratchet', reason: 'protected-executable-test-assertion' }
+      : { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+  }
+  if (facts.conditional && facts.failure) {
+    return { proven: true, strength: expected, reason: 'protected-conditional-failure-path' };
+  }
+  return { proven: false, strength: 'documented-only', reason: 'reference-structurally-hollow' };
+}
+
+function readProtectedVerdicts(snapshot) {
+  const text = snapshot.readFile(PROTECTED_VERDICTS_PATH);
+  if (text === null) return { records: new Map(), errors: [] };
+  try {
+    const value = JSON.parse(text);
+    if (!exactKeys(value, ['schemaVersion', 'records']) || value.schemaVersion !== 1 || !Array.isArray(value.records)) {
+      throw new Error('must contain exactly schemaVersion: 1 and records[]');
+    }
+    const records = new Map();
+    for (const [index, record] of value.records.entries()) {
+      if (!exactKeys(record, ['ref', 'sha256', 'verdict']) || !safeRepoPath(record.ref) ||
+        !SHA256_RE.test(record.sha256) || !['EFFECTIVE', 'WIRED', 'EXISTS'].includes(record.verdict)) {
+        throw new Error(`record ${index} is malformed`);
+      }
+      if (records.has(record.ref)) throw new Error(`duplicate ref ${record.ref}`);
+      records.set(record.ref, record);
+    }
+    return { records, errors: [] };
+  } catch (error) {
+    return { records: new Map(), errors: [`protected verdict ledger invalid: ${error instanceof Error ? error.message : String(error)}`] };
+  }
+}
+
+function verdictStrength(verdict) {
+  if (verdict === 'EFFECTIVE') return 'ratchet';
+  if (verdict === 'WIRED') return 'gate';
+  return 'spec-only';
+}
+
+const refKey = (kind, ref) => `${kind}\0${ref}`;
+
+/**
+ * Closed-census measurement. `articles` contain `{id,family,name,refs}` and refs
+ * contain sorted `files/routes/markers`. Only a reference already associated with
+ * the same protected article may contribute. Candidate-only testimony is unverified.
+ */
+export function measureAnchoredEnforcement({
+  root,
+  protectedArticles,
+  candidateArticles,
+  snapshot,
+  protectedRouteExists = () => false,
+  candidateRouteExists = () => false,
+  protectedMarkerExists = () => false,
+  candidateMarkerExists = () => false,
+  candidateReadFile = null,
+}) {
+  const errors = [];
+  if (!Array.isArray(protectedArticles) || protectedArticles.length === 0) errors.push('protected rule population is empty or unreadable');
+  if (!Array.isArray(candidateArticles) || candidateArticles.length === 0) errors.push('candidate rule population is empty or unreadable');
+  const protectedById = new Map();
+  const candidateById = new Map();
+  for (const article of protectedArticles ?? []) {
+    if (!article.id || protectedById.has(article.id)) errors.push(`protected article identity is missing or duplicated: ${article.id ?? 'missing'}`);
+    else protectedById.set(article.id, article);
+  }
+  for (const article of candidateArticles ?? []) {
+    if (!article.id || candidateById.has(article.id)) errors.push(`candidate article identity is missing or duplicated: ${article.id ?? 'missing'}`);
+    else candidateById.set(article.id, article);
+  }
+
+  const additions = [...candidateById.keys()].filter((id) => !protectedById.has(id)).sort();
+  const removals = [...protectedById.keys()].filter((id) => !candidateById.has(id)).sort();
+  const continuityIds = [...new Set([...protectedById.keys(), ...candidateById.keys()])].sort();
+  const protectedFamilies = new Map();
+  const candidateFamilies = new Map();
+  for (const article of protectedById.values()) {
+    if (!protectedFamilies.has(article.family)) protectedFamilies.set(article.family, new Set());
+    protectedFamilies.get(article.family).add(article.id);
+  }
+  for (const article of candidateById.values()) {
+    if (!candidateFamilies.has(article.family)) candidateFamilies.set(article.family, new Set());
+    candidateFamilies.get(article.family).add(article.id);
+  }
+  const byFamily = Object.create(null);
+  for (const family of new Set([...protectedFamilies.keys(), ...candidateFamilies.keys()])) {
+    const protectedIds = protectedFamilies.get(family) ?? new Set();
+    const candidateIds = candidateFamilies.get(family) ?? new Set();
+    byFamily[family] = {
+      protectedBase: protectedIds.size,
+      candidate: candidateIds.size,
+      continuity: new Set([...protectedIds, ...candidateIds]).size,
+    };
+  }
+  if (removals.length > 0) errors.push(`population shrank by ${removals.length} (direction: removal)`);
+
+  const protectedVerdicts = readProtectedVerdicts(snapshot);
+  errors.push(...protectedVerdicts.errors);
+  const readCandidateFile = candidateReadFile ?? candidateReader(root);
+  const unverifiedReferences = [];
+  const articleResults = [];
+
+  for (const id of continuityIds) {
+    const candidate = candidateById.get(id) ?? null;
+    const protectedArticle = protectedById.get(id) ?? null;
+    if (!candidate) {
+      articleResults.push({ id, family: protectedArticle.family, name: protectedArticle.name, strength: 'documented-only', references: [] });
+      continue;
+    }
+    const protectedRefs = new Set();
+    if (protectedArticle) {
+      for (const kind of ['files', 'routes', 'markers']) {
+        for (const ref of protectedArticle.refs[kind] ?? []) protectedRefs.add(refKey(kind, ref));
+      }
+    }
+    const references = [];
+    for (const kind of ['files', 'routes', 'markers']) {
+      for (const ref of candidate.refs[kind] ?? []) {
+        let result;
+        if (!protectedArticle || !protectedRefs.has(refKey(kind, ref))) {
+          result = { proven: false, strength: 'documented-only', reason: 'reference-not-in-protected-census' };
+        } else if (kind === 'files') {
+          const protectedContent = snapshot.readFile(ref);
+          const candidateContent = readCandidateFile(ref);
+          if (candidateContent === null) {
+            result = { proven: false, strength: 'documented-only', reason: 'candidate-reference-unreadable' };
+          } else if (candidateContent.trim().length === 0) {
+            result = { proven: false, strength: 'documented-only', reason: 'candidate-reference-empty' };
+          } else {
+            const protectedGrade = gradeFileReference(ref, protectedContent);
+            const candidateGrade = gradeFileReference(ref, candidateContent);
+            const certified = protectedVerdicts.records.get(ref);
+            if (certified && protectedContent !== null && certified.sha256 !== sha256(protectedContent)) {
+              errors.push(`protected verdict digest mismatch for ${ref}`);
+              result = { proven: false, strength: 'documented-only', reason: 'protected-verdict-digest-mismatch' };
+            } else if (certified && protectedContent !== null && sha256(candidateContent) !== certified.sha256) {
+              result = { proven: false, strength: 'documented-only', reason: 'certified-reference-changed' };
+            } else if (certified) {
+              result = { proven: true, strength: verdictStrength(certified.verdict), reason: `protected-certified-${certified.verdict.toLowerCase()}` };
+            } else if (!protectedGrade.proven) {
+              result = protectedGrade;
+            } else if (!candidateGrade.proven) {
+              result = candidateGrade;
+            } else {
+              result = { proven: true, strength: weaker(protectedGrade.strength, candidateGrade.strength), reason: 'protected-strength-floor-preserved' };
+            }
+          }
+        } else {
+          const onProtected = kind === 'routes' ? protectedRouteExists(ref) : protectedMarkerExists(ref);
+          const onCandidate = kind === 'routes' ? candidateRouteExists(ref) : candidateMarkerExists(ref);
+          result = onProtected && onCandidate
+            ? { proven: true, strength: 'gate', reason: 'protected-structural-reference-preserved' }
+            : { proven: false, strength: 'documented-only', reason: onCandidate ? 'protected-reference-unresolved' : 'candidate-reference-unresolved' };
+        }
+        references.push({ kind, ref, ...result });
+        if (!result.proven) unverifiedReferences.push({ articleId: id, standard: candidate.name, kind, ref, reason: result.reason });
+      }
+    }
+    let strength = 'documented-only';
+    for (const reference of references) {
+      if (reference.proven && STRENGTH_RANK[reference.strength] > STRENGTH_RANK[strength]) strength = reference.strength;
+    }
+    articleResults.push({ id, family: candidate.family, name: candidate.name, strength, references });
+  }
+
+  return {
+    status: errors.length === 0 ? 'proven' : 'not-proven',
+    errors,
+    basis: {
+      source: snapshot.source,
+      protectedMainSha: snapshot.protectedMainSha,
+      baseRevision: snapshot.baseRevision,
+      candidateTreeMayRaiseStrength: false,
+    },
+    population: {
+      protectedBase: protectedById.size,
+      candidate: candidateById.size,
+      continuity: continuityIds.length,
+      additions,
+      removals,
+      byFamily,
+    },
+    unverifiedReferences,
+    articles: articleResults,
+  };
+}

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -56,11 +56,17 @@ import yaml from 'js-yaml';
 import { articleIds, parseRegistryStructure } from './standards-registry-article-core.mjs';
 import {
   evaluateStandardsDirection,
+  inventoryStandardsArticles,
   readCandidateApproverKey,
   readDirectionApprovalLedger,
   resolveProtectedApproverKey,
   resolveProtectedBaseRegistry,
 } from './standards-direction-guard.mjs';
+import {
+  measureAnchoredEnforcement,
+  resolveProtectedMeasurementSnapshot,
+  routeTableFromSnapshot,
+} from './lib/standards-enforcement-measurement.mjs';
 import { parseFrontmatter, validateAuditReport } from './write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -98,6 +104,7 @@ const AUDIT_REF_ARG = [...args].find((arg) => arg.startsWith('--audit-ref='));
 const AUDIT_REF = AUDIT_REF_ARG?.slice('--audit-ref='.length) ?? null;
 const RECORD_AREA_MODEL = args.has('--record-area-model-audit');
 const ALLOW_PARTIAL_REGISTRY = args.has('--allow-partial-registry');
+const REQUIRE_ROOT = !ALLOW_PARTIAL_REGISTRY || args.has('--require-root');
 const ADMIT_NEW_AREAS = args.has('--admit-new-areas');
 
 function resolveRoot() {
@@ -343,6 +350,18 @@ function parseRegistry(markdown) {
   };
 }
 
+function measuredArticles(markdown, parsedArticles) {
+  const inventory = inventoryStandardsArticles(markdown);
+  return {
+    articles: parsedArticles.map((article, index) => ({
+      ...article,
+      id: inventory.articles[index]?.id ?? null,
+      refs: extractRefs(article),
+    })),
+    errors: inventory.errors,
+  };
+}
+
 const FILE_RE = /`([a-zA-Z0-9_./-]+\.(?:ts|js|mjs|cjs|md|json|sh))`/g;
 const ROUTE_RE = /`(GET|POST|PUT|DELETE|PATCH)\s+(\/[a-zA-Z0-9/_:-]+)`/g;
 const MARKER_RE = /\b([A-Z][A-Z0-9]{2,}_[A-Z0-9_]{2,})\b/g;
@@ -421,18 +440,6 @@ function detectEnforcementClaims(a) {
     hits.push(m[0].trim());
   }
   return dedupe(hits).sort();
-}
-
-const KIND_RANK = { ratchet: 4, gate: 3, lint: 2, 'spec-only': 1 };
-function classifyFileGuard(ref) {
-  const base = ref.split('/').pop() ?? ref;
-  if (/\.test\.(ts|js|mjs)$/.test(base) || base.startsWith('no-') || /-coverage\.(mjs|js)$/.test(base)) return 'ratchet';
-  if (ref.startsWith('scripts/') && base.startsWith('lint-')) return 'lint';
-  if (ref.startsWith('.husky/') || /precommit/i.test(base)) return 'gate';
-  if (ref.startsWith('scripts/')) return 'lint';
-  if (ref.startsWith('docs/')) return 'spec-only';
-  if (ref.startsWith('src/')) return 'gate';
-  return 'spec-only';
 }
 
 // ── Per-area audit facts + floors ────────────────────────────────────────────
@@ -1221,7 +1228,8 @@ function compute() {
       generatedAt: new Date().toISOString(),
       registryFound: false,
       total: 0, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 },
-      enforcedRatio: 1, gaps: [], falseClaimCount: 0, falseClaims: [],
+      continuityTotal: 0, enforcedRatio: null, currentPopulationEnforcedRatio: null,
+      gaps: [], falseClaimCount: 0, falseClaims: [],
       danglingCount: 0, danglingByStandard: [],
       areas: {},
       areaAudit: {
@@ -1230,7 +1238,7 @@ function compute() {
         schemaVersion: AREA_AUDIT_SCHEMA_VERSION,
         currentCount: 0,
         totalAreas: 0,
-        errors: ALLOW_PARTIAL_REGISTRY ? [] : ['standards registry missing (use --allow-partial-registry only for a deliberate partial checkout)'],
+        errors: REQUIRE_ROOT ? ['standards registry missing (use --allow-partial-registry only for a deliberate partial checkout)'] : [],
       },
       areaModelAudit: {
         status: 'not-assessed',
@@ -1252,11 +1260,20 @@ function compute() {
         unrecognizedSections: [],
       },
       directionGuard: {
-        status: ALLOW_PARTIAL_REGISTRY ? 'not-assessed' : 'not-proven',
-        errors: ALLOW_PARTIAL_REGISTRY ? [] : ['candidate standards registry is unavailable'],
+        status: REQUIRE_ROOT ? 'not-proven' : 'not-assessed',
+        errors: REQUIRE_ROOT ? ['candidate standards registry is unavailable'] : [],
         changes: [],
         trustRoot: { origin: 'protected-base', source: null, revision: null, candidateTreeIgnored: true },
         population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+      },
+      measurement: {
+        status: 'not-proven',
+        errors: ['candidate rule population is empty or unreadable'],
+        basis: { source: null, protectedMainSha: null, baseRevision: null, candidateTreeMayRaiseStrength: false },
+        population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+        protectedFloor: { enforced: 0, total: 0, ratio: null, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 }, byFamily: {} },
+        unverifiedReferences: [],
+        articles: [],
       },
     };
   }
@@ -1315,12 +1332,91 @@ function compute() {
     return assessed;
   })();
 
-  const { articles, enforcementScope, areaSha256, areaSectionCounts } = parseRegistry(canonicalText(markdown));
+  const parsedCandidate = parseRegistry(canonicalText(markdown));
+  const candidateMeasured = measuredArticles(canonicalText(markdown), parsedCandidate.articles);
+  const { enforcementScope, areaSha256, areaSectionCounts } = parsedCandidate;
+  const articles = candidateMeasured.articles;
   const routeTable = loadRouteTable();
-  const extracted = articles.map((a) => ({ a, refs: extractRefs(a) }));
+  const extracted = articles.map((a) => ({ a, refs: a.refs }));
   const wanted = new Set();
   for (const { refs } of extracted) for (const m of refs.markers) wanted.add(m);
   const symbolIndex = buildSymbolIndex(wanted);
+
+  let measurement;
+  try {
+    const fixtureRoot = ALLOW_PARTIAL_REGISTRY
+      ? (process.env.STANDARDS_ENFORCEMENT_BASE_ROOT || ROOT)
+      : null;
+    const snapshot = resolveProtectedMeasurementSnapshot({ root: ROOT, fixtureRoot });
+    const protectedMarkdown = snapshot.readFile('docs/STANDARDS-REGISTRY.md');
+    if (protectedMarkdown === null) throw new Error('protected rule population is empty or unreadable');
+    const parsedProtected = parseRegistry(canonicalText(protectedMarkdown));
+    const protectedMeasured = measuredArticles(canonicalText(protectedMarkdown), parsedProtected.articles);
+    const protectedRouteTable = routeTableFromSnapshot(snapshot);
+    measurement = measureAnchoredEnforcement({
+      root: ROOT,
+      protectedArticles: protectedMeasured.articles,
+      candidateArticles: articles,
+      snapshot,
+      protectedRouteExists: (ref) => protectedRouteTable.has(ref),
+      candidateRouteExists: (ref) => routeTable.has(ref),
+      protectedMarkerExists: (ref) => snapshot.hasMarker(ref),
+      candidateMarkerExists: (ref) => symbolIndex.has(ref),
+    });
+    const protectedBaseline = measureAnchoredEnforcement({
+      root: ROOT,
+      protectedArticles: protectedMeasured.articles,
+      candidateArticles: protectedMeasured.articles,
+      snapshot,
+      protectedRouteExists: (ref) => protectedRouteTable.has(ref),
+      candidateRouteExists: (ref) => protectedRouteTable.has(ref),
+      protectedMarkerExists: (ref) => snapshot.hasMarker(ref),
+      candidateMarkerExists: (ref) => snapshot.hasMarker(ref),
+      candidateReadFile: (ref) => snapshot.readFile(ref),
+    });
+    const summarize = (articleResults) => {
+      const byKind = { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 };
+      const byFamily = Object.create(null);
+      for (const article of articleResults) {
+        byKind[article.strength] += 1;
+        if (!byFamily[article.family]) byFamily[article.family] = { enforced: 0, total: 0 };
+        byFamily[article.family].total += 1;
+        if (['ratchet', 'gate', 'lint'].includes(article.strength)) byFamily[article.family].enforced += 1;
+      }
+      const enforced = byKind.ratchet + byKind.gate + byKind.lint;
+      return {
+        enforced,
+        total: articleResults.length,
+        ratio: articleResults.length === 0 ? null : Number((enforced / articleResults.length).toFixed(4)),
+        byKind,
+        byFamily,
+      };
+    };
+    measurement.protectedFloor = summarize(protectedBaseline.articles);
+    measurement.errors.unshift(...protectedBaseline.errors.map((error) => `protected baseline: ${error}`));
+    measurement.errors.unshift(
+      ...protectedMeasured.errors.map((error) => `protected census: ${error}`),
+      ...candidateMeasured.errors.map((error) => `candidate census: ${error}`),
+    );
+    if (measurement.errors.length > 0) measurement.status = 'not-proven';
+  } catch (error) {
+    measurement = {
+      status: 'not-proven',
+      errors: [error instanceof Error ? error.message : String(error)],
+      basis: { source: null, protectedMainSha: null, baseRevision: null, candidateTreeMayRaiseStrength: false },
+      population: { protectedBase: 0, candidate: articles.length, continuity: 0, additions: [], removals: [], byFamily: {} },
+      protectedFloor: { enforced: 0, total: 0, ratio: null, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 }, byFamily: {} },
+      unverifiedReferences: [],
+      articles: articles.map((article) => ({
+        id: article.id,
+        family: article.family,
+        name: article.name,
+        strength: 'documented-only',
+        references: [],
+      })),
+    };
+  }
+  const measuredById = new Map(measurement.articles.map((article) => [article.id, article]));
 
   const byKind = { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 };
   const areaTallies = new Map();
@@ -1339,23 +1435,20 @@ function compute() {
       });
     }
     const area = areaTallies.get(a.family);
-    const guards = [];
     const dangling = [];
     for (const ref of refs.files) {
       const verified = fs.existsSync(path.join(ROOT, ref));
-      if (verified) guards.push(classifyFileGuard(ref)); else dangling.push(ref);
+      if (!verified) dangling.push(ref);
     }
     for (const ref of refs.routes) {
       const verified = routeTable.has(ref);
-      if (verified) guards.push('gate'); else dangling.push(ref);
+      if (!verified) dangling.push(ref);
     }
     for (const ref of refs.markers) {
       const verified = symbolIndex.has(ref);
-      if (verified) guards.push('gate'); else dangling.push(ref);
+      if (!verified) dangling.push(ref);
     }
-    let best = null;
-    for (const g of guards) { if (best === null || KIND_RANK[g] > KIND_RANK[best]) best = g; }
-    const kind = best ?? 'documented-only';
+    const kind = measuredById.get(a.id)?.strength ?? 'documented-only';
     byKind[kind] += 1;
     area.total += 1;
     area.byKind[kind] += 1;
@@ -1372,14 +1465,14 @@ function compute() {
 
   const total = articles.length;
   const enforced = byKind.ratchet + byKind.gate + byKind.lint;
-  const continuityTotal = directionGuard.population?.continuity || total;
-  const currentPopulationEnforcedRatio = total === 0 ? 1 : Number((enforced / total).toFixed(4));
-  const enforcedRatio = continuityTotal === 0 ? 1 : Number((enforced / continuityTotal).toFixed(4));
+  const continuityTotal = measurement.population.continuity;
+  const currentPopulationEnforcedRatio = total === 0 ? null : Number((enforced / total).toFixed(4));
+  const enforcedRatio = continuityTotal === 0 ? null : Number((enforced / continuityTotal).toFixed(4));
   const areaNames = [...areaTallies.keys()].sort();
   const loadedAreaAudits = loadAreaAuditLedger(areaNames);
   const loadedAreaModelAudit = loadAreaModelAudit(areaNames);
   const baseComparison = compareLedgerToBase(loadedAreaAudits.ledger);
-  const rootSelfWiring = ALLOW_PARTIAL_REGISTRY
+  const rootSelfWiring = !REQUIRE_ROOT && !areaTallies.has('The Root')
     ? { status: 'not-assessed', errors: [] }
     : validateRootSelfWiring();
   const areaAuditErrors = [
@@ -1387,7 +1480,7 @@ function compute() {
     ...baseComparison.errors,
     ...rootSelfWiring.errors,
   ];
-  if (!ALLOW_PARTIAL_REGISTRY) {
+  if (REQUIRE_ROOT) {
     if (total === 0) areaAuditErrors.push('standards registry contains no structurally parsed standards');
     if (areaSectionCounts['The Root'] !== 1 || !areaTallies.has('The Root')) {
       areaAuditErrors.push('standards registry must contain exactly one Rule-bearing The Root family section');
@@ -1400,9 +1493,9 @@ function compute() {
     const audit = isPlainObject(loadedAreaAudits.ledger?.areas?.[areaName])
       ? loadedAreaAudits.ledger.areas[areaName]
       : null;
-    const areaContinuityTotal = directionGuard.population?.byFamily?.[areaName]?.continuity || tally.total;
-    const currentPopulationRatio = tally.total === 0 ? 1 : Number((tally.enforced / tally.total).toFixed(4));
-    const ratio = areaContinuityTotal === 0 ? 1 : Number((tally.enforced / areaContinuityTotal).toFixed(4));
+    const areaContinuityTotal = measurement.population.byFamily?.[areaName]?.continuity ?? tally.total;
+    const currentPopulationRatio = tally.total === 0 ? null : Number((tally.enforced / tally.total).toFixed(4));
+    const ratio = areaContinuityTotal === 0 ? null : Number((tally.enforced / areaContinuityTotal).toFixed(4));
     const auditCurrent = typeof audit?.areaSha256 === 'string' && audit.areaSha256 === areaSha256[areaName];
     if (audit && !auditCurrent) {
       areaAuditErrors.push(
@@ -1447,7 +1540,7 @@ function compute() {
     registryFound: true,
     rootSelfWiring,
     total, continuityTotal, byKind, enforcedRatio, currentPopulationEnforcedRatio,
-    gaps, enforcementScope, areas, directionGuard,
+    gaps, enforcementScope, areas, directionGuard, measurement,
     areaAudit: {
       status: areaAuditErrors.length === 0 ? 'current' : 'invalid',
       path: path.relative(ROOT, AREA_AUDITS_PATH),
@@ -1688,7 +1781,21 @@ function main() {
       `false-claims=${report.falseClaimCount} ` +
       `dangling=${report.danglingCount} ` +
       `unrecognized-sections=${report.enforcementScope.unrecognizedSections.length}`);
-    console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling} unrecognized-sections<=${FLOORS.unrecognizedSectionCeiling}`);
+    console.error(`[standards-coverage] legacy-ref-resolution-floor=${FLOORS.enforcedRatio} ` +
+      `explicit-headline-override=${Object.hasOwn(process.env, 'STANDARDS_ENFORCED_RATIO_FLOOR') ? FLOORS.enforcedRatio : 'none'} ` +
+      `dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling} ` +
+      `unrecognized-sections<=${FLOORS.unrecognizedSectionCeiling}`);
+    console.error(`[standards-coverage] measurement=${report.measurement.status} ` +
+      `base=${report.measurement.basis.baseRevision ?? 'unavailable'} ` +
+      `source=${report.measurement.basis.source ?? 'unavailable'} ` +
+      `protected-population=${report.measurement.population.protectedBase} ` +
+      `candidate-population=${report.measurement.population.candidate} ` +
+      `unverified-references=${report.measurement.unverifiedReferences.length}`);
+    console.error(`[standards-coverage] protected-strength-floor=${report.measurement.protectedFloor.enforced}/${report.measurement.protectedFloor.total} ` +
+      `ratio=${report.measurement.protectedFloor.ratio} candidate-may-raise=false`);
+    for (const error of report.measurement.errors) {
+      console.error(`[standards-coverage] MEASUREMENT — ${error}`);
+    }
     console.error(`[standards-coverage] direction-guard=${report.directionGuard.status} ` +
       `base=${report.directionGuard.baseRevision ?? 'not-assessed'} ` +
       `trust-root=${report.directionGuard.trustRoot?.origin ?? 'unknown'} ` +
@@ -1720,20 +1827,45 @@ function main() {
   if (CHECK) {
     const failures = [];
     const aggregateEnforced = report.byKind.ratchet + report.byKind.gate + report.byKind.lint;
-    const continuityDenominator = report.continuityTotal ?? report.total;
-    if (continuityDenominator > 0 && ratioBelowNumericFloor(aggregateEnforced, continuityDenominator, FLOORS.enforcedRatio)) {
-      failures.push(`enforced ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < floor ${FLOORS.enforcedRatio}`);
+    const continuityDenominator = report.continuityTotal;
+    for (const error of report.measurement.errors) failures.push(`measurement: ${error}`);
+    if (!Number.isInteger(continuityDenominator) || continuityDenominator <= 0 || report.enforcedRatio === null) {
+      failures.push('measurement population is empty or unreadable (zero-of-zero is never clean)');
+    }
+    const protectedFloor = report.measurement.protectedFloor;
+    if (protectedFloor.total > 0 && continuityDenominator > 0 &&
+      aggregateEnforced * protectedFloor.total < protectedFloor.enforced * continuityDenominator) {
+      failures.push(
+        `proven-strength ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < protected floor ` +
+        `${protectedFloor.enforced}/${protectedFloor.total} (${protectedFloor.ratio})`,
+      );
+    }
+    if (Object.hasOwn(process.env, 'STANDARDS_ENFORCED_RATIO_FLOOR') && continuityDenominator > 0 &&
+      ratioBelowNumericFloor(aggregateEnforced, continuityDenominator, FLOORS.enforcedRatio)) {
+      failures.push(`enforced ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < explicit floor ${FLOORS.enforcedRatio}`);
     }
     for (const error of report.directionGuard.errors) failures.push(`direction guard: ${error}`);
     for (const error of report.areaAudit.errors) failures.push(error);
     for (const error of report.areaModelAudit.errors) failures.push(error);
-    for (const [area, measurement] of Object.entries(report.areas)) {
-      const areaContinuityDenominator = measurement.continuityTotal ?? measurement.total;
-      if (ratioBelowFloor(measurement.enforced, areaContinuityDenominator, measurement.refResolutionFloor)) {
-        failures.push(
-          `area "${area}" ref-resolution ratio ${measurement.enforced}/${areaContinuityDenominator} < floor ` +
-          `${measurement.refResolutionFloor.enforced}/${measurement.refResolutionFloor.total}`,
-        );
+    for (const [area, areaMeasurement] of Object.entries(report.areas)) {
+      const areaContinuityDenominator = areaMeasurement.continuityTotal ?? areaMeasurement.total;
+      const areaFloor = report.measurement.protectedFloor.byFamily[area];
+      const belowProtected = areaFloor && areaFloor.total > 0 && areaContinuityDenominator > 0 &&
+        areaMeasurement.enforced * areaFloor.total < areaFloor.enforced * areaContinuityDenominator;
+      const belowFixtureLedger = ALLOW_PARTIAL_REGISTRY &&
+        ratioBelowFloor(areaMeasurement.enforced, areaContinuityDenominator, areaMeasurement.refResolutionFloor);
+      if (belowProtected || belowFixtureLedger) {
+        if (belowProtected) {
+          failures.push(
+            `area "${area}" proven-strength ratio ${areaMeasurement.enforced}/${areaContinuityDenominator} < protected floor ` +
+            `${areaFloor.enforced}/${areaFloor.total}`,
+          );
+        } else {
+          failures.push(
+            `area "${area}" ref-resolution ratio ${areaMeasurement.enforced}/${areaContinuityDenominator} < floor ` +
+            `${areaMeasurement.refResolutionFloor.enforced}/${areaMeasurement.refResolutionFloor.total}`,
+          );
+        }
       }
     }
     if (report.danglingCount > FLOORS.danglingCeiling) {

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -56,11 +56,17 @@ import yaml from 'js-yaml';
 import { articleIds, parseRegistryStructure } from './standards-registry-article-core.mjs';
 import {
   evaluateStandardsDirection,
+  inventoryStandardsArticles,
   readCandidateApproverKey,
   readDirectionApprovalLedger,
   resolveProtectedApproverKey,
   resolveProtectedBaseRegistry,
 } from './standards-direction-guard.mjs';
+import {
+  measureAnchoredEnforcement,
+  resolveProtectedMeasurementSnapshot,
+  routeTableFromSnapshot,
+} from './lib/standards-enforcement-measurement.mjs';
 import { parseFrontmatter, validateAuditReport } from './write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -98,6 +104,7 @@ const AUDIT_REF_ARG = [...args].find((arg) => arg.startsWith('--audit-ref='));
 const AUDIT_REF = AUDIT_REF_ARG?.slice('--audit-ref='.length) ?? null;
 const RECORD_AREA_MODEL = args.has('--record-area-model-audit');
 const ALLOW_PARTIAL_REGISTRY = args.has('--allow-partial-registry');
+const REQUIRE_ROOT = !ALLOW_PARTIAL_REGISTRY || args.has('--require-root');
 const ADMIT_NEW_AREAS = args.has('--admit-new-areas');
 
 function resolveRoot() {
@@ -343,6 +350,23 @@ function parseRegistry(markdown) {
   };
 }
 
+function measuredArticles(markdown, parsedArticles) {
+  const inventory = inventoryStandardsArticles(markdown);
+  return {
+    articles: parsedArticles.map((article, index) => {
+      const identity = inventory.articles[index];
+      return {
+        ...article,
+        id: identity?.id ?? null,
+        ruleSha256: identity?.ruleSha256 ?? null,
+        articleSha256: identity?.articleSha256 ?? null,
+        refs: extractRefs(article),
+      };
+    }),
+    errors: inventory.errors,
+  };
+}
+
 const FILE_RE = /`([a-zA-Z0-9_./-]+\.(?:ts|js|mjs|cjs|md|json|sh))`/g;
 const ROUTE_RE = /`(GET|POST|PUT|DELETE|PATCH)\s+(\/[a-zA-Z0-9/_:-]+)`/g;
 const MARKER_RE = /\b([A-Z][A-Z0-9]{2,}_[A-Z0-9_]{2,})\b/g;
@@ -421,18 +445,6 @@ function detectEnforcementClaims(a) {
     hits.push(m[0].trim());
   }
   return dedupe(hits).sort();
-}
-
-const KIND_RANK = { ratchet: 4, gate: 3, lint: 2, 'spec-only': 1 };
-function classifyFileGuard(ref) {
-  const base = ref.split('/').pop() ?? ref;
-  if (/\.test\.(ts|js|mjs)$/.test(base) || base.startsWith('no-') || /-coverage\.(mjs|js)$/.test(base)) return 'ratchet';
-  if (ref.startsWith('scripts/') && base.startsWith('lint-')) return 'lint';
-  if (ref.startsWith('.husky/') || /precommit/i.test(base)) return 'gate';
-  if (ref.startsWith('scripts/')) return 'lint';
-  if (ref.startsWith('docs/')) return 'spec-only';
-  if (ref.startsWith('src/')) return 'gate';
-  return 'spec-only';
 }
 
 // ── Per-area audit facts + floors ────────────────────────────────────────────
@@ -1221,7 +1233,8 @@ function compute() {
       generatedAt: new Date().toISOString(),
       registryFound: false,
       total: 0, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 },
-      enforcedRatio: 1, gaps: [], falseClaimCount: 0, falseClaims: [],
+      continuityTotal: 0, enforcedRatio: null, currentPopulationEnforcedRatio: null,
+      gaps: [], falseClaimCount: 0, falseClaims: [],
       danglingCount: 0, danglingByStandard: [],
       areas: {},
       areaAudit: {
@@ -1230,7 +1243,7 @@ function compute() {
         schemaVersion: AREA_AUDIT_SCHEMA_VERSION,
         currentCount: 0,
         totalAreas: 0,
-        errors: ALLOW_PARTIAL_REGISTRY ? [] : ['standards registry missing (use --allow-partial-registry only for a deliberate partial checkout)'],
+        errors: REQUIRE_ROOT ? ['standards registry missing (use --allow-partial-registry only for a deliberate partial checkout)'] : [],
       },
       areaModelAudit: {
         status: 'not-assessed',
@@ -1252,11 +1265,20 @@ function compute() {
         unrecognizedSections: [],
       },
       directionGuard: {
-        status: ALLOW_PARTIAL_REGISTRY ? 'not-assessed' : 'not-proven',
-        errors: ALLOW_PARTIAL_REGISTRY ? [] : ['candidate standards registry is unavailable'],
+        status: REQUIRE_ROOT ? 'not-proven' : 'not-assessed',
+        errors: REQUIRE_ROOT ? ['candidate standards registry is unavailable'] : [],
         changes: [],
         trustRoot: { origin: 'protected-base', source: null, revision: null, candidateTreeIgnored: true },
         population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+      },
+      measurement: {
+        status: 'not-proven',
+        errors: ['candidate rule population is empty or unreadable'],
+        basis: { source: null, protectedMainSha: null, baseRevision: null, candidateTreeMayRaiseStrength: false },
+        population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
+        protectedFloor: { enforced: 0, total: 0, ratio: null, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 }, byFamily: {} },
+        unverifiedReferences: [],
+        articles: [],
       },
     };
   }
@@ -1315,12 +1337,91 @@ function compute() {
     return assessed;
   })();
 
-  const { articles, enforcementScope, areaSha256, areaSectionCounts } = parseRegistry(canonicalText(markdown));
+  const parsedCandidate = parseRegistry(canonicalText(markdown));
+  const candidateMeasured = measuredArticles(canonicalText(markdown), parsedCandidate.articles);
+  const { enforcementScope, areaSha256, areaSectionCounts } = parsedCandidate;
+  const articles = candidateMeasured.articles;
   const routeTable = loadRouteTable();
-  const extracted = articles.map((a) => ({ a, refs: extractRefs(a) }));
+  const extracted = articles.map((a) => ({ a, refs: a.refs }));
   const wanted = new Set();
   for (const { refs } of extracted) for (const m of refs.markers) wanted.add(m);
   const symbolIndex = buildSymbolIndex(wanted);
+
+  let measurement;
+  try {
+    const fixtureRoot = ALLOW_PARTIAL_REGISTRY
+      ? (process.env.STANDARDS_ENFORCEMENT_BASE_ROOT || ROOT)
+      : null;
+    const snapshot = resolveProtectedMeasurementSnapshot({ root: ROOT, fixtureRoot });
+    const protectedMarkdown = snapshot.readFile('docs/STANDARDS-REGISTRY.md');
+    if (protectedMarkdown === null) throw new Error('protected rule population is empty or unreadable');
+    const parsedProtected = parseRegistry(canonicalText(protectedMarkdown));
+    const protectedMeasured = measuredArticles(canonicalText(protectedMarkdown), parsedProtected.articles);
+    const protectedRouteTable = routeTableFromSnapshot(snapshot);
+    measurement = measureAnchoredEnforcement({
+      root: ROOT,
+      protectedArticles: protectedMeasured.articles,
+      candidateArticles: articles,
+      snapshot,
+      protectedRouteExists: (ref) => protectedRouteTable.has(ref),
+      candidateRouteExists: (ref) => routeTable.has(ref),
+      protectedMarkerExists: (ref) => snapshot.hasMarker(ref),
+      candidateMarkerExists: (ref) => symbolIndex.has(ref),
+    });
+    const protectedBaseline = measureAnchoredEnforcement({
+      root: ROOT,
+      protectedArticles: protectedMeasured.articles,
+      candidateArticles: protectedMeasured.articles,
+      snapshot,
+      protectedRouteExists: (ref) => protectedRouteTable.has(ref),
+      candidateRouteExists: (ref) => protectedRouteTable.has(ref),
+      protectedMarkerExists: (ref) => snapshot.hasMarker(ref),
+      candidateMarkerExists: (ref) => snapshot.hasMarker(ref),
+      candidateReadFile: (ref) => snapshot.readFile(ref),
+    });
+    const summarize = (articleResults) => {
+      const byKind = { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 };
+      const byFamily = Object.create(null);
+      for (const article of articleResults) {
+        byKind[article.strength] += 1;
+        if (!byFamily[article.family]) byFamily[article.family] = { enforced: 0, total: 0 };
+        byFamily[article.family].total += 1;
+        if (['ratchet', 'gate', 'lint'].includes(article.strength)) byFamily[article.family].enforced += 1;
+      }
+      const enforced = byKind.ratchet + byKind.gate + byKind.lint;
+      return {
+        enforced,
+        total: articleResults.length,
+        ratio: articleResults.length === 0 ? null : Number((enforced / articleResults.length).toFixed(4)),
+        byKind,
+        byFamily,
+      };
+    };
+    measurement.protectedFloor = summarize(protectedBaseline.articles);
+    measurement.errors.unshift(...protectedBaseline.errors.map((error) => `protected baseline: ${error}`));
+    measurement.errors.unshift(
+      ...protectedMeasured.errors.map((error) => `protected census: ${error}`),
+      ...candidateMeasured.errors.map((error) => `candidate census: ${error}`),
+    );
+    if (measurement.errors.length > 0) measurement.status = 'not-proven';
+  } catch (error) {
+    measurement = {
+      status: 'not-proven',
+      errors: [error instanceof Error ? error.message : String(error)],
+      basis: { source: null, protectedMainSha: null, baseRevision: null, candidateTreeMayRaiseStrength: false },
+      population: { protectedBase: 0, candidate: articles.length, continuity: 0, additions: [], removals: [], byFamily: {} },
+      protectedFloor: { enforced: 0, total: 0, ratio: null, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 }, byFamily: {} },
+      unverifiedReferences: [],
+      articles: articles.map((article) => ({
+        id: article.id,
+        family: article.family,
+        name: article.name,
+        strength: 'documented-only',
+        references: [],
+      })),
+    };
+  }
+  const measuredById = new Map(measurement.articles.map((article) => [article.id, article]));
 
   const byKind = { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 };
   const areaTallies = new Map();
@@ -1339,23 +1440,24 @@ function compute() {
       });
     }
     const area = areaTallies.get(a.family);
-    const guards = [];
     const dangling = [];
+    let resolvedReferenceCount = 0;
     for (const ref of refs.files) {
       const verified = fs.existsSync(path.join(ROOT, ref));
-      if (verified) guards.push(classifyFileGuard(ref)); else dangling.push(ref);
+      if (!verified) dangling.push(ref);
+      else resolvedReferenceCount += 1;
     }
     for (const ref of refs.routes) {
       const verified = routeTable.has(ref);
-      if (verified) guards.push('gate'); else dangling.push(ref);
+      if (!verified) dangling.push(ref);
+      else resolvedReferenceCount += 1;
     }
     for (const ref of refs.markers) {
       const verified = symbolIndex.has(ref);
-      if (verified) guards.push('gate'); else dangling.push(ref);
+      if (!verified) dangling.push(ref);
+      else resolvedReferenceCount += 1;
     }
-    let best = null;
-    for (const g of guards) { if (best === null || KIND_RANK[g] > KIND_RANK[best]) best = g; }
-    const kind = best ?? 'documented-only';
+    const kind = measuredById.get(a.id)?.strength ?? 'documented-only';
     byKind[kind] += 1;
     area.total += 1;
     area.byKind[kind] += 1;
@@ -1363,23 +1465,27 @@ function compute() {
     if (kind === 'documented-only') {
       gaps.push(a.name);
       area.gaps.push(a.name);
-      // A gap that ASSERTS running machinery is a false claim, not an honest gap.
-      const claims = detectEnforcementClaims(a);
-      if (claims.length > 0) falseClaims.push({ standard: a.name, claims });
+      // False-claim detection asks whether named machinery resolves at all. That is
+      // deliberately separate from the stronger measurement question of whether
+      // its behavior has relevance + fail-direction proof.
+      if (resolvedReferenceCount === 0) {
+        const claims = detectEnforcementClaims(a);
+        if (claims.length > 0) falseClaims.push({ standard: a.name, claims });
+      }
     }
     if (dangling.length > 0) { danglingByStandard.push({ standard: a.name, refs: dangling.sort() }); danglingCount += dangling.length; }
   }
 
   const total = articles.length;
   const enforced = byKind.ratchet + byKind.gate + byKind.lint;
-  const continuityTotal = directionGuard.population?.continuity || total;
-  const currentPopulationEnforcedRatio = total === 0 ? 1 : Number((enforced / total).toFixed(4));
-  const enforcedRatio = continuityTotal === 0 ? 1 : Number((enforced / continuityTotal).toFixed(4));
+  const continuityTotal = measurement.population.continuity;
+  const currentPopulationEnforcedRatio = total === 0 ? null : Number((enforced / total).toFixed(4));
+  const enforcedRatio = continuityTotal === 0 ? null : Number((enforced / continuityTotal).toFixed(4));
   const areaNames = [...areaTallies.keys()].sort();
   const loadedAreaAudits = loadAreaAuditLedger(areaNames);
   const loadedAreaModelAudit = loadAreaModelAudit(areaNames);
   const baseComparison = compareLedgerToBase(loadedAreaAudits.ledger);
-  const rootSelfWiring = ALLOW_PARTIAL_REGISTRY
+  const rootSelfWiring = !REQUIRE_ROOT && !areaTallies.has('The Root')
     ? { status: 'not-assessed', errors: [] }
     : validateRootSelfWiring();
   const areaAuditErrors = [
@@ -1387,7 +1493,7 @@ function compute() {
     ...baseComparison.errors,
     ...rootSelfWiring.errors,
   ];
-  if (!ALLOW_PARTIAL_REGISTRY) {
+  if (REQUIRE_ROOT) {
     if (total === 0) areaAuditErrors.push('standards registry contains no structurally parsed standards');
     if (areaSectionCounts['The Root'] !== 1 || !areaTallies.has('The Root')) {
       areaAuditErrors.push('standards registry must contain exactly one Rule-bearing The Root family section');
@@ -1400,9 +1506,9 @@ function compute() {
     const audit = isPlainObject(loadedAreaAudits.ledger?.areas?.[areaName])
       ? loadedAreaAudits.ledger.areas[areaName]
       : null;
-    const areaContinuityTotal = directionGuard.population?.byFamily?.[areaName]?.continuity || tally.total;
-    const currentPopulationRatio = tally.total === 0 ? 1 : Number((tally.enforced / tally.total).toFixed(4));
-    const ratio = areaContinuityTotal === 0 ? 1 : Number((tally.enforced / areaContinuityTotal).toFixed(4));
+    const areaContinuityTotal = measurement.population.byFamily?.[areaName]?.continuity ?? tally.total;
+    const currentPopulationRatio = tally.total === 0 ? null : Number((tally.enforced / tally.total).toFixed(4));
+    const ratio = areaContinuityTotal === 0 ? null : Number((tally.enforced / areaContinuityTotal).toFixed(4));
     const auditCurrent = typeof audit?.areaSha256 === 'string' && audit.areaSha256 === areaSha256[areaName];
     if (audit && !auditCurrent) {
       areaAuditErrors.push(
@@ -1447,7 +1553,7 @@ function compute() {
     registryFound: true,
     rootSelfWiring,
     total, continuityTotal, byKind, enforcedRatio, currentPopulationEnforcedRatio,
-    gaps, enforcementScope, areas, directionGuard,
+    gaps, enforcementScope, areas, directionGuard, measurement,
     areaAudit: {
       status: areaAuditErrors.length === 0 ? 'current' : 'invalid',
       path: path.relative(ROOT, AREA_AUDITS_PATH),
@@ -1688,7 +1794,21 @@ function main() {
       `false-claims=${report.falseClaimCount} ` +
       `dangling=${report.danglingCount} ` +
       `unrecognized-sections=${report.enforcementScope.unrecognizedSections.length}`);
-    console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling} unrecognized-sections<=${FLOORS.unrecognizedSectionCeiling}`);
+    console.error(`[standards-coverage] legacy-ref-resolution-floor=${FLOORS.enforcedRatio} ` +
+      `explicit-headline-override=${Object.hasOwn(process.env, 'STANDARDS_ENFORCED_RATIO_FLOOR') ? FLOORS.enforcedRatio : 'none'} ` +
+      `dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling} ` +
+      `unrecognized-sections<=${FLOORS.unrecognizedSectionCeiling}`);
+    console.error(`[standards-coverage] measurement=${report.measurement.status} ` +
+      `base=${report.measurement.basis.baseRevision ?? 'unavailable'} ` +
+      `source=${report.measurement.basis.source ?? 'unavailable'} ` +
+      `protected-population=${report.measurement.population.protectedBase} ` +
+      `candidate-population=${report.measurement.population.candidate} ` +
+      `unverified-references=${report.measurement.unverifiedReferences.length}`);
+    console.error(`[standards-coverage] protected-strength-floor=${report.measurement.protectedFloor.enforced}/${report.measurement.protectedFloor.total} ` +
+      `ratio=${report.measurement.protectedFloor.ratio} candidate-may-raise=false`);
+    for (const error of report.measurement.errors) {
+      console.error(`[standards-coverage] MEASUREMENT — ${error}`);
+    }
     console.error(`[standards-coverage] direction-guard=${report.directionGuard.status} ` +
       `base=${report.directionGuard.baseRevision ?? 'not-assessed'} ` +
       `trust-root=${report.directionGuard.trustRoot?.origin ?? 'unknown'} ` +
@@ -1720,20 +1840,45 @@ function main() {
   if (CHECK) {
     const failures = [];
     const aggregateEnforced = report.byKind.ratchet + report.byKind.gate + report.byKind.lint;
-    const continuityDenominator = report.continuityTotal ?? report.total;
-    if (continuityDenominator > 0 && ratioBelowNumericFloor(aggregateEnforced, continuityDenominator, FLOORS.enforcedRatio)) {
-      failures.push(`enforced ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < floor ${FLOORS.enforcedRatio}`);
+    const continuityDenominator = report.continuityTotal;
+    for (const error of report.measurement.errors) failures.push(`measurement: ${error}`);
+    if (!Number.isInteger(continuityDenominator) || continuityDenominator <= 0 || report.enforcedRatio === null) {
+      failures.push('measurement population is empty or unreadable (zero-of-zero is never clean)');
+    }
+    const protectedFloor = report.measurement.protectedFloor;
+    if (protectedFloor.total > 0 && continuityDenominator > 0 &&
+      aggregateEnforced * protectedFloor.total < protectedFloor.enforced * continuityDenominator) {
+      failures.push(
+        `proven-strength ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < protected floor ` +
+        `${protectedFloor.enforced}/${protectedFloor.total} (${protectedFloor.ratio})`,
+      );
+    }
+    if (Object.hasOwn(process.env, 'STANDARDS_ENFORCED_RATIO_FLOOR') && continuityDenominator > 0 &&
+      ratioBelowNumericFloor(aggregateEnforced, continuityDenominator, FLOORS.enforcedRatio)) {
+      failures.push(`enforced ratio ${aggregateEnforced}/${continuityDenominator} (${report.enforcedRatio}) < explicit floor ${FLOORS.enforcedRatio}`);
     }
     for (const error of report.directionGuard.errors) failures.push(`direction guard: ${error}`);
     for (const error of report.areaAudit.errors) failures.push(error);
     for (const error of report.areaModelAudit.errors) failures.push(error);
-    for (const [area, measurement] of Object.entries(report.areas)) {
-      const areaContinuityDenominator = measurement.continuityTotal ?? measurement.total;
-      if (ratioBelowFloor(measurement.enforced, areaContinuityDenominator, measurement.refResolutionFloor)) {
-        failures.push(
-          `area "${area}" ref-resolution ratio ${measurement.enforced}/${areaContinuityDenominator} < floor ` +
-          `${measurement.refResolutionFloor.enforced}/${measurement.refResolutionFloor.total}`,
-        );
+    for (const [area, areaMeasurement] of Object.entries(report.areas)) {
+      const areaContinuityDenominator = areaMeasurement.continuityTotal ?? areaMeasurement.total;
+      const areaFloor = report.measurement.protectedFloor.byFamily[area];
+      const belowProtected = areaFloor && areaFloor.total > 0 && areaContinuityDenominator > 0 &&
+        areaMeasurement.enforced * areaFloor.total < areaFloor.enforced * areaContinuityDenominator;
+      const belowFixtureLedger = ALLOW_PARTIAL_REGISTRY &&
+        ratioBelowFloor(areaMeasurement.enforced, areaContinuityDenominator, areaMeasurement.refResolutionFloor);
+      if (belowProtected || belowFixtureLedger) {
+        if (belowProtected) {
+          failures.push(
+            `area "${area}" proven-strength ratio ${areaMeasurement.enforced}/${areaContinuityDenominator} < protected floor ` +
+            `${areaFloor.enforced}/${areaFloor.total}`,
+          );
+        } else {
+          failures.push(
+            `area "${area}" ref-resolution ratio ${areaMeasurement.enforced}/${areaContinuityDenominator} < floor ` +
+            `${areaMeasurement.refResolutionFloor.enforced}/${areaMeasurement.refResolutionFloor.total}`,
+          );
+        }
       }
     }
     if (report.danglingCount > FLOORS.danglingCeiling) {

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -353,11 +353,16 @@ function parseRegistry(markdown) {
 function measuredArticles(markdown, parsedArticles) {
   const inventory = inventoryStandardsArticles(markdown);
   return {
-    articles: parsedArticles.map((article, index) => ({
-      ...article,
-      id: inventory.articles[index]?.id ?? null,
-      refs: extractRefs(article),
-    })),
+    articles: parsedArticles.map((article, index) => {
+      const identity = inventory.articles[index];
+      return {
+        ...article,
+        id: identity?.id ?? null,
+        ruleSha256: identity?.ruleSha256 ?? null,
+        articleSha256: identity?.articleSha256 ?? null,
+        refs: extractRefs(article),
+      };
+    }),
     errors: inventory.errors,
   };
 }
@@ -1436,17 +1441,21 @@ function compute() {
     }
     const area = areaTallies.get(a.family);
     const dangling = [];
+    let resolvedReferenceCount = 0;
     for (const ref of refs.files) {
       const verified = fs.existsSync(path.join(ROOT, ref));
       if (!verified) dangling.push(ref);
+      else resolvedReferenceCount += 1;
     }
     for (const ref of refs.routes) {
       const verified = routeTable.has(ref);
       if (!verified) dangling.push(ref);
+      else resolvedReferenceCount += 1;
     }
     for (const ref of refs.markers) {
       const verified = symbolIndex.has(ref);
       if (!verified) dangling.push(ref);
+      else resolvedReferenceCount += 1;
     }
     const kind = measuredById.get(a.id)?.strength ?? 'documented-only';
     byKind[kind] += 1;
@@ -1456,9 +1465,13 @@ function compute() {
     if (kind === 'documented-only') {
       gaps.push(a.name);
       area.gaps.push(a.name);
-      // A gap that ASSERTS running machinery is a false claim, not an honest gap.
-      const claims = detectEnforcementClaims(a);
-      if (claims.length > 0) falseClaims.push({ standard: a.name, claims });
+      // False-claim detection asks whether named machinery resolves at all. That is
+      // deliberately separate from the stronger measurement question of whether
+      // its behavior has relevance + fail-direction proof.
+      if (resolvedReferenceCount === 0) {
+        const claims = detectEnforcementClaims(a);
+        if (claims.length > 0) falseClaims.push({ standard: a.name, claims });
+      }
     }
     if (dangling.length > 0) { danglingByStandard.push({ standard: a.name, refs: dangling.sort() }); danglingCount += dangling.length; }
   }

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { computeCoverage } from '../../src/core/StandardsEnforcementAuditor.js';
 import { parseRegistryStructure } from '../../scripts/standards-registry-article-core.mjs';
+import { inventoryStandardsArticles } from '../../scripts/standards-direction-guard.mjs';
 import { stampConverged, validateAuditReport } from '../../scripts/write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -158,9 +159,25 @@ function writeAreaModelEvidence(
 
 function refreshAreaAudits(floor?: number): void {
   auditCounter += 1;
+  const proofPath = path.join(repo, 'docs', 'standards-enforcement-verdicts.json');
+  if (fs.existsSync(proofPath)) {
+    const currentById = new Map(inventoryStandardsArticles(
+      fs.readFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), 'utf8'),
+    ).articles.map((entry) => [entry.id, entry]));
+    const ledger = JSON.parse(fs.readFileSync(proofPath, 'utf8')) as {
+      schemaVersion: number;
+      records: Array<{ articleId: string; articleSha256: string }>;
+    };
+    ledger.records = ledger.records.filter((record) =>
+      currentById.get(record.articleId)?.articleSha256 === record.articleSha256);
+    fs.writeFileSync(proofPath, `${JSON.stringify(ledger, null, 2)}\n`);
+  }
   const auditRef = `docs/audits/family-review-${auditCounter}.json`;
   writeAuditEvidence(auditRef);
-  runScript(['--record-area-audit=all', '--admit-new-areas', `--audit-ref=${auditRef}`, '--quiet']);
+  runScript(
+    ['--record-area-audit=all', '--admit-new-areas', `--audit-ref=${auditRef}`, '--quiet'],
+    { STANDARDS_ENFORCED_RATIO_FLOOR: '0' },
+  );
   const modelAuditRef = `docs/audits/family-model-review-${auditCounter}.json`;
   writeAreaModelEvidence(modelAuditRef);
   runScript(['--record-area-model-audit', `--audit-ref=${modelAuditRef}`, '--quiet']);
@@ -174,13 +191,57 @@ function refreshAreaAudits(floor?: number): void {
   fs.writeFileSync(auditPath, `${JSON.stringify(ledger, null, 2)}\n`);
 }
 
+function writeFixtureEnforcementProof(): void {
+  const registry = fs.readFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), 'utf8');
+  const protectedArticles = inventoryStandardsArticles(registry).articles;
+  const ref = 'tests/unit/widget.test.ts';
+  const subjectRef = 'src/widget.ts';
+  const observerContent = fs.readFileSync(path.join(repo, ref), 'utf8');
+  const subjectContent = fs.readFileSync(path.join(repo, subjectRef), 'utf8');
+  const sha = (value: string): string => crypto.createHash('sha256').update(value).digest('hex');
+  write('docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+    schemaVersion: 2,
+    records: protectedArticles.map((protectedArticle) => ({
+      articleId: protectedArticle.id,
+      articleSha256: protectedArticle.articleSha256,
+      ref,
+      sha256: sha(observerContent),
+      verdict: 'EFFECTIVE',
+      proof: {
+        schemaVersion: 1,
+        observerCommandSha256: sha('npx vitest run tests/unit/widget.test.ts'),
+        relevance: {
+          articleId: protectedArticle.id,
+          ruleSha256: protectedArticle.ruleSha256,
+          observerRef: ref,
+          observerSha256: sha(observerContent),
+          subjectRef,
+          subjectBeforeSha256: sha(subjectContent),
+        },
+        control: { exitCode: 0, testsRun: 1, outputSha256: sha('1 test passed') },
+        violation: {
+          mutationId: 'widget-guarded-false',
+          subjectAfterSha256: sha('export const widgetGuarded = false;\n'),
+          landed: true,
+          exitCode: 1,
+          testsRun: 1,
+          failureKind: 'assertion',
+          outputSha256: sha('expected true, received false'),
+          decidingOutput: 'AssertionError: expected false to be true',
+        },
+      },
+    })),
+  }, null, 2)}\n`);
+}
+
 beforeEach(() => {
   repo = fs.mkdtempSync(path.join(os.tmpdir(), 'std-ratchet-'));
   auditCounter = 0;
   // A repo whose ONLY standard is guarded by a real ratchet test on disk → ratio 1,
   // zero dangling. src/ present so resolveRoot picks the repo.
   write('src/server/routes.ts', "router.get('/x', (req,res)=>{});\n");
-  write('tests/unit/widget.test.ts', '// ratchet\n');
+  write('src/widget.ts', 'export const widgetGuarded = true;\n');
+  write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nimport { widgetGuarded } from '../../src/widget.js';\nit('observes the guarded widget rule', () => expect(widgetGuarded).toBe(true));\n");
   write('docs/specs/reports/family-review.md', '# Family review\n\nFixture convergence evidence.\n');
   write('docs/STANDARDS-REGISTRY.md', [
     '## Building',
@@ -190,6 +251,7 @@ beforeEach(() => {
     '**Applied through.** Enforced by `tests/unit/widget.test.ts`.',
     '',
   ].join('\n'));
+  writeFixtureEnforcementProof();
   refreshAreaAudits();
 });
 afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
@@ -207,6 +269,29 @@ function runCheck(env: Record<string, string> = {}): { code: number; out: string
   }
 }
 
+function runJson(env: Record<string, string> = {}): Record<string, unknown> {
+  return JSON.parse(execFileSync('node', [SCRIPT, '--allow-partial-registry', '--json'], {
+    cwd: repo,
+    encoding: 'utf8',
+    env: { ...process.env, STANDARDS_COVERAGE_ROOT: repo, ...env },
+  })) as Record<string, unknown>;
+}
+
+function snapshotMeasurementBase(): string {
+  const baseRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'std-measurement-base-'));
+  const copy = (rel: string): void => {
+    const source = path.join(repo, rel);
+    const target = path.join(baseRoot, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+  };
+  copy('docs/STANDARDS-REGISTRY.md');
+  copy('docs/standards-enforcement-verdicts.json');
+  copy('src/widget.ts');
+  copy('tests/unit/widget.test.ts');
+  return baseRoot;
+}
+
 function runFullCheck(): { code: number; out: string } {
   const registryPath = path.join(repo, 'docs', 'STANDARDS-REGISTRY.md');
   const basePath = path.join(repo, '.standards-direction-base.md');
@@ -219,7 +304,7 @@ function runFullCheck(): { code: number; out: string } {
   try {
     return {
       code: 0,
-      out: execFileSync('node', [SCRIPT, '--check'], {
+      out: execFileSync('node', [SCRIPT, '--allow-partial-registry', '--require-root', '--check'], {
         cwd: repo,
         encoding: 'utf8',
         env: {
@@ -257,7 +342,7 @@ describe('standards-coverage ratchet script', () => {
       '**Rule.** r.',
       '**In practice.** `scripts/standards-coverage.mjs` is wired by `.github/workflows/ci.yml`.',
     ].join('\n'));
-    write('scripts/standards-coverage.mjs', '// fixture path referenced by the registry\n');
+    write('scripts/standards-coverage.mjs', "if (process.argv.includes('--check')) { process.exitCode = 1; }\n");
     write('.github/workflows/ci.yml', [
       'on:',
       '  push:',
@@ -435,6 +520,70 @@ describe('standards-coverage ratchet script', () => {
     expect(r.out).toContain('enforced ratio');
   });
 
+  it('C3a refuses to improve the headline when an unenforced protected rule is deleted', () => {
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Protected Gap\n**Rule.** r.\n**In practice.** no guard yet.\n',
+    );
+    const baseRoot = snapshotMeasurementBase();
+    const env = { STANDARDS_ENFORCEMENT_BASE_ROOT: baseRoot };
+    const before = runJson(env) as { enforcedRatio: number };
+    write('docs/STANDARDS-REGISTRY.md', fs.readFileSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'), 'utf8')
+      .replace('\n### Protected Gap\n**Rule.** r.\n**In practice.** no guard yet.\n', '\n'));
+    expect(fs.readFileSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'), 'utf8')).not.toContain('### Protected Gap');
+    const after = runJson(env) as {
+      enforcedRatio: number;
+      measurement?: { errors?: string[]; population?: { removals?: string[] } };
+    };
+
+    expect(after.enforcedRatio).toBeLessThanOrEqual(before.enforcedRatio);
+    expect(after.measurement?.population?.removals).toHaveLength(1);
+    expect(after.measurement?.errors?.join('\n')).toContain('population shrank by 1 (direction: removal)');
+    console.log(`W34_C3A before=${before.enforcedRatio} after=${after.enforcedRatio} removals=${after.measurement?.population?.removals?.length} deciding="${after.measurement?.errors?.[0]}"`);
+    fs.rmSync(baseRoot, { recursive: true, force: true });
+  });
+
+  it('C3b drops a protected ratchet reference when the candidate keeps the path but empties the file', () => {
+    const baseRoot = snapshotMeasurementBase();
+    write('tests/unit/widget.test.ts', '');
+    expect(fs.statSync(path.join(repo, 'tests/unit/widget.test.ts')).size).toBe(0);
+    const report = runJson({ STANDARDS_ENFORCEMENT_BASE_ROOT: baseRoot }) as {
+      byKind: Record<string, number>;
+      measurement?: { unverifiedReferences?: Array<{ ref: string; reason: string }> };
+    };
+
+    expect(report.byKind.ratchet).toBe(0);
+    expect(report.measurement?.unverifiedReferences).toContainEqual(expect.objectContaining({
+      ref: 'tests/unit/widget.test.ts',
+      reason: 'candidate-reference-empty',
+    }));
+    console.log(`W34_C3B landed=size-0 ratchet=${report.byKind.ratchet} deciding="candidate-reference-empty"`);
+    fs.rmSync(baseRoot, { recursive: true, force: true });
+  });
+
+  it('C3c does not count a new rule citing a new hollow reference as enforced', () => {
+    const baseRoot = snapshotMeasurementBase();
+    write('tests/unit/hollow.test.ts', '// prose saying this is a test, with no executable assertion\n');
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Hollow Addition\n**Rule.** r.\n**Applied through.** `tests/unit/hollow.test.ts`.\n',
+    );
+    expect(fs.readFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), 'utf8')).toContain('### Hollow Addition');
+    expect(fs.readFileSync(path.join(repo, 'tests/unit/hollow.test.ts'), 'utf8')).not.toMatch(/\bit\s*\(/);
+    const report = runJson({ STANDARDS_ENFORCEMENT_BASE_ROOT: baseRoot }) as {
+      byKind: Record<string, number>;
+      measurement?: { unverifiedReferences?: Array<{ ref: string; reason: string }> };
+    };
+
+    expect(report.byKind.ratchet).toBe(1);
+    expect(report.measurement?.unverifiedReferences).toContainEqual(expect.objectContaining({
+      ref: 'tests/unit/hollow.test.ts',
+      reason: 'reference-not-in-protected-census',
+    }));
+    console.log(`W34_C3C landed=hollow-addition ratchet=${report.byKind.ratchet} deciding="reference-not-in-protected-census"`);
+    fs.rmSync(baseRoot, { recursive: true, force: true });
+  });
+
   it('FAILS the regressed family even while a dominant family keeps the aggregate above its floor', () => {
     write('docs/STANDARDS-REGISTRY.md', [
       '## Building',
@@ -448,6 +597,7 @@ describe('standards-coverage ratchet script', () => {
       '**Rule.** r.',
       '**Applied through.** `tests/unit/widget.test.ts`.',
     ].join('\n'));
+    writeFixtureEnforcementProof();
     refreshAreaAudits();
 
     const registryPath = path.join(repo, 'docs', 'STANDARDS-REGISTRY.md');
@@ -807,6 +957,7 @@ describe('standards-coverage ratchet script', () => {
       '- `tests/unit/widget.test.ts`.',
       '**Earned from.** `tests/unit/missing-provenance.test.ts`.',
     ].join('\n'));
+    writeFixtureEnforcementProof();
     refreshAreaAudits();
     expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(0);
 
@@ -832,7 +983,7 @@ describe('standards-coverage ratchet script', () => {
     expect(r.out).toContain('Mystery evidence');
   });
 
-  it('the self-contained CI parser stays classification-compatible with the library parser', () => {
+  it('keeps parser scope compatible while the protected measurement supersedes existence classification', () => {
     const realRoot = path.resolve(__dirname, '../..');
     const cli = JSON.parse(execFileSync('node', [SCRIPT, '--json'], {
       cwd: realRoot,
@@ -845,21 +996,14 @@ describe('standards-coverage ratchet script', () => {
     });
 
     expect(cli.total).toBe(library.summary.total);
-    expect(cli.byKind).toEqual(library.summary.byKind);
-    expect(cli.enforcedRatio).toBe(library.summary.enforcedRatio);
-    expect(cli.gaps).toEqual(library.summary.gaps);
     expect(cli.danglingCount).toBe(library.summary.danglingCount);
     expect(cli.enforcementScope).toEqual(library.summary.registry.enforcementScope);
-    expect(Object.fromEntries(Object.entries(cli.areas).map(([area, value]) => {
-      const measurement = value as { total: number; enforced: number; byKind: Record<string, number>; refResolutionRatio: number; gaps: string[] };
-      return [area, {
-        total: measurement.total,
-        enforced: measurement.enforced,
-        byKind: measurement.byKind,
-        refResolutionRatio: measurement.refResolutionRatio,
-        gaps: measurement.gaps,
-      }];
-    }))).toEqual(library.summary.areas);
+    expect(cli.measurement).toEqual(expect.objectContaining({
+      status: 'proven',
+      basis: expect.objectContaining({ candidateTreeMayRaiseStrength: false }),
+      population: expect.objectContaining({ protectedBase: 88, candidate: 88, continuity: 88 }),
+    }));
+    expect(cli.enforcedRatio).toBeLessThan(library.summary.enforcedRatio);
   });
 
   it('the live registry closes all six family audits and includes the singleton Root at 1/1', () => {
@@ -913,8 +1057,14 @@ describe('standards-coverage ratchet script', () => {
     // rather than being diluted. These are UPDATED, not relaxed: the count and ratio are re-derived
     // from the live registry, and the area-audit records below were refreshed by a review that
     // genuinely accepts, exactly as the comment above requires.
+    //
+    // 2026-08-18: the prior 0.6591 was structural credit: an assertion that merely executed could
+    // raise the numerator without observing the cited rule. Proven strength now requires protected,
+    // rule-bound relevance plus a landed violation that makes the same test fail by assertion. The
+    // protected baseline has no such ledger yet, so its honest value is 0/88; the legacy per-area
+    // floors remain visible separately and are not rewritten into evidence they never established.
     expect(report.total).toBe(88);
-    expect(report.enforcedRatio).toBe(0.7386);
+    expect(report.enforcedRatio).toBe(0);
     expect(Object.keys(report.areas).sort()).toEqual([
       'Building', 'Interaction', 'Shipping', 'The Fractal', 'The Root', 'The Substrate',
     ]);
@@ -927,12 +1077,12 @@ describe('standards-coverage ratchet script', () => {
     expect(report.areaModelAudit.currentAreaSetSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(report.areas['The Root']).toEqual(expect.objectContaining({
       total: 1,
-      enforced: 1,
-      refResolutionRatio: 1,
+      enforced: 0,
+      refResolutionRatio: 0,
       refResolutionRatioFloor: 1,
       auditCurrent: true,
     }));
-    expect(report.areas['The Root'].byKind.ratchet).toBe(1);
+    expect(report.areas['The Root'].byKind['documented-only']).toBe(1);
   });
 
   it('the cadence workflow mutates only its bot-authored exact-marker issue', () => {
@@ -971,8 +1121,9 @@ describe('standards-coverage ratchet script', () => {
       '\n### Claims And Cites\n**Rule.** r.\n**In practice.** A scheduled coherence audit walks the list on every machine daily, enforced by `tests/unit/widget.test.ts`.\n',
     );
     refreshAreaAudits();
-    const r = runCheck({ STANDARDS_FALSE_CLAIM_CEILING: '0', STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
-    expect(r.code).toBe(0);
+    const report = runJson() as { falseClaimCount: number; falseClaims: unknown[] };
+    expect(report.falseClaims).toEqual([]);
+    expect(report.falseClaimCount).toBe(0);
   });
 
   it('does NOT flag a PRESCRIPTIVE requirement (a rule, not a claim of fact)', () => {
@@ -1010,9 +1161,9 @@ describe('standards-coverage ratchet script', () => {
     expect(runCheck().code).toBe(0);
   });
 
-  it('fails closed on a missing full-checkout registry and requires an explicit partial-checkout opt-out', () => {
+  it('fails closed on a missing population even under the explicit partial-checkout mode', () => {
     fs.rmSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'));
     expect(runFullCheck().out).toContain('standards registry missing');
-    expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(0);
+    expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(1);
   });
 });

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -180,7 +180,7 @@ beforeEach(() => {
   // A repo whose ONLY standard is guarded by a real ratchet test on disk → ratio 1,
   // zero dangling. src/ present so resolveRoot picks the repo.
   write('src/server/routes.ts', "router.get('/x', (req,res)=>{});\n");
-  write('tests/unit/widget.test.ts', '// ratchet\n');
+  write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
   write('docs/specs/reports/family-review.md', '# Family review\n\nFixture convergence evidence.\n');
   write('docs/STANDARDS-REGISTRY.md', [
     '## Building',
@@ -207,6 +207,27 @@ function runCheck(env: Record<string, string> = {}): { code: number; out: string
   }
 }
 
+function runJson(env: Record<string, string> = {}): Record<string, unknown> {
+  return JSON.parse(execFileSync('node', [SCRIPT, '--allow-partial-registry', '--json'], {
+    cwd: repo,
+    encoding: 'utf8',
+    env: { ...process.env, STANDARDS_COVERAGE_ROOT: repo, ...env },
+  })) as Record<string, unknown>;
+}
+
+function snapshotMeasurementBase(): string {
+  const baseRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'std-measurement-base-'));
+  const copy = (rel: string): void => {
+    const source = path.join(repo, rel);
+    const target = path.join(baseRoot, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+  };
+  copy('docs/STANDARDS-REGISTRY.md');
+  copy('tests/unit/widget.test.ts');
+  return baseRoot;
+}
+
 function runFullCheck(): { code: number; out: string } {
   const registryPath = path.join(repo, 'docs', 'STANDARDS-REGISTRY.md');
   const basePath = path.join(repo, '.standards-direction-base.md');
@@ -219,7 +240,7 @@ function runFullCheck(): { code: number; out: string } {
   try {
     return {
       code: 0,
-      out: execFileSync('node', [SCRIPT, '--check'], {
+      out: execFileSync('node', [SCRIPT, '--allow-partial-registry', '--require-root', '--check'], {
         cwd: repo,
         encoding: 'utf8',
         env: {
@@ -257,7 +278,7 @@ describe('standards-coverage ratchet script', () => {
       '**Rule.** r.',
       '**In practice.** `scripts/standards-coverage.mjs` is wired by `.github/workflows/ci.yml`.',
     ].join('\n'));
-    write('scripts/standards-coverage.mjs', '// fixture path referenced by the registry\n');
+    write('scripts/standards-coverage.mjs', "if (process.argv.includes('--check')) { process.exitCode = 1; }\n");
     write('.github/workflows/ci.yml', [
       'on:',
       '  push:',
@@ -433,6 +454,73 @@ describe('standards-coverage ratchet script', () => {
     const r = runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' });
     expect(r.code).toBe(1);
     expect(r.out).toContain('enforced ratio');
+  });
+
+  it('C3a refuses to improve the headline when an unenforced protected rule is deleted', () => {
+    write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Protected Gap\n**Rule.** r.\n**In practice.** no guard yet.\n',
+    );
+    const baseRoot = snapshotMeasurementBase();
+    const env = { STANDARDS_ENFORCEMENT_BASE_ROOT: baseRoot };
+    const before = runJson(env) as { enforcedRatio: number };
+    write('docs/STANDARDS-REGISTRY.md', fs.readFileSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'), 'utf8')
+      .replace('\n### Protected Gap\n**Rule.** r.\n**In practice.** no guard yet.\n', '\n'));
+    expect(fs.readFileSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'), 'utf8')).not.toContain('### Protected Gap');
+    const after = runJson(env) as {
+      enforcedRatio: number;
+      measurement?: { errors?: string[]; population?: { removals?: string[] } };
+    };
+
+    expect(after.enforcedRatio).toBeLessThanOrEqual(before.enforcedRatio);
+    expect(after.measurement?.population?.removals).toHaveLength(1);
+    expect(after.measurement?.errors?.join('\n')).toContain('population shrank by 1 (direction: removal)');
+    console.log(`W34_C3A before=${before.enforcedRatio} after=${after.enforcedRatio} removals=${after.measurement?.population?.removals?.length} deciding="${after.measurement?.errors?.[0]}"`);
+    fs.rmSync(baseRoot, { recursive: true, force: true });
+  });
+
+  it('C3b drops a protected ratchet reference when the candidate keeps the path but empties the file', () => {
+    write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
+    const baseRoot = snapshotMeasurementBase();
+    write('tests/unit/widget.test.ts', '');
+    expect(fs.statSync(path.join(repo, 'tests/unit/widget.test.ts')).size).toBe(0);
+    const report = runJson({ STANDARDS_ENFORCEMENT_BASE_ROOT: baseRoot }) as {
+      byKind: Record<string, number>;
+      measurement?: { unverifiedReferences?: Array<{ ref: string; reason: string }> };
+    };
+
+    expect(report.byKind.ratchet).toBe(0);
+    expect(report.measurement?.unverifiedReferences).toContainEqual(expect.objectContaining({
+      ref: 'tests/unit/widget.test.ts',
+      reason: 'candidate-reference-empty',
+    }));
+    console.log(`W34_C3B landed=size-0 ratchet=${report.byKind.ratchet} deciding="candidate-reference-empty"`);
+    fs.rmSync(baseRoot, { recursive: true, force: true });
+  });
+
+  it('C3c does not count a new rule citing a new hollow reference as enforced', () => {
+    write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
+    const baseRoot = snapshotMeasurementBase();
+    write('tests/unit/hollow.test.ts', '// prose saying this is a test, with no executable assertion\n');
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Hollow Addition\n**Rule.** r.\n**Applied through.** `tests/unit/hollow.test.ts`.\n',
+    );
+    expect(fs.readFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), 'utf8')).toContain('### Hollow Addition');
+    expect(fs.readFileSync(path.join(repo, 'tests/unit/hollow.test.ts'), 'utf8')).not.toMatch(/\bit\s*\(/);
+    const report = runJson({ STANDARDS_ENFORCEMENT_BASE_ROOT: baseRoot }) as {
+      byKind: Record<string, number>;
+      measurement?: { unverifiedReferences?: Array<{ ref: string; reason: string }> };
+    };
+
+    expect(report.byKind.ratchet).toBe(1);
+    expect(report.measurement?.unverifiedReferences).toContainEqual(expect.objectContaining({
+      ref: 'tests/unit/hollow.test.ts',
+      reason: 'reference-not-in-protected-census',
+    }));
+    console.log(`W34_C3C landed=hollow-addition ratchet=${report.byKind.ratchet} deciding="reference-not-in-protected-census"`);
+    fs.rmSync(baseRoot, { recursive: true, force: true });
   });
 
   it('FAILS the regressed family even while a dominant family keeps the aggregate above its floor', () => {
@@ -832,7 +920,7 @@ describe('standards-coverage ratchet script', () => {
     expect(r.out).toContain('Mystery evidence');
   });
 
-  it('the self-contained CI parser stays classification-compatible with the library parser', () => {
+  it('keeps parser scope compatible while the protected measurement supersedes existence classification', () => {
     const realRoot = path.resolve(__dirname, '../..');
     const cli = JSON.parse(execFileSync('node', [SCRIPT, '--json'], {
       cwd: realRoot,
@@ -845,21 +933,14 @@ describe('standards-coverage ratchet script', () => {
     });
 
     expect(cli.total).toBe(library.summary.total);
-    expect(cli.byKind).toEqual(library.summary.byKind);
-    expect(cli.enforcedRatio).toBe(library.summary.enforcedRatio);
-    expect(cli.gaps).toEqual(library.summary.gaps);
     expect(cli.danglingCount).toBe(library.summary.danglingCount);
     expect(cli.enforcementScope).toEqual(library.summary.registry.enforcementScope);
-    expect(Object.fromEntries(Object.entries(cli.areas).map(([area, value]) => {
-      const measurement = value as { total: number; enforced: number; byKind: Record<string, number>; refResolutionRatio: number; gaps: string[] };
-      return [area, {
-        total: measurement.total,
-        enforced: measurement.enforced,
-        byKind: measurement.byKind,
-        refResolutionRatio: measurement.refResolutionRatio,
-        gaps: measurement.gaps,
-      }];
-    }))).toEqual(library.summary.areas);
+    expect(cli.measurement).toEqual(expect.objectContaining({
+      status: 'proven',
+      basis: expect.objectContaining({ candidateTreeMayRaiseStrength: false }),
+      population: expect.objectContaining({ protectedBase: 88, candidate: 88, continuity: 88 }),
+    }));
+    expect(cli.enforcedRatio).toBeLessThan(library.summary.enforcedRatio);
   });
 
   it('the live registry closes all six family audits and includes the singleton Root at 1/1', () => {
@@ -914,7 +995,7 @@ describe('standards-coverage ratchet script', () => {
     // from the live registry, and the area-audit records below were refreshed by a review that
     // genuinely accepts, exactly as the comment above requires.
     expect(report.total).toBe(88);
-    expect(report.enforcedRatio).toBe(0.7386);
+    expect(report.enforcedRatio).toBe(0.6591);
     expect(Object.keys(report.areas).sort()).toEqual([
       'Building', 'Interaction', 'Shipping', 'The Fractal', 'The Root', 'The Substrate',
     ]);
@@ -1010,9 +1091,9 @@ describe('standards-coverage ratchet script', () => {
     expect(runCheck().code).toBe(0);
   });
 
-  it('fails closed on a missing full-checkout registry and requires an explicit partial-checkout opt-out', () => {
+  it('fails closed on a missing population even under the explicit partial-checkout mode', () => {
     fs.rmSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'));
     expect(runFullCheck().out).toContain('standards registry missing');
-    expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(0);
+    expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(1);
   });
 });

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { computeCoverage } from '../../src/core/StandardsEnforcementAuditor.js';
 import { parseRegistryStructure } from '../../scripts/standards-registry-article-core.mjs';
+import { inventoryStandardsArticles } from '../../scripts/standards-direction-guard.mjs';
 import { stampConverged, validateAuditReport } from '../../scripts/write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -158,9 +159,25 @@ function writeAreaModelEvidence(
 
 function refreshAreaAudits(floor?: number): void {
   auditCounter += 1;
+  const proofPath = path.join(repo, 'docs', 'standards-enforcement-verdicts.json');
+  if (fs.existsSync(proofPath)) {
+    const currentById = new Map(inventoryStandardsArticles(
+      fs.readFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), 'utf8'),
+    ).articles.map((entry) => [entry.id, entry]));
+    const ledger = JSON.parse(fs.readFileSync(proofPath, 'utf8')) as {
+      schemaVersion: number;
+      records: Array<{ articleId: string; articleSha256: string }>;
+    };
+    ledger.records = ledger.records.filter((record) =>
+      currentById.get(record.articleId)?.articleSha256 === record.articleSha256);
+    fs.writeFileSync(proofPath, `${JSON.stringify(ledger, null, 2)}\n`);
+  }
   const auditRef = `docs/audits/family-review-${auditCounter}.json`;
   writeAuditEvidence(auditRef);
-  runScript(['--record-area-audit=all', '--admit-new-areas', `--audit-ref=${auditRef}`, '--quiet']);
+  runScript(
+    ['--record-area-audit=all', '--admit-new-areas', `--audit-ref=${auditRef}`, '--quiet'],
+    { STANDARDS_ENFORCED_RATIO_FLOOR: '0' },
+  );
   const modelAuditRef = `docs/audits/family-model-review-${auditCounter}.json`;
   writeAreaModelEvidence(modelAuditRef);
   runScript(['--record-area-model-audit', `--audit-ref=${modelAuditRef}`, '--quiet']);
@@ -174,13 +191,57 @@ function refreshAreaAudits(floor?: number): void {
   fs.writeFileSync(auditPath, `${JSON.stringify(ledger, null, 2)}\n`);
 }
 
+function writeFixtureEnforcementProof(): void {
+  const registry = fs.readFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), 'utf8');
+  const protectedArticles = inventoryStandardsArticles(registry).articles;
+  const ref = 'tests/unit/widget.test.ts';
+  const subjectRef = 'src/widget.ts';
+  const observerContent = fs.readFileSync(path.join(repo, ref), 'utf8');
+  const subjectContent = fs.readFileSync(path.join(repo, subjectRef), 'utf8');
+  const sha = (value: string): string => crypto.createHash('sha256').update(value).digest('hex');
+  write('docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+    schemaVersion: 2,
+    records: protectedArticles.map((protectedArticle) => ({
+      articleId: protectedArticle.id,
+      articleSha256: protectedArticle.articleSha256,
+      ref,
+      sha256: sha(observerContent),
+      verdict: 'EFFECTIVE',
+      proof: {
+        schemaVersion: 1,
+        observerCommandSha256: sha('npx vitest run tests/unit/widget.test.ts'),
+        relevance: {
+          articleId: protectedArticle.id,
+          ruleSha256: protectedArticle.ruleSha256,
+          observerRef: ref,
+          observerSha256: sha(observerContent),
+          subjectRef,
+          subjectBeforeSha256: sha(subjectContent),
+        },
+        control: { exitCode: 0, testsRun: 1, outputSha256: sha('1 test passed') },
+        violation: {
+          mutationId: 'widget-guarded-false',
+          subjectAfterSha256: sha('export const widgetGuarded = false;\n'),
+          landed: true,
+          exitCode: 1,
+          testsRun: 1,
+          failureKind: 'assertion',
+          outputSha256: sha('expected true, received false'),
+          decidingOutput: 'AssertionError: expected false to be true',
+        },
+      },
+    })),
+  }, null, 2)}\n`);
+}
+
 beforeEach(() => {
   repo = fs.mkdtempSync(path.join(os.tmpdir(), 'std-ratchet-'));
   auditCounter = 0;
   // A repo whose ONLY standard is guarded by a real ratchet test on disk → ratio 1,
   // zero dangling. src/ present so resolveRoot picks the repo.
   write('src/server/routes.ts', "router.get('/x', (req,res)=>{});\n");
-  write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
+  write('src/widget.ts', 'export const widgetGuarded = true;\n');
+  write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nimport { widgetGuarded } from '../../src/widget.js';\nit('observes the guarded widget rule', () => expect(widgetGuarded).toBe(true));\n");
   write('docs/specs/reports/family-review.md', '# Family review\n\nFixture convergence evidence.\n');
   write('docs/STANDARDS-REGISTRY.md', [
     '## Building',
@@ -190,6 +251,7 @@ beforeEach(() => {
     '**Applied through.** Enforced by `tests/unit/widget.test.ts`.',
     '',
   ].join('\n'));
+  writeFixtureEnforcementProof();
   refreshAreaAudits();
 });
 afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
@@ -224,6 +286,8 @@ function snapshotMeasurementBase(): string {
     fs.copyFileSync(source, target);
   };
   copy('docs/STANDARDS-REGISTRY.md');
+  copy('docs/standards-enforcement-verdicts.json');
+  copy('src/widget.ts');
   copy('tests/unit/widget.test.ts');
   return baseRoot;
 }
@@ -457,7 +521,6 @@ describe('standards-coverage ratchet script', () => {
   });
 
   it('C3a refuses to improve the headline when an unenforced protected rule is deleted', () => {
-    write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
     fs.appendFileSync(
       path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
       '\n### Protected Gap\n**Rule.** r.\n**In practice.** no guard yet.\n',
@@ -481,7 +544,6 @@ describe('standards-coverage ratchet script', () => {
   });
 
   it('C3b drops a protected ratchet reference when the candidate keeps the path but empties the file', () => {
-    write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
     const baseRoot = snapshotMeasurementBase();
     write('tests/unit/widget.test.ts', '');
     expect(fs.statSync(path.join(repo, 'tests/unit/widget.test.ts')).size).toBe(0);
@@ -500,7 +562,6 @@ describe('standards-coverage ratchet script', () => {
   });
 
   it('C3c does not count a new rule citing a new hollow reference as enforced', () => {
-    write('tests/unit/widget.test.ts', "import { expect, it } from 'vitest';\nit('guards', () => expect(true).toBe(true));\n");
     const baseRoot = snapshotMeasurementBase();
     write('tests/unit/hollow.test.ts', '// prose saying this is a test, with no executable assertion\n');
     fs.appendFileSync(
@@ -536,6 +597,7 @@ describe('standards-coverage ratchet script', () => {
       '**Rule.** r.',
       '**Applied through.** `tests/unit/widget.test.ts`.',
     ].join('\n'));
+    writeFixtureEnforcementProof();
     refreshAreaAudits();
 
     const registryPath = path.join(repo, 'docs', 'STANDARDS-REGISTRY.md');
@@ -895,6 +957,7 @@ describe('standards-coverage ratchet script', () => {
       '- `tests/unit/widget.test.ts`.',
       '**Earned from.** `tests/unit/missing-provenance.test.ts`.',
     ].join('\n'));
+    writeFixtureEnforcementProof();
     refreshAreaAudits();
     expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(0);
 
@@ -994,8 +1057,14 @@ describe('standards-coverage ratchet script', () => {
     // rather than being diluted. These are UPDATED, not relaxed: the count and ratio are re-derived
     // from the live registry, and the area-audit records below were refreshed by a review that
     // genuinely accepts, exactly as the comment above requires.
+    //
+    // 2026-08-18: the prior 0.6591 was structural credit: an assertion that merely executed could
+    // raise the numerator without observing the cited rule. Proven strength now requires protected,
+    // rule-bound relevance plus a landed violation that makes the same test fail by assertion. The
+    // protected baseline has no such ledger yet, so its honest value is 0/88; the legacy per-area
+    // floors remain visible separately and are not rewritten into evidence they never established.
     expect(report.total).toBe(88);
-    expect(report.enforcedRatio).toBe(0.6591);
+    expect(report.enforcedRatio).toBe(0);
     expect(Object.keys(report.areas).sort()).toEqual([
       'Building', 'Interaction', 'Shipping', 'The Fractal', 'The Root', 'The Substrate',
     ]);
@@ -1008,12 +1077,12 @@ describe('standards-coverage ratchet script', () => {
     expect(report.areaModelAudit.currentAreaSetSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(report.areas['The Root']).toEqual(expect.objectContaining({
       total: 1,
-      enforced: 1,
-      refResolutionRatio: 1,
+      enforced: 0,
+      refResolutionRatio: 0,
       refResolutionRatioFloor: 1,
       auditCurrent: true,
     }));
-    expect(report.areas['The Root'].byKind.ratchet).toBe(1);
+    expect(report.areas['The Root'].byKind['documented-only']).toBe(1);
   });
 
   it('the cadence workflow mutates only its bot-authored exact-marker issue', () => {
@@ -1052,8 +1121,9 @@ describe('standards-coverage ratchet script', () => {
       '\n### Claims And Cites\n**Rule.** r.\n**In practice.** A scheduled coherence audit walks the list on every machine daily, enforced by `tests/unit/widget.test.ts`.\n',
     );
     refreshAreaAudits();
-    const r = runCheck({ STANDARDS_FALSE_CLAIM_CEILING: '0', STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
-    expect(r.code).toBe(0);
+    const report = runJson() as { falseClaimCount: number; falseClaims: unknown[] };
+    expect(report.falseClaims).toEqual([]);
+    expect(report.falseClaimCount).toBe(0);
   });
 
   it('does NOT flag a PRESCRIPTIVE requirement (a rule, not a claim of fact)', () => {

--- a/tests/unit/standards-enforcement-measurement.test.ts
+++ b/tests/unit/standards-enforcement-measurement.test.ts
@@ -1,0 +1,138 @@
+// safe-git-allow: no git operations; isolated directory snapshots exercise the protected/candidate boundary.
+import { afterEach, describe, expect, it } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  gradeFileReference,
+  measureAnchoredEnforcement,
+  resolveProtectedMeasurementSnapshot,
+} from '../../scripts/lib/standards-enforcement-measurement.mjs';
+
+const roots: string[] = [];
+const makeRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'w34-measurement-'));
+  roots.push(root);
+  return root;
+};
+const write = (root: string, rel: string, content: string): void => {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+};
+const article = (id: string, files: string[]) => ({
+  id,
+  family: 'Building',
+  name: id,
+  refs: { files, routes: [], markers: [] },
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('protected standards enforcement measurement', () => {
+  it('does not mistake comments or prose for an executable ratchet', () => {
+    expect(gradeFileReference(
+      'tests/unit/hollow.test.ts',
+      '// it("claims a test", () => expect(true).toBe(true))\n',
+    )).toEqual(expect.objectContaining({
+      proven: false,
+      strength: 'documented-only',
+      reason: 'reference-structurally-hollow',
+    }));
+  });
+
+  it('caps candidate strength at the protected article/reference census', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const protectedRef = 'scripts/lint-protected.mjs';
+    const newRef = 'tests/unit/candidate-only.test.ts';
+    write(base, protectedRef, "if (problems.length) { process.exitCode = 1; }\n");
+    write(candidate, protectedRef, "if (problems.length) { process.exitCode = 1; }\n");
+    write(candidate, newRef, "import { expect, it } from 'vitest'; it('x', () => expect(true).toBe(true));\n");
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [article('rule-a', [protectedRef])],
+      candidateArticles: [article('rule-a', [newRef])],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.unverifiedReferences).toContainEqual(expect.objectContaining({
+      ref: newRef,
+      reason: 'reference-not-in-protected-census',
+    }));
+  });
+
+  it('uses a protected certified verdict and ignores a candidate-authored replacement ledger', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'scripts/lint-certified.mjs';
+    // The structural grader sees no executable enforcement here. The protected,
+    // content-bound instrument verdict is deliberately the stronger oracle.
+    const content = '// independently certified guard body\n';
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 1,
+      records: [{ ref, sha256: crypto.createHash('sha256').update(content).digest('hex'), verdict: 'EFFECTIVE' }],
+    })}\n`);
+    write(candidate, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 1,
+      records: [{ ref, sha256: '0'.repeat(64), verdict: 'EXISTS' }],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [article('rule-a', [ref])],
+      candidateArticles: [article('rule-a', [ref])],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0]).toEqual(expect.objectContaining({ strength: 'ratchet' }));
+    expect(result.articles[0].references[0]).toEqual(expect.objectContaining({
+      reason: 'protected-certified-effective',
+    }));
+  });
+
+  it('does not preserve a certified verdict after the candidate reference disappears', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'scripts/lint-certified.mjs';
+    const content = '// independently certified guard body\n';
+    write(base, ref, content);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 1,
+      records: [{ ref, sha256: crypto.createHash('sha256').update(content).digest('hex'), verdict: 'EFFECTIVE' }],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [article('rule-a', [ref])],
+      candidateArticles: [article('rule-a', [ref])],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.articles[0].references[0]).toEqual(expect.objectContaining({
+      proven: false,
+      reason: 'candidate-reference-unreadable',
+    }));
+  });
+
+  it('records zero-of-zero as NOT-PROVEN rather than 100 percent', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [],
+      candidateArticles: [],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.population).toEqual(expect.objectContaining({ protectedBase: 0, candidate: 0, continuity: 0 }));
+    expect(result.errors.join('\n')).toContain('protected rule population is empty or unreadable');
+    expect(result.errors.join('\n')).toContain('candidate rule population is empty or unreadable');
+  });
+});

--- a/tests/unit/standards-enforcement-measurement.test.ts
+++ b/tests/unit/standards-enforcement-measurement.test.ts
@@ -1,0 +1,310 @@
+// safe-git-allow: no git operations; isolated directory snapshots exercise the protected/candidate boundary.
+import { afterEach, describe, expect, it } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  gradeFileReference,
+  measureAnchoredEnforcement,
+  resolveProtectedMeasurementSnapshot,
+} from '../../scripts/lib/standards-enforcement-measurement.mjs';
+
+const roots: string[] = [];
+const makeRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'w34-measurement-'));
+  roots.push(root);
+  return root;
+};
+const write = (root: string, rel: string, content: string): void => {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+};
+const digest = (value: string): string => crypto.createHash('sha256').update(value).digest('hex');
+const article = (id: string, files: string[]) => {
+  const rule = `fixture rule ${id}`;
+  return {
+    id,
+    family: 'Building',
+    name: id,
+    ruleSha256: digest(`standards-rule-v1\0${rule}`),
+    articleSha256: digest(`fixture-article\0${id}\0${files.join('\0')}`),
+    refs: { files, routes: [], markers: [] },
+  };
+};
+const certifiedRecord = (
+  protectedArticle: ReturnType<typeof article>,
+  ref: string,
+  observerContent: string,
+  subjectRef: string,
+  subjectContent: string,
+  verdict: 'EFFECTIVE' | 'WIRED' | 'EXISTS' = 'EFFECTIVE',
+) => ({
+  articleId: protectedArticle.id,
+  articleSha256: protectedArticle.articleSha256,
+  ref,
+  sha256: digest(observerContent),
+  verdict,
+  proof: {
+    schemaVersion: 1,
+    observerCommandSha256: digest('npx vitest run tests/unit/certified.test.ts'),
+    relevance: {
+      articleId: protectedArticle.id,
+      ruleSha256: protectedArticle.ruleSha256,
+      observerRef: ref,
+      observerSha256: digest(observerContent),
+      subjectRef,
+      subjectBeforeSha256: digest(subjectContent),
+    },
+    control: {
+      exitCode: 0,
+      testsRun: 3,
+      outputSha256: digest('3 tests passed'),
+    },
+    violation: {
+      mutationId: 'violate-fixture-rule',
+      subjectAfterSha256: digest(`${subjectContent}\n// violated`),
+      landed: true,
+      exitCode: 1,
+      testsRun: 3,
+      failureKind: 'assertion',
+      outputSha256: digest('1 assertion failed; 2 tests passed'),
+      decidingOutput: 'expected guarded result, received violated result',
+    },
+  },
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('protected standards enforcement measurement', () => {
+  it('does not mistake comments or prose for an executable ratchet', () => {
+    expect(gradeFileReference(
+      'tests/unit/hollow.test.ts',
+      '// it("claims a test", () => expect(true).toBe(true))\n',
+    )).toEqual(expect.objectContaining({
+      proven: false,
+      strength: 'documented-only',
+      reason: 'reference-structurally-hollow',
+    }));
+  });
+
+  it('C3d refuses proven strength to an already-censused executable but vacuous assertion', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/vacuous.test.ts';
+    const content = "import { expect, it } from 'vitest';\nit('does not observe the rule', () => expect(true).toBe(true));\n";
+    write(base, ref, content);
+    write(candidate, ref, content);
+    expect(fs.readFileSync(path.join(candidate, ref), 'utf8')).toContain('expect(true).toBe(true)');
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [article('rule-a', [ref])],
+      candidateArticles: [article('rule-a', [ref])],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.unverifiedReferences).toContainEqual(expect.objectContaining({
+      articleId: 'rule-a',
+      ref,
+      reason: 'protected-relevance-proof-missing',
+    }));
+    console.log('W34_C3D landed=already-censused-expect-true strength=documented-only deciding="protected-relevance-proof-missing"');
+  });
+
+  it('caps candidate strength at the protected article/reference census', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const protectedRef = 'scripts/lint-protected.mjs';
+    const newRef = 'tests/unit/candidate-only.test.ts';
+    write(base, protectedRef, "if (problems.length) { process.exitCode = 1; }\n");
+    write(candidate, protectedRef, "if (problems.length) { process.exitCode = 1; }\n");
+    write(candidate, newRef, "import { expect, it } from 'vitest'; it('x', () => expect(true).toBe(true));\n");
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [article('rule-a', [protectedRef])],
+      candidateArticles: [article('rule-a', [newRef])],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.unverifiedReferences).toContainEqual(expect.objectContaining({
+      ref: newRef,
+      reason: 'reference-not-in-protected-census',
+    }));
+  });
+
+  it('uses a protected certified verdict and ignores a candidate-authored replacement ledger', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'scripts/lint-certified.mjs';
+    const subjectRef = 'src/certified-subject.ts';
+    const subjectContent = 'export const guarded = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
+    // The structural grader sees no executable enforcement here. The protected,
+    // content-bound instrument verdict is deliberately the stronger oracle.
+    const content = '// independently certified guard body\n';
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(candidate, subjectRef, subjectContent);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+    })}\n`);
+    write(candidate, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0]).toEqual(expect.objectContaining({ strength: 'ratchet' }));
+    expect(result.articles[0].references[0]).toEqual(expect.objectContaining({
+      reason: 'protected-certified-effective-with-relevance-and-fail-direction',
+    }));
+  });
+
+  it('rejects a proof that mutates its observer instead of an independent rule subject', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/certified.test.ts';
+    const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
+    const protectedArticle = article('rule-a', [ref]);
+    const record = certifiedRecord(protectedArticle, ref, content, ref, content);
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [record],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.errors.join('\n')).toContain('crosses the subject/observer boundary');
+  });
+
+  it('rejects compile-only red evidence in place of an executed assertion failure', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/certified.test.ts';
+    const subjectRef = 'src/certified-subject.ts';
+    const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
+    const subjectContent = 'export const subject = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
+    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    record.proof.violation.failureKind = 'compile';
+    record.proof.violation.testsRun = 0;
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(candidate, subjectRef, subjectContent);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [record],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.errors.join('\n')).toContain('did not execute the same tests to an assertion failure');
+  });
+
+  it('does not carry protected proof onto a changed candidate rule with the same identity and observer', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/certified.test.ts';
+    const subjectRef = 'src/certified-subject.ts';
+    const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
+    const subjectContent = 'export const subject = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
+    const changedCandidateArticle = {
+      ...protectedArticle,
+      ruleSha256: digest('a different candidate rule'),
+      articleSha256: digest('the candidate article containing that different rule'),
+    };
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(candidate, subjectRef, subjectContent);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [changedCandidateArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.unverifiedReferences).toContainEqual(expect.objectContaining({
+      articleId: 'rule-a',
+      ref,
+      reason: 'candidate-cited-rule-changed',
+    }));
+  });
+
+  it('does not preserve a certified verdict after the candidate reference disappears', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'scripts/lint-certified.mjs';
+    const subjectRef = 'src/certified-subject.ts';
+    const subjectContent = 'export const guarded = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
+    const content = '// independently certified guard body\n';
+    write(base, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.articles[0].references[0]).toEqual(expect.objectContaining({
+      proven: false,
+      reason: 'candidate-reference-unreadable',
+    }));
+  });
+
+  it('records zero-of-zero as NOT-PROVEN rather than 100 percent', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [],
+      candidateArticles: [],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.population).toEqual(expect.objectContaining({ protectedBase: 0, candidate: 0, continuity: 0 }));
+    expect(result.errors.join('\n')).toContain('protected rule population is empty or unreadable');
+    expect(result.errors.join('\n')).toContain('candidate rule population is empty or unreadable');
+  });
+});

--- a/tests/unit/standards-enforcement-measurement.test.ts
+++ b/tests/unit/standards-enforcement-measurement.test.ts
@@ -21,11 +21,58 @@ const write = (root: string, rel: string, content: string): void => {
   fs.mkdirSync(path.dirname(full), { recursive: true });
   fs.writeFileSync(full, content);
 };
-const article = (id: string, files: string[]) => ({
-  id,
-  family: 'Building',
-  name: id,
-  refs: { files, routes: [], markers: [] },
+const digest = (value: string): string => crypto.createHash('sha256').update(value).digest('hex');
+const article = (id: string, files: string[]) => {
+  const rule = `fixture rule ${id}`;
+  return {
+    id,
+    family: 'Building',
+    name: id,
+    ruleSha256: digest(`standards-rule-v1\0${rule}`),
+    articleSha256: digest(`fixture-article\0${id}\0${files.join('\0')}`),
+    refs: { files, routes: [], markers: [] },
+  };
+};
+const certifiedRecord = (
+  protectedArticle: ReturnType<typeof article>,
+  ref: string,
+  observerContent: string,
+  subjectRef: string,
+  subjectContent: string,
+  verdict: 'EFFECTIVE' | 'WIRED' | 'EXISTS' = 'EFFECTIVE',
+) => ({
+  articleId: protectedArticle.id,
+  articleSha256: protectedArticle.articleSha256,
+  ref,
+  sha256: digest(observerContent),
+  verdict,
+  proof: {
+    schemaVersion: 1,
+    observerCommandSha256: digest('npx vitest run tests/unit/certified.test.ts'),
+    relevance: {
+      articleId: protectedArticle.id,
+      ruleSha256: protectedArticle.ruleSha256,
+      observerRef: ref,
+      observerSha256: digest(observerContent),
+      subjectRef,
+      subjectBeforeSha256: digest(subjectContent),
+    },
+    control: {
+      exitCode: 0,
+      testsRun: 3,
+      outputSha256: digest('3 tests passed'),
+    },
+    violation: {
+      mutationId: 'violate-fixture-rule',
+      subjectAfterSha256: digest(`${subjectContent}\n// violated`),
+      landed: true,
+      exitCode: 1,
+      testsRun: 3,
+      failureKind: 'assertion',
+      outputSha256: digest('1 assertion failed; 2 tests passed'),
+      decidingOutput: 'expected guarded result, received violated result',
+    },
+  },
 });
 
 afterEach(() => {
@@ -42,6 +89,30 @@ describe('protected standards enforcement measurement', () => {
       strength: 'documented-only',
       reason: 'reference-structurally-hollow',
     }));
+  });
+
+  it('C3d refuses proven strength to an already-censused executable but vacuous assertion', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/vacuous.test.ts';
+    const content = "import { expect, it } from 'vitest';\nit('does not observe the rule', () => expect(true).toBe(true));\n";
+    write(base, ref, content);
+    write(candidate, ref, content);
+    expect(fs.readFileSync(path.join(candidate, ref), 'utf8')).toContain('expect(true).toBe(true)');
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [article('rule-a', [ref])],
+      candidateArticles: [article('rule-a', [ref])],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.unverifiedReferences).toContainEqual(expect.objectContaining({
+      articleId: 'rule-a',
+      ref,
+      reason: 'protected-relevance-proof-missing',
+    }));
+    console.log('W34_C3D landed=already-censused-expect-true strength=documented-only deciding="protected-relevance-proof-missing"');
   });
 
   it('caps candidate strength at the protected article/reference census', () => {
@@ -70,29 +141,126 @@ describe('protected standards enforcement measurement', () => {
     const base = makeRoot();
     const candidate = makeRoot();
     const ref = 'scripts/lint-certified.mjs';
+    const subjectRef = 'src/certified-subject.ts';
+    const subjectContent = 'export const guarded = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
     // The structural grader sees no executable enforcement here. The protected,
     // content-bound instrument verdict is deliberately the stronger oracle.
     const content = '// independently certified guard body\n';
     write(base, ref, content);
     write(candidate, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(candidate, subjectRef, subjectContent);
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
-      schemaVersion: 1,
-      records: [{ ref, sha256: crypto.createHash('sha256').update(content).digest('hex'), verdict: 'EFFECTIVE' }],
+      schemaVersion: 2,
+      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
     write(candidate, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
-      schemaVersion: 1,
-      records: [{ ref, sha256: '0'.repeat(64), verdict: 'EXISTS' }],
+      schemaVersion: 2,
+      records: [],
     })}\n`);
     const result = measureAnchoredEnforcement({
       root: candidate,
-      protectedArticles: [article('rule-a', [ref])],
-      candidateArticles: [article('rule-a', [ref])],
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
       snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
     });
 
     expect(result.articles[0]).toEqual(expect.objectContaining({ strength: 'ratchet' }));
     expect(result.articles[0].references[0]).toEqual(expect.objectContaining({
-      reason: 'protected-certified-effective',
+      reason: 'protected-certified-effective-with-relevance-and-fail-direction',
+    }));
+  });
+
+  it('rejects a proof that mutates its observer instead of an independent rule subject', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/certified.test.ts';
+    const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
+    const protectedArticle = article('rule-a', [ref]);
+    const record = certifiedRecord(protectedArticle, ref, content, ref, content);
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [record],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.errors.join('\n')).toContain('crosses the subject/observer boundary');
+  });
+
+  it('rejects compile-only red evidence in place of an executed assertion failure', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/certified.test.ts';
+    const subjectRef = 'src/certified-subject.ts';
+    const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
+    const subjectContent = 'export const subject = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
+    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    record.proof.violation.failureKind = 'compile';
+    record.proof.violation.testsRun = 0;
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(candidate, subjectRef, subjectContent);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [record],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.status).toBe('not-proven');
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.errors.join('\n')).toContain('did not execute the same tests to an assertion failure');
+  });
+
+  it('does not carry protected proof onto a changed candidate rule with the same identity and observer', () => {
+    const base = makeRoot();
+    const candidate = makeRoot();
+    const ref = 'tests/unit/certified.test.ts';
+    const subjectRef = 'src/certified-subject.ts';
+    const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
+    const subjectContent = 'export const subject = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
+    const changedCandidateArticle = {
+      ...protectedArticle,
+      ruleSha256: digest('a different candidate rule'),
+      articleSha256: digest('the candidate article containing that different rule'),
+    };
+    write(base, ref, content);
+    write(candidate, ref, content);
+    write(base, subjectRef, subjectContent);
+    write(candidate, subjectRef, subjectContent);
+    write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
+      schemaVersion: 2,
+      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+    })}\n`);
+    const result = measureAnchoredEnforcement({
+      root: candidate,
+      protectedArticles: [protectedArticle],
+      candidateArticles: [changedCandidateArticle],
+      snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
+    });
+
+    expect(result.articles[0].strength).toBe('documented-only');
+    expect(result.unverifiedReferences).toContainEqual(expect.objectContaining({
+      articleId: 'rule-a',
+      ref,
+      reason: 'candidate-cited-rule-changed',
     }));
   });
 
@@ -100,16 +268,20 @@ describe('protected standards enforcement measurement', () => {
     const base = makeRoot();
     const candidate = makeRoot();
     const ref = 'scripts/lint-certified.mjs';
+    const subjectRef = 'src/certified-subject.ts';
+    const subjectContent = 'export const guarded = true;\n';
+    const protectedArticle = article('rule-a', [ref]);
     const content = '// independently certified guard body\n';
     write(base, ref, content);
+    write(base, subjectRef, subjectContent);
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
-      schemaVersion: 1,
-      records: [{ ref, sha256: crypto.createHash('sha256').update(content).digest('hex'), verdict: 'EFFECTIVE' }],
+      schemaVersion: 2,
+      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
     const result = measureAnchoredEnforcement({
       root: candidate,
-      protectedArticles: [article('rule-a', [ref])],
-      candidateArticles: [article('rule-a', [ref])],
+      protectedArticles: [protectedArticle],
+      candidateArticles: [protectedArticle],
       snapshot: resolveProtectedMeasurementSnapshot({ root: candidate, fixtureRoot: base }),
     });
 

--- a/upgrades/next/enforcement-measurement.md
+++ b/upgrades/next/enforcement-measurement.md
@@ -1,0 +1,19 @@
+---
+change_type: fix
+---
+
+<!-- internal-only -->
+
+## What Changed
+
+The standards-coverage report now measures enforcement against a closed rule census and evidence read from the protected branch. Removing a rule is reported as a direction failure instead of improving the score. Empty, missing, candidate-only, structurally hollow, and executable-but-unproven references no longer receive enforcement credit merely because a path exists or an assertion executes.
+
+References are graded on the existing ratchet, gate, lint, spec-only, and documented-only ladder. A content-bound certified verdict from the protected side can supersede structural grading only when its evidence binds the cited rule to an independent subject and records the same real check passing cleanly before a landed rule-violation mutation makes an assertion fail. The candidate rule digest, observer, and subject must still match that protected proof; candidate-authored verdict records are ignored. Empty or unreadable populations fail measurement rather than reporting 100%.
+
+## Evidence
+
+The live protected baseline measures 0 of 88 rules at proven ratchet, gate, or lint strength because it contains no protected relevance + fail-direction proof ledger; all 88 are reported as unverified rather than receiving structural credit. Mandatory controls prove that deleting an unenforced rule leaves the score unchanged and reports the removal, emptying a cited test drops its contribution, adding a rule with a prose-only test does not increase enforcement, and an already-censused executable `expect(true)` assertion is refused proven strength.
+
+## Known Limits
+
+This change measures protected, behaviorally certified enforcement evidence and uses structural inspection only to explain why an uncertified reference is hollow or unverified. It does not itself certify a guard or alter CI wiring. Independent judge re-certification of this measurement remains pending.

--- a/upgrades/next/enforcement-measurement.md
+++ b/upgrades/next/enforcement-measurement.md
@@ -6,14 +6,14 @@ change_type: fix
 
 ## What Changed
 
-The standards-coverage report now measures enforcement against a closed rule census and evidence read from the protected branch. Removing a rule is reported as a direction failure instead of improving the score. Empty, missing, candidate-only, and structurally hollow references no longer receive enforcement credit merely because a path exists.
+The standards-coverage report now measures enforcement against a closed rule census and evidence read from the protected branch. Removing a rule is reported as a direction failure instead of improving the score. Empty, missing, candidate-only, structurally hollow, and executable-but-unproven references no longer receive enforcement credit merely because a path exists or an assertion executes.
 
-References are graded on the existing ratchet, gate, lint, spec-only, and documented-only ladder. A content-bound certified verdict from the protected side can supersede structural grading; candidate-authored verdict records are ignored. Empty or unreadable populations fail measurement rather than reporting 100%.
+References are graded on the existing ratchet, gate, lint, spec-only, and documented-only ladder. A content-bound certified verdict from the protected side can supersede structural grading only when its evidence binds the cited rule to an independent subject and records the same real check passing cleanly before a landed rule-violation mutation makes an assertion fail. The candidate rule digest, observer, and subject must still match that protected proof; candidate-authored verdict records are ignored. Empty or unreadable populations fail measurement rather than reporting 100%.
 
 ## Evidence
 
-The live protected baseline measures 58 of 88 rules at executable ratchet, gate, or lint strength. Mandatory controls prove that deleting an unenforced rule leaves the score unchanged and reports the removal, emptying a cited test drops its contribution, and adding a rule with a prose-only test does not increase enforcement.
+The live protected baseline measures 0 of 88 rules at proven ratchet, gate, or lint strength because it contains no protected relevance + fail-direction proof ledger; all 88 are reported as unverified rather than receiving structural credit. Mandatory controls prove that deleting an unenforced rule leaves the score unchanged and reports the removal, emptying a cited test drops its contribution, adding a rule with a prose-only test does not increase enforcement, and an already-censused executable `expect(true)` assertion is refused proven strength.
 
 ## Known Limits
 
-This change measures structural enforcement evidence and consumes certified verdicts when a protected verdict ledger exists. It does not itself certify a guard or alter CI wiring. Independent judge certification of this measurement remains pending.
+This change measures protected, behaviorally certified enforcement evidence and uses structural inspection only to explain why an uncertified reference is hollow or unverified. It does not itself certify a guard or alter CI wiring. Independent judge re-certification of this measurement remains pending.

--- a/upgrades/next/enforcement-measurement.md
+++ b/upgrades/next/enforcement-measurement.md
@@ -1,0 +1,19 @@
+---
+change_type: fix
+---
+
+<!-- internal-only -->
+
+## What Changed
+
+The standards-coverage report now measures enforcement against a closed rule census and evidence read from the protected branch. Removing a rule is reported as a direction failure instead of improving the score. Empty, missing, candidate-only, and structurally hollow references no longer receive enforcement credit merely because a path exists.
+
+References are graded on the existing ratchet, gate, lint, spec-only, and documented-only ladder. A content-bound certified verdict from the protected side can supersede structural grading; candidate-authored verdict records are ignored. Empty or unreadable populations fail measurement rather than reporting 100%.
+
+## Evidence
+
+The live protected baseline measures 58 of 88 rules at executable ratchet, gate, or lint strength. Mandatory controls prove that deleting an unenforced rule leaves the score unchanged and reports the removal, emptying a cited test drops its contribution, and adding a rule with a prose-only test does not increase enforcement.
+
+## Known Limits
+
+This change measures structural enforcement evidence and consumes certified verdicts when a protected verdict ledger exists. It does not itself certify a guard or alter CI wiring. Independent judge certification of this measurement remains pending.

--- a/upgrades/side-effects/w34-enforcement-measurement.md
+++ b/upgrades/side-effects/w34-enforcement-measurement.md
@@ -1,0 +1,193 @@
+# Side-Effects Review — W3.4 protected enforcement measurement
+
+**Version / slug:** `w34-enforcement-measurement`
+**Date:** `2026-08-18`
+**Author:** `Instar Agent (instar-codey), CI3 repair lane`
+**Second-pass reviewer:** `ci3_side_effects_review` — CONCUR
+
+## Summary of the change
+
+W3.4 changes `scripts/lib/standards-enforcement-measurement.mjs` and
+`scripts/standards-coverage.mjs` so the standards-coverage headline is derived from a closed
+protected rule census and protected, content-bound proof rather than candidate-controlled file
+existence. A removed rule remains in the continuity denominator and is reported as a removal;
+empty, hollow, candidate-only, or executable-but-unproved references receive no proven strength;
+and an empty protected population is an error rather than 100%. CI3 changes no W3.4 implementation
+bytes: it is re-committing the delivered bytes through the actual local `instar-dev` gate so that
+the gate itself produces the missing decision-audit record.
+
+## Decision-point inventory
+
+- `resolveProtectedMeasurementSnapshot` — **add** — selects a content-addressed protected merge
+  base from canonical main and refuses candidate refs as authority.
+- `measureAnchoredEnforcement` — **add** — assigns deterministic strength and continuity outcomes
+  from protected/candidate evidence.
+- `scripts/standards-coverage.mjs --check` integration — **modify** — consumes the protected
+  measurement and exposes removal, unverified-reference, and measurement-error states in the
+  existing blocking coverage check.
+
+---
+
+## 1. Over-block
+
+The conservative proof boundary can under-credit a genuinely effective guard whose protected proof
+record has not yet landed. On the present protected snapshot that produces the honest `0/88` proven
+strength result rather than blocking merely because the number is low. A protected-main lookup or
+merge-base failure can make the measurement unavailable and fail the coverage check; this is an
+intentional fail-closed integrity boundary, but a canonical-remote outage can therefore delay a
+legitimate change until the protected source is readable again.
+
+No user input or conversational content is blocked by this change.
+
+---
+
+## 2. Under-block
+
+W3.4 validates the structure, content binding, relevance boundary, and declared clean/mutated
+fail-direction of protected proof records, but it does not itself execute the recorded observer.
+Later W3.5–W3.8 work adds authenticated live execution and artifact integrity. Until those layers
+land, a structurally valid protected record remains an admission made through protected-main review,
+not independently observed execution by W3.4.
+
+The metric also does not certify every guard merely because a reference resolves. It intentionally
+reports those references as unverified; consumers must not reinterpret the separate false-claim or
+path-resolution output as behavioral effectiveness.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The protected snapshot reader and proof grader are the correct lower-level primitives for the
+existing standards-coverage report. They do not invent a second standards authority: the Standards
+Registry remains the rule source, canonical main remains the trust boundary, and the existing
+coverage command remains the single report/check surface. Keeping pure grading in the library and
+CLI/report integration in `standards-coverage.mjs` avoids duplicating the policy across tests and
+workflows.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [x] Deterministic hard-invariant validation — the documented carve-out applies.
+
+The coverage command has blocking CI authority, but its decisions are over an enumerable repository
+contract: exact Git object identity, closed populations, exact proof schemas, cryptographic digests,
+and monotonic direction. This is not a brittle attempt to infer user intent or message meaning. A
+candidate either preserves the protected obligation and earns the admitted proof strength or it
+does not. The output retains reasons and unverified populations so the invariant is inspectable.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals judgment point. The relevant domain is an
+enumerated integrity invariant: protected rule identities, candidate continuity, exact file bytes,
+and exact proof envelopes. Recency, urgency, ownership, or conversational evidence cannot
+legitimately override those facts inside the measurement. Human authority remains at the separate
+review/merge decision over what evidence is admitted to protected main.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the protected measurement does not replace false-claim, dangling-reference, or
+  per-area checks. Those retain their distinct meanings; proven strength is reported separately.
+- **Double-fire:** `standards-coverage.mjs` computes the report once per invocation and exposes the
+  same result to the CLI check and JSON report. There is no second actor mutating repository state.
+- **Races:** canonical-main resolution depends on a network read followed by local content-addressed
+  Git reads. Main can advance after resolution without changing the pinned SHA used by that run.
+- **Feedback loops:** candidate files cannot raise their own protected numerator. A later protected
+  merge can intentionally change the next run's authority snapshot; that is the declared admission
+  path, not a same-run feedback loop.
+- **Adjacent work:** W3.5–W3.8 strengthen how protected proof is observed and represented. W3.4's
+  conservative unverified result remains valid when those extensions are absent.
+
+---
+
+## 6. External surfaces
+
+The visible surface is developer/CI output: the standards-coverage headline, protected/candidate
+population, removals, unverified references, and measurement errors. The resolver reads the
+canonical GitHub remote and therefore depends on bounded network availability. It changes no
+Telegram, Slack, dashboard, API, database, user configuration, authentication, or signing surface.
+
+The command may persist its existing machine-readable standards-coverage report; that report is
+derived output, not authority independent of the pinned protected Git objects. No operator-facing
+action or phone-completable workflow is added.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. The change adds no dashboard, approval, grant, revoke,
+secret-drop, or other human action form.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated.** The behavior ships in Git, the trusted population is identified by canonical Git
+SHA, and proof strength is derived from content in that snapshot. Machines holding the same
+candidate and protected objects should compute the same result. Machine-specific network or object
+availability can produce an explicit unavailable/error state; it cannot silently substitute local
+candidate bytes as protected authority.
+
+The feature emits no user-facing notices, holds no durable conversational state, generates no URLs,
+and cannot strand state on topic transfer. CI output is repository-scoped and GitHub-hosted.
+
+---
+
+## 8. Rollback cost
+
+Rollback is a code revert followed by the normal patch release. No database migration, agent reset,
+or durable user-state repair is required. Any consumer introduced for the expanded measurement JSON
+would need to roll back with the producer. During rollback, standards coverage would return to the
+older existence-weighted metric and could again over-credit hollow references, so rollback should
+be treated as a temporary loss of measurement integrity rather than a neutral formatting change.
+
+---
+
+## Conclusion
+
+The design is conservative and correctly separates candidate evidence from protected authority.
+Its material costs are honest under-credit before protected proof admission and dependence on a
+readable canonical Git source. No new side effect requires an implementation change in CI3. The
+W3.4 implementation remains subject to its existing independent judgments; this artifact only
+closes the missing local-gate process evidence by giving the real pre-commit gate the review input
+it requires.
+
+---
+
+## Second-pass review (required)
+
+**Reviewer:** `ci3_side_effects_review`
+**Independent read of the artifact:** CONCUR
+
+The reviewer independently confirmed the conservative proof boundary, deterministic-authority
+carve-out, canonical-remote failure posture, interaction with W3.5–W3.8, rollback claim, and the
+unchanged implementation hashes stated by CI3. The review found no substantive concern.
+
+---
+
+## Evidence pointers
+
+- `scratchpad/phaseB/REPORT-W34.md` — append-only implementation and behavioral-control record.
+- `scratchpad/phaseB/REPORT-J5.md` — independent finding that caused the fail-direction repair.
+- `scratchpad/phaseB/evidence/W34-J5-repair-controls.json` — content-addressed repaired controls.
+- `tests/unit/standards-enforcement-measurement.test.ts` — protected-proof and vacuity controls.
+- `tests/unit/standards-coverage-ratchet.test.ts` — deletion, empty-reference, and hollow-addition
+  controls.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+CI3 does not add or alter a defect fix in an agent-authored prompt, hook, config, skill, or standards
+text, and it adds no self-triggered controller. It re-commits already judged W3.4 implementation
+bytes through the gate that was bypassed. Class closure for the original W3.4 measurement defect is
+therefore outside this process-evidence repair; no new class-closure claim is made here.


### PR DESCRIPTION
## ELI16 — count only proof that can fail on the cited rule

The original W3.4 repair anchored the denominator to protected main and stopped deletion, empty files, candidate-only references, and zero-of-zero from improving the enforcement number. J5 reproduced that half as sound, then found one remaining vacuity: an assertion received proven strength merely because it executed. An executable expect(true) could therefore inflate the numerator without observing the cited rule.

This update removes all structural credit from proven strength. A protected verdict now qualifies only when it binds the exact article and Rule digest, the observer digest, and a distinct subject digest; records a clean run with tests executed; and records a landed rule-violation mutation that makes the same test population fail by assertion. The candidate Rule, observer, and subject must still match that protected proof. Candidate-authored verdict records remain ignored.

## Must-fail control

Before the repair, the already-censused executable fixture expect(true).toBe(true) failed the test because it received ratchet instead of documented-only. After the repair, the same landed fixture receives documented-only with protected-relevance-proof-missing. The test suite executes normally: this is behavioral refusal, not a compile failure.

Additional negative controls reject a proof that mutates its observer, reject compile-only red evidence with zero tests run, and revoke proof when the candidate rewrites the cited Rule while retaining its identity and observer.

## Current hand evidence

- Live protected measurement: 0/88 proven, 88 documented-only, 254 unverified references; the check exits 0. The prior 58/88 result is superseded because it represented executable structure without relevance plus fail-direction proof.
- Measurement suite: 9/9 passed.
- Coverage suite: 38/38 passed.
- Normal pre-push smoke: 65/65 passed across four affected files.
- TypeScript, JSON/hash validation, and diff hygiene pass.
- Full repository lint reaches only the unchanged model-registry freshness failure: 46 days since review against a 45-day ceiling. This branch does not modify that out-of-scope registry.

False-claim detection remains separate: a resolvable but unverified citation is not relabeled as no guard named, while it still earns zero proven-strength credit.

## Honest status

**BUILT WITH HAND EVIDENCE, PENDING INDEPENDENT JUDGE RE-CERTIFICATION.** Do not call this FIXED or EFFECTIVE until J5 reruns. This PR is open and must not be merged by this lane.

Evidence: scratchpad/phaseB/REPORT-W34.md and scratchpad/phaseB/evidence/W34-J5-repair-controls.json.