### PR TITLE
fix: bind verifier entries to the same regular file

### DIFF
--- a/scratchpad/phaseB/REPORT-W1.md
+++ b/scratchpad/phaseB/REPORT-W1.md
@@ -1,0 +1,218 @@
+# Phase B Lane W1 — Validated Pipeline-Wiring Proof
+
+> **Append-only chronology:** This report preserves the evidence known at each step. Read entries from top to bottom: the newest entry is last and supersedes earlier status statements for the same claim.
+
+## 2026-08-17 23:25:52 -0700 (PDT) — Brief read, design pinned, first failing test proven
+
+### Ground
+
+```text
+model=GPT-5 Codex
+tree=/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring
+branch=phaseb/w1-validated-pipeline-wiring
+base=upstream/main
+commit=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+git status before implementation=clean
+```
+
+### C3 restatement before build
+
+Deliberately bypass the declared guard entry while its wrapper still exits successfully; the envelope must then be invalid and wiring must be NOT-PROVEN or UNKNOWN, never PROVEN.
+
+### Design decision
+
+The core—not an adapter—mints a per-run token and controls a `node` process observer placed first on `PATH`. The observer records the exact manifest-pinned guard child only after that child exits. The core accepts the receipt only when the adapter command is anchored to the manifest-pinned protected workflow command. C3 runs the same wrapper command while the observer short-circuits only that exact child, and requires wrapper success with no receipt.
+
+The isolation seed fetches the manifest-pinned protected remote/ref and installs that server-resolved commit as `origin/main` and `main` in every case. No `HEAD^` or candidate-chosen base is accepted as the protected reference.
+
+### First failing test
+
+```text
+$ node --test scratchpad/phaseB/fix-verifier.test.mjs
+exit=1
+SyntaxError: The requested module './fix-verifier.mjs' does not provide an export named 'runPipelineWiringControls'
+Subtest: scratchpad/phaseB/fix-verifier.test.mjs
+not ok 1
+# tests 1
+# pass 0
+# fail 1
+```
+
+This is the intended pre-implementation failure: the runtime relationship envelope does not exist yet.
+
+## 2026-08-18 00:07:36 -0700 (PDT) — Core implementation and three settled live runs
+
+### Implementation
+
+- The manifest now pins the protected remote URL, branch ref, workflow path/job/command, real invocation prefix, and exact observed Node child for each fix-lane guard.
+- The core resolves the protected ref with `git ls-remote`, fetches that exact SHA into an isolation seed, verifies the fetch matches the server answer, reads the workflow from that protected commit, and installs the commit as `origin/main`, `upstream/main`, and `main` in every isolated case.
+- The core mints tokens itself and places its own `node` observer first on `PATH`. The token is not supplied through the candidate environment. The observer writes a receipt only after the manifest-pinned child exits.
+- C3 uses the same wrapper command and an observer that skips only the exact child, records that short-circuit independently, exits the child as success, and emits no execution receipt.
+- Static `adapter.pipelineRelevance` testimony is rejected. A runtime envelope must have `source=fix-verifier-core`, mode `core-minted-process-receipt`, a token-bound post-child receipt, all checks true, and a proven C3 with zero receipts.
+- `--wiring-only` measures this relationship without rerunning the already-certified property mutations. It can render only WIRED/EXISTS for this scoped run; it never emits EFFECTIVE.
+
+### Core tests
+
+```text
+$ node --test scratchpad/phaseB/fix-verifier.test.mjs
+exit=0
+tests 14
+pass 14
+fail 0
+
+C3 behavioral fixture:
+  positive wrapper exit=0; receipts=1
+  C3 wrapper exit=0; exact-child short-circuit events=1; receipts=0
+
+blocked-before-entry fixture:
+  positive exit=1; receipts=0
+  C3 short-circuit events=0
+  C3 outcome=unknown; envelope status=unknown
+```
+
+### S5 standards direction — wiring PROVEN
+
+```text
+target=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+protected=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+mergeBase=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+C1=proven C2=proven C3=proven wiring=proven rung=wired
+positive exit=0 receipts=1
+[fix-verifier-wiring] token=<per-run> guard=standards-direction-guard entry=scripts/standards-coverage.mjs childExit=0
+C3 exit=0 short-circuit-events=1 receipts=0
+[fix-verifier-C3] short-circuited guard=standards-direction-guard entry=scripts/standards-coverage.mjs
+```
+
+The wiring-only S5 preparation reads the protected registry and public pin from the server-resolved protected commit. It generated, rotated, installed, or wrote no approver key and did not run the key-generating property fixture.
+
+### B1.2 Testing Integrity — merge-base fixed; wiring UNKNOWN behind an earlier real gate
+
+```text
+target=fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf
+protected=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+mergeBase=24f1bb4f76d8303f2124131743aa3b3d90bc972d
+former no-merge-base output=ABSENT
+positive exit=1 receipts=0
+C3 exit=1 short-circuit-events=0 receipts=0
+C1=unknown C2=unknown C3=unknown wiring=unknown rung=exists
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+```
+
+The real `npm run lint` command now has a genuine protected merge base but stops at `lint-model-registry-freshness.mjs`, before `scripts/lint-testing-integrity.mjs`. No bypass or pipeline weakening was applied. Because the guard child was never reached, both the positive wiring claim and C3 are UNKNOWN, not NOT-PROVEN.
+
+### S3 blind checkers — merge-base fixed; wiring UNKNOWN behind the same earlier real gate
+
+```text
+target=2f3cd8e16c7608fcd75c12f51623783f3da8824d
+protected=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+mergeBase=e5085f969d604cf067383ab3446f5f49c7dccf74
+former no-merge-base output=ABSENT
+positive exit=1 receipts=0
+C3 exit=1 short-circuit-events=0 receipts=0
+C1=unknown C2=unknown C3=unknown wiring=unknown rung=exists
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+```
+
+The adapter no longer writes `HEAD^` into a purported protected ref. It validates the three core-installed refs against the server-resolved SHA. The real lint command still cannot reach `scripts/lint-checker-blind-input-coverage.mjs` because the earlier staleness guard refuses first; the honest wiring result is UNKNOWN.
+
+### Discarded S4 run
+
+One S4 rerun was discarded after its targeted Vitest child slept for more than nine minutes without output. It was interrupted through the observer's signal-forwarding path; no conclusion rests on it, no process survived, and its 148 MB isolated directory was moved to Trash as `instar-fix-verifier-UUBEGe-discarded-W1` (recoverable). A fresh S4 run is in progress.
+
+## 2026-08-18 00:27:27 -0700 (PDT) — Final builder evidence
+
+### S4 operator binding — wiring PROVEN after a legitimate queued wait
+
+```text
+target=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+protected=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+mergeBase=4318a1e150e9a8304e6c2e7ad381bf66d03998e5
+positive durationMs=612133
+Test Files  3 passed (3)
+Tests       34 passed (34)
+[fix-verifier-wiring] token=<per-run> guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs childExit=0
+positive exit=0 receipts=1
+[fix-verifier-C3] short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs
+C3 exit=0 short-circuit-events=1 receipts=0
+C1=proven C2=proven C3=proven wiring=proven rung=wired
+```
+
+The 612-second duration is the deciding confirmation that the earlier silence was legitimate waiting, not a guard failure. No host limit was raised or disabled.
+
+### Discarded-run correction and boundary
+
+The earlier “one discarded S4 run” paragraph is incomplete and is superseded by this accounting. Three attempts produced no usable verdict: one hit the former five-minute caller timeout and then exposed a cleanup race (`p1FXLn`); two were manually interrupted while diagnosing detached observer process groups (`UUBEGe`, `oS1yRq`). No final claim uses them. Their exact temporary directories were moved to Trash and are recoverable. No matching process survived. The final non-detached run `daZkpG` completed normally and is the sole S4 verdict source.
+
+### Final per-guard builder state
+
+| guard | protected command reached exact child | C1 | C2 | C3 | wiring-only rung | deciding boundary |
+|---|---:|---:|---:|---:|---|---|
+| S4 operator binding | yes | PROVEN | PROVEN | PROVEN | WIRED | 34/34 tests; one post-child receipt; C3 zero receipts |
+| S5 rulebook direction | yes | PROVEN | PROVEN | PROVEN | WIRED | standards coverage child exit 0; one receipt; C3 zero receipts |
+| B1.2 Testing Integrity | no | UNKNOWN | UNKNOWN | UNKNOWN | EXISTS | real lint stops first at model-registry staleness |
+| S3 blind checkers | no | UNKNOWN | UNKNOWN | UNKNOWN | EXISTS | real lint stops first at model-registry staleness |
+
+The known `no-merge-base` blocker is cleared for both B1.2 and S3 with real server-resolved merge bases. A different live pipeline gate now prevents both exact children from running. This lane did not change that gate, bypass it, modify `.github/**`, or widen into model-registry maintenance.
+
+Nothing here is called FIXED or EFFECTIVE by the builder. The B0.3 judge must re-gate the implementation and decide whether/how to combine validated wiring with the earlier property-complete records. At this builder boundary, two wiring relationships are PROVEN and two are honestly UNKNOWN.
+
+### Final hashes
+
+```text
+92425be2ecec5969f650c23851153c7e3396ef27582acc141cc6c45d88d116d2  scratchpad/phaseB/fix-verifier.mjs
+08af9989637bc1acb2342101a5fb3d66d91343f125d188a440534f1f644f6b03  scratchpad/phaseB/fix-verifier.test.mjs
+a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677  scratchpad/phaseB/fix-verifier.manifest.json
+4b154729282c2dc7f237290c5d34e645a12f357a857442cff5dd66e731d96ec2  scratchpad/phaseB/evidence/W1-topic-operator-evidence.json
+a9149512c85438d56a913dc583fe3d0270cb9e700d8c686d734981afc020e867  scratchpad/phaseB/evidence/W1-standards-direction-guard.json
+d34f8f1e309c9364577a524870f4d1f93580808d01a172c4946ea8bdc842fe63  scratchpad/phaseB/evidence/W1-testing-integrity-route-enforcement.json
+ecd163ff2ed35166a945f235a064d783d759aedd34836f461d782ed7d085ad4a  scratchpad/phaseB/evidence/W1-checker-blind-input-coverage.json
+1f4ce83e270a1a89f20aaa39fff25be9556f876ddaa356c5e4888369df6394ab  scratchpad/phaseB/evidence/W1-evidence-stamps.json
+```
+
+## 2026-08-18 00:31 PDT — Repository lint and artifact integrity
+
+```text
+$ npm run lint
+exit=1
+tsc --noEmit completed and the lint chain reached lint-model-registry-freshness.mjs.
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+FAIL — 1 finding(s) under strict enforcement.
+```
+
+This reproduces on the untouched `upstream/main` base and is unrelated to the W1 scratchpad-only paths, but it is a real blocking gate. It was not bypassed, disabled, or “refreshed” by this lane.
+
+```text
+stdout/evidence byte comparison:
+topic-operator-evidence cmp_exit=0
+standards-direction-guard cmp_exit=0
+testing-integrity-route-enforcement cmp_exit=0
+checker-blind-input-coverage cmp_exit=0
+
+W1-evidence-stamps.json verification:
+11/11 recorded SHA-256 values match the current files
+exit=0
+```
+
+## 2026-08-18 00:36 PDT — Whitespace-only import cleanup and restamp
+
+`git diff --cached --check` identified extra blank EOF lines introduced while mechanically importing seven pre-existing adapter files into the PR worktree. Those blank lines were removed without semantic changes. Because one affected file is the B1.2 adapter, its wiring-only UNKNOWN run was repeated on the unchanged target and produced the same deciding outcome and merge base.
+
+The earlier B1.2 adapter/evidence/stamp hashes are superseded by:
+
+```text
+21bf4fa7c026fcbb3d0f745945af163884e7496ce4455fbf55b315f79c4c4337  scratchpad/phaseB/adapters/testing-integrity-route-enforcement.mjs
+3a556c7f639267c16160a7dbb7ba1675ee7c001465d8762a783982447c20aa2d  scratchpad/phaseB/evidence/W1-testing-integrity-route-enforcement.json
+f2afd386bf36967ee82145afb217d7a241353d06de25e210944f6569ef86af08  scratchpad/phaseB/evidence/W1-evidence-stamps.json
+```
+
+## 2026-08-18 00:40 PDT — Landing blocked by the live fail-closed hook
+
+```text
+$ git commit -m 'test: validate live pipeline wiring receipts'
+exit=1
+husky - pre-commit script failed (code 1)
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+FAIL — 1 finding(s) under strict enforcement.
+```
+
+No commit was created. No hook, test, or gate was bypassed. The W1 changes remain staged on `phaseb/w1-validated-pipeline-wiring`. Opening a PR is genuinely blocked until an authorized model-registry re-review makes the repository's own lint green, or the orchestrator explicitly authorizes a different landing procedure. The lane does not claim a PR exists.

--- a/scratchpad/phaseB/REPORT-W4.md
+++ b/scratchpad/phaseB/REPORT-W4.md
@@ -89,3 +89,38 @@ The observed argv used the `.bin/vitest` spelling, all three observer events aut
 Task B after-verdict: **PROVEN**, wiring-only rung **WIRED**. Evidence: `scratchpad/phaseB/evidence/W4-topic-operator-evidence.json` (`e3fedbdd72f6392615b18a6fee3dcce0bbbf527da96fb7cad5155c41001a07e0`).
 
 Could Task B make a genuinely wrong entry pass? **No.** Successful equality requires both filesystem resolutions and exact equality of their canonical results. The wrong-target fixture is specifically a symlink plus same-named file in another directory—the two permissive mistakes this change could otherwise invite—and it stays UNKNOWN with zero receipts. Resolution failure is also explicitly refused.
+
+## 2026-08-18 06:04:14 -0700 (PDT) — W4-R: regular-file identity repair
+
+### Independent finding and correction
+
+J8 demonstrated that the preceding “genuinely wrong entry” conclusion was incorrect. The comparator required equal canonical paths but did not require either resolved operand to be a regular file. Consequently a declared directory compared equal to itself while Node executed its contained `index.js`; the end-to-end control minted one authenticated receipt and returned `proven`. A symlink chain ending at a directory had the same defect. The earlier operator-binding run remains a real execution fact but its certification is inadmissible until this repair is re-proved.
+
+The deciding J8 output was:
+
+```text
+[fix-verifier-wiring] authenticated guard=j8-directory-entry entry=entry-dir childPid=11777 childExit=0
+{"directoryComparisonAccepted":true,"executedContainedFile":true,"wrapperExit":0,"authenticatedReceipts":1,"verdict":"proven"}
+```
+
+J8 names both consumers of the comparison: the parent-side authenticated `observer-ready` / `child-start` identity validation and the generated observer's target selection. The repair requires both canonical operands to pass `statSync(...).isFile()` before exact real-path equality can succeed in both locations. No authentication, signing, sequencing, receipt binding, manifest, adapter, or enforcement-evidence logic changed.
+
+### Authenticated negative fixtures
+
+The full observer/authority controls now exercise both omitted cases. In each case Node really executes the contained index file, but the generated observer emits no authenticated target events, the authority mints zero receipts, C3 emits no short-circuit, and the envelope remains `unknown`:
+
+```text
+W4R_DIRECTORY executedContainedFile=true authenticatedEvents=0 authenticatedReceipts=0 verdict=UNKNOWN
+W4R_DIRECTORY_SYMLINK chainEndsAtDirectory=true executedContainedFile=true authenticatedEvents=0 authenticatedReceipts=0 verdict=UNKNOWN
+```
+
+The pre-proof focused suite passed 24/24:
+
+```text
+node --test scratchpad/phaseB/authenticated-execution-receipt.test.mjs scratchpad/phaseB/fix-verifier.test.mjs
+tests=24 pass=24 fail=0
+```
+
+Pre-proof amended instrument SHA-256: `c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a`.
+
+Operator-binding certification status at this point: **UNKNOWN pending a fresh wiring proof with the repaired instrument**.

--- a/scratchpad/phaseB/REPORT-W4.md
+++ b/scratchpad/phaseB/REPORT-W4.md
@@ -124,3 +124,17 @@ tests=24 pass=24 fail=0
 Pre-proof amended instrument SHA-256: `c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a`.
 
 Operator-binding certification status at this point: **UNKNOWN pending a fresh wiring proof with the repaired instrument**.
+
+### Repaired operator-binding proof
+
+At `2026-08-18 06:07:51 -0700 (PDT)`, the committed repaired instrument re-ran the same wiring-only operator-binding measurement against clean target `4318a1e150e9a8304e6c2e7ad381bf66d03998e5`. The protected base resolved to `248ed7177f5bf416aa7bdad9763741478195e1fc`; the target remained unchanged by measurement.
+
+The real positive run authenticated three signed observer events and minted exactly one post-child receipt. C3 authenticated the observer short-circuit and minted zero guard execution receipts. The deciding verdict line, verbatim, was:
+
+```text
+[fix-verifier-wiring] authenticated guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs childPid=77868 childExit=0
+```
+
+After verdict: **PROVEN**, wiring-only rung **WIRED**. Unlike the superseded W4 certification, this result is admissible under the repaired regular-file identity predicate and the two authenticated negative fixtures.
+
+Evidence: `scratchpad/phaseB/evidence/W4R-topic-operator-evidence.json` (SHA-256 `c877831e3e0d03621eb41469f82282af8168e7847f423c4dc3bf3963fe1f700c`). Instrument SHA-256: `c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a`.

--- a/scratchpad/phaseB/REPORT-W4.md
+++ b/scratchpad/phaseB/REPORT-W4.md
@@ -1,0 +1,91 @@
+# Phase B Lane W4 — conversion of the two UNKNOWN wiring proofs
+
+> **Append-only chronology:** entries are recorded in execution order. Task A was completed before Task B began.
+
+## 2026-08-18 05:33:21 -0700 (PDT) — Task A: coverage claim
+
+### Before
+
+J7's hardened re-gate of PR #1922 at `c0e77e8e11000c54be1b96604752cdbd30eabc20` was **UNKNOWN**. Both pipeline passes stopped before the declared checker with zero observer lines because the protected pipeline rejected stale model-registry review metadata:
+
+```text
+FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window.
+```
+
+The instrument verdict line was:
+
+```text
+    "outcome": "unknown",
+```
+
+### Conversion attempt and after
+
+PR #1922's branch `phaseb/f1-blind-checker-ratchet` was rebased cleanly onto server-fetched protected main `248ed7177f5bf416aa7bdad9763741478195e1fc`. Its new head is `3801aefe9825e1258f5f235c123c56bee9e6a98b`, and the branch was pushed with a lease pinned to the previously observed head. No model-registry manifest, freshness gate, CI configuration, checker, or test was changed.
+
+The wiring-only proof used the unchanged certified PR #1924 instrument, SHA-256 `584a0a0b7248c4bede3f99e58f369db2183ca298fc5c1209862a6e3dc41edd72`, and the same manifest and adapter bytes J7 used. The protected lint pipeline now reached the exact declared checker and authenticated all three observer events, but the checker exited 1 and therefore minted no successful execution receipt. Its own Vitest fixture expected legacy Node test-runner summary text `# tests 4`; Node 25 emitted `ℹ tests 4`.
+
+The new deciding line is:
+
+```text
+checker-blind-input: NOT-PROVEN — executable blind cases exited 1
+```
+
+The instrument verdict remains, verbatim:
+
+```text
+    "outcome": "unknown",
+```
+
+Task A after-verdict: **UNKNOWN**. Per the brief, the run stopped here; the pipeline was not massaged and the verdict was not promoted. Evidence: `scratchpad/phaseB/evidence/W4-checker-blind-input-coverage.json` (`4fa11fc9c00b40038e95ddca2445971b2be0604ccae3e060bb9823a94879aa4f`).
+
+Could Task A make a genuinely wrong entry pass? **No.** The only branch change was rebasing the existing PR commits onto protected main. The certified instrument, declared entry, checker, pipeline, and all entry-matching behavior were unchanged for this measurement; the result stayed UNKNOWN.
+
+## 2026-08-18 05:33:21 -0700 (PDT) — Task B: operator-binding claim
+
+### Before
+
+J7's hardened re-gate was **UNKNOWN** even though three observer events authenticated, because the live child used the `.bin` shim spelling and the manifest declared the module entry spelling:
+
+```text
+observed child pid was not the exact declared descendant process
+```
+
+The instrument verdict line was:
+
+```text
+    "outcome": "unknown",
+```
+
+### Precision fix
+
+Only declared-entry path comparison changed. Both observed and declared spellings must resolve successfully through `fs.realpathSync`, and their resulting real-path strings must be exactly equal. Any resolution failure returns false. There is no prefix comparison, basename comparison, fallback lexical comparison, or other "close enough" direction. Authentication authority, signing, event sequence/identity checks, receipt binding, manifest, adapters, and enforcement-evidence logic were not changed.
+
+Fixture deciding output:
+
+```text
+W4_POSITIVE shimRealPathEqualsModule=true authenticatedReceipts=1 verdict=PROVEN
+W4_NEGATIVE symlinkTargetsDifferentSameNamedFile=true authenticatedReceipts=0 verdict=UNKNOWN
+```
+
+The positive fixture proves that a `.bin` symlink and module spelling of the same real file are accepted. The negative fixture makes a `.bin/vitest` symlink point to a different `vitest.mjs` in another directory; despite the same basename and successful wrapper exit, it receives zero authenticated receipts and the verdict is not promoted. A separate control proves two missing equal spellings, one missing side, and an empty side all refuse rather than match.
+
+Focused suite:
+
+```text
+node --test scratchpad/phaseB/authenticated-execution-receipt.test.mjs scratchpad/phaseB/fix-verifier.test.mjs
+tests=22 pass=22 fail=0
+```
+
+### After
+
+The amended instrument SHA-256 is `e49d10fd4d98a93a8011efa6807d180cab56fdf5a7745744879bad7c0afb4897`. The wiring-only proof re-ran against J7's exact target `4318a1e150e9a8304e6c2e7ad381bf66d03998e5`, with protected main resolved to `248ed7177f5bf416aa7bdad9763741478195e1fc`.
+
+The observed argv used the `.bin/vitest` spelling, all three observer events authenticated, the real child exited 0, exactly one authenticated child-exit receipt was minted, and C3 produced zero guard execution receipts. The instrument verdict line was, verbatim:
+
+```text
+[fix-verifier-wiring] authenticated guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs childPid=91450 childExit=0
+```
+
+Task B after-verdict: **PROVEN**, wiring-only rung **WIRED**. Evidence: `scratchpad/phaseB/evidence/W4-topic-operator-evidence.json` (`e3fedbdd72f6392615b18a6fee3dcce0bbbf527da96fb7cad5155c41001a07e0`).
+
+Could Task B make a genuinely wrong entry pass? **No.** Successful equality requires both filesystem resolutions and exact equality of their canonical results. The wrong-target fixture is specifically a symlink plus same-named file in another directory—the two permissive mistakes this change could otherwise invite—and it stays UNKNOWN with zero receipts. Resolution failure is also explicitly refused.

--- a/scratchpad/phaseB/adapters/acceptance-fixtures.mjs
+++ b/scratchpad/phaseB/adapters/acceptance-fixtures.mjs
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export function absolute(root, rel) {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`path escapes isolated root: ${rel}`);
+  }
+  return resolved;
+}
+export function read(root, rel) {
+  return fs.readFileSync(absolute(root, rel), 'utf8');
+}
+
+export function write(root, rel, text) {
+  const target = absolute(root, rel);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, text, 'utf8');
+}
+
+export function replaceOnce(root, rel, before, after) {
+  const content = read(root, rel);
+  const first = content.indexOf(before);
+  const last = content.lastIndexOf(before);
+  if (first === -1 || first !== last) {
+    throw new Error(`${rel}: expected one replacement target; first=${first} last=${last}`);
+  }
+  write(root, rel, `${content.slice(0, first)}${after}${content.slice(first + before.length)}`);
+}
+
+export function replaceThroughMarker(root, rel, startToken, endToken, replacement, fromToken = null) {
+  const content = read(root, rel);
+  const from = fromToken === null ? 0 : content.indexOf(fromToken);
+  if (from < 0) throw new Error(`${rel}: anchor missing: ${fromToken}`);
+  const start = content.indexOf(startToken, from);
+  if (start < 0) throw new Error(`${rel}: start token missing after anchor: ${startToken}`);
+  const end = content.indexOf(endToken, start + startToken.length);
+  if (end < 0) throw new Error(`${rel}: end token missing after start: ${endToken}`);
+  write(root, rel, `${content.slice(0, start)}${replacement}${content.slice(end)}`);
+}
+
+export function commentAll(root, rel) {
+  write(root, rel, read(root, rel).split('\n').map((line) => `// ${line}`).join('\n'));
+}
+
+export function checksResult(checks) {
+  return { ok: checks.every((item) => item.passed), checks };
+}
+
+export function includesChecks(root, rel, included = [], excluded = []) {
+  const content = read(root, rel);
+  return checksResult([
+    ...included.map((token) => ({ check: `${rel} includes ${JSON.stringify(token)}`, passed: content.includes(token) })),
+    ...excluded.map((token) => ({ check: `${rel} excludes ${JSON.stringify(token)}`, passed: !content.includes(token) })),
+  ]);
+}
+
+export function writeVitestConfig(root) {
+  write(root, '.b0-fix-verifier.vitest.config.mjs', `export default {\n  test: {\n    environment: 'node',\n    fileParallelism: false,\n    testTimeout: 20_000,\n    hookTimeout: 20_000,\n  },\n};\n`);
+}
+
+export function run(root, argv) {
+  const result = spawnSync(argv[0], argv.slice(1), {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30_000,
+  });
+  return {
+    exitCode: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    error: result.error?.message ?? null,
+  };
+}
+
+export function structuredRelevance(mode, checks) {
+  return {
+    status: checks.every((item) => item.passed) ? 'proven' : 'unknown',
+    mode,
+    checks,
+  };
+}

--- a/scratchpad/phaseB/adapters/audit-convergence-validator.mjs
+++ b/scratchpad/phaseB/adapters/audit-convergence-validator.mjs
@@ -1,0 +1,358 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const VALIDATOR = 'scripts/write-audit-convergence.mjs';
+const GUARD_IMPLEMENTATION = 'scripts/write-audit-convergence.mjs';
+const CI_RATCHET = 'tests/unit/audit-convergence-reports.test.ts';
+const UNIT_GUARD = 'tests/unit/write-audit-convergence.test.ts';
+const STANDARDS = 'docs/STANDARDS-REGISTRY.md';
+const ENUMERATED_AUDIT_INPUT = 'docs/audits/full-decision-visibility-enactment.md';
+
+function absolute(root, rel) {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`path escapes isolated root: ${rel}`);
+  }
+  return resolved;
+}
+function read(root, rel) {
+  return fs.readFileSync(absolute(root, rel), 'utf8');
+}
+
+function write(root, rel, content) {
+  fs.writeFileSync(absolute(root, rel), content, 'utf8');
+}
+
+function replaceOnce(root, rel, before, after) {
+  const content = read(root, rel);
+  const first = content.indexOf(before);
+  const last = content.lastIndexOf(before);
+  if (first === -1 || first !== last) {
+    throw new Error(`${rel}: expected exactly one replacement target; first=${first} last=${last}`);
+  }
+  write(root, rel, `${content.slice(0, first)}${after}${content.slice(first + before.length)}`);
+}
+
+function replaceFunctionThroughMarker(root, rel, signature, endMarker, replacement) {
+  const content = read(root, rel);
+  const start = content.indexOf(signature);
+  if (start === -1 || content.indexOf(signature, start + signature.length) !== -1) {
+    throw new Error(`${rel}: function signature is missing or ambiguous: ${signature}`);
+  }
+  const end = content.indexOf(endMarker, start);
+  if (end === -1) throw new Error(`${rel}: end marker missing after ${signature}`);
+  write(root, rel, `${content.slice(0, start)}${replacement}${content.slice(end)}`);
+}
+
+function runGit(root, args) {
+  const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  if (result.error || result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.error?.message ?? result.stderr ?? result.stdout}`);
+  }
+}
+
+function verifyIncludes(root, rel, included, excluded = []) {
+  const content = read(root, rel);
+  const checks = [
+    ...included.map((value) => ({ check: `${rel} includes ${JSON.stringify(value)}`, passed: content.includes(value) })),
+    ...excluded.map((value) => ({ check: `${rel} excludes ${JSON.stringify(value)}`, passed: !content.includes(value) })),
+  ];
+  return { ok: checks.every((item) => item.passed), checks };
+}
+
+export const pipelineCommands = [
+  {
+    argv: [
+      'npm', 'run', 'test:push', '--',
+      CI_RATCHET,
+      UNIT_GUARD,
+      '--reporter=verbose',
+    ],
+    observeAny: [
+      'audit-convergence CI ratchet',
+      'validateAuditReport',
+      'write-audit-convergence',
+      'No test files found',
+    ],
+    timeoutMs: 300_000,
+  },
+];
+
+export const guardCommands = [
+  {
+    argv: [
+      'node_modules/.bin/vitest', 'run',
+      CI_RATCHET,
+      UNIT_GUARD,
+      '--config=.b0-fix-verifier.vitest.config.mjs',
+      '--reporter=verbose',
+    ],
+    observeAny: [
+      'audit-convergence CI ratchet',
+      'validateAuditReport',
+      'write-audit-convergence',
+      'No test files found',
+    ],
+    timeoutMs: 60_000,
+  },
+];
+
+export function prepareWorkspace(root) {
+  write(root, '.b0-fix-verifier.vitest.config.mjs', `export default {\n  test: {\n    environment: 'node',\n    fileParallelism: false,\n    testTimeout: 10_000,\n  },\n};\n`);
+}
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+  const routed = changedPaths.some((rel) => declared.has(rel));
+  if (mutation.id === 'p4b-hidden-real-violation') {
+    const outsideEnumeration = changedPaths.some((rel) => rel.startsWith('docs/phase-b-b0-4-hidden/'));
+    const planted = outsideEnumeration && fs.existsSync(absolute(root, changedPaths.find((rel) => outsideEnumeration && rel)));
+    const rel = changedPaths.find((item) => item.startsWith('docs/phase-b-b0-4-hidden/'));
+    const auditShaped = planted && /^---\naudit:/m.test(read(root, rel));
+    return {
+      status: outsideEnumeration && planted && auditShaped ? 'proven' : 'unknown',
+      mode: 'outside-enumeration',
+      checks: [
+        { check: 'planted path is outside docs/audits/ and outside declared baseline inputs', passed: outsideEnumeration && rel && !declared.has(rel) },
+        { check: 'planted path exists in isolated tree', passed: planted },
+        { check: 'planted bytes are a real audit-frontmatter violation', passed: auditShaped },
+      ],
+    };
+  }
+  let semantic = false;
+  if (mutation.id === 'p1-symbol-preserving-hollow') semantic = read(root, VALIDATOR).includes('B0.4 symbol-preserving inert stub');
+  if (mutation.id === 'p2-subject-self-reports-clean') semantic = read(root, VALIDATOR).includes('B0.4 false testimony');
+  if (mutation.id === 'p3a-delete') semantic = [CI_RATCHET, UNIT_GUARD].every((rel) => !fs.existsSync(absolute(root, rel)));
+  if (mutation.id === 'p3b-comment-out') semantic = [CI_RATCHET, UNIT_GUARD].every((rel) => read(root, rel).split('\n').filter(Boolean).every((line) => line.startsWith('// ')));
+  if (mutation.id === 'p3c-superstring-rename') semantic = [CI_RATCHET, UNIT_GUARD].every((rel) => read(root, rel).includes('validateAuditReportDisabled') && !/\bvalidateAuditReport\b/.test(read(root, rel)));
+  if (mutation.id === 'p3d-type-preserving-hollow') semantic = read(root, GUARD_IMPLEMENTATION).includes('B0.4 type-preserving hollow');
+  if (mutation.id === 'p4a-empty-population') semantic = read(root, CI_RATCHET).includes('B0.4 forced vacuous denominator');
+  if (mutation.id === 'p5-blind-input') {
+    const blinded = `${ENUMERATED_AUDIT_INPUT}.b0-4-blinded`;
+    semantic = !fs.existsSync(absolute(root, ENUMERATED_AUDIT_INPUT)) && fs.existsSync(absolute(root, blinded)) && /^---\naudit:/m.test(read(root, blinded));
+  }
+  return {
+    status: routed && semantic ? 'proven' : 'unknown',
+    mode: 'declared-load-bearing-input',
+    checks: [
+      { check: 'changed path routed through declared guard/subject set', passed: routed },
+      { check: `semantic mutation ${mutation.id} changes the load-bearing body/input`, passed: semantic },
+    ],
+  };
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-hollow',
+    property: 'P1',
+    violationClass: 'hollowing',
+    label: 'SYMBOL-PRESERVING HOLLOW',
+    paths: [VALIDATOR],
+    apply(root) {
+      replaceFunctionThroughMarker(
+        root,
+        VALIDATOR,
+        'export function stampConverged(text, roundsCount, nowIso) {',
+        '\n// ─── main ───────────────────────────────────────────────────────────────────',
+        `export function stampConverged(text, roundsCount, nowIso) {\n  // B0.4 symbol-preserving inert stub: same API, no state transition.\n  void roundsCount;\n  void nowIso;\n  return text;\n}\n`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, VALIDATOR, [
+        'export function stampConverged(text, roundsCount, nowIso) {',
+        'B0.4 symbol-preserving inert stub',
+        'return text;',
+      ]);
+    },
+  },
+  {
+    id: 'p2-subject-self-reports-clean',
+    property: 'P2',
+    violationClass: 'self-report / false testimony',
+    label: 'SUBJECT SELF-REPORTS CLEAN',
+    paths: [VALIDATOR],
+    apply(root) {
+      replaceFunctionThroughMarker(
+        root,
+        VALIDATOR,
+        'export function validateAuditReport(text, opts = {}) {',
+        '\n// ─── stamping (byte-idempotent) ─────────────────────────────────────────────',
+        `export function validateAuditReport(text, opts = {}) {\n  // B0.4 false testimony: behavior is not inspected, but the subject claims clean.\n  void text;\n  void opts;\n  return {\n    ok: true,\n    reason: 'subject-self-reports-clean',\n    rounds: [{ n: 1 }, { n: 2 }],\n    responseKind: 'no-change',\n  };\n}\n`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, VALIDATOR, [
+        'export function validateAuditReport(text, opts = {}) {',
+        'B0.4 false testimony',
+        "reason: 'subject-self-reports-clean'",
+      ]);
+    },
+  },
+  {
+    id: 'p3a-delete',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'DELETE',
+    paths: [CI_RATCHET, UNIT_GUARD],
+    apply(root) {
+      fs.unlinkSync(absolute(root, CI_RATCHET));
+      fs.unlinkSync(absolute(root, UNIT_GUARD));
+    },
+    verify(root) {
+      const checks = [CI_RATCHET, UNIT_GUARD].map((rel) => ({
+        check: `${rel} is absent`,
+        passed: !fs.existsSync(absolute(root, rel)),
+      }));
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+  {
+    id: 'p3b-comment-out',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'COMMENT OUT',
+    paths: [CI_RATCHET, UNIT_GUARD],
+    apply(root) {
+      for (const rel of [CI_RATCHET, UNIT_GUARD]) {
+        write(root, rel, read(root, rel).split('\n').map((line) => `// ${line}`).join('\n'));
+      }
+    },
+    verify(root) {
+      const checks = [CI_RATCHET, UNIT_GUARD].map((rel) => {
+        const lines = read(root, rel).split('\n').filter((line) => line.length > 0);
+        return { check: `${rel} has no executable non-comment line`, passed: lines.length > 0 && lines.every((line) => line.startsWith('// ')) };
+      });
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+  {
+    id: 'p3c-superstring-rename',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'SUPERSTRING RENAME',
+    paths: [CI_RATCHET, UNIT_GUARD],
+    apply(root) {
+      for (const rel of [CI_RATCHET, UNIT_GUARD]) {
+        const content = read(root, rel);
+        if (!content.includes('validateAuditReport')) throw new Error(`${rel}: validateAuditReport symbol missing`);
+        write(root, rel, content.replaceAll('validateAuditReport', 'validateAuditReportDisabled'));
+      }
+    },
+    verify(root) {
+      const checks = [CI_RATCHET, UNIT_GUARD].flatMap((rel) => {
+        const content = read(root, rel);
+        return [
+          { check: `${rel} contains longer superstring`, passed: content.includes('validateAuditReportDisabled') },
+          { check: `${rel} still contains original substring`, passed: content.includes('validateAuditReport') },
+          { check: `${rel} has no standalone original symbol`, passed: !/\bvalidateAuditReport\b/.test(content) },
+        ];
+      });
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+  {
+    id: 'p3d-type-preserving-hollow',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'TYPE-PRESERVING HOLLOW',
+    paths: [GUARD_IMPLEMENTATION],
+    apply(root) {
+      replaceFunctionThroughMarker(
+        root,
+        GUARD_IMPLEMENTATION,
+        'export function validateAuditReport(text, opts = {}) {',
+        '\n// ─── stamping (byte-idempotent) ─────────────────────────────────────────────',
+        `export function validateAuditReport(text, opts = {}) {
+  // B0.4 type-preserving hollow: constant passing verdict; suite must assert behavior.
+  void text;
+  void opts;
+  return { ok: true, rounds: [{ n: 1 }, { n: 2 }], responseKind: 'no-change' };
+}
+`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, GUARD_IMPLEMENTATION, [
+        'export function validateAuditReport(text, opts = {}) {',
+        'B0.4 type-preserving hollow',
+        "return { ok: true, rounds: [{ n: 1 }, { n: 2 }], responseKind: 'no-change' };",
+      ]);
+    },
+  },
+  {
+    id: 'p4a-empty-population',
+    property: 'P4',
+    violationClass: 'vacuous measurement',
+    label: 'EMPTY THE POPULATION',
+    paths: [CI_RATCHET],
+    apply(root) {
+      const before = `function committedDocsMd(): string[] {\n  const out = execFileSync('git', ['ls-files', 'docs/**/*.md'], { cwd: ROOT, encoding: 'utf8' });\n  return out.split('\\n').map((s) => s.trim()).filter(Boolean);\n}`;
+      const after = `function committedDocsMd(): string[] {\n  // B0.4 forced vacuous denominator.\n  return [];\n}`;
+      replaceOnce(root, CI_RATCHET, before, after);
+    },
+    verify(root) {
+      return verifyIncludes(root, CI_RATCHET, ['B0.4 forced vacuous denominator', 'return [];']);
+    },
+  },
+  {
+    id: 'p4b-hidden-real-violation',
+    property: 'P4',
+    violationClass: 'population evasion',
+    label: 'HIDE A REAL VIOLATION OUTSIDE THE PRIMARY ENUMERATION',
+    paths: ['docs/phase-b-b0-4-hidden/audit-outside-canonical-root.md'],
+    apply(root) {
+      const rel = this.paths[0];
+      fs.mkdirSync(path.dirname(absolute(root, rel)), { recursive: true });
+      write(root, rel, `---\naudit: "outside-canonical-root"\nconverged: "2099-01-01T00:00:00.000Z"\n---\n\n# Real audit-shaped violation outside docs/audits/\n`);
+      // The CI ratchet enumerates committed/indexed docs. Stage only inside the isolated clone.
+      runGit(root, ['add', '--', rel]);
+    },
+    verify(root) {
+      const rel = this.paths[0];
+      const content = read(root, rel);
+      const indexed = spawnSync('git', ['ls-files', '--error-unmatch', rel], { cwd: root, encoding: 'utf8' });
+      const checks = [
+        { check: `${rel} contains audit frontmatter`, passed: /^---\naudit:/m.test(content) },
+        { check: `${rel} is outside docs/audits/`, passed: rel.startsWith('docs/') && !rel.startsWith('docs/audits/') },
+        { check: `${rel} is in the isolated Git index`, passed: indexed.status === 0 },
+      ];
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+  {
+    id: 'p5-blind-input',
+    property: 'P5',
+    violationClass: 'blind input / fail-open',
+    label: 'BLIND THE GUARD',
+    paths: [ENUMERATED_AUDIT_INPUT, `${ENUMERATED_AUDIT_INPUT}.b0-4-blinded`],
+    apply(root) {
+      fs.renameSync(
+        absolute(root, ENUMERATED_AUDIT_INPUT),
+        absolute(root, `${ENUMERATED_AUDIT_INPUT}.b0-4-blinded`),
+      );
+    },
+    verify(root) {
+      const checks = [
+        { check: `${ENUMERATED_AUDIT_INPUT} is unavailable`, passed: !fs.existsSync(absolute(root, ENUMERATED_AUDIT_INPUT)) },
+        { check: 'blinded control file retains the bytes', passed: fs.existsSync(absolute(root, `${ENUMERATED_AUDIT_INPUT}.b0-4-blinded`)) },
+      ];
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+];
+
+export function applyDeliberatelyHollowGuard(root) {
+  const hollow = `import { describe, it, expect } from 'vitest';\n\ndescribe('audit-convergence deliberately hollow guard', () => {\n  it('self-reports clean without inspecting the subject', () => {\n    expect(true).toBe(true);\n  });\n});\n`;
+  for (const rel of [CI_RATCHET, UNIT_GUARD]) write(root, rel, hollow);
+  return {
+    paths: [CI_RATCHET, UNIT_GUARD],
+    verify() {
+      const checks = [CI_RATCHET, UNIT_GUARD].map((rel) => ({
+        check: `${rel} carries deliberate hollow marker`,
+        passed: read(root, rel).includes('audit-convergence deliberately hollow guard'),
+      }));
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  };
+}

--- a/scratchpad/phaseB/adapters/b0-4-execution-proof.mjs
+++ b/scratchpad/phaseB/adapters/b0-4-execution-proof.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const [adapterPathArg, repoArg, commitArg, nodeModulesArg, outputArg] = process.argv.slice(2);
+if (![adapterPathArg, repoArg, commitArg, nodeModulesArg, outputArg].every(Boolean)) {
+  throw new Error('usage: b0-4-execution-proof.mjs <adapter> <repo> <commit> <node_modules> <output>');
+}
+
+const adapterPath = fs.realpathSync(adapterPathArg);
+const repo = fs.realpathSync(repoArg);
+const nodeModules = fs.realpathSync(nodeModulesArg);
+const output = path.resolve(outputArg);
+const adapter = await import(`${pathToFileURL(adapterPath).href}?proof=${Date.now()}`);
+const manifest = JSON.parse(fs.readFileSync(path.join(path.dirname(adapterPath), '..', 'fix-verifier.manifest.json'), 'utf8'));
+const manifestEntry = manifest.adapters.find((entry) => path.basename(entry.adapter) === path.basename(adapterPath));
+if (!manifestEntry) throw new Error(`adapter has no manifest entry: ${adapterPath}`);
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'b0-4-execution-proof-'));
+
+function spawn(argv, cwd, timeoutMs = 180_000) {
+  const result = spawnSync(argv[0], argv.slice(1), {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, CI: '1', B0_4_EXECUTION_PROOF: '1' },
+    timeout: timeoutMs,
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const combined = `${stdout}\n${stderr}`;
+  const decidingLines = combined.split('\n').filter((line) =>
+    /Test Files|Tests\s+(?:\d+|no tests)|AssertionError|expected|received|No test files found|Cannot find name|failed to load|Transform failed|ERR_MODULE_NOT_FOUND|B0\.4-|lint-no-unregistered-self-action:/.test(line),
+  ).slice(-20);
+  let decidingKind = 'no-deciding-output';
+  if (/No test files found|Tests\s+no tests|Cannot find name|failed to load|Transform failed|ERR_MODULE_NOT_FOUND|does not provide an export|ReferenceError/.test(combined)) decidingKind = 'compile-or-no-tests';
+  else if (result.status === 0) decidingKind = 'suite-passed';
+  else if (/AssertionError|expected|received|(?:Test Files|Tests)\s+\d+\s+failed|violation\(s\)/.test(combined)) decidingKind = 'assertion-or-test-failure';
+  return {
+    argv,
+    exitCode: result.status,
+    signal: result.signal ?? null,
+    error: result.error?.message ?? null,
+    decidingOutput: { kind: decidingKind, lines: decidingLines },
+    stdoutTail: stdout.split('\n').slice(-40),
+    stderrTail: stderr.split('\n').slice(-40),
+  };
+}
+
+function requireOk(argv, cwd) {
+  const result = spawn(argv, cwd, 120_000);
+  if (result.exitCode !== 0 || result.error) throw new Error(`${argv.join(' ')} failed: ${JSON.stringify(result)}`);
+}
+
+let copyIndex = 0;
+function cloneCase(label) {
+  const root = path.join(tempRoot, `${String(++copyIndex).padStart(2, '0')}-${label.replace(/[^a-zA-Z0-9_-]/g, '-')}`);
+  requireOk(['git', 'clone', '--shared', '--no-checkout', '--quiet', repo, root], tempRoot);
+  requireOk(['git', 'checkout', '--detach', '--quiet', commitArg], root);
+  fs.symlinkSync(nodeModules, path.join(root, 'node_modules'), 'dir');
+  adapter.prepareWorkspace?.(root);
+  return root;
+}
+
+function runCommands(root) {
+  return adapter.guardCommands.map((command) => spawn(command.argv, root, command.timeoutMs));
+}
+
+function snapshot(root, rel) {
+  try {
+    const stat = fs.lstatSync(path.join(root, rel));
+    return {
+      exists: true,
+      mode: (stat.mode % 0o1000).toString(8).padStart(3, '0'),
+      bytes: stat.isFile() ? stat.size : null,
+      sha256: stat.isFile() && (stat.mode % 0o1000) !== 0 ? crypto.createHash('sha256').update(fs.readFileSync(path.join(root, rel))).digest('hex') : null,
+    };
+  } catch (error) {
+    return { exists: false, error: error.code ?? error.message };
+  }
+}
+
+const record = {
+  schemaVersion: 1,
+  purpose: 'mutation execution proof only; no instrument verdict is derived',
+  adapter: adapterPath,
+  pinnedCommit: commitArg,
+  positive: null,
+  mutations: [],
+};
+
+try {
+  const positiveRoot = cloneCase('positive');
+  record.positive = { runs: runCommands(positiveRoot) };
+
+  for (const mutation of adapter.mutations) {
+    const root = cloneCase(mutation.id);
+    const before = Object.fromEntries(mutation.paths.map((rel) => [rel, snapshot(root, rel)]));
+    let applyError = null;
+    let verification = { ok: false, checks: [] };
+    let relevance = { status: 'unknown', mode: 'not-run', checks: [] };
+    try {
+      mutation.apply(root);
+      verification = mutation.verify(root);
+      const afterForRelevance = Object.fromEntries(mutation.paths.map((rel) => [rel, snapshot(root, rel)]));
+      const changedPaths = mutation.paths.filter((rel) => JSON.stringify(before[rel]) !== JSON.stringify(afterForRelevance[rel]));
+      relevance = adapter.verifyMutationRelevant({
+        root,
+        mutation,
+        changedPaths,
+        guardFiles: manifestEntry.guardFiles,
+        subjectFiles: manifestEntry.subjectFiles,
+      });
+    } catch (error) {
+      applyError = error.message;
+    }
+    const runs = applyError ? [] : runCommands(root);
+    const after = Object.fromEntries(mutation.paths.map((rel) => [rel, snapshot(root, rel)]));
+    const changedPaths = mutation.paths.filter((rel) => JSON.stringify(before[rel]) !== JSON.stringify(after[rel]));
+    record.mutations.push({
+      id: mutation.id,
+      property: mutation.property,
+      violationClass: mutation.violationClass,
+      applyError,
+      verification,
+      relevance,
+      proof: { before, after, changedPaths },
+      runs,
+    });
+  }
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+fs.mkdirSync(path.dirname(output), { recursive: true });
+fs.writeFileSync(output, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+console.log(JSON.stringify({
+  adapter: path.basename(adapterPath),
+  pinnedCommit: record.pinnedCommit,
+  positive: record.positive.runs.map((run) => ({ exitCode: run.exitCode, decidingOutput: run.decidingOutput })),
+  mutations: record.mutations.map((item) => ({
+    id: item.id,
+    applyError: item.applyError,
+    verification: item.verification.ok,
+    relevance: item.relevance.status,
+    runs: item.runs.map((run) => ({ exitCode: run.exitCode, decidingOutput: run.decidingOutput })),
+  })),
+}, null, 2));

--- a/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs
+++ b/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ENTRY = 'scripts/lint-checker-blind-input-coverage.mjs';
+const GUARD = 'scripts/lib/checker-blind-input-ratchet.mjs';
+const GUARD_TEST = 'tests/unit/checker-blind-input-ratchet.test.ts';
+const ATTRIBUTION = 'scripts/lint-llm-attribution.js';
+const PLANTED = 'scripts/phase-b/deep/lint-s3-uncovered.mjs';
+
+function absolute(root, rel) {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) throw new Error(`path escapes isolated root: ${rel}`);
+  return resolved;
+}
+function read(root, rel) { return fs.readFileSync(absolute(root, rel), 'utf8'); }
+function write(root, rel, content) {
+  fs.mkdirSync(path.dirname(absolute(root, rel)), { recursive: true });
+  fs.writeFileSync(absolute(root, rel), content, 'utf8');
+}
+function verification(checks) { return { ok: checks.every((item) => item.passed), checks }; }
+function replaceOnce(root, rel, before, after) {
+  const content = read(root, rel);
+  const first = content.indexOf(before);
+  if (first === -1 || first !== content.lastIndexOf(before)) throw new Error(`${rel}: replacement target missing or ambiguous`);
+  write(root, rel, `${content.slice(0, first)}${after}${content.slice(first + before.length)}`);
+}
+function replaceFunctionBody(root, rel, signature, replacement) {
+  const content = read(root, rel);
+  const match = signature.exec(content);
+  if (!match || signature.exec(content)) throw new Error(`${rel}: function signature missing or ambiguous`);
+  const open = match.index + match[0].length - 1;
+  let depth = 0;
+  for (let i = open; i < content.length; i += 1) {
+    if (content[i] === '{') depth += 1;
+    if (content[i] === '}') depth -= 1;
+    if (depth === 0) {
+      write(root, rel, `${content.slice(0, open + 1)}\n${replacement}\n${content.slice(i)}`);
+      return;
+    }
+  }
+  throw new Error(`${rel}: function body did not close`);
+}
+
+export const pipelineCommands = [{
+  argv: ['npm', 'run', 'lint'],
+  observeAny: ['checker-blind-input: population=', 'checker-blind-input: NOT-PROVEN'],
+  timeoutMs: 1_200_000,
+}];
+export const guardCommands = [{
+  argv: [process.execPath, ENTRY],
+  observeAny: ['checker-blind-input', 'checker blind-input class ratchet', 'Test Files'],
+  timeoutMs: 300_000,
+}];
+
+export function prepareWorkspace(root, protectedBaseEvidence) {
+  const expected = protectedBaseEvidence?.commit;
+  if (!/^[a-f0-9]{40}$/.test(expected ?? '')) throw new Error('core did not supply a server-resolved protected base');
+  for (const ref of ['refs/remotes/origin/main', 'refs/remotes/upstream/main', 'refs/heads/main']) {
+    const actual = spawnSync('git', ['rev-parse', `${ref}^{commit}`], { cwd: root, encoding: 'utf8' });
+    if (actual.status !== 0 || actual.stdout.trim() !== expected) {
+      throw new Error(`isolated protected-base ref mismatch: ${ref}`);
+    }
+  }
+}
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+  if (mutation.id === 'p4b-planted-nested-checker') {
+    const planted = changedPaths.includes(PLANTED) && fs.existsSync(absolute(root, PLANTED)) &&
+      read(root, PLANTED).includes('s3PlantedChecker');
+    return { status: planted ? 'proven' : 'unknown', mode: 'outside-enumeration', checks: [
+      { check: 'new nested lint is a real recursively enumerated checker candidate', passed: planted },
+      { check: 'new checker has no blind-case coverage id', passed: !read(root, 'scripts/checker-blind-input-cases.mjs').includes(PLANTED) },
+    ] };
+  }
+  const routed = changedPaths.some((rel) => declared.has(rel));
+  const marker = mutation.marker;
+  const marked = !marker || changedPaths.some((rel) => fs.existsSync(absolute(root, rel)) && read(root, rel).includes(marker));
+  return { status: routed && marked ? 'proven' : 'unknown', mode: 'declared-load-bearing-input', checks: [
+    { check: 'changed path is a declared guard or production subject', passed: routed },
+    { check: marker ? `semantic mutation marker ${marker} is present` : 'exact structural mutation verified', passed: marked },
+  ] };
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-checker-hollow', property: 'P1', violationClass: 'hollowing', label: 'SYMBOL-PRESERVING HOLLOW', paths: [ATTRIBUTION], marker: 'S3 adapter P1',
+    apply(root) {
+      replaceFunctionBody(root, ATTRIBUTION, /export function runLint\(files, \{ allowlist = VIOLATIONS_ALLOWLIST, funnelFiles = FUNNEL_FILES, checkStale = false \} = \{\}\) \{/g,
+        "  // S3 adapter P1: exact API preserved; blind input is fabricated clean.\n  void files; void allowlist; void funnelFiles; void checkStale;\n  return { real: [], stale: [], blind: [] };");
+    },
+    verify(root) { const content = read(root, ATTRIBUTION); return verification([
+      { check: 'runLint export and signature remain', passed: content.includes('export function runLint(files, { allowlist = VIOLATIONS_ALLOWLIST') },
+      { check: 'constant clean result replaced implementation', passed: content.includes('S3 adapter P1') && content.includes('blind: []') },
+    ]); },
+  },
+  {
+    id: 'p2-subject-self-reports-clean', property: 'P2', violationClass: 'self-report / false testimony', label: 'SUBJECT SELF-REPORTS CLEAN', paths: [ATTRIBUTION], marker: 'S3 adapter P2',
+    apply(root) {
+      replaceFunctionBody(root, ATTRIBUTION, /export function runLint\(files, \{ allowlist = VIOLATIONS_ALLOWLIST, funnelFiles = FUNNEL_FILES, checkStale = false \} = \{\}\) \{/g,
+        "  // S3 adapter P2: subject testimony claims every input was inspected.\n  void files; void allowlist; void funnelFiles; void checkStale;\n  return { real: [], stale: [], blind: [], subjectClaim: 'all-inputs-readable' };");
+    },
+    verify(root) { const content = read(root, ATTRIBUTION); return verification([
+      { check: 'subject emits explicit false testimony', passed: content.includes("subjectClaim: 'all-inputs-readable'") },
+      { check: 'independent blind field is falsely empty', passed: content.includes('S3 adapter P2') && content.includes('blind: []') },
+    ]); },
+  },
+  {
+    id: 'p3a-delete', property: 'P3', violationClass: 'guard removal', label: 'DELETE', paths: [GUARD],
+    apply(root) { fs.unlinkSync(absolute(root, GUARD)); },
+    verify(root) { return verification([{ check: `${GUARD} is absent`, passed: !fs.existsSync(absolute(root, GUARD)) }]); },
+  },
+  {
+    id: 'p3b-comment-out', property: 'P3', violationClass: 'guard removal', label: 'COMMENT OUT', paths: [GUARD],
+    apply(root) { write(root, GUARD, read(root, GUARD).split('\n').map((line) => `// ${line}`).join('\n')); },
+    verify(root) { const lines = read(root, GUARD).split('\n').filter(Boolean); return verification([{ check: 'guard has no executable lines', passed: lines.length > 0 && lines.every((line) => line.startsWith('// ')) }]); },
+  },
+  {
+    id: 'p3c-superstring-rename', property: 'P3', violationClass: 'guard removal', label: 'SUPERSTRING RENAME', paths: [GUARD],
+    apply(root) { write(root, GUARD, read(root, GUARD).replaceAll('evaluateBlindInputCoverage', 'evaluateBlindInputCoverageDisabled')); },
+    verify(root) { const content = read(root, GUARD); return verification([
+      { check: 'longer symbol exists', passed: content.includes('evaluateBlindInputCoverageDisabled') },
+      { check: 'standalone original is absent', passed: !/\bevaluateBlindInputCoverage\b/.test(content) },
+    ]); },
+  },
+  {
+    id: 'p3d-type-preserving-hollow', property: 'P3', violationClass: 'guard removal', label: 'TYPE-PRESERVING HOLLOW', paths: [GUARD], marker: 'S3 adapter P3d',
+    apply(root) {
+      replaceFunctionBody(root, GUARD, /export function evaluateBlindInputCoverage\(\{ population, coverageIds, maxUncovered \}\) \{/g,
+        "  // S3 adapter P3d: exact signature/shape retained, constant passing lie.\n  return { passed: true, reason: 'within-ratchet', populationCount: population.length, coveredCount: coverageIds.length, uncovered: [], maxUncovered };");
+    },
+    verify(root) { const content = read(root, GUARD); return verification([
+      { check: 'exact exported evaluator signature remains', passed: content.includes('export function evaluateBlindInputCoverage({ population, coverageIds, maxUncovered }) {') },
+      { check: 'constant passing body is present', passed: content.includes('S3 adapter P3d') && content.includes('passed: true') },
+    ]); },
+  },
+  {
+    id: 'p4a-empty-population', property: 'P4', violationClass: 'vacuous measurement', label: 'EMPTY THE POPULATION', paths: [GUARD], marker: 'S3 adapter P4a',
+    apply(root) {
+      replaceFunctionBody(root, GUARD, /export function deriveCheckerPopulation\(root\) \{/g,
+        '  // S3 adapter P4a: enumeration is forced to the empty set.\n  void root;\n  return [];');
+    },
+    verify(root) { const content = read(root, GUARD); return verification([{ check: 'enumerator is forced empty', passed: content.includes('S3 adapter P4a') && content.includes('return [];') }]); },
+  },
+  {
+    id: 'p4b-planted-nested-checker', property: 'P4', violationClass: 'population evasion', label: 'PLANT A NESTED CHECKER', paths: [PLANTED],
+    apply(root) { write(root, PLANTED, 'export const s3PlantedChecker = true;\n'); },
+    verify(root) { return verification([{ check: 'nested production checker exists', passed: fs.existsSync(absolute(root, PLANTED)) && read(root, PLANTED).includes('s3PlantedChecker') }]); },
+  },
+  {
+    id: 'p5-blind-production-checker', property: 'P5', violationClass: 'blind input / fail-open', label: 'BLIND A POPULATION MEMBER', paths: [ATTRIBUTION],
+    apply(root) { fs.chmodSync(absolute(root, ATTRIBUTION), 0o000); },
+    verify(root) { const mode = fs.statSync(absolute(root, ATTRIBUTION)).mode & 0o777; return verification([{ check: `${ATTRIBUTION} mode is 000`, passed: mode === 0 }]); },
+  },
+];
+
+export function applyDeliberatelyHollowGuard(root) {
+  const hollow = "import { describe, expect, it } from 'vitest';\ndescribe('S3 deliberately hollow guard', () => { it('asserts no behavior', () => expect(true).toBe(true)); });\n";
+  write(root, GUARD_TEST, hollow);
+  return { paths: [GUARD_TEST], verify() { return verification([{ check: 'guard suite is deliberately hollow', passed: read(root, GUARD_TEST).includes('S3 deliberately hollow guard') }]); } };
+}

--- a/scratchpad/phaseB/adapters/guard-posture-probe.mjs
+++ b/scratchpad/phaseB/adapters/guard-posture-probe.mjs
@@ -1,0 +1,237 @@
+import fs from 'node:fs';
+import {
+  absolute,
+  checksResult,
+  commentAll,
+  includesChecks,
+  read,
+  replaceOnce,
+  replaceThroughMarker,
+  run,
+  structuredRelevance,
+  write,
+  writeVitestConfig,
+} from './acceptance-fixtures.mjs';
+
+const GUARD_TEST = 'tests/unit/monitoring/guard-posture-probe.test.ts';
+const PROBE = 'src/monitoring/probes/GuardPostureProbe.ts';
+const SERVER = 'src/commands/server.ts';
+const MACHINE_REGISTRY = '.instar/machines/registry.json';
+const POSTURE_STORE = '.instar/state/guard-posture-peers.json';
+const SOURCE_PROOF = '.b0-guard-posture-source-proof.ts';
+const P4B_PEER_ID = 'm_b0fourpeer0000000000000000000000';
+
+const testCommand = {
+  argv: ['node_modules/.bin/vitest', 'run', GUARD_TEST, '--config=.b0-fix-verifier.vitest.config.mjs', '--reporter=verbose'],
+  observeAny: ['GuardPostureProbe', 'Test Files', 'No test files found', 'AssertionError'],
+  timeoutMs: 120_000,
+};
+
+export const pipelineCommands = [testCommand];
+export const guardCommands = [testCommand];
+
+export function prepareWorkspace(root) {
+  writeVitestConfig(root);
+  write(root, SOURCE_PROOF, `import path from 'node:path';
+import { MachineIdentityManager } from './src/core/MachineIdentity.js';
+import { GuardPostureStore } from './src/core/GuardPostureStore.js';
+import { MachinePoolRegistry } from './src/core/MachinePoolRegistry.js';
+
+const stateDir = path.join(process.cwd(), '.instar');
+const identities = new MachineIdentityManager(stateDir);
+const postureStore = new GuardPostureStore(stateDir);
+const pool = new MachinePoolRegistry({
+  postureStore,
+  listMachines: () => identities.getActiveMachines().map(({ machineId, entry }) => ({ machineId, nickname: entry.nickname })),
+  clockSkewToleranceMs: 300_000,
+  failoverThresholdMs: 900_000,
+  now: () => Date.now(),
+});
+const active = identities.getActiveMachines().filter((m) => m.machineId === '${P4B_PEER_ID}');
+const capacity = pool.getCapacities().find((m) => m.machineId === '${P4B_PEER_ID}');
+const offDeviant = capacity?.guardPosture?.offDeviant ?? null;
+console.log('B0.4-posture-source active=' + active.length + ' capacity=' + (capacity ? 1 : 0) + ' offDeviant=' + offDeviant + ' enumerated=' + Boolean(capacity));
+if (active.length !== 1 || !capacity || offDeviant !== 1 || capacity.guardPosture?.offDeviantKeys[0] !== 'monitoring.sessionReaper.enabled') process.exit(1);
+`);
+}
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+  if (mutation.id === 'p4b-hidden-real-violation') {
+    const sourceProof = run(root, ['node_modules/.bin/vite-node', '--script', SOURCE_PROOF]);
+    return {
+      status: 'unknown',
+      mode: 'outside-enumeration',
+      checks: [
+        { check: 'real MachineIdentity registry and GuardPostureStore inputs changed outside declared unit-guard paths', passed: changedPaths.includes(MACHINE_REGISTRY) && changedPaths.includes(POSTURE_STORE) && !declared.has(MACHINE_REGISTRY) && !declared.has(POSTURE_STORE) },
+        { check: 'production classes load the active peer and actual deviant GuardPostureSummary schema', passed: sourceProof.exitCode === 0 && sourceProof.stdout.includes('active=1 capacity=1 offDeviant=1 enumerated=true') },
+        { check: 'production getPeerPostures maps MachinePoolRegistry.getCapacities, so this real source is enumerated rather than escaped', passed: read(root, SERVER).includes('(machinePoolRegistry?.getCapacities() ?? [])') && read(root, SERVER).includes('posture: m.guardPosture ?? null') },
+      ],
+      reason: 'P4b relevance is unknown: the real active-machine plus durable-posture source is enumerated by production; no honest omitted peer-posture source exists at this unit-guard boundary.',
+      decidingOutput: {
+        kind: 'production-source-enumeration-proof',
+        lines: sourceProof.stdout.split('\n').filter(Boolean),
+        exitCode: sourceProof.exitCode,
+      },
+    };
+  }
+
+  const routed = changedPaths.some((rel) => declared.has(rel));
+  let semantic = false;
+  if (mutation.id === 'p1-symbol-preserving-hollow') semantic = read(root, PROBE).includes('B0.4 inert posture evaluation');
+  if (mutation.id === 'p2-subject-self-reports-clean') semantic = read(root, PROBE).includes('B0.4 false clean posture testimony');
+  if (mutation.id === 'p3a-delete') semantic = !fs.existsSync(absolute(root, GUARD_TEST));
+  if (mutation.id === 'p3b-comment-out') semantic = read(root, GUARD_TEST).split('\n').filter(Boolean).every((line) => line.startsWith('// '));
+  if (mutation.id === 'p3c-superstring-rename') semantic = read(root, GUARD_TEST).includes('function makeProbeDisabled(') && !read(root, GUARD_TEST).includes('function makeProbe(');
+  if (mutation.id === 'p3d-type-preserving-hollow') semantic = read(root, GUARD_TEST).includes('B0.4 type-preserving hollow makeProbe');
+  if (mutation.id === 'p4a-empty-population') semantic = read(root, PROBE).includes('B0.4 empty probe population');
+  if (mutation.id === 'p5-blind-input') {
+    const text = read(root, GUARD_TEST);
+    semantic = text.includes('B0.4 blinded local posture input') && text.includes('local: () => null') && text.includes("expect(result.passed).toBe(true)");
+  }
+  return structuredRelevance('declared-load-bearing-input', [
+    { check: 'changed path intersects the declared load-bearing guard/subject set', passed: routed },
+    { check: `semantic mutation ${mutation.id} changes the load-bearing body/input`, passed: semantic },
+  ]);
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-hollow', property: 'P1', violationClass: 'hollowing', label: 'SYMBOL-PRESERVING HOLLOW', paths: [PROBE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        PROBE,
+        '  async function runTick(): Promise<ProbeResult> {',
+        '\n\n  return [',
+        `  async function runTick(): Promise<ProbeResult> {\n    // B0.4 inert posture evaluation: same function/signature, no state read or anomaly transition.\n    return {\n      probeId, name: probeName, tier, durationMs: 0, passed: true,\n      description: 'No guard-posture anomalies across machines',\n    };\n  }`,
+      );
+    },
+    verify(root) { return includesChecks(root, PROBE, ['async function runTick(): Promise<ProbeResult> {', 'B0.4 inert posture evaluation', 'passed: true']); },
+  },
+  {
+    id: 'p2-subject-self-reports-clean', property: 'P2', violationClass: 'self-report / false testimony', label: 'SUBJECT SELF-REPORTS CLEAN', paths: [PROBE],
+    apply(root) {
+      replaceOnce(
+        root,
+        PROBE,
+        `        return {\n          ...base,\n          passed: false,\n          description: \`Guard-posture anomalies persisting (\${alertable.length}): \${lines.join('; ')}\`,`,
+        `        return {\n          ...base,\n          // B0.4 false clean posture testimony: anomaly behavior and emission remain, verdict lies.\n          passed: true,\n          description: \`Guard-posture anomalies persisting (\${alertable.length}): \${lines.join('; ')}\`,`,
+      );
+    },
+    verify(root) { return includesChecks(root, PROBE, ['B0.4 false clean posture testimony', 'passed: true', 'Guard-posture anomalies persisting']); },
+  },
+  {
+    id: 'p3a-delete', property: 'P3', violationClass: 'guard removal', label: 'DELETE', paths: [GUARD_TEST],
+    apply(root) { fs.unlinkSync(absolute(root, GUARD_TEST)); },
+    verify(root) { return checksResult([{ check: `${GUARD_TEST} is absent`, passed: !fs.existsSync(absolute(root, GUARD_TEST)) }]); },
+  },
+  {
+    id: 'p3b-comment-out', property: 'P3', violationClass: 'guard removal', label: 'COMMENT OUT', paths: [GUARD_TEST],
+    apply(root) { commentAll(root, GUARD_TEST); },
+    verify(root) {
+      const lines = read(root, GUARD_TEST).split('\n').filter(Boolean);
+      return checksResult([{ check: `${GUARD_TEST} has no executable non-comment line`, passed: lines.length > 0 && lines.every((line) => line.startsWith('// ')) }]);
+    },
+  },
+  {
+    id: 'p3c-superstring-rename', property: 'P3', violationClass: 'guard removal', label: 'SUPERSTRING RENAME', paths: [GUARD_TEST],
+    apply(root) { replaceOnce(root, GUARD_TEST, 'function makeProbe(opts:', 'function makeProbeDisabled(opts:'); },
+    verify(root) {
+      const text = read(root, GUARD_TEST);
+      return checksResult([
+        { check: 'longer makeProbeDisabled declaration exists', passed: text.includes('function makeProbeDisabled(') },
+        { check: 'original makeProbe remains a substring', passed: text.includes('makeProbe') },
+        { check: 'original declaration is absent while call sites remain', passed: !text.includes('function makeProbe(') && /\bmakeProbe\(/.test(text) },
+      ]);
+    },
+  },
+  {
+    id: 'p3d-type-preserving-hollow', property: 'P3', violationClass: 'guard removal', label: 'TYPE-PRESERVING HOLLOW', paths: [GUARD_TEST],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        GUARD_TEST,
+        'function makeProbe(opts:',
+        '\n\nconst DEVIANT_INV',
+        `function makeProbe(opts: {\n  local?: () => GuardInventoryResult | null;\n  peers?: () => PeerPostureRead[];\n  deepReadPeer?: GuardPostureProbeDeps['deepReadPeer'];\n  emitAttention?: GuardPostureProbeDeps['emitAttention'];\n}) {\n  // B0.4 type-preserving hollow makeProbe: name/parameters/return shape retained; constant pass.\n  void opts;\n  const emitted: GuardPostureAttentionItem[] = [];\n  const probe = {\n    id: 'instar.guard-posture.anomalies', name: 'Guard Posture Anomalies', tier: 2 as const,\n    feature: 'Guard Posture', timeoutMs: 10_000, prerequisites: () => true,\n    run: async () => ({ probeId: 'instar.guard-posture.anomalies', name: 'Guard Posture Anomalies', tier: 2 as const, durationMs: 0, passed: true, description: 'No guard-posture anomalies across machines' }),\n  };\n  return { probe, emitted };\n}`,
+      );
+    },
+    verify(root) { return includesChecks(root, GUARD_TEST, ['function makeProbe(opts:', 'B0.4 type-preserving hollow makeProbe', 'passed: true', 'return { probe, emitted };']); },
+  },
+  {
+    id: 'p4a-empty-population', property: 'P4', violationClass: 'vacuous measurement', label: 'EMPTY THE PROBE POPULATION', paths: [PROBE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        PROBE,
+        'export function createGuardPostureProbes(deps: GuardPostureProbeDeps): Probe[] {',
+        '\n}',
+        `export function createGuardPostureProbes(deps: GuardPostureProbeDeps): Probe[] {\n  // B0.4 empty probe population.\n  void deps;\n  return [];`,
+      );
+    },
+    verify(root) { return includesChecks(root, PROBE, ['export function createGuardPostureProbes(deps: GuardPostureProbeDeps): Probe[] {', 'B0.4 empty probe population', 'return [];']); },
+  },
+  {
+    id: 'p4b-hidden-real-violation', property: 'P4', violationClass: 'population evasion', label: 'P4B RELEVANCE UNKNOWN — REAL SOURCE IS ENUMERATED', paths: [MACHINE_REGISTRY, POSTURE_STORE],
+    apply(root) {
+      const now = Date.now();
+      write(root, MACHINE_REGISTRY, `${JSON.stringify({
+        version: 1,
+        machines: {
+          [P4B_PEER_ID]: {
+            name: 'B0.4 real peer source',
+            nickname: 'b0-four-peer',
+            status: 'active',
+            role: 'standby',
+            pairedAt: new Date(now - 60_000).toISOString(),
+            lastSeen: new Date(now - 30_000).toISOString(),
+          },
+        },
+      }, null, 2)}\n`);
+      write(root, POSTURE_STORE, `${JSON.stringify({
+        version: 1,
+        machines: {
+          [P4B_PEER_ID]: {
+            receivedAtMs: now,
+            posture: {
+              onConfirmed: 0,
+              onUnverified: 0,
+              onStale: 0,
+              onBlind: 0,
+              onDryRun: 0,
+              offDeviant: 1,
+              offDeviantKeys: ['monitoring.sessionReaper.enabled'],
+              offRuntimeDivergent: 0,
+              offRuntimeDivergentKeys: [],
+              divergedPendingRestart: 0,
+              errored: 0,
+              missing: 0,
+              generatedAt: new Date(now).toISOString(),
+            },
+          },
+        },
+      }, null, 2)}\n`);
+    },
+    verify(root) {
+      const sourceProof = run(root, ['node_modules/.bin/vite-node', '--script', SOURCE_PROOF]);
+      return checksResult([
+        { check: 'real machine registry contains an active peer', passed: read(root, MACHINE_REGISTRY).includes(`"${P4B_PEER_ID}"`) && read(root, MACHINE_REGISTRY).includes('"status": "active"') },
+        { check: 'real posture store contains actual-schema deviance', passed: read(root, POSTURE_STORE).includes('"offDeviant": 1') && read(root, POSTURE_STORE).includes('"monitoring.sessionReaper.enabled"') },
+        { check: 'production source loaders prove the peer is enumerated, so no evasion is claimed', passed: sourceProof.exitCode === 0 && sourceProof.stdout.includes('active=1 capacity=1 offDeviant=1 enumerated=true') },
+      ]);
+    },
+  },
+  {
+    id: 'p5-blind-input', property: 'P5', violationClass: 'blind input / fail-open', label: 'LOCAL POSTURE UNAVAILABLE', paths: [GUARD_TEST],
+    apply(root) {
+      replaceOnce(
+        root,
+        GUARD_TEST,
+        `    const { probe } = makeProbe({ local: () => CLEAN_INV });\n    expect(probe.id).toBe('instar.guard-posture.anomalies');`,
+        `    // B0.4 blinded local posture input: unavailable, not wrong; expectations stay unchanged.\n    const { probe } = makeProbe({ local: () => null });\n    expect(probe.id).toBe('instar.guard-posture.anomalies');`,
+      );
+    },
+    verify(root) { return includesChecks(root, GUARD_TEST, ['B0.4 blinded local posture input', 'local: () => null', 'expect(result.passed).toBe(true)']); },
+  },
+];

--- a/scratchpad/phaseB/adapters/lint-llm-attribution.mjs
+++ b/scratchpad/phaseB/adapters/lint-llm-attribution.mjs
@@ -1,0 +1,221 @@
+import fs from 'node:fs';
+import {
+  absolute,
+  checksResult,
+  commentAll,
+  includesChecks,
+  read,
+  replaceOnce,
+  replaceThroughMarker,
+  run,
+  structuredRelevance,
+  write,
+  writeVitestConfig,
+} from './acceptance-fixtures.mjs';
+
+const GUARD_TEST = 'tests/unit/llm-attribution-ratchet.test.ts';
+const LINTER = 'scripts/lint-llm-attribution.js';
+const DIRECT_INPUT = 'src/__b0_4_attribution_input.txt';
+const HIDDEN_VIOLATION = 'src/core/B0FourUnattributedFunnel.ts';
+
+const testCommand = {
+  argv: ['node_modules/.bin/vitest', 'run', GUARD_TEST, '--config=.b0-fix-verifier.vitest.config.mjs', '--reporter=verbose'],
+  observeAny: ['lint self-test', 'Test Files', 'No test files found', 'AssertionError'],
+  timeoutMs: 120_000,
+};
+
+const directDriver = `import path from 'node:path'; import { runLint } from './scripts/lint-llm-attribution.js'; const result = runLint([path.resolve('${DIRECT_INPUT}')]); console.log('B0.4-attribution-direct real=' + result.real.length + ' stale=' + result.stale.length); if (result.real.length || result.stale.length) process.exit(1);`;
+const directCommand = {
+  argv: ['node', '--input-type=module', '-e', directDriver],
+  observeAny: ['B0.4-attribution-direct'],
+  timeoutMs: 30_000,
+};
+
+export const pipelineCommands = [testCommand, directCommand];
+export const guardCommands = [testCommand, directCommand];
+
+export function prepareWorkspace(root) {
+  writeVitestConfig(root);
+  write(root, DIRECT_INPUT, `await provider.evaluate(prompt, { attribution: { component: 'B0FourControl' } });\n`);
+}
+
+function verifySemanticViolation(root, rel) {
+  const program = `import fs from 'node:fs'; import { checkFileText } from './${LINTER}'; const text = fs.readFileSync(${JSON.stringify(rel)}, 'utf8'); const hits = checkFileText(${JSON.stringify(rel)}, text); console.log('actualPath=' + ${JSON.stringify(rel)} + ' hits=' + hits.length); if (hits.length !== 1 || hits[0]?.file !== ${JSON.stringify(rel)}) process.exit(1);`;
+  return run(root, ['node', '--input-type=module', '-e', program]);
+}
+
+function verifyRealEnumerationEscape(root) {
+  const program = `import path from 'node:path'; import fs from 'node:fs'; import { FUNNEL_FILES, checkFileText, runLint } from './${LINTER}'; const rel = ${JSON.stringify(HIDDEN_VIOLATION)}; const text = fs.readFileSync(rel, 'utf8'); const raw = checkFileText(rel, text); const lint = runLint([path.resolve(rel)]); const exempt = FUNNEL_FILES.has(rel); console.log('actualPath=' + rel + ' rawHits=' + raw.length + ' real=' + lint.real.length + ' exempt=' + exempt); if (raw.length !== 1 || raw[0]?.file !== rel || lint.real.length !== 0 || !exempt) process.exit(1);`;
+  return run(root, ['node', '--input-type=module', '-e', program]);
+}
+
+function inspectUnreadableViolation(root) {
+  const target = absolute(root, DIRECT_INPUT);
+  const mode = fs.statSync(target).mode % 0o1000;
+  try {
+    fs.chmodSync(target, 0o600);
+    return verifySemanticViolation(root, DIRECT_INPUT);
+  } finally {
+    fs.chmodSync(target, mode);
+  }
+}
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+  if (mutation.id === 'p4b-hidden-real-violation') {
+    const semantic = fs.existsSync(absolute(root, HIDDEN_VIOLATION))
+      ? verifyRealEnumerationEscape(root)
+      : { exitCode: null, stdout: '', stderr: 'missing' };
+    const relevance = structuredRelevance('outside-enumeration', [
+      { check: 'violation is an actual in-src TypeScript path', passed: changedPaths.includes(HIDDEN_VIOLATION) && HIDDEN_VIOLATION.startsWith('src/') && !declared.has(HIDDEN_VIOLATION) },
+      { check: 'real exemption surface changed in the declared linter subject', passed: changedPaths.includes(LINTER) && declared.has(LINTER) && read(root, LINTER).includes(`'${HIDDEN_VIOLATION}'`) },
+      { check: 'the real checker classifies the actual path as one violation and runLint hides that same path through FUNNEL_FILES', passed: semantic.exitCode === 0 && semantic.stdout.includes(`actualPath=${HIDDEN_VIOLATION} rawHits=1 real=0 exempt=true`) },
+    ]);
+    return {
+      ...relevance,
+      decidingOutput: {
+        kind: 'actual-path-enumeration-proof',
+        lines: semantic.stdout.split('\n').filter(Boolean),
+        exitCode: semantic.exitCode,
+      },
+    };
+  }
+
+  const routed = changedPaths.some((rel) => declared.has(rel)) || mutation.id === 'p5-blind-input';
+  let semantic = false;
+  if (mutation.id === 'p1-symbol-preserving-hollow') semantic = read(root, LINTER).includes('B0.4 hollow checkFileText');
+  if (mutation.id === 'p2-subject-self-reports-clean') semantic = read(root, LINTER).includes('B0.4 forced clean lint testimony');
+  if (mutation.id === 'p3a-delete') semantic = !fs.existsSync(absolute(root, GUARD_TEST));
+  if (mutation.id === 'p3b-comment-out') semantic = read(root, GUARD_TEST).split('\n').filter(Boolean).every((line) => line.startsWith('// '));
+  if (mutation.id === 'p3c-superstring-rename') semantic = read(root, GUARD_TEST).includes('const flagDisabled =') && !read(root, GUARD_TEST).includes('const flag =');
+  if (mutation.id === 'p3d-type-preserving-hollow') semantic = read(root, GUARD_TEST).includes('B0.4 type-preserving hollow flag');
+  if (mutation.id === 'p4a-empty-population') semantic = read(root, GUARD_TEST).includes('B0.4 empty source population');
+  if (mutation.id === 'p5-blind-input') {
+    const mode = fs.statSync(absolute(root, DIRECT_INPUT)).mode % 0o1000;
+    const semanticViolation = inspectUnreadableViolation(root);
+    const childRead = run(root, ['node', '-e', `require('node:fs').readFileSync(${JSON.stringify(DIRECT_INPUT)}, 'utf8')`]);
+    semantic = changedPaths.includes(DIRECT_INPUT) && mode === 0 && semanticViolation.exitCode === 0 && semanticViolation.stdout.includes('hits=1') && childRead.exitCode !== 0 && /EACCES|permission denied/i.test(`${childRead.stderr}${childRead.stdout}`);
+  }
+  return structuredRelevance('declared-load-bearing-input', [
+    { check: 'mutation routes to the declared guard/subject or the explicitly scanned generated input', passed: routed },
+    { check: `semantic mutation ${mutation.id} changes the load-bearing body/input`, passed: semantic },
+  ]);
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-hollow', property: 'P1', violationClass: 'hollowing', label: 'SYMBOL-PRESERVING HOLLOW', paths: [LINTER],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        LINTER,
+        'export function checkFileText(rel, rawText) {',
+        '\n\nfunction walk(',
+        `export function checkFileText(rel, rawText) {\n  // B0.4 hollow checkFileText: same export/name/signature; no inspection.\n  void rel;\n  void rawText;\n  return [];\n}`,
+      );
+    },
+    verify(root) { return includesChecks(root, LINTER, ['export function checkFileText(rel, rawText) {', 'B0.4 hollow checkFileText', 'return [];']); },
+  },
+  {
+    id: 'p2-subject-self-reports-clean', property: 'P2', violationClass: 'self-report / false testimony', label: 'SUBJECT SELF-REPORTS CLEAN', paths: [LINTER],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        LINTER,
+        'export function runLint(files, { allowlist = VIOLATIONS_ALLOWLIST, funnelFiles = FUNNEL_FILES, checkStale = false } = {}) {',
+        '\n\nfunction main()',
+        `export function runLint(files, { allowlist = VIOLATIONS_ALLOWLIST, funnelFiles = FUNNEL_FILES, checkStale = false } = {}) {\n  // B0.4 forced clean lint testimony: inputs are ignored and the subject claims zero findings.\n  void files;\n  void allowlist;\n  void funnelFiles;\n  void checkStale;\n  return { real: [], allowlisted: [], stale: [] };\n}`,
+      );
+    },
+    verify(root) { return includesChecks(root, LINTER, ['B0.4 forced clean lint testimony', 'return { real: [], allowlisted: [], stale: [] };']); },
+  },
+  {
+    id: 'p3a-delete', property: 'P3', violationClass: 'guard removal', label: 'DELETE', paths: [GUARD_TEST],
+    apply(root) { fs.unlinkSync(absolute(root, GUARD_TEST)); },
+    verify(root) { return checksResult([{ check: `${GUARD_TEST} is absent`, passed: !fs.existsSync(absolute(root, GUARD_TEST)) }]); },
+  },
+  {
+    id: 'p3b-comment-out', property: 'P3', violationClass: 'guard removal', label: 'COMMENT OUT', paths: [GUARD_TEST],
+    apply(root) { commentAll(root, GUARD_TEST); },
+    verify(root) {
+      const lines = read(root, GUARD_TEST).split('\n').filter(Boolean);
+      return checksResult([{ check: `${GUARD_TEST} has no executable non-comment line`, passed: lines.length > 0 && lines.every((line) => line.startsWith('// ')) }]);
+    },
+  },
+  {
+    id: 'p3c-superstring-rename', property: 'P3', violationClass: 'guard removal', label: 'SUPERSTRING RENAME', paths: [GUARD_TEST],
+    apply(root) { replaceOnce(root, GUARD_TEST, '  const flag = (text: string)', '  const flagDisabled = (text: string)'); },
+    verify(root) {
+      const text = read(root, GUARD_TEST);
+      return checksResult([
+        { check: 'longer flagDisabled declaration exists', passed: text.includes('const flagDisabled =') },
+        { check: 'original flag remains a substring', passed: text.includes('flag') },
+        { check: 'standalone flag declaration is absent while call sites remain', passed: !text.includes('const flag =') && /\bflag\(/.test(text) },
+      ]);
+    },
+  },
+  {
+    id: 'p3d-type-preserving-hollow', property: 'P3', violationClass: 'guard removal', label: 'TYPE-PRESERVING HOLLOW', paths: [GUARD_TEST],
+    apply(root) {
+      replaceOnce(
+        root,
+        GUARD_TEST,
+        "  const flag = (text: string) => checkFileText('src/fixture.ts', text);",
+        "  const flag = (text: string) => { void text; /* B0.4 type-preserving hollow flag */ return [] as ReturnType<typeof checkFileText>; };",
+      );
+    },
+    verify(root) { return includesChecks(root, GUARD_TEST, ['const flag = (text: string)', 'B0.4 type-preserving hollow flag', 'return [] as ReturnType<typeof checkFileText>;']); },
+  },
+  {
+    id: 'p4a-empty-population', property: 'P4', violationClass: 'vacuous measurement', label: 'EMPTY THE POPULATION', paths: [GUARD_TEST],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        GUARD_TEST,
+        'function walkSrc(): string[] {',
+        '\n\ndescribe(',
+        `function walkSrc(): string[] {\n  // B0.4 empty source population.\n  return [];\n}`,
+      );
+    },
+    verify(root) { return includesChecks(root, GUARD_TEST, ['function walkSrc(): string[] {', 'B0.4 empty source population', 'return [];']); },
+  },
+  {
+    id: 'p4b-hidden-real-violation', property: 'P4', violationClass: 'population evasion', label: 'REAL in-src VIOLATION HIDDEN BY FUNNEL_FILES EXEMPTION', paths: [HIDDEN_VIOLATION, LINTER],
+    apply(root) {
+      write(root, HIDDEN_VIOLATION, `export async function hiddenSpend(provider: { evaluate(prompt: string, options: { model: string }): Promise<unknown> }, prompt: string) {\n  return provider.evaluate(prompt, { model: 'fast' });\n}\n`);
+      replaceOnce(
+        root,
+        LINTER,
+        "  'src/core/TopicIntentCapture.ts',\n]);",
+        `  'src/core/TopicIntentCapture.ts',\n  '${HIDDEN_VIOLATION}',\n]);`,
+      );
+    },
+    verify(root) {
+      const semantic = verifyRealEnumerationEscape(root);
+      return checksResult([
+        { check: `${HIDDEN_VIOLATION} is an actual in-src TypeScript file`, passed: HIDDEN_VIOLATION.startsWith('src/') && fs.existsSync(absolute(root, HIDDEN_VIOLATION)) },
+        { check: `${HIDDEN_VIOLATION} is added to the real FUNNEL_FILES exemption`, passed: read(root, LINTER).includes(`'${HIDDEN_VIOLATION}'`) },
+        { check: 'actual-path semantic proof shows rawHits=1 and real=0 through the exemption', passed: semantic.exitCode === 0 && semantic.stdout.includes(`actualPath=${HIDDEN_VIOLATION} rawHits=1 real=0 exempt=true`) },
+      ]);
+    },
+  },
+  {
+    id: 'p5-blind-input', property: 'P5', violationClass: 'blind input / fail-open', label: 'UNREADABLE VIOLATING SCANNED INPUT', paths: [DIRECT_INPUT],
+    apply(root) {
+      write(root, DIRECT_INPUT, `await provider.evaluate(prompt, { model: 'fast' });\n`);
+      const semantic = verifySemanticViolation(root, DIRECT_INPUT);
+      if (semantic.exitCode !== 0 || !semantic.stdout.includes('hits=1')) throw new Error(`prepared input is not a real violation: ${semantic.stderr || semantic.stdout}`);
+      fs.chmodSync(absolute(root, DIRECT_INPUT), 0o000);
+    },
+    verify(root) {
+      const mode = fs.statSync(absolute(root, DIRECT_INPUT)).mode % 0o1000;
+      const semanticViolation = inspectUnreadableViolation(root);
+      const childRead = run(root, ['node', '-e', `require('node:fs').readFileSync(${JSON.stringify(DIRECT_INPUT)}, 'utf8')`]);
+      return checksResult([
+        { check: `${DIRECT_INPUT} mode is 000`, passed: mode === 0 },
+        { check: 'temporarily readable bytes are classified as exactly one real attribution violation', passed: semanticViolation.exitCode === 0 && semanticViolation.stdout.includes('hits=1') },
+        { check: 'independent child cannot read the scanned input', passed: childRead.exitCode !== 0 && /EACCES|permission denied/i.test(`${childRead.stderr}${childRead.stdout}`) },
+      ]);
+    },
+  },
+];

--- a/scratchpad/phaseB/adapters/self-action-convergence.mjs
+++ b/scratchpad/phaseB/adapters/self-action-convergence.mjs
@@ -1,0 +1,220 @@
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  absolute,
+  checksResult,
+  commentAll,
+  includesChecks,
+  read,
+  replaceOnce,
+  replaceThroughMarker,
+  structuredRelevance,
+  write,
+  writeVitestConfig,
+} from './acceptance-fixtures.mjs';
+
+const GUARD_TEST = 'tests/unit/self-action-convergence.test.ts';
+const FORCING_LINT = 'scripts/lint-no-unregistered-self-action.js';
+const REGISTRY = 'src/testing/selfActionRegistry.ts';
+const HIDDEN_CONTROLLER = 'src/phaseB/B0FourHiddenSelfActionMonitor.ts';
+
+const testCommand = {
+  argv: ['node_modules/.bin/vitest', 'run', GUARD_TEST, '--config=.b0-fix-verifier.vitest.config.mjs', '--reporter=verbose'],
+  observeAny: ['self-action convergence ratchet', 'Test Files', 'No test files found', 'AssertionError'],
+  timeoutMs: 180_000,
+};
+
+const lintCommand = {
+  argv: ['node', FORCING_LINT, '--staged'],
+  observeAny: ['lint-no-unregistered-self-action:'],
+  timeoutMs: 60_000,
+};
+
+const pipelineTestCommand = {
+  argv: ['npm', 'run', 'test:push', '--', GUARD_TEST, '--reporter=verbose'],
+  observeAny: ['self-action convergence ratchet', 'Test Files'],
+  timeoutMs: 180_000,
+};
+
+const pipelineLintCommand = {
+  argv: ['npm', 'run', 'lint'],
+  observeAny: ['lint-no-unregistered-self-action:', 'lint-framework-list-completeness'],
+  timeoutMs: 600_000,
+};
+
+export const pipelineCommands = [pipelineTestCommand, pipelineLintCommand];
+export const guardCommands = [testCommand, lintCommand];
+
+export function prepareWorkspace(root) {
+  writeVitestConfig(root);
+}
+
+function replaceProactiveMethod(root, replacement) {
+  replaceThroughMarker(
+    root,
+    REGISTRY,
+    '  makeUnderPressure(f, sink) {',
+    '\n  },\n};',
+    replacement,
+    'const proactiveSwapMonitor: SelfActionController = {',
+  );
+}
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+  const routed = changedPaths.some((rel) => declared.has(rel));
+  const checks = [];
+  let mode = 'declared-load-bearing-input';
+
+  if (mutation.id === 'p4b-hidden-real-violation') {
+    mode = 'outside-enumeration';
+    const text = fs.existsSync(absolute(root, HIDDEN_CONTROLLER)) ? read(root, HIDDEN_CONTROLLER) : '';
+    const liveLint = spawnSync('node', [FORCING_LINT, '--staged'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    checks.push(
+      { check: 'hidden controller is outside SELF_ACTION_CONTROLLERS registry source', passed: changedPaths.includes(HIDDEN_CONTROLLER) && !declared.has(HIDDEN_CONTROLLER) },
+      { check: 'hidden source is controller-shaped and contains an executable self-action emit', passed: /SelfActionMonitor\.ts$/.test(HIDDEN_CONTROLLER) && /pool\.swap\(/.test(text) },
+      { check: 'hidden controller has no registration marker', passed: !/@self-action-controller:/.test(text) },
+      { check: 'pinned live lint sees the violation but remains report-only and exits zero', passed: liveLint.status === 0 && /report-only/.test(liveLint.stdout) && /1 unregistered/.test(liveLint.stdout) },
+    );
+    return {
+      status: 'proven',
+      mode,
+      checks,
+      reason: 'P4b relevance is proven: the real controller is detected by both live guards; their clean exits are the substantive not-proven result.',
+      decidingOutput: {
+        kind: 'live-report-only-path',
+        lines: liveLint.stdout.split('\n').filter(Boolean),
+        exitCode: liveLint.status,
+      },
+    };
+  }
+
+  checks.push({ check: 'changed path intersects the declared load-bearing guard/subject set', passed: routed });
+  let semantic = false;
+  if (mutation.id === 'p1-symbol-preserving-hollow') semantic = read(root, REGISTRY).includes('B0.4 inert proactive controller body');
+  if (mutation.id === 'p2-subject-self-reports-clean') semantic = read(root, REGISTRY).includes('B0.4 false count testimony');
+  if (mutation.id === 'p3a-delete') semantic = !fs.existsSync(absolute(root, GUARD_TEST));
+  if (mutation.id === 'p3b-comment-out') semantic = fs.existsSync(absolute(root, GUARD_TEST)) && read(root, GUARD_TEST).split('\n').filter(Boolean).every((line) => line.startsWith('// '));
+  if (mutation.id === 'p3c-superstring-rename') semantic = read(root, GUARD_TEST).includes('function driveControllerDisabled(') && !read(root, GUARD_TEST).includes('function driveController(');
+  if (mutation.id === 'p3d-type-preserving-hollow') semantic = read(root, GUARD_TEST).includes('B0.4 type-preserving hollow driveController');
+  if (mutation.id === 'p4a-empty-population') semantic = read(root, REGISTRY).includes('B0.4 empty controller population');
+  if (mutation.id === 'p5-blind-input') semantic = fs.statSync(absolute(root, REGISTRY)).mode % 0o1000 === 0;
+  checks.push({ check: `semantic mutation ${mutation.id} changed its load-bearing body/input`, passed: semantic });
+  return structuredRelevance(mode, checks);
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-hollow', property: 'P1', violationClass: 'hollowing', label: 'SYMBOL-PRESERVING HOLLOW', paths: [REGISTRY],
+    apply(root) {
+      replaceProactiveMethod(root, `  makeUnderPressure(f, sink) {\n    // B0.4 inert proactive controller body: same id/API, no controller transition.\n    void f;\n    void sink;\n    return { tick() {} };`);
+    },
+    verify(root) {
+      return includesChecks(root, REGISTRY, [
+        "id: 'proactive-swap-monitor'",
+        'makeUnderPressure(f, sink) {',
+        'B0.4 inert proactive controller body',
+        'return { tick() {} };',
+      ]);
+    },
+  },
+  {
+    id: 'p2-subject-self-reports-clean', property: 'P2', violationClass: 'self-report / false testimony', label: 'SUBJECT SELF-REPORTS CLEAN', paths: [REGISTRY],
+    apply(root) {
+      replaceProactiveMethod(root, `  makeUnderPressure(f, sink) {\n    // B0.4 false count testimony: emit unboundedly, then lie through count.\n    void f;\n    return {\n      tick() {\n        sink.considered += 1;\n        sink.emit({ verb: 'account-swap', target: 'acct-A' });\n        sink.count = 0;\n      },\n    };`);
+    },
+    verify(root) {
+      return includesChecks(root, REGISTRY, [
+        'B0.4 false count testimony',
+        "sink.emit({ verb: 'account-swap', target: 'acct-A' });",
+        'sink.count = 0;',
+      ]);
+    },
+  },
+  {
+    id: 'p3a-delete', property: 'P3', violationClass: 'guard removal', label: 'DELETE', paths: [GUARD_TEST],
+    apply(root) { fs.unlinkSync(absolute(root, GUARD_TEST)); },
+    verify(root) { return checksResult([{ check: `${GUARD_TEST} is absent`, passed: !fs.existsSync(absolute(root, GUARD_TEST)) }]); },
+  },
+  {
+    id: 'p3b-comment-out', property: 'P3', violationClass: 'guard removal', label: 'COMMENT OUT', paths: [GUARD_TEST],
+    apply(root) { commentAll(root, GUARD_TEST); },
+    verify(root) {
+      const lines = read(root, GUARD_TEST).split('\n').filter(Boolean);
+      return checksResult([{ check: `${GUARD_TEST} has no executable non-comment line`, passed: lines.length > 0 && lines.every((line) => line.startsWith('// ')) }]);
+    },
+  },
+  {
+    id: 'p3c-superstring-rename', property: 'P3', violationClass: 'guard removal', label: 'SUPERSTRING RENAME', paths: [GUARD_TEST],
+    apply(root) { replaceOnce(root, GUARD_TEST, 'function driveController(', 'function driveControllerDisabled('); },
+    verify(root) {
+      const text = read(root, GUARD_TEST);
+      return checksResult([
+        { check: 'longer driveControllerDisabled declaration exists', passed: text.includes('function driveControllerDisabled(') },
+        { check: 'original remains as a substring', passed: text.includes('driveController') },
+        { check: 'original driveController declaration is absent while call sites remain', passed: !text.includes('function driveController(') && /\bdriveController\(/.test(text) },
+      ]);
+    },
+  },
+  {
+    id: 'p3d-type-preserving-hollow', property: 'P3', violationClass: 'guard removal', label: 'TYPE-PRESERVING HOLLOW', paths: [GUARD_TEST],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        GUARD_TEST,
+        'function driveController(',
+        '\n\ndescribe(',
+        `function driveController(\n  controller: (typeof SELF_ACTION_CONTROLLERS)[number],\n  ticks: number,\n): ReturnType<typeof makeActionSink> {\n  // B0.4 type-preserving hollow driveController: declaration/name/signature/return type retained.\n  void controller;\n  void ticks;\n  return { emit() {}, count: 0, perTarget: new Map(), considered: 0, emitTimesMs: [] };\n}`,
+      );
+    },
+    verify(root) {
+      return includesChecks(root, GUARD_TEST, [
+        'function driveController(',
+        '): ReturnType<typeof makeActionSink> {',
+        'B0.4 type-preserving hollow driveController',
+        'return { emit() {}, count: 0, perTarget: new Map(), considered: 0, emitTimesMs: [] };',
+      ]);
+    },
+  },
+  {
+    id: 'p4a-empty-population', property: 'P4', violationClass: 'vacuous measurement', label: 'EMPTY THE POPULATION', paths: [REGISTRY],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        REGISTRY,
+        'export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [',
+        '\n];',
+        `export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [\n  // B0.4 empty controller population.`,
+      );
+    },
+    verify(root) {
+      return includesChecks(root, REGISTRY, ['export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [', 'B0.4 empty controller population']);
+    },
+  },
+  {
+    id: 'p4b-hidden-real-violation', property: 'P4', violationClass: 'population evasion', label: 'REAL UNREGISTERED CONTROLLER OUTSIDE THE REGISTRY', paths: [HIDDEN_CONTROLLER],
+    apply(root) {
+      write(root, HIDDEN_CONTROLLER, `export function startHiddenSelfActionMonitor(pool: { swap(id: string): void }): () => void {\n  const timer = setInterval(() => {\n    pool.swap('acct-A');\n  }, 1);\n  return () => clearInterval(timer);\n}\n`);
+      const staged = spawnSync('git', ['add', '--', HIDDEN_CONTROLLER], { cwd: root, encoding: 'utf8' });
+      if (staged.status !== 0) throw new Error(`git add hidden controller failed: ${staged.stderr || staged.stdout}`);
+    },
+    verify(root) {
+      const content = includesChecks(root, HIDDEN_CONTROLLER, ['setInterval(', "pool.swap('acct-A')"], ['@self-action-controller:']);
+      const staged = spawnSync('git', ['diff', '--cached', '--name-only', '--', HIDDEN_CONTROLLER], { cwd: root, encoding: 'utf8' });
+      const checks = [...content.checks, { check: 'hidden controller is staged for --staged forcing lint', passed: staged.status === 0 && staged.stdout.trim() === HIDDEN_CONTROLLER }];
+      return checksResult(checks);
+    },
+  },
+  {
+    id: 'p5-blind-input', property: 'P5', violationClass: 'blind input / fail-open', label: 'BLIND THE REGISTRY INPUT', paths: [REGISTRY],
+    apply(root) { fs.chmodSync(absolute(root, REGISTRY), 0o000); },
+    verify(root) {
+      const mode = fs.statSync(absolute(root, REGISTRY)).mode % 0o1000;
+      return checksResult([{ check: `${REGISTRY} mode is 000`, passed: mode === 0 }]);
+    },
+  },
+];

--- a/scratchpad/phaseB/adapters/standards-direction-guard.mjs
+++ b/scratchpad/phaseB/adapters/standards-direction-guard.mjs
@@ -1,0 +1,432 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REGISTRY = 'docs/STANDARDS-REGISTRY.md';
+const APPROVALS = 'docs/standards-direction-approvals.json';
+const CANDIDATE_PIN = '.github/keyrings/telegram-principal-pub.pem';
+const GUARD = 'scripts/standards-direction-guard.mjs';
+const PIPELINE = 'scripts/standards-coverage.mjs';
+const GUARD_TEST = 'tests/unit/standards-direction-guard.test.ts';
+const CONTRACT_TEST = 'tests/unit/standards-direction-guard-contract.test.ts';
+const BASE_REGISTRY = '.b0-s5-protected-registry.md';
+const BASE_PIN = '.b0-s5-protected-approver.pem';
+const BASE_PIN_PRIVATE = '.b0-s5-protected-approver-private.pem';
+const ATTACKER_PRIVATE = '.b0-s5-attacker-private.pem';
+const BLINDED_BASE = `${BASE_REGISTRY}.blinded`;
+const BASE_REVISION = 'b0-s5-protected-base';
+
+const ORIGINAL_RULE = '**Rule.** If a behavior matters, enforce it in architecture, not in instructions. Never rely on an agent "remembering" to follow a rule buried in a long prompt.';
+const HOLLOW_RULE = '**Rule.** If a behavior matters, we should prefer architecture where practical; documenting it and remembering to apply it is an acceptable alternative.';
+
+function absolute(root, rel) {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) throw new Error(`path escapes isolated root: ${rel}`);
+  return resolved;
+}
+
+function read(root, rel) {
+  return fs.readFileSync(absolute(root, rel), 'utf8');
+}
+
+function write(root, rel, content) {
+  fs.mkdirSync(path.dirname(absolute(root, rel)), { recursive: true });
+  fs.writeFileSync(absolute(root, rel), content, 'utf8');
+}
+
+function replaceOnce(root, rel, before, after) {
+  const content = read(root, rel);
+  const first = content.indexOf(before);
+  const last = content.lastIndexOf(before);
+  if (first === -1 || first !== last) throw new Error(`${rel}: expected exactly one replacement target; first=${first} last=${last}`);
+  write(root, rel, `${content.slice(0, first)}${after}${content.slice(first + before.length)}`);
+}
+
+function replaceFunctionThroughMarker(root, replacement) {
+  const content = read(root, GUARD);
+  const signature = 'export function evaluateStandardsDirection({';
+  const start = content.indexOf(signature);
+  const signatureEnd = content.indexOf('}) {', start) + 4;
+  const end = content.indexOf('\n}\n\n/** Fail-closed protected-base registry acquisition', signatureEnd);
+  if (start === -1 || signatureEnd < 4 || end === -1 || content.indexOf(signature, start + signature.length) !== -1) {
+    throw new Error('evaluateStandardsDirection boundary is missing or ambiguous');
+  }
+  write(root, GUARD, `${content.slice(0, signatureEnd)}${replacement}${content.slice(end)}`);
+}
+
+function run(root, argv) {
+  const result = spawnSync(argv[0], argv.slice(1), { cwd: root, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+  if (result.error || result.status !== 0) throw new Error(`${argv.join(' ')} failed: ${result.error?.message ?? result.stderr ?? result.stdout}`);
+  return result.stdout;
+}
+
+function verification(checks) {
+  return { ok: checks.every((item) => item.passed), checks };
+}
+
+function weakeningApplied(root) {
+  const content = read(root, REGISTRY);
+  return verification([
+    { check: 'Root identity and heading remain present', passed: content.includes('### Structure beats Willpower') },
+    { check: 'original constitutional direction is absent', passed: !content.includes(ORIGINAL_RULE) },
+    { check: 'opposite direction is present', passed: content.includes(HOLLOW_RULE) },
+  ]);
+}
+
+function applyWeakening(root) {
+  replaceOnce(root, REGISTRY, ORIGINAL_RULE, HOLLOW_RULE);
+}
+
+function writeAttackerApproval(root) {
+  const generator = `
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { canonicalDirectionPayload, evaluateStandardsDirection, inventoryStandardsArticles } from './scripts/standards-direction-guard.mjs';
+const [baseFile, candidateFile, privateFile] = process.argv.slice(1);
+const base = fs.readFileSync(baseFile, 'utf8');
+const candidate = fs.readFileSync(candidateFile, 'utf8');
+const id = 'legacy/the-root/structure-beats-willpower';
+const result = evaluateStandardsDirection({ baseMarkdown: base, candidateMarkdown: candidate, baseRevision: '${BASE_REVISION}' });
+const summary = (article) => article ? ({ id: article.id, family: article.family, name: article.name, ruleSha256: article.ruleSha256, articleSha256: article.articleSha256 }) : null;
+const before = inventoryStandardsArticles(base).articles.find((article) => article.id === id);
+const after = inventoryStandardsArticles(candidate).articles.find((article) => article.id === id);
+const payload = {
+  schemaVersion: 1,
+  baseRevision: '${BASE_REVISION}',
+  baseRegistrySha256: result.baseRegistrySha256,
+  candidateRegistrySha256: result.candidateRegistrySha256,
+  articleId: id,
+  change: 'edit',
+  direction: 'weaken',
+  before: summary(before),
+  after: summary(after),
+  approvedBy: 'subject-self-reports-clean',
+  approvedAt: new Date().toISOString(),
+};
+const privateKey = crypto.createPrivateKey(fs.readFileSync(privateFile, 'utf8'));
+const signature = crypto.sign(null, Buffer.from(canonicalDirectionPayload(payload), 'utf8'), privateKey).toString('base64');
+process.stdout.write(JSON.stringify({ schemaVersion: 1, approvals: [{ payload, signature }] }, null, 2) + '\\n');
+`;
+  const ledger = run(root, [
+    process.execPath,
+    '--input-type=module',
+    '-e',
+    generator,
+    BASE_REGISTRY,
+    REGISTRY,
+    ATTACKER_PRIVATE,
+  ]);
+  write(root, APPROVALS, ledger);
+}
+
+const baseEnv = [
+  `STANDARDS_DIRECTION_BASE_FILE=${BASE_REGISTRY}`,
+  `STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE=${BASE_PIN}`,
+  `STANDARDS_DIRECTION_BASE_REVISION=${BASE_REVISION}`,
+];
+
+export const pipelineCommands = [{
+  argv: ['env', ...baseEnv, 'node', PIPELINE, '--check'],
+  observeAny: ['standards-coverage', 'standards-direction-guard.mjs', 'DIRECTION GUARD'],
+  timeoutMs: 60_000,
+}];
+
+export const guardCommands = [
+  {
+    argv: ['env', ...baseEnv, 'node', PIPELINE, '--check'],
+    observeAny: ['standards-coverage', 'standards-direction-guard.mjs', 'DIRECTION GUARD'],
+    timeoutMs: 60_000,
+  },
+  {
+    argv: ['node_modules/.bin/vitest', 'run', GUARD_TEST, CONTRACT_TEST, '--reporter=verbose'],
+    observeAny: ['standards direction guard', 'standards-direction-guard', 'Test Files'],
+    timeoutMs: 120_000,
+  },
+];
+
+export function prepareWorkspace(root) {
+  write(root, BASE_REGISTRY, run(root, ['git', 'show', 'HEAD^:docs/STANDARDS-REGISTRY.md']));
+  const operator = crypto.generateKeyPairSync('ed25519');
+  const attacker = crypto.generateKeyPairSync('ed25519');
+  const operatorPin = operator.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+  write(root, BASE_PIN, operatorPin);
+  write(root, CANDIDATE_PIN, operatorPin);
+  write(root, BASE_PIN_PRIVATE, operator.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString());
+  write(root, ATTACKER_PRIVATE, attacker.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString());
+  fs.chmodSync(absolute(root, BASE_PIN_PRIVATE), 0o600);
+  fs.chmodSync(absolute(root, ATTACKER_PRIVATE), 0o600);
+}
+
+export function preparePipelineWorkspace(root, protectedBaseEvidence) {
+  const protectedCommit = protectedBaseEvidence?.commit;
+  if (!/^[a-f0-9]{40}$/.test(protectedCommit ?? '')) throw new Error('core did not supply a server-resolved protected base');
+  write(root, BASE_REGISTRY, run(root, ['git', 'show', `${protectedCommit}:${REGISTRY}`]));
+  write(root, BASE_PIN, run(root, ['git', 'show', `${protectedCommit}:${CANDIDATE_PIN}`]));
+}
+
+function inspectOutsideEnumeration(root) {
+  const program = `
+import fs from 'node:fs';
+import { evaluateStandardsDirection, inventoryStandardsArticles } from './scripts/standards-direction-guard.mjs';
+const [baseFile, candidateFile] = process.argv.slice(1);
+const base = fs.readFileSync(baseFile, 'utf8');
+const candidate = fs.readFileSync(candidateFile, 'utf8');
+const hiddenRule = 'Hidden outside every article heading.';
+const inventory = inventoryStandardsArticles(candidate);
+const verdict = evaluateStandardsDirection({
+  baseMarkdown: base,
+  candidateMarkdown: candidate,
+  baseRevision: '${BASE_REVISION}',
+});
+process.stdout.write(JSON.stringify({
+  hiddenRuleOccurrences: candidate.split(hiddenRule).length - 1,
+  enumeratedHiddenRules: inventory.articles.filter((article) => article.rule.includes(hiddenRule)).length,
+  inventoryErrors: inventory.errors,
+  verdictStatus: verdict.status,
+  verdictErrors: verdict.errors,
+}) + '\\n');
+`;
+  const result = spawnSync(process.execPath, [
+    '--input-type=module',
+    '-e',
+    program,
+    BASE_REGISTRY,
+    REGISTRY,
+  ], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  let proof = null;
+  try {
+    proof = JSON.parse((result.stdout ?? '').trim());
+  } catch { /* malformed output remains fail-closed below */ }
+  return {
+    exitCode: result.status,
+    error: result.error?.message ?? null,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    proof,
+  };
+}
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+
+  if (mutation.id === 'p4b-rule-outside-enumeration') {
+    const mutationVerification = mutation.verify(root);
+    const semantic = inspectOutsideEnumeration(root);
+    const parserReportedOpenEnumeration = semantic.proof?.inventoryErrors?.some((error) =>
+      error.includes('article enumeration is open')) === true;
+    const guardRejectedSameCandidate = semantic.proof?.verdictStatus === 'not-proven'
+      && semantic.proof?.verdictErrors?.some((error) =>
+        error.includes('candidate: article enumeration is open')) === true;
+    const checks = [
+      {
+        check: 'the real registry subject changed and the planted Rule bytes are present',
+        passed: changedPaths.includes(REGISTRY) && declared.has(REGISTRY) && mutationVerification.ok === true,
+      },
+      {
+        check: 'the live inventory parser leaves the planted Rule outside its article enumeration',
+        passed: semantic.exitCode === 0
+          && semantic.proof?.hiddenRuleOccurrences === 1
+          && semantic.proof?.enumeratedHiddenRules === 0,
+      },
+      {
+        check: 'the live parser reports the resulting article enumeration as open',
+        passed: parserReportedOpenEnumeration,
+      },
+      {
+        check: 'the production guard contract returns not-proven for that same unrecognized Rule',
+        passed: guardRejectedSameCandidate,
+      },
+    ];
+    return {
+      status: checks.every((check) => check.passed) ? 'proven' : 'unknown',
+      mode: 'outside-enumeration',
+      checks,
+      decidingOutput: {
+        kind: 'live-unrecognized-rule-parser-contract',
+        exitCode: semantic.exitCode,
+        lines: [
+          ...(semantic.stdout.trim() ? [semantic.stdout.trim()] : []),
+          ...(semantic.stderr.trim() ? semantic.stderr.trim().split('\n').slice(-5) : []),
+        ],
+      },
+    };
+  }
+
+  const protectedBaseRouted = mutation.id === 'p5-blind-protected-base'
+    && changedPaths.includes(BASE_REGISTRY)
+    && baseEnv.includes(`STANDARDS_DIRECTION_BASE_FILE=${BASE_REGISTRY}`);
+  const routed = changedPaths.some((rel) => declared.has(rel)) || protectedBaseRouted;
+  const semantic = mutation.verify(root);
+  const checks = [
+    {
+      check: 'mutation changes a declared guard/subject input or the explicitly configured protected-base input',
+      passed: routed,
+    },
+    {
+      check: `semantic mutation ${mutation.id} changes its load-bearing body or input`,
+      passed: semantic.ok === true && semantic.checks.length > 0 && semantic.checks.every((check) => check.passed === true),
+    },
+  ];
+  return {
+    status: checks.every((check) => check.passed) ? 'proven' : 'unknown',
+    mode: 'declared-load-bearing-input',
+    checks,
+  };
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-rule-hollow',
+    property: 'P1',
+    violationClass: 'hollowing',
+    label: 'SYMBOL-PRESERVING HOLLOW',
+    paths: [REGISTRY],
+    apply(root) { applyWeakening(root); },
+    verify(root) { return weakeningApplied(root); },
+  },
+  {
+    id: 'p2-self-report-plus-candidate-pin-replacement',
+    property: 'P2',
+    violationClass: 'self-report / false testimony',
+    label: 'SUBJECT SELF-REPORTS CLEAN AND MOVES THE CANDIDATE PIN',
+    paths: [REGISTRY, APPROVALS, CANDIDATE_PIN],
+    apply(root) {
+      applyWeakening(root);
+      const attackerPrivate = crypto.createPrivateKey(read(root, ATTACKER_PRIVATE));
+      const attackerPublic = crypto.createPublicKey(attackerPrivate).export({ type: 'spki', format: 'pem' }).toString();
+      write(root, CANDIDATE_PIN, attackerPublic);
+      writeAttackerApproval(root);
+    },
+    verify(root) {
+      const weakened = weakeningApplied(root);
+      const ledger = JSON.parse(read(root, APPROVALS));
+      const candidatePin = read(root, CANDIDATE_PIN);
+      return verification([
+        ...weakened.checks,
+        { check: 'subject declares itself a clean approved weakening', passed: ledger.approvals?.[0]?.payload?.direction === 'weaken' },
+        { check: 'subject carries a syntactically valid signature', passed: typeof ledger.approvals?.[0]?.signature === 'string' && ledger.approvals[0].signature.length > 40 },
+        { check: 'candidate pin was replaced with the attacker public key', passed: candidatePin.includes('BEGIN PUBLIC KEY') && candidatePin !== read(root, BASE_PIN) },
+      ]);
+    },
+  },
+  {
+    id: 'p2-pin-only-two-step-goalpost-move',
+    property: 'P2',
+    violationClass: 'self-report / false testimony',
+    label: 'MOVE THE TRUST ROOT WITHOUT CHANGING THE REGISTRY',
+    paths: [CANDIDATE_PIN],
+    apply(root) {
+      const attackerPrivate = crypto.createPrivateKey(read(root, ATTACKER_PRIVATE));
+      const attackerPublic = crypto.createPublicKey(attackerPrivate).export({ type: 'spki', format: 'pem' }).toString();
+      write(root, CANDIDATE_PIN, attackerPublic);
+    },
+    verify(root) {
+      return verification([
+        { check: 'registry remains byte-identical to protected base', passed: read(root, REGISTRY) === read(root, BASE_REGISTRY) },
+        { check: 'candidate pin differs from protected base', passed: read(root, CANDIDATE_PIN) !== read(root, BASE_PIN) },
+        { check: 'candidate pin remains a syntactically valid public key', passed: read(root, CANDIDATE_PIN).includes('BEGIN PUBLIC KEY') },
+      ]);
+    },
+  },
+  {
+    id: 'p3a-delete',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'DELETE',
+    paths: [GUARD],
+    apply(root) { fs.unlinkSync(absolute(root, GUARD)); },
+    verify(root) { return verification([{ check: `${GUARD} is absent`, passed: !fs.existsSync(absolute(root, GUARD)) }]); },
+  },
+  {
+    id: 'p3b-comment-out',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'COMMENT OUT',
+    paths: [GUARD],
+    apply(root) { write(root, GUARD, read(root, GUARD).split('\n').map((line) => `// ${line}`).join('\n')); },
+    verify(root) {
+      const lines = read(root, GUARD).split('\n').filter(Boolean);
+      return verification([{ check: `${GUARD} has no executable line`, passed: lines.length > 0 && lines.every((line) => line.startsWith('// ')) }]);
+    },
+  },
+  {
+    id: 'p3c-superstring-rename',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'SUPERSTRING RENAME',
+    paths: [GUARD],
+    apply(root) { write(root, GUARD, read(root, GUARD).replaceAll('evaluateStandardsDirection', 'evaluateStandardsDirectionDisabled')); },
+    verify(root) {
+      const content = read(root, GUARD);
+      return verification([
+        { check: 'longer superstring exists', passed: content.includes('evaluateStandardsDirectionDisabled') },
+        { check: 'standalone symbol is absent', passed: !/\bevaluateStandardsDirection\b/.test(content) },
+      ]);
+    },
+  },
+  {
+    id: 'p3d-type-preserving-hollow',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'TYPE-PRESERVING HOLLOW',
+    paths: [GUARD],
+    apply(root) {
+      replaceFunctionThroughMarker(root, `
+  // B0 S5 type-preserving hollow: the exact API fabricates a passing verdict.
+  return {
+    status: 'passed', errors: [], baseRevision,
+    baseRegistrySha256: '0'.repeat(64), candidateRegistrySha256: '0'.repeat(64), changes: [],
+    population: { protectedBase: 1, candidate: 1, continuity: 1, additions: [], removals: [], byFamily: {} },
+  };
+`);
+    },
+    verify(root) {
+      const content = read(root, GUARD);
+      return verification([
+        { check: 'exact exported name and signature remain', passed: content.includes('export function evaluateStandardsDirection({') },
+        { check: 'constant passing body is present', passed: content.includes('B0 S5 type-preserving hollow') && content.includes("status: 'passed'") },
+        { check: 'real evaluation body is absent', passed: !content.includes('const base = inventoryStandardsArticles(baseMarkdown);') },
+      ]);
+    },
+  },
+  {
+    id: 'p4a-empty-article-population',
+    property: 'P4',
+    violationClass: 'vacuous measurement',
+    label: 'EMPTY THE POPULATION',
+    paths: [REGISTRY],
+    apply(root) { write(root, REGISTRY, '# Standards Registry\n'); },
+    verify(root) { return verification([{ check: 'candidate has zero Rule articles', passed: !read(root, REGISTRY).includes('**Rule.**') }]); },
+  },
+  {
+    id: 'p4b-rule-outside-enumeration',
+    property: 'P4',
+    violationClass: 'population evasion',
+    label: 'HIDE A REAL RULE OUTSIDE THE ENUMERATION',
+    paths: [REGISTRY],
+    apply(root) { write(root, REGISTRY, `${read(root, REGISTRY)}\n**Rule.** Hidden outside every article heading.\n`); },
+    verify(root) {
+      const content = read(root, REGISTRY);
+      return verification([{ check: 'a real Rule field exists after all article blocks', passed: content.endsWith('**Rule.** Hidden outside every article heading.\n') }]);
+    },
+  },
+  {
+    id: 'p5-blind-protected-base',
+    property: 'P5',
+    violationClass: 'blind input / fail-open',
+    label: 'BLIND THE GUARD',
+    paths: [BASE_REGISTRY, BLINDED_BASE],
+    apply(root) { fs.renameSync(absolute(root, BASE_REGISTRY), absolute(root, BLINDED_BASE)); },
+    verify(root) {
+      return verification([
+        { check: 'configured protected-base input is unavailable', passed: !fs.existsSync(absolute(root, BASE_REGISTRY)) },
+        { check: 'control retains the original bytes', passed: fs.existsSync(absolute(root, BLINDED_BASE)) && read(root, BLINDED_BASE).includes('### Structure beats Willpower') },
+      ]);
+    },
+  },
+];

--- a/scratchpad/phaseB/adapters/testing-integrity-route-enforcement.mjs
+++ b/scratchpad/phaseB/adapters/testing-integrity-route-enforcement.mjs
@@ -1,0 +1,266 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const GUARD = 'scripts/lint-testing-integrity.mjs';
+const HELPER = 'tests/helpers/testingIntegrity.ts';
+const UNIT = 'tests/unit/scripts/testing-integrity-enforcement.test.ts';
+const INTEGRATION = 'tests/integration/testing-integrity-pipeline.test.ts';
+const E2E = 'tests/e2e/testing-integrity-guard-lifecycle.test.ts';
+const PING_ROUTES = 'src/server/routes.ts';
+
+function absolute(root, rel) {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) throw new Error(`path escapes isolated root: ${rel}`);
+  return resolved;
+}
+function read(root, rel) { return fs.readFileSync(absolute(root, rel), 'utf8'); }
+function write(root, rel, content) {
+  fs.mkdirSync(path.dirname(absolute(root, rel)), { recursive: true });
+  fs.writeFileSync(absolute(root, rel), content, 'utf8');
+}
+function replaceOnce(root, rel, before, after) {
+  const content = read(root, rel);
+  const first = content.indexOf(before);
+  if (first === -1 || first !== content.lastIndexOf(before)) throw new Error(`${rel}: replacement target missing or ambiguous`);
+  write(root, rel, `${content.slice(0, first)}${after}${content.slice(first + before.length)}`);
+}
+function replaceThroughMarker(root, rel, signature, endMarker, replacement) {
+  const content = read(root, rel);
+  const start = content.indexOf(signature);
+  if (start === -1 || content.indexOf(signature, start + signature.length) !== -1) throw new Error(`${rel}: function signature missing or ambiguous`);
+  const end = content.indexOf(endMarker, start);
+  if (end === -1) throw new Error(`${rel}: end marker missing`);
+  write(root, rel, `${content.slice(0, start)}${replacement}${content.slice(end)}`);
+}
+function verifyIncludes(root, rel, included, excluded = []) {
+  const content = read(root, rel);
+  const checks = [
+    ...included.map(value => ({ check: `${rel} includes ${JSON.stringify(value)}`, passed: content.includes(value) })),
+    ...excluded.map(value => ({ check: `${rel} excludes ${JSON.stringify(value)}`, passed: !content.includes(value) })),
+  ];
+  return { ok: checks.every(item => item.passed), checks };
+}
+
+function relevance(mode, checks, extra = {}) {
+  return {
+    status: checks.every(item => item.passed) ? 'proven' : 'unknown',
+    mode,
+    checks,
+    ...extra,
+  };
+}
+
+function enumerateRoute(root, method, routePath, relativeFile) {
+  const program = `
+import { enumerateHttpRoutes } from './scripts/lint-testing-integrity.mjs';
+const [root, method, routePath, relativeFile] = process.argv.slice(1);
+const route = enumerateHttpRoutes({ root }).find((item) =>
+  item.method === method && item.path === routePath && item.declarations.includes(relativeFile));
+if (!route) process.exit(1);
+process.stdout.write(JSON.stringify(route));
+`;
+  return spawnSync(process.execPath, ['--input-type=module', '-e', program, root, method, routePath, relativeFile], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+function enumerateWhileBlind(root) {
+  const program = `
+import { enumerateHttpRoutes } from './scripts/lint-testing-integrity.mjs';
+enumerateHttpRoutes({ root: process.argv[1] });
+`;
+  return spawnSync(process.execPath, ['--input-type=module', '-e', program, root], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+const guardDriver = `
+const { spawnSync } = require('node:child_process');
+const runs = [
+  [process.execPath, ['scripts/lint-testing-integrity.mjs']],
+  [process.execPath, ['node_modules/vitest/vitest.mjs', 'run',
+    'tests/unit/scripts/testing-integrity-enforcement.test.ts',
+    'tests/integration/testing-integrity-pipeline.test.ts',
+    'tests/e2e/testing-integrity-guard-lifecycle.test.ts',
+    '--config', 'vitest.push.config.ts', '--reporter=verbose']],
+];
+let failed = false;
+for (const [command, args] of runs) {
+  const run = spawnSync(command, args, { cwd: process.cwd(), encoding: 'utf8', env: process.env, timeout: 600000 });
+  process.stdout.write(run.stdout || '');
+  process.stderr.write(run.stderr || '');
+  if (run.error || run.status !== 0) failed = true;
+}
+console.log('[testing-integrity-adapter-driver] completed; failed=' + failed);
+process.exitCode = failed ? 1 : 0;
+`;
+
+export const pipelineCommands = [{ argv: ['npm', 'run', 'lint'], observeAny: ['[testing-integrity]'], timeoutMs: 600_000 }];
+export const guardCommands = [{ argv: [process.execPath, '-e', guardDriver], observeAny: ['testing-integrity'], timeoutMs: 1_200_000 }];
+
+export function prepareWorkspace(root) {
+  void root;
+}
+
+const alivePing = `  router.get('/ping', (_req, res) => {\n    res.json({ status: 'ok' });\n  });`;
+const deadPing = `  router.get('/ping', (_req, res) => {\n    // B1.2 adapter: same route symbol and shape, behavior hollowed to dead-on-arrival.\n    res.status(503).json({ status: 'ok' });\n  });`;
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-route-hollow', property: 'P1', violationClass: 'hollowing', label: 'SYMBOL-PRESERVING HOLLOW', paths: [PING_ROUTES],
+    apply(root) { replaceOnce(root, PING_ROUTES, alivePing, deadPing); },
+    verify(root) { return verifyIncludes(root, PING_ROUTES, ["router.get('/ping'", 'B1.2 adapter:', 'res.status(503)']); },
+  },
+  {
+    id: 'p2-route-self-reports-clean', property: 'P2', violationClass: 'self-report / false testimony', label: 'SUBJECT SELF-REPORTS CLEAN', paths: [PING_ROUTES],
+    apply(root) {
+      replaceOnce(root, PING_ROUTES, alivePing, deadPing);
+    },
+    verify(root) {
+      const route = verifyIncludes(root, PING_ROUTES, ['res.status(503)']);
+      const helper = verifyIncludes(root, HELPER, [
+        'expect(response.status).toBe(evidence.expectedStatus);',
+        'expect(response.status).not.toBe(503);',
+        'status: response.status,',
+      ], ['subject suppresses the real status oracle']);
+      return { ok: route.ok && helper.ok, checks: [...route.checks, ...helper.checks] };
+    },
+  },
+  {
+    id: 'p3a-delete', property: 'P3', violationClass: 'guard removal', label: 'DELETE', paths: [GUARD],
+    apply(root) { fs.unlinkSync(absolute(root, GUARD)); },
+    verify(root) { const passed = !fs.existsSync(absolute(root, GUARD)); return { ok: passed, checks: [{ check: `${GUARD} is absent`, passed }] }; },
+  },
+  {
+    id: 'p3b-comment-out', property: 'P3', violationClass: 'guard removal', label: 'COMMENT OUT', paths: [GUARD],
+    apply(root) { write(root, GUARD, read(root, GUARD).split('\n').map(line => `// ${line}`).join('\n')); },
+    verify(root) { const lines = read(root, GUARD).split('\n').filter(Boolean); const passed = lines.length > 0 && lines.every(line => line.startsWith('// ')); return { ok: passed, checks: [{ check: `${GUARD} has no executable line`, passed }] }; },
+  },
+  {
+    id: 'p3c-superstring-rename', property: 'P3', violationClass: 'guard removal', label: 'SUPERSTRING RENAME', paths: [GUARD],
+    apply(root) { const content = read(root, GUARD); if (!/\benforceTestingIntegrity\b/.test(content)) throw new Error('key guard symbol missing'); write(root, GUARD, content.replaceAll('enforceTestingIntegrity', 'enforceTestingIntegrityDisabled')); },
+    verify(root) { const content = read(root, GUARD); const checks = [{ check: 'longer symbol exists', passed: content.includes('enforceTestingIntegrityDisabled') }, { check: 'standalone original is absent', passed: !/\benforceTestingIntegrity\b/.test(content) }]; return { ok: checks.every(item => item.passed), checks }; },
+  },
+  {
+    id: 'p3d-type-preserving-hollow', property: 'P3', violationClass: 'guard removal', label: 'TYPE-PRESERVING HOLLOW', paths: [GUARD],
+    apply(root) { replaceThroughMarker(root, GUARD, 'export async function enforceTestingIntegrity(options = {}) {', '\nasync function main() {', `export async function enforceTestingIntegrity(options = {}) {\n  // B1.2 type-preserving hollow: same export/signature, constant passing verdict.\n  void options;\n  return { passed: true, populationCount: 1, changedRoutes: [], errors: [] };\n}\n`); },
+    verify(root) { return verifyIncludes(root, GUARD, ['export async function enforceTestingIntegrity(options = {}) {', 'B1.2 type-preserving hollow', 'passed: true']); },
+  },
+  {
+    id: 'p4a-empty-route-population', property: 'P4', violationClass: 'vacuous measurement', label: 'EMPTY THE POPULATION', paths: [GUARD],
+    apply(root) { replaceOnce(root, GUARD, 'export function enumerateHttpRoutes({ root }) {\n  const sourceRoot', 'export function enumerateHttpRoutes({ root }) {\n  // B1.2 adapter: forced empty denominator.\n  void root;\n  return [];\n  const sourceRoot'); },
+    verify(root) { return verifyIncludes(root, GUARD, ['B1.2 adapter: forced empty denominator', 'return [];']); },
+  },
+  {
+    id: 'p4b-nested-route-evasion', property: 'P4', violationClass: 'population evasion', label: 'HIDE A REAL VIOLATION AT A NESTED SOURCE PATH', paths: ['src/phase-b/deep/nested/untested-route.ts'],
+    apply(root) { write(root, this.paths[0], "import { Router } from 'express';\nconst router = Router();\nrouter.get('/phase-b-hidden', (_req, res) => res.status(200).end());\n"); },
+    verify(root) { return verifyIncludes(root, this.paths[0], ["router.get('/phase-b-hidden'"]); },
+  },
+  {
+    id: 'p5-blind-route-source', property: 'P5', violationClass: 'blind input / fail-open', label: 'BLIND THE GUARD', paths: [PING_ROUTES],
+    apply(root) { fs.chmodSync(absolute(root, PING_ROUTES), 0o000); },
+    verify(root) { const mode = fs.statSync(absolute(root, PING_ROUTES)).mode & 0o777; return { ok: mode === 0, checks: [{ check: `${PING_ROUTES} mode is 000`, passed: mode === 0 }] }; },
+  },
+];
+
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles, subjectFiles }) {
+  const guards = new Set(guardFiles);
+  const subjects = new Set(subjectFiles);
+  const declared = new Set([...guards, ...subjects]);
+
+  if (mutation.id === 'p4b-nested-route-evasion') {
+    const planted = mutation.paths[0];
+    const routeProbe = enumerateRoute(root, 'GET', '/phase-b-hidden', planted);
+    return relevance('outside-enumeration', [
+      { check: 'planted route is outside the manifest-declared guard and subject paths', passed: changedPaths.includes(planted) && !declared.has(planted) },
+      { check: 'planted source contains a real Express route declaration', passed: fs.existsSync(absolute(root, planted)) && read(root, planted).includes("router.get('/phase-b-hidden'") },
+      { check: 'the live recursive production enumerator sees the exact planted route and source', passed: routeProbe.status === 0 && routeProbe.stdout.includes('"path":"/phase-b-hidden"') && routeProbe.stdout.includes(planted) },
+    ], {
+      decidingOutput: { kind: 'live-route-enumeration', exitCode: routeProbe.status, stdout: routeProbe.stdout, stderr: routeProbe.stderr },
+    });
+  }
+
+  const checks = [];
+  let semantic = false;
+
+  if (mutation.id === 'p1-symbol-preserving-route-hollow') {
+    const routeProbe = enumerateRoute(root, 'GET', '/ping', PING_ROUTES);
+    checks.push(
+      { check: 'only the real production route subject is mutated', passed: changedPaths.length === 1 && changedPaths[0] === PING_ROUTES && subjects.has(PING_ROUTES) },
+      { check: 'the route symbol and response shape remain while behavior is dead', passed: read(root, PING_ROUTES).includes("router.get('/ping'") && read(root, PING_ROUTES).includes('res.status(503)') },
+      { check: 'the live production enumerator still identifies GET /ping from the mutated subject', passed: routeProbe.status === 0 && routeProbe.stdout.includes('"path":"/ping"') && routeProbe.stdout.includes(PING_ROUTES) },
+    );
+    semantic = true;
+  }
+
+  if (mutation.id === 'p2-route-self-reports-clean') {
+    const routeProbe = enumerateRoute(root, 'GET', '/ping', PING_ROUTES);
+    checks.push(
+      { check: 'P2 mutates only the production subject and never the external oracle', passed: changedPaths.length === 1 && changedPaths[0] === PING_ROUTES && subjects.has(PING_ROUTES) && !changedPaths.includes(HELPER) },
+      { check: 'the evidence helper is guard-owned rather than subject-owned', passed: guards.has(HELPER) && !subjects.has(HELPER) },
+      { check: 'subject falsely reports an ok body while returning dead status 503', passed: read(root, PING_ROUTES).includes("res.status(503).json({ status: 'ok' })") },
+      { check: 'external oracle still asserts the observed response status and rejects 503', passed: read(root, HELPER).includes('expect(response.status).toBe(evidence.expectedStatus);') && read(root, HELPER).includes('expect(response.status).not.toBe(503);') && read(root, HELPER).includes('status: response.status,') },
+      { check: 'the live production enumerator still identifies the self-reporting GET /ping subject', passed: routeProbe.status === 0 && routeProbe.stdout.includes('"path":"/ping"') && routeProbe.stdout.includes(PING_ROUTES) },
+    );
+    semantic = true;
+  }
+
+  if (mutation.id === 'p3a-delete') {
+    checks.push({ check: 'declared guard entry point is deleted', passed: changedPaths.includes(GUARD) && guards.has(GUARD) && !fs.existsSync(absolute(root, GUARD)) });
+    semantic = true;
+  }
+  if (mutation.id === 'p3b-comment-out') {
+    const lines = read(root, GUARD).split('\n').filter(Boolean);
+    checks.push({ check: 'declared guard entry point has no executable line', passed: changedPaths.includes(GUARD) && guards.has(GUARD) && lines.length > 0 && lines.every(line => line.startsWith('// ')) });
+    semantic = true;
+  }
+  if (mutation.id === 'p3c-superstring-rename') {
+    const content = read(root, GUARD);
+    checks.push({ check: 'declared guard symbol is superstring-renamed away', passed: changedPaths.includes(GUARD) && guards.has(GUARD) && content.includes('enforceTestingIntegrityDisabled') && !/\benforceTestingIntegrity\b/.test(content) });
+    semantic = true;
+  }
+  if (mutation.id === 'p3d-type-preserving-hollow') {
+    const content = read(root, GUARD);
+    checks.push({ check: 'declared guard keeps its export/signature but returns a constant passing verdict', passed: changedPaths.includes(GUARD) && guards.has(GUARD) && content.includes('export async function enforceTestingIntegrity(options = {}) {') && content.includes('B1.2 type-preserving hollow') && content.includes('passed: true') });
+    semantic = true;
+  }
+  if (mutation.id === 'p4a-empty-route-population') {
+    const content = read(root, GUARD);
+    checks.push({ check: 'live route denominator is forced empty in the declared guard enumerator', passed: changedPaths.includes(GUARD) && guards.has(GUARD) && content.includes('B1.2 adapter: forced empty denominator') && content.includes('return [];') });
+    semantic = true;
+  }
+  if (mutation.id === 'p5-blind-route-source') {
+    const target = absolute(root, PING_ROUTES);
+    const blindedMode = fs.statSync(target).mode & 0o777;
+    fs.chmodSync(target, 0o600);
+    let routeProbe;
+    try {
+      routeProbe = enumerateRoute(root, 'GET', '/ping', PING_ROUTES);
+    } finally {
+      fs.chmodSync(target, blindedMode);
+    }
+    const blindProbe = enumerateWhileBlind(root);
+    checks.push(
+      { check: 'real production route subject is the blinded input', passed: changedPaths.includes(PING_ROUTES) && subjects.has(PING_ROUTES) && blindedMode === 0 },
+      { check: 'the readable control proves this file supplies GET /ping to the live enumerator', passed: routeProbe.status === 0 && routeProbe.stdout.includes('"path":"/ping"') && routeProbe.stdout.includes(PING_ROUTES) },
+      { check: 'the live enumerator cannot inspect the restored mode-000 source', passed: blindProbe.status !== 0 && /could not read[\s\S]*src\/server\/routes\.ts/i.test(`${blindProbe.stderr}${blindProbe.stdout}`) },
+    );
+    semantic = true;
+  }
+
+  if (!semantic) {
+    checks.push({ check: `adapter recognizes mutation ${mutation.id}`, passed: false });
+  }
+  return relevance('declared-load-bearing-input', checks);
+}
+
+export function applyDeliberatelyHollowGuard(root) {
+  const hollow = `import { describe, expect, it } from 'vitest';\ndescribe('deliberately hollow Testing Integrity guard', () => { it('asserts nothing about behavior', () => expect(true).toBe(true)); });\n`;
+  for (const rel of [UNIT, INTEGRATION, E2E]) write(root, rel, hollow);
+  return { paths: [UNIT, INTEGRATION, E2E], verify() { const checks = [UNIT, INTEGRATION, E2E].map(rel => ({ check: `${rel} is deliberately hollow`, passed: read(root, rel).includes('deliberately hollow Testing Integrity guard') })); return { ok: checks.every(item => item.passed), checks }; } };
+}

--- a/scratchpad/phaseB/adapters/topic-operator-evidence.mjs
+++ b/scratchpad/phaseB/adapters/topic-operator-evidence.mjs
@@ -1,0 +1,389 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const STORE = 'src/users/TopicOperatorStore.ts';
+const ROUTES = 'src/server/routes.ts';
+const UNIT_GUARD = 'tests/unit/topic-operator-store.test.ts';
+const ROUTE_GUARD = 'tests/integration/topic-operator-routes.test.ts';
+const AUTH_PATH_GUARD = 'tests/integration/topic-operator-autobind-route.test.ts';
+
+function absolute(root, rel) {
+  const resolved = path.resolve(root, rel);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`path escapes isolated root: ${rel}`);
+  }
+  return resolved;
+}
+
+function read(root, rel) {
+  return fs.readFileSync(absolute(root, rel), 'utf8');
+}
+
+function write(root, rel, content) {
+  fs.writeFileSync(absolute(root, rel), content, 'utf8');
+}
+
+function replaceOnce(root, rel, before, after) {
+  const content = read(root, rel);
+  const first = content.indexOf(before);
+  const last = content.lastIndexOf(before);
+  if (first === -1 || first !== last) {
+    throw new Error(`${rel}: expected exactly one replacement target; first=${first} last=${last}`);
+  }
+  write(root, rel, `${content.slice(0, first)}${after}${content.slice(first + before.length)}`);
+}
+
+function replaceThroughMarker(root, rel, startMarker, endMarker, replacement) {
+  const content = read(root, rel);
+  const start = content.indexOf(startMarker);
+  if (start === -1 || content.indexOf(startMarker, start + startMarker.length) !== -1) {
+    throw new Error(`${rel}: start marker is missing or ambiguous: ${startMarker}`);
+  }
+  const end = content.indexOf(endMarker, start);
+  if (end === -1) throw new Error(`${rel}: end marker missing after ${startMarker}`);
+  write(root, rel, `${content.slice(0, start)}${replacement}${content.slice(end)}`);
+}
+
+function verifyIncludes(root, rel, included, excluded = []) {
+  const content = read(root, rel);
+  const checks = [
+    ...included.map((value) => ({ check: `${rel} includes ${JSON.stringify(value)}`, passed: content.includes(value) })),
+    ...excluded.map((value) => ({ check: `${rel} excludes ${JSON.stringify(value)}`, passed: !content.includes(value) })),
+  ];
+  return { ok: checks.every((item) => item.passed), checks };
+}
+
+const TEST_ARGS = [UNIT_GUARD, ROUTE_GUARD, AUTH_PATH_GUARD];
+
+export const pipelineCommands = [
+  {
+    argv: ['npm', 'run', 'test:push', '--', ...TEST_ARGS, '--reporter=verbose'],
+    observeAny: [
+      'TopicOperatorStore asserted and legacy bindings',
+      'Topic Operator Routes (integration)',
+      'topic-operator auto-bind (integration)',
+      'No test files found',
+    ],
+    timeoutMs: 1_200_000,
+  },
+];
+
+export const guardCommands = [
+  {
+    argv: [
+      'node_modules/.bin/vitest', 'run', ...TEST_ARGS,
+      '--config=.b0-fix-verifier.vitest.config.mjs',
+      '--reporter=verbose',
+    ],
+    observeAny: [
+      'TopicOperatorStore asserted and legacy bindings',
+      'Topic Operator Routes (integration)',
+      'topic-operator auto-bind (integration)',
+      'No test files found',
+    ],
+    timeoutMs: 120_000,
+  },
+];
+
+export function prepareWorkspace(root) {
+  write(root, '.b0-fix-verifier.vitest.config.mjs', `export default {\n  test: {\n    environment: 'node',\n    fileParallelism: false,\n    testTimeout: 20_000,\n  },\n};\n`);
+}
+
+const PREDICATE_START = 'export function isVerifiedTopicOperatorBinding(value: unknown): value is TopicOperator {';
+const PREDICATE_END = '\n\nexport class TopicOperatorStore {';
+const AUTH_WRITER_START = '  setAuthenticatedOperator(';
+const AUTH_WRITER_END = '\n\n  private persistBinding(';
+const ALL_START = '  all(): Record<string, TopicOperator> {';
+const ALL_END = '\n\n  /** All raw bindings for inspection only. */';
+
+function structuredRelevance(mode, checks) {
+  return {
+    status: checks.length > 0 && checks.every((item) => item.passed === true) ? 'proven' : 'unknown',
+    mode,
+    checks,
+  };
+}
+
+/**
+ * Carry semantic evidence that each mutation actually reaches a load-bearing
+ * subject input.  The verifier deliberately refuses an unstructured claim;
+ * these checks are read-only and describe the mutation after it is applied.
+ */
+export function verifyMutationRelevant({ root, mutation, changedPaths, guardFiles = [], subjectFiles = [] }) {
+  const declared = new Set([...guardFiles, ...subjectFiles]);
+  const routed = changedPaths.some((rel) => declared.has(rel));
+  const store = () => read(root, STORE);
+  const routes = () => read(root, ROUTES);
+  const declaredCheck = { check: 'mutation changed a declared load-bearing subject path', passed: routed };
+
+  if (mutation.id === 'p4b-hidden-real-violation') {
+    const content = store();
+    return structuredRelevance('outside-enumeration', [
+      declaredCheck,
+      {
+        check: 'non-numeric topic key is explicitly excluded by the mutated enumeration',
+        passed: content.includes("if (!/^\\d+$/.test(topicId)) continue;"),
+      },
+      {
+        check: 'the mutated enumeration still subjects numeric entries to the evidence predicate',
+        passed: content.includes('isVerifiedTopicOperatorBinding(binding)'),
+      },
+    ]);
+  }
+
+  const checks = [declaredCheck];
+  const content = mutation.id === 'p5-blind-input' ? routes() : store();
+  switch (mutation.id) {
+    case 'p1-symbol-preserving-hollow':
+      checks.push({ check: 'authenticated writer body is the type-correct hollow mutation', passed: content.includes('B0.1 P1: API preserved, authenticated state transition hollowed.') && content.includes('return null;') });
+      break;
+    case 'p2-subject-self-reports-clean':
+      checks.push({ check: 'predicate now trusts provenance instead of evidence', passed: content.includes("B0.1 P2: trust the subject's provenance claim") && content.includes(".boundFrom === 'authenticated-inbound'") && !content.includes('evidence.kind !==') });
+      break;
+    case 'p3a-delete':
+      checks.push({ check: 'predicate declaration is absent after deletion', passed: !content.includes(PREDICATE_START) });
+      break;
+    case 'p3b-comment-out':
+      checks.push({ check: 'predicate declaration and verdict are comments, not executable code', passed: content.includes(`// ${PREDICATE_START}`) && !content.split('\n').includes(PREDICATE_START) });
+      break;
+    case 'p3c-superstring-rename':
+      checks.push({ check: 'only the longer superstring predicate name remains', passed: content.includes('isVerifiedTopicOperatorBindingDisabled') && !content.includes(PREDICATE_START) });
+      break;
+    case 'p3d-type-preserving-hollow':
+      checks.push({ check: 'predicate returns a type-valid constant verdict', passed: content.includes('B0.1 P3d: type-preserving constant passing verdict.') && content.includes('return true;') });
+      break;
+    case 'p4a-empty-population':
+      checks.push({ check: 'enumerator returns the deliberately empty population', passed: content.includes('B0.1 P4a: force a vacuous verified-binding population.') && content.includes('return {};') });
+      break;
+    case 'p5-blind-input':
+      checks.push({ check: 'both direct and raw evidence inputs are blinded', passed: content.includes("messageId: '', // B0.1 P5: authenticated evidence input unavailable.") && content.includes("telegramMessageId: '', // B0.1 P5: raw lifeline evidence input unavailable.") });
+      break;
+    default:
+      checks.push({ check: `adapter recognizes mutation ${mutation.id}`, passed: false });
+  }
+  return structuredRelevance('declared-load-bearing-input', checks);
+}
+
+export const mutations = [
+  {
+    id: 'p1-symbol-preserving-hollow',
+    property: 'P1',
+    violationClass: 'hollowing',
+    label: 'SYMBOL-PRESERVING HOLLOW',
+    paths: [STORE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        STORE,
+        AUTH_WRITER_START,
+        AUTH_WRITER_END,
+        `  setAuthenticatedOperator(\n    topicId: number | string,\n    input: { platform: string; uid: string; displayName?: string; boundAt?: string },\n    evidence: AuthenticatedTopicOperatorEvidence,\n  ): TopicOperator | null {\n    // B0.1 P1: API preserved, authenticated state transition hollowed.\n    void topicId;\n    void input;\n    void evidence;\n    return null;\n  }`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, STORE, [
+        AUTH_WRITER_START,
+        'B0.1 P1: API preserved, authenticated state transition hollowed.',
+        'return null;',
+      ]);
+    },
+  },
+  {
+    id: 'p2-subject-self-reports-clean',
+    property: 'P2',
+    violationClass: 'self-report / false testimony',
+    label: 'SUBJECT SELF-REPORTS CLEAN',
+    paths: [STORE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        STORE,
+        PREDICATE_START,
+        PREDICATE_END,
+        `${PREDICATE_START}\n  // B0.1 P2: trust the subject's provenance claim and ignore its evidence.\n  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;\n  return (value as Partial<TopicOperatorBinding>).boundFrom === 'authenticated-inbound';\n}`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, STORE, [
+        PREDICATE_START,
+        "B0.1 P2: trust the subject's provenance claim",
+        ".boundFrom === 'authenticated-inbound'",
+      ], ['evidence.kind !==']);
+    },
+  },
+  {
+    id: 'p3a-delete',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'DELETE',
+    paths: [STORE],
+    apply(root) {
+      replaceThroughMarker(root, STORE, PREDICATE_START, PREDICATE_END, '');
+    },
+    verify(root) {
+      return verifyIncludes(root, STORE, [], [PREDICATE_START]);
+    },
+  },
+  {
+    id: 'p3b-comment-out',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'COMMENT OUT',
+    paths: [STORE],
+    apply(root) {
+      const content = read(root, STORE);
+      const start = content.indexOf(PREDICATE_START);
+      const end = content.indexOf(PREDICATE_END, start);
+      if (start === -1 || end === -1) throw new Error('predicate block not found');
+      const commented = content.slice(start, end).split('\n').map((line) => `// ${line}`).join('\n');
+      write(root, STORE, `${content.slice(0, start)}${commented}${content.slice(end)}`);
+    },
+    verify(root) {
+      const lines = read(root, STORE).split('\n');
+      const checks = [
+        { check: 'commented predicate declaration exists', passed: lines.includes(`// ${PREDICATE_START}`) },
+        { check: 'commented terminal verdict exists', passed: lines.includes('//   return true;') },
+        { check: 'no executable predicate declaration line remains', passed: !lines.includes(PREDICATE_START) },
+      ];
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+  {
+    id: 'p3c-superstring-rename',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'SUPERSTRING RENAME',
+    paths: [STORE],
+    apply(root) {
+      replaceOnce(
+        root,
+        STORE,
+        PREDICATE_START,
+        'export function isVerifiedTopicOperatorBindingDisabled(value: unknown): value is TopicOperator {',
+      );
+    },
+    verify(root) {
+      const content = read(root, STORE);
+      const checks = [
+        { check: 'longer superstring declaration exists', passed: content.includes('isVerifiedTopicOperatorBindingDisabled') },
+        { check: 'original remains a substring', passed: content.includes('isVerifiedTopicOperatorBinding') },
+        { check: 'standalone original declaration is absent', passed: !content.includes(PREDICATE_START) },
+      ];
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  },
+  {
+    id: 'p3d-type-preserving-hollow',
+    property: 'P3',
+    violationClass: 'guard removal',
+    label: 'TYPE-PRESERVING HOLLOW',
+    paths: [STORE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        STORE,
+        PREDICATE_START,
+        PREDICATE_END,
+        `${PREDICATE_START}\n  // B0.1 P3d: type-preserving constant passing verdict.\n  void value;\n  return true;\n}`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, STORE, [
+        PREDICATE_START,
+        'B0.1 P3d: type-preserving constant passing verdict.',
+        'return true;',
+      ]);
+    },
+  },
+  {
+    id: 'p4a-empty-population',
+    property: 'P4',
+    violationClass: 'vacuous measurement',
+    label: 'EMPTY THE POPULATION',
+    paths: [STORE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        STORE,
+        ALL_START,
+        ALL_END,
+        `${ALL_START}\n    // B0.1 P4a: force a vacuous verified-binding population.\n    return {};\n  }`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, STORE, [
+        ALL_START,
+        'B0.1 P4a: force a vacuous verified-binding population.',
+        'return {};',
+      ]);
+    },
+  },
+  {
+    id: 'p4b-hidden-real-violation',
+    property: 'P4',
+    violationClass: 'population evasion',
+    label: 'HIDE A REAL VIOLATION OUTSIDE THE ENUMERATION',
+    paths: [STORE],
+    apply(root) {
+      replaceThroughMarker(
+        root,
+        STORE,
+        ALL_START,
+        ALL_END,
+        `${ALL_START}\n    const verified: Record<string, TopicOperator> = {};\n    for (const [topicId, binding] of Object.entries(this.load())) {\n      // B0.1 P4b: silently evade a real non-numeric topic key.\n      if (!/^\\d+$/.test(topicId)) continue;\n      if (isVerifiedTopicOperatorBinding(binding)) verified[topicId] = binding;\n    }\n    return verified;\n  }`,
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, STORE, [
+        ALL_START,
+        'B0.1 P4b: silently evade a real non-numeric topic key.',
+        "if (!/^\\d+$/.test(topicId)) continue;",
+      ]);
+    },
+  },
+  {
+    id: 'p5-blind-input',
+    property: 'P5',
+    violationClass: 'blind input / fail-open',
+    label: 'BLIND THE GUARD',
+    paths: [ROUTES],
+    apply(root) {
+      replaceOnce(
+        root,
+        ROUTES,
+        "            messageId: String(messageId ?? ''),",
+        "            messageId: '', // B0.1 P5: authenticated evidence input unavailable.",
+      );
+      replaceOnce(
+        root,
+        ROUTES,
+        "          telegramMessageId: messageId !== undefined && messageId !== null\n            ? String(messageId)\n            : '',",
+        "          telegramMessageId: '', // B0.1 P5: raw lifeline evidence input unavailable.",
+      );
+    },
+    verify(root) {
+      return verifyIncludes(root, ROUTES, [
+        "messageId: '', // B0.1 P5: authenticated evidence input unavailable.",
+        "telegramMessageId: '', // B0.1 P5: raw lifeline evidence input unavailable.",
+      ], [
+        "messageId: String(messageId ?? ''),",
+        'telegramMessageId: messageId !== undefined && messageId !== null',
+      ]);
+    },
+  },
+];
+
+export function applyDeliberatelyHollowGuard(root) {
+  const hollow = `import { describe, it, expect } from 'vitest';\n\ndescribe('topic-operator evidence deliberately hollow guard', () => {\n  it('self-reports clean without invoking production code', () => {\n    expect(true).toBe(true);\n  });\n});\n`;
+  for (const rel of TEST_ARGS) write(root, rel, hollow);
+  return {
+    paths: TEST_ARGS,
+    verify() {
+      const checks = TEST_ARGS.map((rel) => ({
+        check: `${rel} carries deliberate hollow marker`,
+        passed: read(root, rel).includes('topic-operator evidence deliberately hollow guard'),
+      }));
+      return { ok: checks.every((item) => item.passed), checks };
+    },
+  };
+}

--- a/scratchpad/phaseB/authenticated-execution-receipt.mjs
+++ b/scratchpad/phaseB/authenticated-execution-receipt.mjs
@@ -2,7 +2,9 @@ import crypto from 'node:crypto';
 import { MessageChannel, Worker, isMainThread, workerData } from 'node:worker_threads';
 
 const SCHEMA = 'phaseB-authenticated-execution-receipt/v1';
+const OBSERVER_EVENT_SCHEMA = 'phaseB-authenticated-observer-event/v1';
 const liveAuthenticatedReceipts = new WeakSet();
+const liveAuthenticatedObserverEvents = new WeakSet();
 
 function canonical(value) {
   if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
@@ -36,6 +38,9 @@ function normalizeObservation(authorityId, issuer, observation) {
     startedAt: String(observation.startedAt ?? ''),
     childExitedAt: String(observation.childExitedAt ?? ''),
     emittedAfterChildExit: observation.emittedAfterChildExit === true,
+    observerSession: String(observation.observerSession ?? ''),
+    observerEventSequence: Number.isSafeInteger(observation.observerEventSequence) ? observation.observerEventSequence : null,
+    observerEventSignatureHash: String(observation.observerEventSignatureHash ?? ''),
   };
 }
 
@@ -45,6 +50,7 @@ function startAuthorityWorker(port) {
   let issuer = null;
   const issued = new Map();
   const consumed = new Set();
+  const observers = new Map();
   const reply = (requestId, result, error = null) => port.postMessage({ requestId, result, error });
   port.on('message', (message) => {
     try {
@@ -59,10 +65,86 @@ function startAuthorityWorker(port) {
       }
       if (!key) throw new Error('receipt authority is unavailable');
       if (message?.type === 'issue') {
+        if (message.observation?.observerSession) {
+          const observer = observers.get(message.observation.observerSession);
+          const eventBound = observer
+            && observer.lastSequence === message.observation.observerEventSequence
+            && observer.observerPid === message.observation.observerPid
+            && observer.lastKind === message.observation.kind
+            && observer.lastSignatureHash === message.observation.observerEventSignatureHash;
+          if (!eventBound) throw new Error('receipt observation is not bound to the last authenticated observer event');
+        }
         const payload = normalizeObservation(authorityId, issuer, message.observation);
         const mac = crypto.createHmac('sha256', key).update(canonical(payload)).digest('hex');
         issued.set(payload.nonce, mac);
         reply(message.requestId, { ...payload, mac });
+        return;
+      }
+      if (message?.type === 'pin-observer') {
+        const event = message.event;
+        const expected = message.expected ?? {};
+        const payload = event && typeof event === 'object'
+          ? Object.fromEntries(Object.entries(event).filter(([field]) => field !== 'signature'))
+          : null;
+        const publicKey = typeof event?.publicKey === 'string'
+          ? crypto.createPublicKey({ key: Buffer.from(event.publicKey, 'base64'), format: 'der', type: 'spki' })
+          : null;
+        const signature = typeof event?.signature === 'string' ? Buffer.from(event.signature, 'base64') : Buffer.alloc(0);
+        const signatureValid = Boolean(payload && publicKey && signature.length > 0
+          && crypto.verify(null, Buffer.from(canonical(payload)), publicKey, signature));
+        const expectedValid = Object.entries(expected).every(([field, value]) => canonical(event?.[field]) === canonical(value));
+        const valid = Boolean(payload)
+          && event.eventSchema === OBSERVER_EVENT_SCHEMA
+          && event.source === 'fix-verifier-observer'
+          && event.kind === 'observer-ready'
+          && Number.isSafeInteger(event.sequence)
+          && event.sequence === 1
+          && typeof event.observerSession === 'string'
+          && event.observerSession.length > 0
+          && !observers.has(event.observerSession)
+          && signatureValid
+          && expectedValid;
+        if (valid) {
+          observers.set(event.observerSession, {
+            publicKey,
+            lastSequence: 1,
+            observerPid: event.observerPid,
+            guardId: event.guardId,
+            nodeEntry: event.nodeEntry,
+            lastKind: event.kind,
+            lastSignatureHash: crypto.createHash('sha256').update(event.signature).digest('hex'),
+          });
+        }
+        reply(message.requestId, { valid });
+        return;
+      }
+      if (message?.type === 'verify-observer-event') {
+        const event = message.event;
+        const expected = message.expected ?? {};
+        const state = observers.get(event?.observerSession);
+        const payload = event && typeof event === 'object'
+          ? Object.fromEntries(Object.entries(event).filter(([field]) => field !== 'signature'))
+          : null;
+        const signature = typeof event?.signature === 'string' ? Buffer.from(event.signature, 'base64') : Buffer.alloc(0);
+        const signatureValid = Boolean(payload && state && signature.length > 0
+          && crypto.verify(null, Buffer.from(canonical(payload)), state.publicKey, signature));
+        const expectedValid = Object.entries(expected).every(([field, value]) => canonical(event?.[field]) === canonical(value));
+        const valid = Boolean(payload && state)
+          && event.eventSchema === OBSERVER_EVENT_SCHEMA
+          && event.source === 'fix-verifier-observer'
+          && event.observerPid === state.observerPid
+          && event.guardId === state.guardId
+          && event.nodeEntry === state.nodeEntry
+          && Number.isSafeInteger(event.sequence)
+          && event.sequence === state.lastSequence + 1
+          && signatureValid
+          && expectedValid;
+        if (valid) {
+          state.lastSequence = event.sequence;
+          state.lastKind = event.kind;
+          state.lastSignatureHash = crypto.createHash('sha256').update(event.signature).digest('hex');
+        }
+        reply(message.requestId, { valid });
         return;
       }
       if (message?.type === 'verify') {
@@ -95,6 +177,7 @@ function startAuthorityWorker(port) {
         key = null;
         issued.clear();
         consumed.clear();
+        observers.clear();
         reply(message.requestId, { closed: true });
         port.close();
         return;
@@ -152,6 +235,26 @@ export async function createAuthenticatedReceiptAuthority({ issuer }) {
       if (closed) throw new Error('receipt authority is unavailable');
       return request('issue', { observation });
     },
+    async pinObserverEvent(event, expected = {}) {
+      if (closed) return false;
+      const result = await request('pin-observer', { event, expected });
+      if (result.valid && event && typeof event === 'object') {
+        if (Array.isArray(event.argv)) Object.freeze(event.argv);
+        Object.freeze(event);
+        liveAuthenticatedObserverEvents.add(event);
+      }
+      return result.valid;
+    },
+    async authenticateObserverEvent(event, expected = {}) {
+      if (closed) return false;
+      const result = await request('verify-observer-event', { event, expected });
+      if (result.valid && event && typeof event === 'object') {
+        if (Array.isArray(event.argv)) Object.freeze(event.argv);
+        Object.freeze(event);
+        liveAuthenticatedObserverEvents.add(event);
+      }
+      return result.valid;
+    },
     async authenticate(receipt, expected = {}) {
       if (closed) return false;
       const result = await request('verify', { receipt, expected });
@@ -177,4 +280,9 @@ export function isLiveAuthenticatedReceipt(receipt) {
   return Boolean(receipt && typeof receipt === 'object' && liveAuthenticatedReceipts.has(receipt));
 }
 
+export function isLiveAuthenticatedObserverEvent(event) {
+  return Boolean(event && typeof event === 'object' && liveAuthenticatedObserverEvents.has(event));
+}
+
 export const AUTHENTICATED_RECEIPT_SCHEMA = SCHEMA;
+export const AUTHENTICATED_OBSERVER_EVENT_SCHEMA = OBSERVER_EVENT_SCHEMA;

--- a/scratchpad/phaseB/authenticated-execution-receipt.mjs
+++ b/scratchpad/phaseB/authenticated-execution-receipt.mjs
@@ -1,0 +1,176 @@
+import crypto from 'node:crypto';
+import { MessageChannel, Worker, isMainThread, workerData } from 'node:worker_threads';
+
+const SCHEMA = 'phaseB-authenticated-execution-receipt/v1';
+const liveAuthenticatedReceipts = new WeakSet();
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeObservation(authorityId, issuer, observation) {
+  if (!observation || typeof observation !== 'object') throw new Error('execution observation must be an object');
+  if (!Number.isSafeInteger(observation.childPid) || observation.childPid <= 0) throw new Error('execution observation childPid is invalid');
+  if (!Number.isSafeInteger(observation.childExitCode) || observation.childExitCode < 0) throw new Error('execution observation childExitCode is invalid');
+  if (!Array.isArray(observation.argv) || observation.argv.length === 0 || observation.argv.some((item) => typeof item !== 'string')) {
+    throw new Error('execution observation argv is invalid');
+  }
+  const argvHash = crypto.createHash('sha256').update(canonical(observation.argv)).digest('hex');
+  return {
+    schema: SCHEMA,
+    authorityId,
+    issuer,
+    nonce: crypto.randomUUID(),
+    guardId: String(observation.guardId ?? ''),
+    kind: String(observation.kind ?? 'child-exit'),
+    observerPid: Number.isSafeInteger(observation.observerPid) ? observation.observerPid : null,
+    childPid: observation.childPid,
+    childExitCode: observation.childExitCode,
+    signal: observation.signal == null ? null : String(observation.signal),
+    argv: observation.argv,
+    argvHash,
+    startedAt: String(observation.startedAt ?? ''),
+    childExitedAt: String(observation.childExitedAt ?? ''),
+    emittedAfterChildExit: observation.emittedAfterChildExit === true,
+  };
+}
+
+function startAuthorityWorker(port) {
+  let key = null;
+  let authorityId = null;
+  let issuer = null;
+  const issued = new Map();
+  const consumed = new Set();
+  const reply = (requestId, result, error = null) => port.postMessage({ requestId, result, error });
+  port.on('message', (message) => {
+    try {
+      if (message?.type === 'initialize') {
+        if (key) throw new Error('receipt authority was already initialized');
+        key = Buffer.from(message.key);
+        if (key.length !== 32) throw new Error('receipt authority key must be 32 bytes');
+        authorityId = String(message.authorityId);
+        issuer = String(message.issuer);
+        reply(message.requestId, { ready: true, authorityId });
+        return;
+      }
+      if (!key) throw new Error('receipt authority is unavailable');
+      if (message?.type === 'issue') {
+        const payload = normalizeObservation(authorityId, issuer, message.observation);
+        const mac = crypto.createHmac('sha256', key).update(canonical(payload)).digest('hex');
+        issued.set(payload.nonce, mac);
+        reply(message.requestId, { ...payload, mac });
+        return;
+      }
+      if (message?.type === 'verify') {
+        const receipt = message.receipt;
+        const expected = message.expected ?? {};
+        const payload = receipt && typeof receipt === 'object'
+          ? Object.fromEntries(Object.entries(receipt).filter(([field]) => field !== 'mac'))
+          : null;
+        const expectedMac = payload ? crypto.createHmac('sha256', key).update(canonical(payload)).digest('hex') : '';
+        const actualMac = typeof receipt?.mac === 'string' && /^[a-f0-9]{64}$/.test(receipt.mac) ? receipt.mac : '';
+        const macValid = actualMac.length === expectedMac.length
+          && actualMac.length > 0
+          && crypto.timingSafeEqual(Buffer.from(actualMac), Buffer.from(expectedMac));
+        const issuedValid = issued.get(receipt?.nonce) === actualMac && !consumed.has(receipt?.nonce);
+        const expectedValid = Object.entries(expected).every(([field, value]) => canonical(receipt?.[field]) === canonical(value));
+        const valid = Boolean(payload)
+          && receipt.schema === SCHEMA
+          && receipt.authorityId === authorityId
+          && receipt.issuer === issuer
+          && receipt.emittedAfterChildExit === true
+          && macValid
+          && issuedValid
+          && expectedValid;
+        if (valid) consumed.add(receipt.nonce);
+        reply(message.requestId, { valid });
+        return;
+      }
+      if (message?.type === 'close') {
+        key.fill(0);
+        key = null;
+        issued.clear();
+        consumed.clear();
+        reply(message.requestId, { closed: true });
+        port.close();
+        return;
+      }
+      throw new Error('unknown receipt authority request');
+    } catch (error) {
+      reply(message?.requestId, null, error instanceof Error ? error.message : String(error));
+    }
+  });
+  port.start();
+}
+
+if (!isMainThread && workerData?.role === 'phaseB-execution-receipt-authority') {
+  startAuthorityWorker(workerData.port);
+}
+
+export async function createAuthenticatedReceiptAuthority({ issuer }) {
+  if (typeof issuer !== 'string' || issuer.length === 0) throw new Error('receipt authority issuer is required');
+  const authorityId = crypto.randomUUID();
+  const key = new Uint8Array(crypto.randomBytes(32));
+  const { port1, port2 } = new MessageChannel();
+  const worker = new Worker(new URL(import.meta.url), {
+    workerData: { role: 'phaseB-execution-receipt-authority', port: port2 },
+    transferList: [port2],
+  });
+  let requestSequence = 0;
+  const pending = new Map();
+  let workerFailure = null;
+  port1.on('message', (message) => {
+    const waiter = pending.get(message.requestId);
+    if (!waiter) return;
+    pending.delete(message.requestId);
+    if (message.error) waiter.reject(new Error(message.error));
+    else waiter.resolve(message.result);
+  });
+  worker.on('error', (error) => {
+    workerFailure = error;
+    for (const waiter of pending.values()) waiter.reject(error);
+    pending.clear();
+  });
+  const request = (type, fields = {}, transferList = []) => new Promise((resolve, reject) => {
+    if (workerFailure) { reject(workerFailure); return; }
+    const requestId = ++requestSequence;
+    pending.set(requestId, { resolve, reject });
+    port1.postMessage({ type, requestId, ...fields }, transferList);
+  });
+  const keyBuffer = key.buffer;
+  await request('initialize', { authorityId, issuer, key }, [keyBuffer]);
+
+  let closed = false;
+  return {
+    authorityId,
+    issuer,
+    async issue(observation) {
+      if (closed) throw new Error('receipt authority is unavailable');
+      return request('issue', { observation });
+    },
+    async authenticate(receipt, expected = {}) {
+      if (closed) return false;
+      const result = await request('verify', { receipt, expected });
+      if (result.valid && receipt && typeof receipt === 'object') liveAuthenticatedReceipts.add(receipt);
+      return result.valid;
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      try { await request('close'); } finally {
+        port1.close();
+        await worker.terminate();
+      }
+    },
+  };
+}
+
+export function isLiveAuthenticatedReceipt(receipt) {
+  return Boolean(receipt && typeof receipt === 'object' && liveAuthenticatedReceipts.has(receipt));
+}
+
+export const AUTHENTICATED_RECEIPT_SCHEMA = SCHEMA;

--- a/scratchpad/phaseB/authenticated-execution-receipt.mjs
+++ b/scratchpad/phaseB/authenticated-execution-receipt.mjs
@@ -155,7 +155,11 @@ export async function createAuthenticatedReceiptAuthority({ issuer }) {
     async authenticate(receipt, expected = {}) {
       if (closed) return false;
       const result = await request('verify', { receipt, expected });
-      if (result.valid && receipt && typeof receipt === 'object') liveAuthenticatedReceipts.add(receipt);
+      if (result.valid && receipt && typeof receipt === 'object') {
+        if (Array.isArray(receipt.argv)) Object.freeze(receipt.argv);
+        Object.freeze(receipt);
+        liveAuthenticatedReceipts.add(receipt);
+      }
       return result.valid;
     },
     async close() {

--- a/scratchpad/phaseB/authenticated-execution-receipt.test.mjs
+++ b/scratchpad/phaseB/authenticated-execution-receipt.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+
+import {
+  createAuthenticatedReceiptAuthority,
+  isLiveAuthenticatedReceipt,
+} from './authenticated-execution-receipt.mjs';
+
+function runChild(argv) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(argv[0], argv.slice(1), { stdio: ['ignore', 'pipe', 'pipe'] });
+    const pid = child.pid;
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolve({ pid, code, signal }));
+  });
+}
+
+test('C1 private-channel authority issues and authenticates a real child receipt', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H1-C1' });
+  try {
+    const argv = [process.execPath, '-e', 'process.exit(0)'];
+    const startedAt = new Date().toISOString();
+    const child = await runChild(argv);
+    const receipt = await authority.issue({
+      guardId: 'real-child', kind: 'child-exit', observerPid: process.pid,
+      childPid: child.pid, childExitCode: child.code, signal: child.signal,
+      argv, startedAt, childExitedAt: new Date().toISOString(), emittedAfterChildExit: true,
+    });
+    assert.equal(await authority.authenticate(receipt, {
+      guardId: 'real-child', childPid: child.pid, childExitCode: 0,
+    }), true);
+    assert.equal(isLiveAuthenticatedReceipt(receipt), true);
+    console.log(`H1_C1 realChildPid=${child.pid} childExit=0 authenticated=true channel=MessagePort`);
+  } finally {
+    await authority.close();
+  }
+});
+
+test('C3 same-user stand-in cannot forge or replay a receipt from disk-visible values', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'h1-c3-standin-'));
+  const forgedPath = path.join(root, 'forged-receipt.json');
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H1-C3' });
+  try {
+    const honest = await authority.issue({
+      guardId: 'declared-real-child', kind: 'child-exit', observerPid: process.pid,
+      childPid: process.pid, childExitCode: 0, signal: null,
+      argv: [process.execPath, 'declared-real-child.mjs'],
+      startedAt: new Date().toISOString(), childExitedAt: new Date().toISOString(), emittedAfterChildExit: true,
+    });
+    assert.equal(await authority.authenticate(honest, { guardId: 'declared-real-child' }), true);
+
+    const diskVisibleForgery = {
+      ...honest,
+      nonce: 'candidate-chosen-nonce',
+      childPid: process.pid + 10_000,
+      argv: [process.execPath, 'stand-in-that-does-not-run-the-child.mjs'],
+    };
+    const standIn = await runChild([
+      process.execPath,
+      '-e',
+      "require('fs').writeFileSync(process.argv[1], process.argv[2])",
+      forgedPath,
+      JSON.stringify(diskVisibleForgery),
+    ]);
+    assert.equal(standIn.code, 0);
+    const forged = JSON.parse(fs.readFileSync(forgedPath, 'utf8'));
+    assert.equal(await authority.authenticate(forged, { guardId: 'declared-real-child' }), false);
+    assert.equal(isLiveAuthenticatedReceipt(forged), false);
+
+    const replay = JSON.parse(JSON.stringify(honest));
+    assert.equal(await authority.authenticate(replay, { guardId: 'declared-real-child' }), false);
+    assert.equal(isLiveAuthenticatedReceipt(replay), false);
+    console.log(`H1_C3 standInExit=${standIn.code} realChildRan=false forgedAuthenticated=false replayAuthenticated=false verdict=NOT-PROVEN`);
+  } finally {
+    await authority.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('unavailable private authority never authenticates evidence', async () => {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: 'H1-unavailable' });
+  await authority.close();
+  assert.equal(await authority.authenticate({}, {}), false);
+  await assert.rejects(() => authority.issue({}), /unavailable/);
+});

--- a/scratchpad/phaseB/authenticated-execution-receipt.test.mjs
+++ b/scratchpad/phaseB/authenticated-execution-receipt.test.mjs
@@ -33,6 +33,8 @@ test('C1 private-channel authority issues and authenticates a real child receipt
     assert.equal(await authority.authenticate(receipt, {
       guardId: 'real-child', childPid: child.pid, childExitCode: 0,
     }), true);
+    assert.equal(Object.isFrozen(receipt), true);
+    assert.equal(Object.isFrozen(receipt.argv), true);
     assert.equal(isLiveAuthenticatedReceipt(receipt), true);
     console.log(`H1_C1 realChildPid=${child.pid} childExit=0 authenticated=true channel=MessagePort`);
   } finally {

--- a/scratchpad/phaseB/evidence/W1-checker-blind-input-coverage.json
+++ b/scratchpad/phaseB/evidence/W1-checker-blind-input-coverage.json
@@ -1,0 +1,429 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T07:26:52.404Z",
+  "instrument": {
+    "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "92425be2ecec5969f650c23851153c7e3396ef27582acc141cc6c45d88d116d2",
+    "manifest": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs",
+      "sha256": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77"
+    }
+  },
+  "guardId": "checker-blind-input-coverage",
+  "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-s3-no-blind-clean",
+    "requestedCommit": "2f3cd8e16c7608fcd75c12f51623783f3da8824d",
+    "commit": "2f3cd8e16c7608fcd75c12f51623783f3da8824d",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-checker-blind-input-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lib/checker-blind-input-ratchet.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/checker-blind-input-ratchet.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lint-llm-attribution.js",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/checker-blind-input-cases.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "unknown",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "no valid core-minted post-child receipt relationship was established",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "e5085f969d604cf067383ab3446f5f49c7dccf74"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "status": "unknown",
+      "rejected": true,
+      "rejectionReason": "pipeline evidence is not a core-minted proven envelope"
+    },
+    "run": {
+      "token": "cb3e90bd-9ec8-4fc9-a0d2-0c5bb8be4725-d8df6d4fca046d281362aecf899333c9",
+      "tokenSha256": "ffdfa8db25294489db99123eed89d8453510af886f814bc7af82810ffd6cb78d",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:24:43.531Z",
+          "endedAt": "2026-08-18T07:25:49.743Z",
+          "durationMs": 66211,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1178 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10983
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "97af8e95a00fb3b49f993a8ec6d4d7c6d1554eafa80d127dad2820ce85fd2937",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/pipeline-observer/positive/node",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": []
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:25:49.743Z",
+          "endedAt": "2026-08-18T07:26:52.157Z",
+          "durationMs": 62414,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1178 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10983
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "97af8e95a00fb3b49f993a8ec6d4d7c6d1554eafa80d127dad2820ce85fd2937",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/pipeline-observer/c3/node",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [],
+        "outcome": "unknown"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "unknown",
+        "mode": "core-minted-process-receipt",
+        "tokenSha256": "ffdfa8db25294489db99123eed89d8453510af886f814bc7af82810ffd6cb78d",
+        "receipt": null,
+        "C3": {
+          "outcome": "unknown",
+          "receiptCount": 0,
+          "shortCircuitEvent": null
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": false
+          },
+          {
+            "check": "core observer emitted exactly one post-child receipt",
+            "passed": false
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": false
+          },
+          {
+            "check": "C3 short-circuited the exact guard child",
+            "passed": false
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "unknown",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:24:43.531Z",
+          "endedAt": "2026-08-18T07:25:49.743Z",
+          "durationMs": 66211,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1178 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10983
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "97af8e95a00fb3b49f993a8ec6d4d7c6d1554eafa80d127dad2820ce85fd2937",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/pipeline-observer/positive/node",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": []
+      }
+    },
+    "C2": {
+      "outcome": "unknown",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "unknown"
+      }
+    },
+    "C3": {
+      "outcome": "unknown",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:25:49.743Z",
+          "endedAt": "2026-08-18T07:26:52.157Z",
+          "durationMs": 62414,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1178 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10983
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "97af8e95a00fb3b49f993a8ec6d4d7c6d1554eafa80d127dad2820ce85fd2937",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/pipeline-observer/c3/node",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [],
+        "outcome": "unknown"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "exists",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-eAEpDq/01-pipeline-wiring",
+        "commit": "2f3cd8e16c7608fcd75c12f51623783f3da8824d"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "e5085f969d604cf067383ab3446f5f49c7dccf74"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-s3-no-blind-clean/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/W1-evidence-stamps.json
+++ b/scratchpad/phaseB/evidence/W1-evidence-stamps.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-18T00:27:27-07:00",
+  "sha256": {
+    "scratchpad/phaseB/fix-verifier.mjs": "92425be2ecec5969f650c23851153c7e3396ef27582acc141cc6c45d88d116d2",
+    "scratchpad/phaseB/fix-verifier.test.mjs": "08af9989637bc1acb2342101a5fb3d66d91343f125d188a440534f1f644f6b03",
+    "scratchpad/phaseB/fix-verifier.manifest.json": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "scratchpad/phaseB/adapters/topic-operator-evidence.mjs": "d7248e314f779e47d6290500d80d924f30754b8165a524c3992d0160acba49e1",
+    "scratchpad/phaseB/adapters/standards-direction-guard.mjs": "deeb477cdddcd9f5683f62269f50d16aa1ad0d5898d2d9a465fe1f406c5e81a2",
+    "scratchpad/phaseB/adapters/testing-integrity-route-enforcement.mjs": "21bf4fa7c026fcbb3d0f745945af163884e7496ce4455fbf55b315f79c4c4337",
+    "scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77",
+    "scratchpad/phaseB/evidence/W1-topic-operator-evidence.json": "4b154729282c2dc7f237290c5d34e645a12f357a857442cff5dd66e731d96ec2",
+    "scratchpad/phaseB/evidence/W1-standards-direction-guard.json": "a9149512c85438d56a913dc583fe3d0270cb9e700d8c686d734981afc020e867",
+    "scratchpad/phaseB/evidence/W1-testing-integrity-route-enforcement.json": "3a556c7f639267c16160a7dbb7ba1675ee7c001465d8762a783982447c20aa2d",
+    "scratchpad/phaseB/evidence/W1-checker-blind-input-coverage.json": "ecd163ff2ed35166a945f235a064d783d759aedd34836f461d782ed7d085ad4a"
+  }
+}

--- a/scratchpad/phaseB/evidence/W1-standards-direction-guard.json
+++ b/scratchpad/phaseB/evidence/W1-standards-direction-guard.json
@@ -1,0 +1,612 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T07:21:30.469Z",
+  "instrument": {
+    "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "92425be2ecec5969f650c23851153c7e3396ef27582acc141cc6c45d88d116d2",
+    "manifest": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/adapters/standards-direction-guard.mjs",
+      "sha256": "deeb477cdddcd9f5683f62269f50d16aa1ad0d5898d2d9a465fe1f406c5e81a2"
+    }
+  },
+  "guardId": "standards-direction-guard",
+  "description": "Protected-base article identity, continuity denominator, and independently ratified constitutional direction guard.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring",
+    "requestedCommit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": true,
+    "porcelainAtStart": [
+      "?? scratchpad/phaseB/"
+    ]
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/standards-direction-guard.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/standards-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/standards-direction-guard.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/standards-direction-guard-contract.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "docs/STANDARDS-REGISTRY.md",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "docs/standards-direction-approvals.json",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": ".github/keyrings/telegram-principal-pub.pem",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> node scripts/standards-coverage.mjs --check",
+    "establishedBy": "core-minted token received from the exact manifest-pinned guard child after it exited through the protected workflow command; C3 wrapper success produced no receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "node",
+        "scripts/standards-coverage.mjs",
+        "--check"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-minted-process-receipt",
+      "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+      "receipt": {
+        "source": "fix-verifier-core",
+        "guardId": "standards-direction-guard",
+        "token": "d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421",
+        "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+        "nodeEntry": "scripts/standards-coverage.mjs",
+        "argv": [
+          "scripts/standards-coverage.mjs",
+          "--check"
+        ],
+        "startedAt": "2026-08-18T07:21:29.894Z",
+        "childExitedAt": "2026-08-18T07:21:30.255Z",
+        "childExitCode": 0,
+        "signal": null,
+        "emittedAfterChildExit": true
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "source": "fix-verifier-core",
+          "guardId": "standards-direction-guard",
+          "token": "a41158a6-12b2-4eac-8ac3-0a0c671e92c2-1094f504e9a63bc362801fa0782d3f55",
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "argv": [
+            "scripts/standards-coverage.mjs",
+            "--check"
+          ],
+          "shortCircuitedAt": "2026-08-18T07:21:30.418Z"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "core observer emitted exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 short-circuited the exact guard child",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "token": "d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421",
+      "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+      "positive": {
+        "run": {
+          "argv": [
+            "env",
+            "STANDARDS_DIRECTION_BASE_FILE=.b0-s5-protected-registry.md",
+            "STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE=.b0-s5-protected-approver.pem",
+            "STANDARDS_DIRECTION_BASE_REVISION=b0-s5-protected-base",
+            "node",
+            "scripts/standards-coverage.mjs",
+            "--check"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:21:29.741Z",
+          "endedAt": "2026-08-18T07:21:30.258Z",
+          "durationMs": 517,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "[fix-verifier-wiring] token=d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421 guard=standards-direction-guard entry=scripts/standards-coverage.mjs childExit=0\n",
+            "truncated": false,
+            "originalChars": 179
+          },
+          "stderr": {
+            "text": "[standards-coverage] registry=true total=88 continuity-total=88 enforced-ratio=0.7386 (ratchet 26 / gate 33 / lint 6 / spec-only 6 / gap 17) false-claims=0 dangling=0 unrecognized-sections=0\n[standards-coverage] floors: enforced-ratio>=0.7 dangling<=0 false-claims<=1 unrecognized-sections<=0\n[standards-coverage] direction-guard=passed base=b0-s5-protected-base trust-root=protected-base candidate-pin-ignored-as-authority=true candidate-pin-drift-blocked=true\n[standards-coverage] area=\"Building\" total=40 continuity-total=40 ref-resolution-ratio=0.85 floor=34/40 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"Interaction\" total=13 continuity-total=13 ref-resolution-ratio=0.6154 floor=8/13 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"Shipping\" total=7 continuity-total=7 ref-resolution-ratio=0.7143 floor=5/7 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"The Fractal\" total=1 continuity-total=1 ref-resolution-ratio=1 floor=1/1 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"The Root\" total=1 continuity-total=1 ref-resolution-ratio=1 floor=1/1 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"The Substrate\" total=26 continuity-total=26 ref-resolution-ratio=0.6154 floor=16/26 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n✅ standards-coverage check passed.\n",
+            "truncated": false,
+            "originalChars": 1821
+          },
+          "outputSha256": "74f8b21df724cecac4790e0c1a8f67097ab1832fdf21fd0ba385b422cd731c8f",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/pipeline-observer/positive/node",
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "requiredArgs": [
+            "--check"
+          ]
+        },
+        "receipts": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "standards-direction-guard",
+            "token": "d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421",
+            "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+            "nodeEntry": "scripts/standards-coverage.mjs",
+            "argv": [
+              "scripts/standards-coverage.mjs",
+              "--check"
+            ],
+            "startedAt": "2026-08-18T07:21:29.894Z",
+            "childExitedAt": "2026-08-18T07:21:30.255Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true
+          }
+        ],
+        "shortCircuitEvents": []
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "env",
+            "STANDARDS_DIRECTION_BASE_FILE=.b0-s5-protected-registry.md",
+            "STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE=.b0-s5-protected-approver.pem",
+            "STANDARDS_DIRECTION_BASE_REVISION=b0-s5-protected-base",
+            "node",
+            "scripts/standards-coverage.mjs",
+            "--check"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:21:30.258Z",
+          "endedAt": "2026-08-18T07:21:30.421Z",
+          "durationMs": 163,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "[fix-verifier-C3] short-circuited guard=standards-direction-guard entry=scripts/standards-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 103
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "d414cd1abe3cb37813eed4e19d21f4304ee555df0ae22c10110e35e643819076",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/pipeline-observer/c3/node",
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "requiredArgs": [
+            "--check"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "standards-direction-guard",
+            "token": "a41158a6-12b2-4eac-8ac3-0a0c671e92c2-1094f504e9a63bc362801fa0782d3f55",
+            "nodeEntry": "scripts/standards-coverage.mjs",
+            "argv": [
+              "scripts/standards-coverage.mjs",
+              "--check"
+            ],
+            "shortCircuitedAt": "2026-08-18T07:21:30.418Z"
+          }
+        ],
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-minted-process-receipt",
+        "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+        "receipt": {
+          "source": "fix-verifier-core",
+          "guardId": "standards-direction-guard",
+          "token": "d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421",
+          "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "argv": [
+            "scripts/standards-coverage.mjs",
+            "--check"
+          ],
+          "startedAt": "2026-08-18T07:21:29.894Z",
+          "childExitedAt": "2026-08-18T07:21:30.255Z",
+          "childExitCode": 0,
+          "signal": null,
+          "emittedAfterChildExit": true
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "source": "fix-verifier-core",
+            "guardId": "standards-direction-guard",
+            "token": "a41158a6-12b2-4eac-8ac3-0a0c671e92c2-1094f504e9a63bc362801fa0782d3f55",
+            "nodeEntry": "scripts/standards-coverage.mjs",
+            "argv": [
+              "scripts/standards-coverage.mjs",
+              "--check"
+            ],
+            "shortCircuitedAt": "2026-08-18T07:21:30.418Z"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "core observer emitted exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 short-circuited the exact guard child",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "env",
+            "STANDARDS_DIRECTION_BASE_FILE=.b0-s5-protected-registry.md",
+            "STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE=.b0-s5-protected-approver.pem",
+            "STANDARDS_DIRECTION_BASE_REVISION=b0-s5-protected-base",
+            "node",
+            "scripts/standards-coverage.mjs",
+            "--check"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:21:29.741Z",
+          "endedAt": "2026-08-18T07:21:30.258Z",
+          "durationMs": 517,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "[fix-verifier-wiring] token=d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421 guard=standards-direction-guard entry=scripts/standards-coverage.mjs childExit=0\n",
+            "truncated": false,
+            "originalChars": 179
+          },
+          "stderr": {
+            "text": "[standards-coverage] registry=true total=88 continuity-total=88 enforced-ratio=0.7386 (ratchet 26 / gate 33 / lint 6 / spec-only 6 / gap 17) false-claims=0 dangling=0 unrecognized-sections=0\n[standards-coverage] floors: enforced-ratio>=0.7 dangling<=0 false-claims<=1 unrecognized-sections<=0\n[standards-coverage] direction-guard=passed base=b0-s5-protected-base trust-root=protected-base candidate-pin-ignored-as-authority=true candidate-pin-drift-blocked=true\n[standards-coverage] area=\"Building\" total=40 continuity-total=40 ref-resolution-ratio=0.85 floor=34/40 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"Interaction\" total=13 continuity-total=13 ref-resolution-ratio=0.6154 floor=8/13 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"Shipping\" total=7 continuity-total=7 ref-resolution-ratio=0.7143 floor=5/7 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"The Fractal\" total=1 continuity-total=1 ref-resolution-ratio=1 floor=1/1 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"The Root\" total=1 continuity-total=1 ref-resolution-ratio=1 floor=1/1 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n[standards-coverage] area=\"The Substrate\" total=26 continuity-total=26 ref-resolution-ratio=0.6154 floor=16/26 last-audited=2026-08-13T17:48:50.000Z audit-ref=docs/audits/standards-area-audit-2026-08-13c.json audit-current=true\n✅ standards-coverage check passed.\n",
+            "truncated": false,
+            "originalChars": 1821
+          },
+          "outputSha256": "74f8b21df724cecac4790e0c1a8f67097ab1832fdf21fd0ba385b422cd731c8f",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/pipeline-observer/positive/node",
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "requiredArgs": [
+            "--check"
+          ]
+        },
+        "receipts": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "standards-direction-guard",
+            "token": "d9aa9690-ac0d-4379-af78-0f394d723bcc-d2e8d95506e359666e08053285374421",
+            "tokenSha256": "361b7d0b6e46b3fbe1e216695c1c9723da1d333585ea5ca36bfd699b993b4107",
+            "nodeEntry": "scripts/standards-coverage.mjs",
+            "argv": [
+              "scripts/standards-coverage.mjs",
+              "--check"
+            ],
+            "startedAt": "2026-08-18T07:21:29.894Z",
+            "childExitedAt": "2026-08-18T07:21:30.255Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true
+          }
+        ],
+        "shortCircuitEvents": []
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "env",
+            "STANDARDS_DIRECTION_BASE_FILE=.b0-s5-protected-registry.md",
+            "STANDARDS_DIRECTION_BASE_APPROVER_KEY_FILE=.b0-s5-protected-approver.pem",
+            "STANDARDS_DIRECTION_BASE_REVISION=b0-s5-protected-base",
+            "node",
+            "scripts/standards-coverage.mjs",
+            "--check"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:21:30.258Z",
+          "endedAt": "2026-08-18T07:21:30.421Z",
+          "durationMs": 163,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "[fix-verifier-C3] short-circuited guard=standards-direction-guard entry=scripts/standards-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 103
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "d414cd1abe3cb37813eed4e19d21f4304ee555df0ae22c10110e35e643819076",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/pipeline-observer/c3/node",
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "requiredArgs": [
+            "--check"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "standards-direction-guard",
+            "token": "a41158a6-12b2-4eac-8ac3-0a0c671e92c2-1094f504e9a63bc362801fa0782d3f55",
+            "nodeEntry": "scripts/standards-coverage.mjs",
+            "argv": [
+              "scripts/standards-coverage.mjs",
+              "--check"
+            ],
+            "shortCircuitedAt": "2026-08-18T07:21:30.418Z"
+          }
+        ],
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-1F3oYp/01-pipeline-wiring",
+        "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/W1-testing-integrity-route-enforcement.json
+++ b/scratchpad/phaseB/evidence/W1-testing-integrity-route-enforcement.json
@@ -1,0 +1,439 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T07:32:52.481Z",
+  "instrument": {
+    "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "92425be2ecec5969f650c23851153c7e3396ef27582acc141cc6c45d88d116d2",
+    "manifest": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/adapters/testing-integrity-route-enforcement.mjs",
+      "sha256": "21bf4fa7c026fcbb3d0f745945af163884e7496ce4455fbf55b315f79c4c4337"
+    }
+  },
+  "guardId": "testing-integrity-route-enforcement",
+  "description": "The changed-route Tier-3 execution guard and its real-AgentServer evidence oracle.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/.instar/agents/instar-codey/.worktrees/phase-b1.2-testing-integrity",
+    "requestedCommit": "fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf",
+    "commit": "fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-testing-integrity.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/helpers/testingIntegrity.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/scripts/testing-integrity-enforcement.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/testing-integrity-pipeline.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/e2e/testing-integrity-guard-lifecycle.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/server/routes.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "unknown",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "no valid core-minted post-child receipt relationship was established",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "24f1bb4f76d8303f2124131743aa3b3d90bc972d"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "status": "unknown",
+      "rejected": true,
+      "rejectionReason": "pipeline evidence is not a core-minted proven envelope"
+    },
+    "run": {
+      "token": "f40573aa-d5a7-4699-912e-1034bf8bf00d-c913fe357bb4d9bcdd1dacee31d70746",
+      "tokenSha256": "2952b69909098a669b8ee159314d3a1b82445ea5af4cb56b8216fcd4f954b64e",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:31:09.993Z",
+          "endedAt": "2026-08-18T07:32:03.291Z",
+          "durationMs": 53298,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1177 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-testing-integrity.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10972
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "76f0aa035496c91270dca1bd0c2137f24192092bf8c68258c1df21fa98996400",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/pipeline-observer/positive/node",
+          "nodeEntry": "scripts/lint-testing-integrity.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": []
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:32:03.291Z",
+          "endedAt": "2026-08-18T07:32:52.153Z",
+          "durationMs": 48862,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1177 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-testing-integrity.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10972
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "76f0aa035496c91270dca1bd0c2137f24192092bf8c68258c1df21fa98996400",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/pipeline-observer/c3/node",
+          "nodeEntry": "scripts/lint-testing-integrity.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [],
+        "outcome": "unknown"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "unknown",
+        "mode": "core-minted-process-receipt",
+        "tokenSha256": "2952b69909098a669b8ee159314d3a1b82445ea5af4cb56b8216fcd4f954b64e",
+        "receipt": null,
+        "C3": {
+          "outcome": "unknown",
+          "receiptCount": 0,
+          "shortCircuitEvent": null
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": false
+          },
+          {
+            "check": "core observer emitted exactly one post-child receipt",
+            "passed": false
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": false
+          },
+          {
+            "check": "C3 short-circuited the exact guard child",
+            "passed": false
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "unknown",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:31:09.993Z",
+          "endedAt": "2026-08-18T07:32:03.291Z",
+          "durationMs": 53298,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1177 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-testing-integrity.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10972
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "76f0aa035496c91270dca1bd0c2137f24192092bf8c68258c1df21fa98996400",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/pipeline-observer/positive/node",
+          "nodeEntry": "scripts/lint-testing-integrity.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": []
+      }
+    },
+    "C2": {
+      "outcome": "unknown",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "unknown"
+      }
+    },
+    "C3": {
+      "outcome": "unknown",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:32:03.291Z",
+          "endedAt": "2026-08-18T07:32:52.153Z",
+          "durationMs": 48862,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1177 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-testing-integrity.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1656 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[31mFIND\u001b[0m STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.\n",
+            "truncated": false,
+            "originalChars": 10972
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n\u001b[31mFAIL\u001b[0m — 1 finding(s) under strict enforcement.\n",
+            "truncated": false,
+            "originalChars": 1584
+          },
+          "outputSha256": "76f0aa035496c91270dca1bd0c2137f24192092bf8c68258c1df21fa98996400",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/pipeline-observer/c3/node",
+          "nodeEntry": "scripts/lint-testing-integrity.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [],
+        "outcome": "unknown"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "exists",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPZXBi/01-pipeline-wiring",
+        "commit": "fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "24f1bb4f76d8303f2124131743aa3b3d90bc972d"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phase-b1.2-testing-integrity/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/W1-topic-operator-evidence.json
+++ b/scratchpad/phaseB/evidence/W1-topic-operator-evidence.json
@@ -1,0 +1,667 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T07:21:03.750Z",
+  "instrument": {
+    "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "92425be2ecec5969f650c23851153c7e3396ef27582acc141cc6c45d88d116d2",
+    "manifest": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/adapters/topic-operator-evidence.mjs",
+      "sha256": "d7248e314f779e47d6290500d80d924f30754b8165a524c3992d0160acba49e1"
+    }
+  },
+  "guardId": "topic-operator-evidence",
+  "description": "Evidence-bearing topic-operator bindings plus verified-reader refusal of assertions.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring",
+    "requestedCommit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": true,
+    "porcelainAtStart": [
+      "?? scratchpad/phaseB/"
+    ]
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "tests/unit/topic-operator-store.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/topic-operator-routes.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/topic-operator-autobind-route.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/users/TopicOperatorStore.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/server/routes.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/commands/server.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run test:push",
+    "establishedBy": "core-minted token received from the exact manifest-pinned guard child after it exited through the protected workflow command; C3 wrapper success produced no receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "test:push",
+        "--",
+        "tests/unit/topic-operator-store.test.ts",
+        "tests/integration/topic-operator-routes.test.ts",
+        "tests/integration/topic-operator-autobind-route.test.ts",
+        "--reporter=verbose"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-minted-process-receipt",
+      "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+      "receipt": {
+        "source": "fix-verifier-core",
+        "guardId": "topic-operator-evidence",
+        "token": "94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a",
+        "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+        "nodeEntry": "node_modules/vitest/vitest.mjs",
+        "argv": [
+          "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+          "run",
+          "--config",
+          "vitest.push.config.ts",
+          "tests/unit/topic-operator-store.test.ts",
+          "tests/integration/topic-operator-routes.test.ts",
+          "tests/integration/topic-operator-autobind-route.test.ts",
+          "--reporter=verbose"
+        ],
+        "startedAt": "2026-08-18T07:10:51.360Z",
+        "childExitedAt": "2026-08-18T07:21:03.082Z",
+        "childExitCode": 0,
+        "signal": null,
+        "emittedAfterChildExit": true
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "source": "fix-verifier-core",
+          "guardId": "topic-operator-evidence",
+          "token": "472cf887-ecac-4a8e-918b-a9a24c5fbf42-4574d487b98ee91e4eb5e71e763245a2",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "argv": [
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "shortCircuitedAt": "2026-08-18T07:21:03.575Z"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "core observer emitted exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 short-circuited the exact guard child",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "token": "94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a",
+      "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:10:50.957Z",
+          "endedAt": "2026-08-18T07:21:03.090Z",
+          "durationMs": 612133,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\n\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring\n\n✓ standards registry asset: 88 articles, registry 81b53363a440…, guards 44d5cab21f32… → src/data + dist/data\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > establishes from an authenticated uid and reads it back\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES a blank uid — an operator cannot be established without a verified id\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES mismatched or missing authentication evidence\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > a content name can never BECOME the operator — only a uid does (by construction)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > getOperator is null for an unbound topic\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > persists across instances (durable JSON store)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > replacing an operator overwrites the prior record\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > records a manual assertion durably but refuses it as a verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P2: refuses a subject that self-reports authenticated while its evidence says assertion\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P5: legacy evidence-less and malformed/wrong-container inputs are not-proven, never verified\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P4: verified enumeration is non-vacuous and covers every topic-key shape in the raw population\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.asVerifiedOperator (feeds PrincipalGuard) > returns the PrincipalGuard shape when bound, null when unbound\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > builds a <topic-operator> block naming the verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > returns null for an unbound topic (nothing injected)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > falls back to the uid when no display name was provided\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > skips the disk write when the stored record is identical\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > still writes when the record actually changes\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > records an arbitrary body uid as an assertion in the real stored record, never authenticated inbound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a blank uid — a content name can never establish an operator\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a missing topicId\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > persists the binding (a fresh request reads it back)\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > lists assertions separately and excludes them from verified operators\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > returns operator:null for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns the <topic-operator> injection block when bound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an asserted binding\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > 400s when topicId is missing\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > when the store is not initialized > every route returns 503 (feature not available), never a crash\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > BINDS the operator from an AUTHORIZED sender\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an agent-to-agent bot message (short-circuits before the bind)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does not crash when no store is wired (pure additive change)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > keeps the real lifeline→polling convergence evidence-bound when a Telegram message id exists\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > P5: missing Telegram message id stays not-proven across the real lifeline→polling convergence\n\n Test Files  3 passed (3)\n      Tests  34 passed (34)\n   Start at  00:10:51\n   Duration  611.27s (transform 5.50s, setup 5ms, collect 7.70s, tests 343ms, environment 0ms, prepare 108ms)\n\n[fix-verifier-wiring] token=94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs childExit=0\n",
+            "truncated": false,
+            "originalChars": 6800
+          },
+          "stderr": {
+            "text": "[test-runner-bound] ⠹ waiting for a suite-lane test slot (0m elapsed; 1 holder(s): pid 95142 age 1745s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (1m elapsed; 1 holder(s): pid 95142 age 1807s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (2m elapsed; 1 holder(s): pid 95142 age 1869s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (3m elapsed; 1 holder(s): pid 95142 age 1932s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (4m elapsed; 1 holder(s): pid 95142 age 1993s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (5m elapsed; 1 holder(s): pid 95142 age 2058s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (6m elapsed; 1 holder(s): pid 95142 age 2121s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (7m elapsed; 1 holder(s): pid 95142 age 2182s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (8m elapsed; 1 holder(s): pid 95142 age 2243s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (9m elapsed; 1 holder(s): pid 95142 age 2308s) — active work, not a hang\n[test-runner-bound] suite-lane slot acquired (posture: enforcing, cap 1, pid 73244)\n",
+            "truncated": false,
+            "originalChars": 1384
+          },
+          "outputSha256": "2fd75de4c09967124e810ea44db3c47c6e06d4e93c70f79222f16eae2f99d4bc",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/pipeline-observer/positive/node",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "topic-operator-evidence",
+            "token": "94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a",
+            "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "startedAt": "2026-08-18T07:10:51.360Z",
+            "childExitedAt": "2026-08-18T07:21:03.082Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true
+          }
+        ],
+        "shortCircuitEvents": []
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:21:03.091Z",
+          "endedAt": "2026-08-18T07:21:03.582Z",
+          "durationMs": 491,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\n[fix-verifier-C3] short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs\n",
+            "truncated": false,
+            "originalChars": 338
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "2969a79b75055b23fc6eedd174a3b44f70a07710e8758f8e4e6acbc704c1947d",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/pipeline-observer/c3/node",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "topic-operator-evidence",
+            "token": "472cf887-ecac-4a8e-918b-a9a24c5fbf42-4574d487b98ee91e4eb5e71e763245a2",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T07:21:03.575Z"
+          }
+        ],
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-minted-process-receipt",
+        "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+        "receipt": {
+          "source": "fix-verifier-core",
+          "guardId": "topic-operator-evidence",
+          "token": "94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a",
+          "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "argv": [
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "startedAt": "2026-08-18T07:10:51.360Z",
+          "childExitedAt": "2026-08-18T07:21:03.082Z",
+          "childExitCode": 0,
+          "signal": null,
+          "emittedAfterChildExit": true
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "source": "fix-verifier-core",
+            "guardId": "topic-operator-evidence",
+            "token": "472cf887-ecac-4a8e-918b-a9a24c5fbf42-4574d487b98ee91e4eb5e71e763245a2",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T07:21:03.575Z"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "core observer emitted exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 short-circuited the exact guard child",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:10:50.957Z",
+          "endedAt": "2026-08-18T07:21:03.090Z",
+          "durationMs": 612133,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\n\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring\n\n✓ standards registry asset: 88 articles, registry 81b53363a440…, guards 44d5cab21f32… → src/data + dist/data\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > establishes from an authenticated uid and reads it back\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES a blank uid — an operator cannot be established without a verified id\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES mismatched or missing authentication evidence\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > a content name can never BECOME the operator — only a uid does (by construction)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > getOperator is null for an unbound topic\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > persists across instances (durable JSON store)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > replacing an operator overwrites the prior record\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > records a manual assertion durably but refuses it as a verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P2: refuses a subject that self-reports authenticated while its evidence says assertion\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P5: legacy evidence-less and malformed/wrong-container inputs are not-proven, never verified\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P4: verified enumeration is non-vacuous and covers every topic-key shape in the raw population\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.asVerifiedOperator (feeds PrincipalGuard) > returns the PrincipalGuard shape when bound, null when unbound\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > builds a <topic-operator> block naming the verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > returns null for an unbound topic (nothing injected)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > falls back to the uid when no display name was provided\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > skips the disk write when the stored record is identical\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > still writes when the record actually changes\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > records an arbitrary body uid as an assertion in the real stored record, never authenticated inbound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a blank uid — a content name can never establish an operator\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a missing topicId\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > persists the binding (a fresh request reads it back)\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > lists assertions separately and excludes them from verified operators\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > returns operator:null for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns the <topic-operator> injection block when bound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an asserted binding\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > 400s when topicId is missing\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > when the store is not initialized > every route returns 503 (feature not available), never a crash\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > BINDS the operator from an AUTHORIZED sender\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an agent-to-agent bot message (short-circuits before the bind)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does not crash when no store is wired (pure additive change)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > keeps the real lifeline→polling convergence evidence-bound when a Telegram message id exists\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > P5: missing Telegram message id stays not-proven across the real lifeline→polling convergence\n\n Test Files  3 passed (3)\n      Tests  34 passed (34)\n   Start at  00:10:51\n   Duration  611.27s (transform 5.50s, setup 5ms, collect 7.70s, tests 343ms, environment 0ms, prepare 108ms)\n\n[fix-verifier-wiring] token=94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs childExit=0\n",
+            "truncated": false,
+            "originalChars": 6800
+          },
+          "stderr": {
+            "text": "[test-runner-bound] ⠹ waiting for a suite-lane test slot (0m elapsed; 1 holder(s): pid 95142 age 1745s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (1m elapsed; 1 holder(s): pid 95142 age 1807s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (2m elapsed; 1 holder(s): pid 95142 age 1869s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (3m elapsed; 1 holder(s): pid 95142 age 1932s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (4m elapsed; 1 holder(s): pid 95142 age 1993s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (5m elapsed; 1 holder(s): pid 95142 age 2058s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (6m elapsed; 1 holder(s): pid 95142 age 2121s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (7m elapsed; 1 holder(s): pid 95142 age 2182s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (8m elapsed; 1 holder(s): pid 95142 age 2243s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (9m elapsed; 1 holder(s): pid 95142 age 2308s) — active work, not a hang\n[test-runner-bound] suite-lane slot acquired (posture: enforcing, cap 1, pid 73244)\n",
+            "truncated": false,
+            "originalChars": 1384
+          },
+          "outputSha256": "2fd75de4c09967124e810ea44db3c47c6e06d4e93c70f79222f16eae2f99d4bc",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/pipeline-observer/positive/node",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "topic-operator-evidence",
+            "token": "94c56bdc-0da1-4b45-87f1-17523cbb330f-919c0b0bc43d659474209041d1de216a",
+            "tokenSha256": "28f6b891cac184b8ac590cb8077f8af81b23e1576aa1a046bad24fdf33fed2e5",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "startedAt": "2026-08-18T07:10:51.360Z",
+            "childExitedAt": "2026-08-18T07:21:03.082Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true
+          }
+        ],
+        "shortCircuitEvents": []
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring",
+          "startedAt": "2026-08-18T07:21:03.091Z",
+          "endedAt": "2026-08-18T07:21:03.582Z",
+          "durationMs": 491,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\n[fix-verifier-C3] short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs\n",
+            "truncated": false,
+            "originalChars": 338
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "2969a79b75055b23fc6eedd174a3b44f70a07710e8758f8e4e6acbc704c1947d",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/pipeline-observer/c3/node",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "source": "fix-verifier-core",
+            "guardId": "topic-operator-evidence",
+            "token": "472cf887-ecac-4a8e-918b-a9a24c5fbf42-4574d487b98ee91e4eb5e71e763245a2",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T07:21:03.575Z"
+          }
+        ],
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-daZkpG/01-pipeline-wiring",
+        "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/Documents/Projects/instar-codey/.worktrees/phase-b-w1-validated-pipeline-wiring/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/W4-checker-blind-input-coverage.json
+++ b/scratchpad/phaseB/evidence/W4-checker-blind-input-coverage.json
@@ -1,0 +1,770 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T12:18:21.827Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "584a0a0b7248c4bede3f99e58f369db2183ca298fc5c1209862a6e3dc41edd72",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs",
+      "sha256": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77"
+    }
+  },
+  "guardId": "checker-blind-input-coverage",
+  "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f1-blind-checker-ratchet",
+    "requestedCommit": "3801aefe9825e1258f5f235c123c56bee9e6a98b",
+    "commit": "3801aefe9825e1258f5f235c123c56bee9e6a98b",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-checker-blind-input-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lib/checker-blind-input-ratchet.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/checker-blind-input-ratchet.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lint-llm-attribution.js",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/checker-blind-input-cases.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "unknown",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "no valid core-authenticated post-child receipt relationship was established",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "status": "unknown",
+      "rejected": true,
+      "rejectionReason": "pipeline evidence is not a core-minted proven envelope"
+    },
+    "run": {
+      "authorityId": "5fc1cc81-9866-46e7-a5e4-ff973064a549",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:15:55.146Z",
+          "endedAt": "2026-08-18T12:17:22.485Z",
+          "durationMs": 87339,
+          "pid": 92871,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[8780 chars omitted]...\nZiKo/guard-own.test.mjs (97.381917ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs (80.199166ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 85.732416\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs (80.199166ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs (104.782833ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 113.910833\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs (104.782833ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1\n✖ empty population is not proof (4.719084ms)\n✖ unknown coverage id is rejected (0.211958ms)\n✖ new uncovered checker is named and rejected (0.088125ms)\n✔ genuinely covered population passes (0.090125ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 135.310584\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:5:1\n✖ empty population is not proof (4.719084ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.start (node:internal/test_runner/test:1015:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.211958ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.088125ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 1 failed) 7857ms\n   ✓ checker blind-input class ratchet > executes every declared blind case and none reports clean 5619ms\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 1255ms\n   × P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 232ms\n     → expected '✖ empty population is not proof (4.71…' to contain '# tests 4'\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  05:16:49\n   Duration  33.35s (transform 350ms, setup 3ms, collect 131ms, tests 7.86s, environment 0ms, prepare 97ms)\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":31065,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":31144,\"startedAt\":\"2026-08-18T12:16:47.771Z\",\"childExitedAt\":\"2026-08-18T12:17:22.477Z\",\"childExitCode\":1,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"BG+aa5B5ycQg+k4gZ+cdelDpg9+NwUlJoc70M7tYze37Efbe0Jck1RfpZK03NbwQoZqrXHSqnHZ8snagbFwhBg==\"}\n",
+            "truncated": true,
+            "originalChars": 24780
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 31887)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nAssertionError: expected '✖ empty population is not proof (4.71…' to contain '# tests 4'\n\n- Expected\n+ Received\n\n- # tests 4\n+ ✖ empty population is not proof (4.719084ms)\n+ ✖ unknown coverage id is rejected (0.211958ms)\n+ ✖ new uncovered checker is named and rejected (0.088125ms)\n+ ✔ genuinely covered population passes (0.090125ms)\n+ ℹ tests 4\n+ ℹ suites 0\n+ ℹ pass 1\n+ ℹ fail 3\n+ ℹ cancelled 0\n+ ℹ skipped 0\n+ ℹ todo 0\n+ ℹ duration_ms 135.310584\n+\n+ ✖ failing tests:\n+\n+ test at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:5:1\n+ ✖ empty population is not proof (4.719084ms)\n+   AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n+   + actual - expected\n+   \n+     {\n+       coveredCount: 0,\n+   +   maxUncovered: 0,\n+   +   passed: true,\n+   -   passed: false,\n+       populationCount: 0,\n+   +   reason: 'within-ratchet',\n+   -   reason: 'empty-population',\n+       uncovered: []\n+     }\n+   \n+       at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:6:10)\n+       at Test.runInAsyncScope (node:async_hooks:226:14)\n+       at Test.run (node:internal/test_runner/test:1118:25)\n+       at Test.start (node:internal/test_runner/test:1015:17)\n+       at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n+     generatedMessage: true,\n+     code: 'ERR_ASSERTION',\n+     actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n+     expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n+     operator: 'deepStrictEqual',\n+     diff: 'simple'\n+   }\n+\n+ test at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:10:1\n+ ✖ unknown coverage id is rejected (0.211958ms)\n+   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n+   \n+   true !== false\n+   \n+       at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:11:10)\n+       at Test.runInAsyncScope (node:async_hooks:226:14)\n+       at Test.run (node:internal/test_runner/test:1118:25)\n+       at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n+       at Test.postRun (node:internal/test_runner/test:1247:19)\n+       at Test.run (node:internal/test_runner/test:1175:12)\n+       at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n+     generatedMessage: true,\n+     code: 'ERR_ASSERTION',\n+     actual: true,\n+     expected: false,\n+     operator: 'strictEqual',\n+     diff: 'simple'\n+   }\n+\n+ test at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:13:1\n+ ✖ new uncovered checker is named and rejected (0.088125ms)\n+   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n+   \n+   true !== false\n+   \n+       at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:15:10)\n+       at Test.runInAsyncScope (node:async_hooks:226:14)\n+       at Test.run (node:internal/test_runner/test:1118:25)\n+       at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n+       at Test.postRun (node:internal/test_runner/test:1247:19)\n+       at Test.run (node:internal/test_runner/test:1175:12)\n+       at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n+     generatedMessage: true,\n+     code: 'ERR_ASSERTION',\n+     actual: true,\n+     expected: false,\n+     operator: 'strictEqual',\n+     diff: 'simple'\n+   }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:572:22\n    570|       console.log(`P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true g…\n    571|       expect(result.status).not.toBe(0);\n    572|       expect(output).toContain('# tests 4');\n       |                      ^\n    573|       expect(output).toContain('# fail 3');\n    574|       expect(output).toMatch(/AssertionError|Expected values to be str…\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+            "truncated": false,
+            "originalChars": 5930
+          },
+          "outputSha256": "55a8a970078682bebb5fd8d389c9d22a8b4e103e4ab822167ce42cbb83c83f95",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 31065,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAV6SnX0b650jenjBF9XQsCxTFZcxXeGGamO2rRslWO2Q=",
+              "signature": "hpv1CRpmXAtvzdd+QaeUu7cKgyMHDfhaqvSsVy71QV9Ie1LW+tNPP5jqGScLhOOMi+bwb0tQSMRHetkcyWK0Bw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 31065,
+              "ppid": 93252,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 31065,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 31144,
+              "startedAt": "2026-08-18T12:16:47.771Z",
+              "signature": "5gcaV4kWkMJVaj2L+EUfym53wP9AMKBuknRtiGFjO2S8rXDKKl4adzM0xkv8riSw7wt2+WbXJURGcNu+pgJhAQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 31144,
+              "ppid": 31065,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 31065,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 31144,
+            "startedAt": "2026-08-18T12:16:47.771Z",
+            "childExitedAt": "2026-08-18T12:17:22.477Z",
+            "childExitCode": 1,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "BG+aa5B5ycQg+k4gZ+cdelDpg9+NwUlJoc70M7tYze37Efbe0Jck1RfpZK03NbwQoZqrXHSqnHZ8snagbFwhBg=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:17:22.486Z",
+          "endedAt": "2026-08-18T12:18:21.619Z",
+          "durationMs": 59133,
+          "pid": 56964,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"f33f463d-11f8-47f9-bcb5-d730df2587b2\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93502,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAeRxMgjBxH4iib7kyhCshHyIy4CbH6QI7oOkfW1v/WOw=\",\"signature\":\"WATLBH84hgxKHXxc2UtLS9P8Fy4rF8uvU2v0uO8zILUh1Ve9/EWWWJEfJNp1WmHPjnpd+sgYV803xJN1skZfAg==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"f33f463d-11f8-47f9-bcb5-d730df2587b2\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93502,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T12:18:21.610Z\",\"signature\":\"cMAJYq27XhtJzHfdbq9W3weo7FyNFGw7NpWv/4XACseTsd1bzTNuPMxcPEzJfzSA2j0whi3AhXpx+oL8YXPmAA==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "d014fbf5d6babe121b80b496f074bf7f9df35b2f379852b56c65848fd5f90e67",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 93502,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:18:21.610Z",
+            "signature": "cMAJYq27XhtJzHfdbq9W3weo7FyNFGw7NpWv/4XACseTsd1bzTNuPMxcPEzJfzSA2j0whi3AhXpx+oL8YXPmAA=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "5fc1cc81-9866-46e7-a5e4-ff973064a549",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "33f70151-565c-45cb-aa99-287f4950c2c7",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 93502,
+          "childPid": 93502,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "6b75f80fa8205dbb68da4d940a20a04e7b67e56640ca9e68cc95d60c180cce83",
+          "startedAt": "2026-08-18T12:18:21.610Z",
+          "childExitedAt": "2026-08-18T12:18:21.619Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "61bbf2fa8a49afaa7d10af8ff99a2ea529c3d4208da16acd4e2417a805875036",
+          "mac": "28cf6f53fa0d387a88f9a618de2e2866f409b4fbaace5285f2cb72465482c0a1"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 93502,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAeRxMgjBxH4iib7kyhCshHyIy4CbH6QI7oOkfW1v/WOw=",
+              "signature": "WATLBH84hgxKHXxc2UtLS9P8Fy4rF8uvU2v0uO8zILUh1Ve9/EWWWJEfJNp1WmHPjnpd+sgYV803xJN1skZfAg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 93502,
+              "ppid": 57304,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "unknown",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": null,
+        "receipt": null,
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 93502,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:18:21.610Z",
+            "signature": "cMAJYq27XhtJzHfdbq9W3weo7FyNFGw7NpWv/4XACseTsd1bzTNuPMxcPEzJfzSA2j0whi3AhXpx+oL8YXPmAA=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "5fc1cc81-9866-46e7-a5e4-ff973064a549",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "33f70151-565c-45cb-aa99-287f4950c2c7",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "short-circuit",
+            "observerPid": 93502,
+            "childPid": 93502,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "6b75f80fa8205dbb68da4d940a20a04e7b67e56640ca9e68cc95d60c180cce83",
+            "startedAt": "2026-08-18T12:18:21.610Z",
+            "childExitedAt": "2026-08-18T12:18:21.619Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "61bbf2fa8a49afaa7d10af8ff99a2ea529c3d4208da16acd4e2417a805875036",
+            "mac": "28cf6f53fa0d387a88f9a618de2e2866f409b4fbaace5285f2cb72465482c0a1"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": false
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": false
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "unknown",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:15:55.146Z",
+          "endedAt": "2026-08-18T12:17:22.485Z",
+          "durationMs": 87339,
+          "pid": 92871,
+          "exitCode": 1,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[8780 chars omitted]...\nZiKo/guard-own.test.mjs (97.381917ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs (80.199166ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 85.732416\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-vrRFtW/guard-own.test.mjs (80.199166ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs (104.782833ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 113.910833\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-UJIJtj/guard-own.test.mjs (104.782833ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1\n✖ empty population is not proof (4.719084ms)\n✖ unknown coverage id is rejected (0.211958ms)\n✖ new uncovered checker is named and rejected (0.088125ms)\n✔ genuinely covered population passes (0.090125ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 135.310584\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:5:1\n✖ empty population is not proof (4.719084ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.start (node:internal/test_runner/test:1015:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.211958ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.088125ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 1 failed) 7857ms\n   ✓ checker blind-input class ratchet > executes every declared blind case and none reports clean 5619ms\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 1255ms\n   × P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 232ms\n     → expected '✖ empty population is not proof (4.71…' to contain '# tests 4'\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  05:16:49\n   Duration  33.35s (transform 350ms, setup 3ms, collect 131ms, tests 7.86s, environment 0ms, prepare 97ms)\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":31065,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":31144,\"startedAt\":\"2026-08-18T12:16:47.771Z\",\"childExitedAt\":\"2026-08-18T12:17:22.477Z\",\"childExitCode\":1,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"BG+aa5B5ycQg+k4gZ+cdelDpg9+NwUlJoc70M7tYze37Efbe0Jck1RfpZK03NbwQoZqrXHSqnHZ8snagbFwhBg==\"}\n",
+            "truncated": true,
+            "originalChars": 24780
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 31887)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nAssertionError: expected '✖ empty population is not proof (4.71…' to contain '# tests 4'\n\n- Expected\n+ Received\n\n- # tests 4\n+ ✖ empty population is not proof (4.719084ms)\n+ ✖ unknown coverage id is rejected (0.211958ms)\n+ ✖ new uncovered checker is named and rejected (0.088125ms)\n+ ✔ genuinely covered population passes (0.090125ms)\n+ ℹ tests 4\n+ ℹ suites 0\n+ ℹ pass 1\n+ ℹ fail 3\n+ ℹ cancelled 0\n+ ℹ skipped 0\n+ ℹ todo 0\n+ ℹ duration_ms 135.310584\n+\n+ ✖ failing tests:\n+\n+ test at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:5:1\n+ ✖ empty population is not proof (4.719084ms)\n+   AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n+   + actual - expected\n+   \n+     {\n+       coveredCount: 0,\n+   +   maxUncovered: 0,\n+   +   passed: true,\n+   -   passed: false,\n+       populationCount: 0,\n+   +   reason: 'within-ratchet',\n+   -   reason: 'empty-population',\n+       uncovered: []\n+     }\n+   \n+       at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:6:10)\n+       at Test.runInAsyncScope (node:async_hooks:226:14)\n+       at Test.run (node:internal/test_runner/test:1118:25)\n+       at Test.start (node:internal/test_runner/test:1015:17)\n+       at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n+     generatedMessage: true,\n+     code: 'ERR_ASSERTION',\n+     actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n+     expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n+     operator: 'deepStrictEqual',\n+     diff: 'simple'\n+   }\n+\n+ test at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:10:1\n+ ✖ unknown coverage id is rejected (0.211958ms)\n+   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n+   \n+   true !== false\n+   \n+       at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:11:10)\n+       at Test.runInAsyncScope (node:async_hooks:226:14)\n+       at Test.run (node:internal/test_runner/test:1118:25)\n+       at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n+       at Test.postRun (node:internal/test_runner/test:1247:19)\n+       at Test.run (node:internal/test_runner/test:1175:12)\n+       at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n+     generatedMessage: true,\n+     code: 'ERR_ASSERTION',\n+     actual: true,\n+     expected: false,\n+     operator: 'strictEqual',\n+     diff: 'simple'\n+   }\n+\n+ test at ../../checker-p3-hollow-mNMzky/guard-own.test.mjs:13:1\n+ ✖ new uncovered checker is named and rejected (0.088125ms)\n+   AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n+   \n+   true !== false\n+   \n+       at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-mNMzky/guard-own.test.mjs:15:10)\n+       at Test.runInAsyncScope (node:async_hooks:226:14)\n+       at Test.run (node:internal/test_runner/test:1118:25)\n+       at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n+       at Test.postRun (node:internal/test_runner/test:1247:19)\n+       at Test.run (node:internal/test_runner/test:1175:12)\n+       at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n+     generatedMessage: true,\n+     code: 'ERR_ASSERTION',\n+     actual: true,\n+     expected: false,\n+     operator: 'strictEqual',\n+     diff: 'simple'\n+   }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:572:22\n    570|       console.log(`P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true g…\n    571|       expect(result.status).not.toBe(0);\n    572|       expect(output).toContain('# tests 4');\n       |                      ^\n    573|       expect(output).toContain('# fail 3');\n    574|       expect(output).toMatch(/AssertionError|Expected values to be str…\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+            "truncated": false,
+            "originalChars": 5930
+          },
+          "outputSha256": "55a8a970078682bebb5fd8d389c9d22a8b4e103e4ab822167ce42cbb83c83f95",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 31065,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAV6SnX0b650jenjBF9XQsCxTFZcxXeGGamO2rRslWO2Q=",
+              "signature": "hpv1CRpmXAtvzdd+QaeUu7cKgyMHDfhaqvSsVy71QV9Ie1LW+tNPP5jqGScLhOOMi+bwb0tQSMRHetkcyWK0Bw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 31065,
+              "ppid": 93252,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 31065,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 31144,
+              "startedAt": "2026-08-18T12:16:47.771Z",
+              "signature": "5gcaV4kWkMJVaj2L+EUfym53wP9AMKBuknRtiGFjO2S8rXDKKl4adzM0xkv8riSw7wt2+WbXJURGcNu+pgJhAQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 31144,
+              "ppid": 31065,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "71ffee0f-bcc4-47f6-bd4b-2ffa3f6699ee",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 31065,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 31144,
+            "startedAt": "2026-08-18T12:16:47.771Z",
+            "childExitedAt": "2026-08-18T12:17:22.477Z",
+            "childExitCode": 1,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "BG+aa5B5ycQg+k4gZ+cdelDpg9+NwUlJoc70M7tYze37Efbe0Jck1RfpZK03NbwQoZqrXHSqnHZ8snagbFwhBg=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:17:22.486Z",
+          "endedAt": "2026-08-18T12:18:21.619Z",
+          "durationMs": 59133,
+          "pid": 56964,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"f33f463d-11f8-47f9-bcb5-d730df2587b2\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93502,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAeRxMgjBxH4iib7kyhCshHyIy4CbH6QI7oOkfW1v/WOw=\",\"signature\":\"WATLBH84hgxKHXxc2UtLS9P8Fy4rF8uvU2v0uO8zILUh1Ve9/EWWWJEfJNp1WmHPjnpd+sgYV803xJN1skZfAg==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"f33f463d-11f8-47f9-bcb5-d730df2587b2\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93502,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T12:18:21.610Z\",\"signature\":\"cMAJYq27XhtJzHfdbq9W3weo7FyNFGw7NpWv/4XACseTsd1bzTNuPMxcPEzJfzSA2j0whi3AhXpx+oL8YXPmAA==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "d014fbf5d6babe121b80b496f074bf7f9df35b2f379852b56c65848fd5f90e67",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 93502,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:18:21.610Z",
+            "signature": "cMAJYq27XhtJzHfdbq9W3weo7FyNFGw7NpWv/4XACseTsd1bzTNuPMxcPEzJfzSA2j0whi3AhXpx+oL8YXPmAA=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "5fc1cc81-9866-46e7-a5e4-ff973064a549",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "33f70151-565c-45cb-aa99-287f4950c2c7",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 93502,
+          "childPid": 93502,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "6b75f80fa8205dbb68da4d940a20a04e7b67e56640ca9e68cc95d60c180cce83",
+          "startedAt": "2026-08-18T12:18:21.610Z",
+          "childExitedAt": "2026-08-18T12:18:21.619Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "61bbf2fa8a49afaa7d10af8ff99a2ea529c3d4208da16acd4e2417a805875036",
+          "mac": "28cf6f53fa0d387a88f9a618de2e2866f409b4fbaace5285f2cb72465482c0a1"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "f33f463d-11f8-47f9-bcb5-d730df2587b2",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 93502,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAeRxMgjBxH4iib7kyhCshHyIy4CbH6QI7oOkfW1v/WOw=",
+              "signature": "WATLBH84hgxKHXxc2UtLS9P8Fy4rF8uvU2v0uO8zILUh1Ve9/EWWWJEfJNp1WmHPjnpd+sgYV803xJN1skZfAg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 93502,
+              "ppid": 57304,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "exists",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-6N5E8i/01-pipeline-wiring",
+        "commit": "3801aefe9825e1258f5f235c123c56bee9e6a98b"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/W4-topic-operator-evidence.json
+++ b/scratchpad/phaseB/evidence/W4-topic-operator-evidence.json
@@ -1,0 +1,1120 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T12:32:48.834Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "e49d10fd4d98a93a8011efa6807d180cab56fdf5a7745744879bad7c0afb4897",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/adapters/topic-operator-evidence.mjs",
+      "sha256": "d7248e314f779e47d6290500d80d924f30754b8165a524c3992d0160acba49e1"
+    }
+  },
+  "guardId": "topic-operator-evidence",
+  "description": "Evidence-bearing topic-operator bindings plus verified-reader refusal of assertions.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/Documents/Projects/instar-codey/.worktrees/b0-3-fixlane-20260817",
+    "requestedCommit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-convert-wiring-proofs/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "tests/unit/topic-operator-store.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/topic-operator-routes.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/topic-operator-autobind-route.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/users/TopicOperatorStore.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/server/routes.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/commands/server.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run test:push",
+    "establishedBy": "the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "test:push",
+        "--",
+        "tests/unit/topic-operator-store.test.ts",
+        "tests/integration/topic-operator-routes.test.ts",
+        "tests/integration/topic-operator-autobind-route.test.ts",
+        "--reporter=verbose"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-authenticated-observer-events-hmac-receipt",
+      "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+      "receipt": {
+        "schema": "phaseB-authenticated-execution-receipt/v1",
+        "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+        "issuer": "fix-verifier:topic-operator-evidence",
+        "nonce": "a9d102c5-2473-4584-a2df-4321fa471205",
+        "guardId": "topic-operator-evidence",
+        "kind": "child-exit",
+        "observerPid": 91371,
+        "childPid": 91450,
+        "childExitCode": 0,
+        "signal": null,
+        "argv": [
+          "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+          "run",
+          "--config",
+          "vitest.push.config.ts",
+          "tests/unit/topic-operator-store.test.ts",
+          "tests/integration/topic-operator-routes.test.ts",
+          "tests/integration/topic-operator-autobind-route.test.ts",
+          "--reporter=verbose"
+        ],
+        "argvHash": "d16b01a2a5b0f9cc49fc9bf1331c5ce4a8fe0c25ffe3cefb5dceb6408721a7f8",
+        "startedAt": "2026-08-18T12:25:55.670Z",
+        "childExitedAt": "2026-08-18T12:32:47.756Z",
+        "emittedAfterChildExit": true,
+        "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+        "observerEventSequence": 3,
+        "observerEventSignatureHash": "995c5a117de8bb6fd6b70f32a94239e87391377819c776a30af9d1a0c6998593",
+        "mac": "fe40c4d41fecdbcae0d5df7b8e2b37bc66dfe642d515bd048bf4e9c53fbc7aff"
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "eventSchema": "phaseB-authenticated-observer-event/v1",
+          "source": "fix-verifier-observer",
+          "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+          "sequence": 2,
+          "kind": "short-circuit",
+          "guardId": "topic-operator-evidence",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "observerPid": 43173,
+          "argv": [
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "shortCircuitedAt": "2026-08-18T12:32:48.603Z",
+          "signature": "xVs/Xhhg+u/6TQUrYLp1G85J5RQ+6s/DUMy1DNZth0OWfAcWUlnV7wfhXJI4wMAMtrOJ6XoPDiA2zrSJh84nAQ=="
+        },
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "417d0b79-cb00-4022-9a61-5eccefc4e1c8",
+          "guardId": "topic-operator-evidence",
+          "kind": "short-circuit",
+          "observerPid": 43173,
+          "childPid": 43173,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs",
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "0dfac7b2add3c3f275a269ee6389994a06691c4de859b9785981eb48a3a99577",
+          "startedAt": "2026-08-18T12:32:48.603Z",
+          "childExitedAt": "2026-08-18T12:32:48.611Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "2082af619a3d196b4681cdee17ab6e3ee75b8d94f36af96d4d89b3d355439750",
+          "mac": "083dca40e17ad058c078bc3ce5af184fd2079e599ef2dde70b9e1e3237cc84f5"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "private-channel authority authenticated exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 authenticated the instrument observer short-circuit",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:25:55.140Z",
+          "endedAt": "2026-08-18T12:32:47.766Z",
+          "durationMs": 412626,
+          "pid": 91131,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"2c61b471-c63a-41c4-ac67-87cc5da536db\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":91371,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEA4DkqMgaLWEqoxtnFFAQrsNl/wLvRFFr0k0Q4ikUGUX8=\",\"signature\":\"460UV10MJN6fN+zYhgNlqK2f13iXEvIVWnhAX54pWSaERkV+Y+tFLHO+IgYNT64DPyFqZ19u635KZ6p1qWKCDQ==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"2c61b471-c63a-41c4-ac67-87cc5da536db\",\"sequence\":2,\"kind\":\"child-start\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":91371,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":91450,\"startedAt\":\"2026-08-18T12:25:55.670Z\",\"signature\":\"dd7JjhwEo6fNW3QD5FmKD/kCzhzjd/E9nQ8mAEA42XAy9BLPWA6T4TowREMCUBtzuhWkoNXTqN5kpWxAfPprAQ==\"}\n\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring\n\n✓ standards registry asset: 88 articles, registry 81b53363a440…, guards 44d5cab21f32… → src/data + dist/data\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > establishes from an authenticated uid and reads it back\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES a blank uid — an operator cannot be established without a verified id\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES mismatched or missing authentication evidence\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > a content name can never BECOME the operator — only a uid does (by construction)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > getOperator is null for an unbound topic\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > persists across instances (durable JSON store)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > replacing an operator overwrites the prior record\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > records a manual assertion durably but refuses it as a verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P2: refuses a subject that self-reports authenticated while its evidence says assertion\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P5: legacy evidence-less and malformed/wrong-container inputs are not-proven, never verified\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P4: verified enumeration is non-vacuous and covers every topic-key shape in the raw population\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.asVerifiedOperator (feeds PrincipalGuard) > returns the PrincipalGuard shape when bound, null when unbound\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > builds a <topic-operator> block naming the verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > returns null for an unbound topic (nothing injected)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > falls back to the uid when no display name was provided\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > skips the disk write when the stored record is identical\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > still writes when the record actually changes\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > records an arbitrary body uid as an assertion in the real stored record, never authenticated inbound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a blank uid — a content name can never establish an operator\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a missing topicId\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > persists the binding (a fresh request reads it back)\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > lists assertions separately and excludes them from verified operators\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > returns operator:null for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns the <topic-operator> injection block when bound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an asserted binding\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > 400s when topicId is missing\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > when the store is not initialized > every route returns 503 (feature not available), never a crash\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > BINDS the operator from an AUTHORIZED sender\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an agent-to-agent bot message (short-circuits before the bind)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does not crash when no store is wired (pure additive change)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > keeps the real lifeline→polling convergence evidence-bound when a Telegram message id exists\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > P5: missing Telegram message id stays not-proven across the real lifeline→polling convergence\n\n Test Files  3 passed (3)\n      Tests  34 passed (34)\n   Start at  05:25:56\n   Duration  411.40s (transform 6.91s, setup 10ms, collect 11.12s, tests 413ms, environment 0ms, prepare 181ms)\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"2c61b471-c63a-41c4-ac67-87cc5da536db\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":91371,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":91450,\"startedAt\":\"2026-08-18T12:25:55.670Z\",\"childExitedAt\":\"2026-08-18T12:32:47.756Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"6jdjwp+XLMSzjumO5mBAF1Y2RzoI7CTw6d9zFsjW2nbF3En3KTkZR43q5Yrjm9mzdcI9mhD2LnwCLeQdv03JBQ==\"}\n",
+            "truncated": false,
+            "originalChars": 9210
+          },
+          "stderr": {
+            "text": "[test-runner-bound] ⠹ waiting for a suite-lane test slot (0m elapsed; 1 holder(s): pid 46168 age 77s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (1m elapsed; 1 holder(s): pid 46168 age 139s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (2m elapsed; 1 holder(s): pid 46168 age 200s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (3m elapsed; 1 holder(s): pid 46168 age 265s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (4m elapsed; 1 holder(s): pid 46168 age 331s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (5m elapsed; 1 holder(s): pid 46168 age 393s) — active work, not a hang\n[test-runner-bound] suite-lane slot acquired (posture: enforcing, cap 1, pid 91450)\n",
+            "truncated": false,
+            "originalChars": 857
+          },
+          "outputSha256": "d76196819d7263f472d188324a5e975d91cf418b6d4f80d7025d0d59375fb831",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+            "issuer": "fix-verifier:topic-operator-evidence",
+            "nonce": "a9d102c5-2473-4584-a2df-4321fa471205",
+            "guardId": "topic-operator-evidence",
+            "kind": "child-exit",
+            "observerPid": 91371,
+            "childPid": 91450,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "argvHash": "d16b01a2a5b0f9cc49fc9bf1331c5ce4a8fe0c25ffe3cefb5dceb6408721a7f8",
+            "startedAt": "2026-08-18T12:25:55.670Z",
+            "childExitedAt": "2026-08-18T12:32:47.756Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "995c5a117de8bb6fd6b70f32a94239e87391377819c776a30af9d1a0c6998593",
+            "mac": "fe40c4d41fecdbcae0d5df7b8e2b37bc66dfe642d515bd048bf4e9c53fbc7aff"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 91371,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEA4DkqMgaLWEqoxtnFFAQrsNl/wLvRFFr0k0Q4ikUGUX8=",
+              "signature": "460UV10MJN6fN+zYhgNlqK2f13iXEvIVWnhAX54pWSaERkV+Y+tFLHO+IgYNT64DPyFqZ19u635KZ6p1qWKCDQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 91371,
+              "ppid": 91273,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/positive/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 91371,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "childPid": 91450,
+              "startedAt": "2026-08-18T12:25:55.670Z",
+              "signature": "dd7JjhwEo6fNW3QD5FmKD/kCzhzjd/E9nQ8mAEA42XAy9BLPWA6T4TowREMCUBtzuhWkoNXTqN5kpWxAfPprAQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 91450,
+              "ppid": 91371,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 91371,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "childPid": 91450,
+            "startedAt": "2026-08-18T12:25:55.670Z",
+            "childExitedAt": "2026-08-18T12:32:47.756Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "6jdjwp+XLMSzjumO5mBAF1Y2RzoI7CTw6d9zFsjW2nbF3En3KTkZR43q5Yrjm9mzdcI9mhD2LnwCLeQdv03JBQ=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:32:47.769Z",
+          "endedAt": "2026-08-18T12:32:48.611Z",
+          "durationMs": 842,
+          "pid": 42793,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"a9af9135-1dce-4ddd-84c7-c1722ff34eae\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":43173,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEAW4DsysPoQaoV6VGdAUFWAoPBVaRwddy8sDRp/4qCgMc=\",\"signature\":\"AHkIUT3qA4LKfLqNA1+/cEd2UmEQ9Wk2xfNOIa3b/rTQFcJk7mP7Or4LSeXcHnkYtejZTgUFMKbB00zHK2f0Bw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"a9af9135-1dce-4ddd-84c7-c1722ff34eae\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":43173,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"shortCircuitedAt\":\"2026-08-18T12:32:48.603Z\",\"signature\":\"xVs/Xhhg+u/6TQUrYLp1G85J5RQ+6s/DUMy1DNZth0OWfAcWUlnV7wfhXJI4wMAMtrOJ6XoPDiA2zrSJh84nAQ==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs\n",
+            "truncated": false,
+            "originalChars": 2015
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "2b447d6a960cb6439c911ab4af499f23469955ffbc306e964553071e327d211d",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 43173,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:32:48.603Z",
+            "signature": "xVs/Xhhg+u/6TQUrYLp1G85J5RQ+6s/DUMy1DNZth0OWfAcWUlnV7wfhXJI4wMAMtrOJ6XoPDiA2zrSJh84nAQ=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "417d0b79-cb00-4022-9a61-5eccefc4e1c8",
+          "guardId": "topic-operator-evidence",
+          "kind": "short-circuit",
+          "observerPid": 43173,
+          "childPid": 43173,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs",
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "0dfac7b2add3c3f275a269ee6389994a06691c4de859b9785981eb48a3a99577",
+          "startedAt": "2026-08-18T12:32:48.603Z",
+          "childExitedAt": "2026-08-18T12:32:48.611Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "2082af619a3d196b4681cdee17ab6e3ee75b8d94f36af96d4d89b3d355439750",
+          "mac": "083dca40e17ad058c078bc3ce5af184fd2079e599ef2dde70b9e1e3237cc84f5"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 43173,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAW4DsysPoQaoV6VGdAUFWAoPBVaRwddy8sDRp/4qCgMc=",
+              "signature": "AHkIUT3qA4LKfLqNA1+/cEd2UmEQ9Wk2xfNOIa3b/rTQFcJk7mP7Or4LSeXcHnkYtejZTgUFMKbB00zHK2f0Bw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 43173,
+              "ppid": 43019,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+        "receipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "a9d102c5-2473-4584-a2df-4321fa471205",
+          "guardId": "topic-operator-evidence",
+          "kind": "child-exit",
+          "observerPid": 91371,
+          "childPid": 91450,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "d16b01a2a5b0f9cc49fc9bf1331c5ce4a8fe0c25ffe3cefb5dceb6408721a7f8",
+          "startedAt": "2026-08-18T12:25:55.670Z",
+          "childExitedAt": "2026-08-18T12:32:47.756Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+          "observerEventSequence": 3,
+          "observerEventSignatureHash": "995c5a117de8bb6fd6b70f32a94239e87391377819c776a30af9d1a0c6998593",
+          "mac": "fe40c4d41fecdbcae0d5df7b8e2b37bc66dfe642d515bd048bf4e9c53fbc7aff"
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 43173,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:32:48.603Z",
+            "signature": "xVs/Xhhg+u/6TQUrYLp1G85J5RQ+6s/DUMy1DNZth0OWfAcWUlnV7wfhXJI4wMAMtrOJ6XoPDiA2zrSJh84nAQ=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+            "issuer": "fix-verifier:topic-operator-evidence",
+            "nonce": "417d0b79-cb00-4022-9a61-5eccefc4e1c8",
+            "guardId": "topic-operator-evidence",
+            "kind": "short-circuit",
+            "observerPid": 43173,
+            "childPid": 43173,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs",
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "argvHash": "0dfac7b2add3c3f275a269ee6389994a06691c4de859b9785981eb48a3a99577",
+            "startedAt": "2026-08-18T12:32:48.603Z",
+            "childExitedAt": "2026-08-18T12:32:48.611Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "2082af619a3d196b4681cdee17ab6e3ee75b8d94f36af96d4d89b3d355439750",
+            "mac": "083dca40e17ad058c078bc3ce5af184fd2079e599ef2dde70b9e1e3237cc84f5"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:25:55.140Z",
+          "endedAt": "2026-08-18T12:32:47.766Z",
+          "durationMs": 412626,
+          "pid": 91131,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"2c61b471-c63a-41c4-ac67-87cc5da536db\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":91371,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEA4DkqMgaLWEqoxtnFFAQrsNl/wLvRFFr0k0Q4ikUGUX8=\",\"signature\":\"460UV10MJN6fN+zYhgNlqK2f13iXEvIVWnhAX54pWSaERkV+Y+tFLHO+IgYNT64DPyFqZ19u635KZ6p1qWKCDQ==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"2c61b471-c63a-41c4-ac67-87cc5da536db\",\"sequence\":2,\"kind\":\"child-start\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":91371,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":91450,\"startedAt\":\"2026-08-18T12:25:55.670Z\",\"signature\":\"dd7JjhwEo6fNW3QD5FmKD/kCzhzjd/E9nQ8mAEA42XAy9BLPWA6T4TowREMCUBtzuhWkoNXTqN5kpWxAfPprAQ==\"}\n\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring\n\n✓ standards registry asset: 88 articles, registry 81b53363a440…, guards 44d5cab21f32… → src/data + dist/data\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > establishes from an authenticated uid and reads it back\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES a blank uid — an operator cannot be established without a verified id\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES mismatched or missing authentication evidence\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > a content name can never BECOME the operator — only a uid does (by construction)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > getOperator is null for an unbound topic\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > persists across instances (durable JSON store)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > replacing an operator overwrites the prior record\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > records a manual assertion durably but refuses it as a verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P2: refuses a subject that self-reports authenticated while its evidence says assertion\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P5: legacy evidence-less and malformed/wrong-container inputs are not-proven, never verified\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P4: verified enumeration is non-vacuous and covers every topic-key shape in the raw population\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.asVerifiedOperator (feeds PrincipalGuard) > returns the PrincipalGuard shape when bound, null when unbound\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > builds a <topic-operator> block naming the verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > returns null for an unbound topic (nothing injected)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > falls back to the uid when no display name was provided\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > skips the disk write when the stored record is identical\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > still writes when the record actually changes\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > records an arbitrary body uid as an assertion in the real stored record, never authenticated inbound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a blank uid — a content name can never establish an operator\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a missing topicId\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > persists the binding (a fresh request reads it back)\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > lists assertions separately and excludes them from verified operators\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > returns operator:null for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns the <topic-operator> injection block when bound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an asserted binding\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > 400s when topicId is missing\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > when the store is not initialized > every route returns 503 (feature not available), never a crash\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > BINDS the operator from an AUTHORIZED sender\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an agent-to-agent bot message (short-circuits before the bind)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does not crash when no store is wired (pure additive change)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > keeps the real lifeline→polling convergence evidence-bound when a Telegram message id exists\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > P5: missing Telegram message id stays not-proven across the real lifeline→polling convergence\n\n Test Files  3 passed (3)\n      Tests  34 passed (34)\n   Start at  05:25:56\n   Duration  411.40s (transform 6.91s, setup 10ms, collect 11.12s, tests 413ms, environment 0ms, prepare 181ms)\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"2c61b471-c63a-41c4-ac67-87cc5da536db\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":91371,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":91450,\"startedAt\":\"2026-08-18T12:25:55.670Z\",\"childExitedAt\":\"2026-08-18T12:32:47.756Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"6jdjwp+XLMSzjumO5mBAF1Y2RzoI7CTw6d9zFsjW2nbF3En3KTkZR43q5Yrjm9mzdcI9mhD2LnwCLeQdv03JBQ==\"}\n",
+            "truncated": false,
+            "originalChars": 9210
+          },
+          "stderr": {
+            "text": "[test-runner-bound] ⠹ waiting for a suite-lane test slot (0m elapsed; 1 holder(s): pid 46168 age 77s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (1m elapsed; 1 holder(s): pid 46168 age 139s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (2m elapsed; 1 holder(s): pid 46168 age 200s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (3m elapsed; 1 holder(s): pid 46168 age 265s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (4m elapsed; 1 holder(s): pid 46168 age 331s) — active work, not a hang\n[test-runner-bound] ⠹ waiting for a suite-lane test slot (5m elapsed; 1 holder(s): pid 46168 age 393s) — active work, not a hang\n[test-runner-bound] suite-lane slot acquired (posture: enforcing, cap 1, pid 91450)\n",
+            "truncated": false,
+            "originalChars": 857
+          },
+          "outputSha256": "d76196819d7263f472d188324a5e975d91cf418b6d4f80d7025d0d59375fb831",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+            "issuer": "fix-verifier:topic-operator-evidence",
+            "nonce": "a9d102c5-2473-4584-a2df-4321fa471205",
+            "guardId": "topic-operator-evidence",
+            "kind": "child-exit",
+            "observerPid": 91371,
+            "childPid": 91450,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "argvHash": "d16b01a2a5b0f9cc49fc9bf1331c5ce4a8fe0c25ffe3cefb5dceb6408721a7f8",
+            "startedAt": "2026-08-18T12:25:55.670Z",
+            "childExitedAt": "2026-08-18T12:32:47.756Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "995c5a117de8bb6fd6b70f32a94239e87391377819c776a30af9d1a0c6998593",
+            "mac": "fe40c4d41fecdbcae0d5df7b8e2b37bc66dfe642d515bd048bf4e9c53fbc7aff"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 91371,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEA4DkqMgaLWEqoxtnFFAQrsNl/wLvRFFr0k0Q4ikUGUX8=",
+              "signature": "460UV10MJN6fN+zYhgNlqK2f13iXEvIVWnhAX54pWSaERkV+Y+tFLHO+IgYNT64DPyFqZ19u635KZ6p1qWKCDQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 91371,
+              "ppid": 91273,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/positive/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 91371,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "childPid": 91450,
+              "startedAt": "2026-08-18T12:25:55.670Z",
+              "signature": "dd7JjhwEo6fNW3QD5FmKD/kCzhzjd/E9nQ8mAEA42XAy9BLPWA6T4TowREMCUBtzuhWkoNXTqN5kpWxAfPprAQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 91450,
+              "ppid": 91371,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "2c61b471-c63a-41c4-ac67-87cc5da536db",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 91371,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "childPid": 91450,
+            "startedAt": "2026-08-18T12:25:55.670Z",
+            "childExitedAt": "2026-08-18T12:32:47.756Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "6jdjwp+XLMSzjumO5mBAF1Y2RzoI7CTw6d9zFsjW2nbF3En3KTkZR43q5Yrjm9mzdcI9mhD2LnwCLeQdv03JBQ=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:32:47.769Z",
+          "endedAt": "2026-08-18T12:32:48.611Z",
+          "durationMs": 842,
+          "pid": 42793,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"a9af9135-1dce-4ddd-84c7-c1722ff34eae\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":43173,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEAW4DsysPoQaoV6VGdAUFWAoPBVaRwddy8sDRp/4qCgMc=\",\"signature\":\"AHkIUT3qA4LKfLqNA1+/cEd2UmEQ9Wk2xfNOIa3b/rTQFcJk7mP7Or4LSeXcHnkYtejZTgUFMKbB00zHK2f0Bw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"a9af9135-1dce-4ddd-84c7-c1722ff34eae\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":43173,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"shortCircuitedAt\":\"2026-08-18T12:32:48.603Z\",\"signature\":\"xVs/Xhhg+u/6TQUrYLp1G85J5RQ+6s/DUMy1DNZth0OWfAcWUlnV7wfhXJI4wMAMtrOJ6XoPDiA2zrSJh84nAQ==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs\n",
+            "truncated": false,
+            "originalChars": 2015
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "2b447d6a960cb6439c911ab4af499f23469955ffbc306e964553071e327d211d",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 43173,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:32:48.603Z",
+            "signature": "xVs/Xhhg+u/6TQUrYLp1G85J5RQ+6s/DUMy1DNZth0OWfAcWUlnV7wfhXJI4wMAMtrOJ6XoPDiA2zrSJh84nAQ=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "8c1ade92-3010-4ca4-80fc-59410b36df93",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "417d0b79-cb00-4022-9a61-5eccefc4e1c8",
+          "guardId": "topic-operator-evidence",
+          "kind": "short-circuit",
+          "observerPid": 43173,
+          "childPid": 43173,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs",
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "0dfac7b2add3c3f275a269ee6389994a06691c4de859b9785981eb48a3a99577",
+          "startedAt": "2026-08-18T12:32:48.603Z",
+          "childExitedAt": "2026-08-18T12:32:48.611Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "2082af619a3d196b4681cdee17ab6e3ee75b8d94f36af96d4d89b3d355439750",
+          "mac": "083dca40e17ad058c078bc3ce5af184fd2079e599ef2dde70b9e1e3237cc84f5"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "a9af9135-1dce-4ddd-84c7-c1722ff34eae",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 43173,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAW4DsysPoQaoV6VGdAUFWAoPBVaRwddy8sDRp/4qCgMc=",
+              "signature": "AHkIUT3qA4LKfLqNA1+/cEd2UmEQ9Wk2xfNOIa3b/rTQFcJk7mP7Or4LSeXcHnkYtejZTgUFMKbB00zHK2f0Bw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 43173,
+              "ppid": 43019,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/pipeline-observer/c3/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-zbr7PO/01-pipeline-wiring",
+        "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/W4R-topic-operator-evidence.json
+++ b/scratchpad/phaseB/evidence/W4R-topic-operator-evidence.json
@@ -1,0 +1,1120 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T13:07:38.110Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/adapters/topic-operator-evidence.mjs",
+      "sha256": "d7248e314f779e47d6290500d80d924f30754b8165a524c3992d0160acba49e1"
+    }
+  },
+  "guardId": "topic-operator-evidence",
+  "description": "Evidence-bearing topic-operator bindings plus verified-reader refusal of assertions.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/Documents/Projects/instar-codey/.worktrees/b0-3-fixlane-20260817",
+    "requestedCommit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "tests/unit/topic-operator-store.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/topic-operator-routes.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/integration/topic-operator-autobind-route.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/users/TopicOperatorStore.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/server/routes.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "src/commands/server.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run test:push",
+    "establishedBy": "the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "test:push",
+        "--",
+        "tests/unit/topic-operator-store.test.ts",
+        "tests/integration/topic-operator-routes.test.ts",
+        "tests/integration/topic-operator-autobind-route.test.ts",
+        "--reporter=verbose"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-authenticated-observer-events-hmac-receipt",
+      "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+      "receipt": {
+        "schema": "phaseB-authenticated-execution-receipt/v1",
+        "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+        "issuer": "fix-verifier:topic-operator-evidence",
+        "nonce": "cf90a58c-671a-480b-a4ce-f3ac6cce3da2",
+        "guardId": "topic-operator-evidence",
+        "kind": "child-exit",
+        "observerPid": 77785,
+        "childPid": 77868,
+        "childExitCode": 0,
+        "signal": null,
+        "argv": [
+          "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+          "run",
+          "--config",
+          "vitest.push.config.ts",
+          "tests/unit/topic-operator-store.test.ts",
+          "tests/integration/topic-operator-routes.test.ts",
+          "tests/integration/topic-operator-autobind-route.test.ts",
+          "--reporter=verbose"
+        ],
+        "argvHash": "86c5c6575336cd89eb1b1f1601f0e7476eae67a9d1ef7ed533535b8626f9312f",
+        "startedAt": "2026-08-18T13:06:34.402Z",
+        "childExitedAt": "2026-08-18T13:07:37.302Z",
+        "emittedAfterChildExit": true,
+        "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+        "observerEventSequence": 3,
+        "observerEventSignatureHash": "ec9b155c1d130ef05465982ec5cd3546698c15ec156e08e7d1559d5f2601f1d1",
+        "mac": "291a0626208e6f4f69674bea8db1cfb1ef1dd464291877a1f18a9485f9ce466f"
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "eventSchema": "phaseB-authenticated-observer-event/v1",
+          "source": "fix-verifier-observer",
+          "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+          "sequence": 2,
+          "kind": "short-circuit",
+          "guardId": "topic-operator-evidence",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "observerPid": 3593,
+          "argv": [
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "shortCircuitedAt": "2026-08-18T13:07:37.957Z",
+          "signature": "qMov3qCwLZzxEAaR/RFDCehNueukP4Zq+VFrBhUaHMyo4UHhVKa8BxMvQS/9r2JhaoMEkmY1k8YSmHoVWFfhCg=="
+        },
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "4cdbbac0-def4-4c26-b21d-1c88be09d885",
+          "guardId": "topic-operator-evidence",
+          "kind": "short-circuit",
+          "observerPid": 3593,
+          "childPid": 3593,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs",
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "ca35ad4d97f30ed5de5b66ccbf4c3b8e8cff11b15b744c4edd4b3c7a2ef21c5a",
+          "startedAt": "2026-08-18T13:07:37.957Z",
+          "childExitedAt": "2026-08-18T13:07:37.966Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "b5f85f28c9f4b7bd85ef8d29698f7dce7e3b45f981141169ac7d4082a93cddae",
+          "mac": "b0f01c8e21503e9fb8ee07e6eb2781abadb3e640fc3fb15f3dbc6ead28f8a385"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "private-channel authority authenticated exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 authenticated the instrument observer short-circuit",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:06:33.556Z",
+          "endedAt": "2026-08-18T13:07:37.319Z",
+          "durationMs": 63763,
+          "pid": 77467,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"eb41b468-720d-42f6-a524-a3f1991ce048\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":77785,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEAlJdoD8O88ns8MjUnRaqyOmFxYEt3LMaqRcV9Q3e+i4Y=\",\"signature\":\"xap4w60QO0FDNjOLToF+0Lwj6enaW3OF3pUepWdb7ZV0WY71IG40XQAIEtEvvsdn5BLuViIMvIEDcd+IkmapCQ==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"eb41b468-720d-42f6-a524-a3f1991ce048\",\"sequence\":2,\"kind\":\"child-start\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":77785,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":77868,\"startedAt\":\"2026-08-18T13:06:34.402Z\",\"signature\":\"N9wojHCTHeqLWWiTqXLtrK25ilmWWCeRfPqs4gb7ExVo5rMv9BqcuQgGLUZZM2UH7ly0DrzqhkjwqlWku2BUCw==\"}\n\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring\n\n✓ standards registry asset: 88 articles, registry 81b53363a440…, guards 44d5cab21f32… → src/data + dist/data\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > establishes from an authenticated uid and reads it back\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES a blank uid — an operator cannot be established without a verified id\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES mismatched or missing authentication evidence\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > a content name can never BECOME the operator — only a uid does (by construction)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > getOperator is null for an unbound topic\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > persists across instances (durable JSON store)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > replacing an operator overwrites the prior record\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > records a manual assertion durably but refuses it as a verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P2: refuses a subject that self-reports authenticated while its evidence says assertion\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P5: legacy evidence-less and malformed/wrong-container inputs are not-proven, never verified\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P4: verified enumeration is non-vacuous and covers every topic-key shape in the raw population\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.asVerifiedOperator (feeds PrincipalGuard) > returns the PrincipalGuard shape when bound, null when unbound\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > builds a <topic-operator> block naming the verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > returns null for an unbound topic (nothing injected)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > falls back to the uid when no display name was provided\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > skips the disk write when the stored record is identical\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > still writes when the record actually changes\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > records an arbitrary body uid as an assertion in the real stored record, never authenticated inbound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a blank uid — a content name can never establish an operator\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a missing topicId\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > persists the binding (a fresh request reads it back)\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > lists assertions separately and excludes them from verified operators\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > returns operator:null for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns the <topic-operator> injection block when bound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an asserted binding\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > 400s when topicId is missing\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > when the store is not initialized > every route returns 503 (feature not available), never a crash\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > BINDS the operator from an AUTHORIZED sender\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an agent-to-agent bot message (short-circuits before the bind)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does not crash when no store is wired (pure additive change)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > keeps the real lifeline→polling convergence evidence-bound when a Telegram message id exists\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > P5: missing Telegram message id stays not-proven across the real lifeline→polling convergence\n\n Test Files  3 passed (3)\n      Tests  34 passed (34)\n   Start at  06:06:35\n   Duration  62.11s (transform 5.97s, setup 13ms, collect 8.57s, tests 446ms, environment 1ms, prepare 222ms)\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"eb41b468-720d-42f6-a524-a3f1991ce048\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":77785,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":77868,\"startedAt\":\"2026-08-18T13:06:34.402Z\",\"childExitedAt\":\"2026-08-18T13:07:37.302Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"zYZBtgOK4V5IsYUWUZf9ktxbEYg9V9kds7aEYrX+ViGU/jG1NQbDJmochg7lKlgzS1JASJk42B2x44sqgs09Bg==\"}\n",
+            "truncated": false,
+            "originalChars": 9208
+          },
+          "stderr": {
+            "text": "[test-runner-bound] suite-lane slot acquired (posture: enforcing, cap 1, pid 77868)\n",
+            "truncated": false,
+            "originalChars": 84
+          },
+          "outputSha256": "daed0060b01f6868a244ecbba92361a11aa1d812091dcaaf60e7a0476b400f6e",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+            "issuer": "fix-verifier:topic-operator-evidence",
+            "nonce": "cf90a58c-671a-480b-a4ce-f3ac6cce3da2",
+            "guardId": "topic-operator-evidence",
+            "kind": "child-exit",
+            "observerPid": 77785,
+            "childPid": 77868,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "argvHash": "86c5c6575336cd89eb1b1f1601f0e7476eae67a9d1ef7ed533535b8626f9312f",
+            "startedAt": "2026-08-18T13:06:34.402Z",
+            "childExitedAt": "2026-08-18T13:07:37.302Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "ec9b155c1d130ef05465982ec5cd3546698c15ec156e08e7d1559d5f2601f1d1",
+            "mac": "291a0626208e6f4f69674bea8db1cfb1ef1dd464291877a1f18a9485f9ce466f"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 77785,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAlJdoD8O88ns8MjUnRaqyOmFxYEt3LMaqRcV9Q3e+i4Y=",
+              "signature": "xap4w60QO0FDNjOLToF+0Lwj6enaW3OF3pUepWdb7ZV0WY71IG40XQAIEtEvvsdn5BLuViIMvIEDcd+IkmapCQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 77785,
+              "ppid": 77607,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/positive/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 77785,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "childPid": 77868,
+              "startedAt": "2026-08-18T13:06:34.402Z",
+              "signature": "N9wojHCTHeqLWWiTqXLtrK25ilmWWCeRfPqs4gb7ExVo5rMv9BqcuQgGLUZZM2UH7ly0DrzqhkjwqlWku2BUCw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 77868,
+              "ppid": 77785,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 77785,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "childPid": 77868,
+            "startedAt": "2026-08-18T13:06:34.402Z",
+            "childExitedAt": "2026-08-18T13:07:37.302Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "zYZBtgOK4V5IsYUWUZf9ktxbEYg9V9kds7aEYrX+ViGU/jG1NQbDJmochg7lKlgzS1JASJk42B2x44sqgs09Bg=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:07:37.321Z",
+          "endedAt": "2026-08-18T13:07:37.966Z",
+          "durationMs": 645,
+          "pid": 3396,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":3593,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEADB4rolFP4TmM/my99It7LDC2vJ3OPMR4nd1jbCOjSfg=\",\"signature\":\"amc7PU62RFtaXcxufy/5DecJlHVR6IbZiE/l2oPUJAUbgSMDsFKMkAtbi50Y07rzI9XJ2TofnIFQkxRw6xW5Dw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":3593,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"shortCircuitedAt\":\"2026-08-18T13:07:37.957Z\",\"signature\":\"qMov3qCwLZzxEAaR/RFDCehNueukP4Zq+VFrBhUaHMyo4UHhVKa8BxMvQS/9r2JhaoMEkmY1k8YSmHoVWFfhCg==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs\n",
+            "truncated": false,
+            "originalChars": 2013
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "44f09ae2ad211f4ee8ef6c27c07fcfea3f163456f428000e3ffa65b7d84ba263",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 3593,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T13:07:37.957Z",
+            "signature": "qMov3qCwLZzxEAaR/RFDCehNueukP4Zq+VFrBhUaHMyo4UHhVKa8BxMvQS/9r2JhaoMEkmY1k8YSmHoVWFfhCg=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "4cdbbac0-def4-4c26-b21d-1c88be09d885",
+          "guardId": "topic-operator-evidence",
+          "kind": "short-circuit",
+          "observerPid": 3593,
+          "childPid": 3593,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs",
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "ca35ad4d97f30ed5de5b66ccbf4c3b8e8cff11b15b744c4edd4b3c7a2ef21c5a",
+          "startedAt": "2026-08-18T13:07:37.957Z",
+          "childExitedAt": "2026-08-18T13:07:37.966Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "b5f85f28c9f4b7bd85ef8d29698f7dce7e3b45f981141169ac7d4082a93cddae",
+          "mac": "b0f01c8e21503e9fb8ee07e6eb2781abadb3e640fc3fb15f3dbc6ead28f8a385"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 3593,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEADB4rolFP4TmM/my99It7LDC2vJ3OPMR4nd1jbCOjSfg=",
+              "signature": "amc7PU62RFtaXcxufy/5DecJlHVR6IbZiE/l2oPUJAUbgSMDsFKMkAtbi50Y07rzI9XJ2TofnIFQkxRw6xW5Dw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 3593,
+              "ppid": 3505,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+        "receipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "cf90a58c-671a-480b-a4ce-f3ac6cce3da2",
+          "guardId": "topic-operator-evidence",
+          "kind": "child-exit",
+          "observerPid": 77785,
+          "childPid": 77868,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "86c5c6575336cd89eb1b1f1601f0e7476eae67a9d1ef7ed533535b8626f9312f",
+          "startedAt": "2026-08-18T13:06:34.402Z",
+          "childExitedAt": "2026-08-18T13:07:37.302Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+          "observerEventSequence": 3,
+          "observerEventSignatureHash": "ec9b155c1d130ef05465982ec5cd3546698c15ec156e08e7d1559d5f2601f1d1",
+          "mac": "291a0626208e6f4f69674bea8db1cfb1ef1dd464291877a1f18a9485f9ce466f"
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 3593,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T13:07:37.957Z",
+            "signature": "qMov3qCwLZzxEAaR/RFDCehNueukP4Zq+VFrBhUaHMyo4UHhVKa8BxMvQS/9r2JhaoMEkmY1k8YSmHoVWFfhCg=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+            "issuer": "fix-verifier:topic-operator-evidence",
+            "nonce": "4cdbbac0-def4-4c26-b21d-1c88be09d885",
+            "guardId": "topic-operator-evidence",
+            "kind": "short-circuit",
+            "observerPid": 3593,
+            "childPid": 3593,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs",
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "argvHash": "ca35ad4d97f30ed5de5b66ccbf4c3b8e8cff11b15b744c4edd4b3c7a2ef21c5a",
+            "startedAt": "2026-08-18T13:07:37.957Z",
+            "childExitedAt": "2026-08-18T13:07:37.966Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "b5f85f28c9f4b7bd85ef8d29698f7dce7e3b45f981141169ac7d4082a93cddae",
+            "mac": "b0f01c8e21503e9fb8ee07e6eb2781abadb3e640fc3fb15f3dbc6ead28f8a385"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:06:33.556Z",
+          "endedAt": "2026-08-18T13:07:37.319Z",
+          "durationMs": 63763,
+          "pid": 77467,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"eb41b468-720d-42f6-a524-a3f1991ce048\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":77785,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEAlJdoD8O88ns8MjUnRaqyOmFxYEt3LMaqRcV9Q3e+i4Y=\",\"signature\":\"xap4w60QO0FDNjOLToF+0Lwj6enaW3OF3pUepWdb7ZV0WY71IG40XQAIEtEvvsdn5BLuViIMvIEDcd+IkmapCQ==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"eb41b468-720d-42f6-a524-a3f1991ce048\",\"sequence\":2,\"kind\":\"child-start\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":77785,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":77868,\"startedAt\":\"2026-08-18T13:06:34.402Z\",\"signature\":\"N9wojHCTHeqLWWiTqXLtrK25ilmWWCeRfPqs4gb7ExVo5rMv9BqcuQgGLUZZM2UH7ly0DrzqhkjwqlWku2BUCw==\"}\n\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring\n\n✓ standards registry asset: 88 articles, registry 81b53363a440…, guards 44d5cab21f32… → src/data + dist/data\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > establishes from an authenticated uid and reads it back\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES a blank uid — an operator cannot be established without a verified id\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > REFUSES mismatched or missing authentication evidence\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > a content name can never BECOME the operator — only a uid does (by construction)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > getOperator is null for an unbound topic\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > persists across instances (durable JSON store)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore authenticated binding / verified reads > replacing an operator overwrites the prior record\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > records a manual assertion durably but refuses it as a verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P2: refuses a subject that self-reports authenticated while its evidence says assertion\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P5: legacy evidence-less and malformed/wrong-container inputs are not-proven, never verified\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore asserted and legacy bindings > P4: verified enumeration is non-vacuous and covers every topic-key shape in the raw population\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.asVerifiedOperator (feeds PrincipalGuard) > returns the PrincipalGuard shape when bound, null when unbound\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > builds a <topic-operator> block naming the verified operator\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > returns null for an unbound topic (nothing injected)\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.sessionContextBlock > falls back to the uid when no display name was provided\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > skips the disk write when the stored record is identical\n ✓ tests/unit/topic-operator-store.test.ts > TopicOperatorStore.setAuthenticatedOperator idempotency (increment 2e) > still writes when the record actually changes\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > records an arbitrary body uid as an assertion in the real stored record, never authenticated inbound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a blank uid — a content name can never establish an operator\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > 400s a missing topicId\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > POST /topic-operator > persists the binding (a fresh request reads it back)\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > lists assertions separately and excludes them from verified operators\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator > returns operator:null for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns the <topic-operator> injection block when bound\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an asserted binding\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > returns { present: false } for an unbound topic\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > GET /topic-operator/session-context > 400s when topicId is missing\n ✓ tests/integration/topic-operator-routes.test.ts > Topic Operator Routes (integration) > when the store is not initialized > every route returns 503 (feature not available), never a crash\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > BINDS the operator from an AUTHORIZED sender\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an UNAUTHORIZED sender (the Caroline-class guard over the wire)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does NOT bind an agent-to-agent bot message (short-circuits before the bind)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > does not crash when no store is wired (pure additive change)\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > keeps the real lifeline→polling convergence evidence-bound when a Telegram message id exists\n ✓ tests/integration/topic-operator-autobind-route.test.ts > /internal/telegram-forward → topic-operator auto-bind (integration) > P5: missing Telegram message id stays not-proven across the real lifeline→polling convergence\n\n Test Files  3 passed (3)\n      Tests  34 passed (34)\n   Start at  06:06:35\n   Duration  62.11s (transform 5.97s, setup 13ms, collect 8.57s, tests 446ms, environment 1ms, prepare 222ms)\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"eb41b468-720d-42f6-a524-a3f1991ce048\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":77785,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"childPid\":77868,\"startedAt\":\"2026-08-18T13:06:34.402Z\",\"childExitedAt\":\"2026-08-18T13:07:37.302Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"zYZBtgOK4V5IsYUWUZf9ktxbEYg9V9kds7aEYrX+ViGU/jG1NQbDJmochg7lKlgzS1JASJk42B2x44sqgs09Bg==\"}\n",
+            "truncated": false,
+            "originalChars": 9208
+          },
+          "stderr": {
+            "text": "[test-runner-bound] suite-lane slot acquired (posture: enforcing, cap 1, pid 77868)\n",
+            "truncated": false,
+            "originalChars": 84
+          },
+          "outputSha256": "daed0060b01f6868a244ecbba92361a11aa1d812091dcaaf60e7a0476b400f6e",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+            "issuer": "fix-verifier:topic-operator-evidence",
+            "nonce": "cf90a58c-671a-480b-a4ce-f3ac6cce3da2",
+            "guardId": "topic-operator-evidence",
+            "kind": "child-exit",
+            "observerPid": 77785,
+            "childPid": 77868,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "argvHash": "86c5c6575336cd89eb1b1f1601f0e7476eae67a9d1ef7ed533535b8626f9312f",
+            "startedAt": "2026-08-18T13:06:34.402Z",
+            "childExitedAt": "2026-08-18T13:07:37.302Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "ec9b155c1d130ef05465982ec5cd3546698c15ec156e08e7d1559d5f2601f1d1",
+            "mac": "291a0626208e6f4f69674bea8db1cfb1ef1dd464291877a1f18a9485f9ce466f"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 77785,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAlJdoD8O88ns8MjUnRaqyOmFxYEt3LMaqRcV9Q3e+i4Y=",
+              "signature": "xap4w60QO0FDNjOLToF+0Lwj6enaW3OF3pUepWdb7ZV0WY71IG40XQAIEtEvvsdn5BLuViIMvIEDcd+IkmapCQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 77785,
+              "ppid": 77607,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/positive/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 77785,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "childPid": 77868,
+              "startedAt": "2026-08-18T13:06:34.402Z",
+              "signature": "N9wojHCTHeqLWWiTqXLtrK25ilmWWCeRfPqs4gb7ExVo5rMv9BqcuQgGLUZZM2UH7ly0DrzqhkjwqlWku2BUCw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 77868,
+              "ppid": 77785,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "eb41b468-720d-42f6-a524-a3f1991ce048",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 77785,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "childPid": 77868,
+            "startedAt": "2026-08-18T13:06:34.402Z",
+            "childExitedAt": "2026-08-18T13:07:37.302Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "zYZBtgOK4V5IsYUWUZf9ktxbEYg9V9kds7aEYrX+ViGU/jG1NQbDJmochg7lKlgzS1JASJk42B2x44sqgs09Bg=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "test:push",
+            "--",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:07:37.321Z",
+          "endedAt": "2026-08-18T13:07:37.966Z",
+          "durationMs": 645,
+          "pid": 3396,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1179 test:push\n> vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose\n\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":3593,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"publicKey\":\"MCowBQYDK2VwAyEADB4rolFP4TmM/my99It7LDC2vJ3OPMR4nd1jbCOjSfg=\",\"signature\":\"amc7PU62RFtaXcxufy/5DecJlHVR6IbZiE/l2oPUJAUbgSMDsFKMkAtbi50Y07rzI9XJ2TofnIFQkxRw6xW5Dw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"topic-operator-evidence\",\"nodeEntry\":\"node_modules/vitest/vitest.mjs\",\"observerPid\":3593,\"argv\":[\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest\",\"run\",\"--config\",\"vitest.push.config.ts\",\"tests/unit/topic-operator-store.test.ts\",\"tests/integration/topic-operator-routes.test.ts\",\"tests/integration/topic-operator-autobind-route.test.ts\",\"--reporter=verbose\"],\"shortCircuitedAt\":\"2026-08-18T13:07:37.957Z\",\"signature\":\"qMov3qCwLZzxEAaR/RFDCehNueukP4Zq+VFrBhUaHMyo4UHhVKa8BxMvQS/9r2JhaoMEkmY1k8YSmHoVWFfhCg==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs\n",
+            "truncated": false,
+            "originalChars": 2013
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "44f09ae2ad211f4ee8ef6c27c07fcfea3f163456f428000e3ffa65b7d84ba263",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "topic-operator-evidence",
+            "nodeEntry": "node_modules/vitest/vitest.mjs",
+            "observerPid": 3593,
+            "argv": [
+              "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+              "run",
+              "--config",
+              "vitest.push.config.ts",
+              "tests/unit/topic-operator-store.test.ts",
+              "tests/integration/topic-operator-routes.test.ts",
+              "tests/integration/topic-operator-autobind-route.test.ts",
+              "--reporter=verbose"
+            ],
+            "shortCircuitedAt": "2026-08-18T13:07:37.957Z",
+            "signature": "qMov3qCwLZzxEAaR/RFDCehNueukP4Zq+VFrBhUaHMyo4UHhVKa8BxMvQS/9r2JhaoMEkmY1k8YSmHoVWFfhCg=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c418db9e-d643-43ee-9b7c-17fc37bdd0fe",
+          "issuer": "fix-verifier:topic-operator-evidence",
+          "nonce": "4cdbbac0-def4-4c26-b21d-1c88be09d885",
+          "guardId": "topic-operator-evidence",
+          "kind": "short-circuit",
+          "observerPid": 3593,
+          "childPid": 3593,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs",
+            "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+            "run",
+            "--config",
+            "vitest.push.config.ts",
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts",
+            "--reporter=verbose"
+          ],
+          "argvHash": "ca35ad4d97f30ed5de5b66ccbf4c3b8e8cff11b15b744c4edd4b3c7a2ef21c5a",
+          "startedAt": "2026-08-18T13:07:37.957Z",
+          "childExitedAt": "2026-08-18T13:07:37.966Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "b5f85f28c9f4b7bd85ef8d29698f7dce7e3b45f981141169ac7d4082a93cddae",
+          "mac": "b0f01c8e21503e9fb8ee07e6eb2781abadb3e640fc3fb15f3dbc6ead28f8a385"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "78ab0ad6-7d4c-47c8-94c6-d30ddfe95fba",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "topic-operator-evidence",
+              "nodeEntry": "node_modules/vitest/vitest.mjs",
+              "observerPid": 3593,
+              "argv": [
+                "/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest",
+                "run",
+                "--config",
+                "vitest.push.config.ts",
+                "tests/unit/topic-operator-store.test.ts",
+                "tests/integration/topic-operator-routes.test.ts",
+                "tests/integration/topic-operator-autobind-route.test.ts",
+                "--reporter=verbose"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEADB4rolFP4TmM/my99It7LDC2vJ3OPMR4nd1jbCOjSfg=",
+              "signature": "amc7PU62RFtaXcxufy/5DecJlHVR6IbZiE/l2oPUJAUbgSMDsFKMkAtbi50Y07rzI9XJ2TofnIFQkxRw6xW5Dw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 3593,
+              "ppid": 3505,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/pipeline-observer/c3/authenticated-observer.mjs /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring/node_modules/.bin/vitest run --config vitest.push.config.ts tests/unit/topic-operator-store.test.ts tests/integration/topic-operator-routes.test.ts tests/integration/topic-operator-autobind-route.test.ts --reporter=verbose"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-rlua2F/01-pipeline-wiring",
+        "commit": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "4318a1e150e9a8304e6c2e7ad381bf66d03998e5"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/fix-verifier.manifest.json
+++ b/scratchpad/phaseB/fix-verifier.manifest.json
@@ -1,0 +1,170 @@
+{
+  "schemaVersion": 1,
+  "adapters": [
+    {
+      "id": "self-action-convergence",
+      "description": "B0.4 third-party acceptance control: convergence model plus the pinned report-only registration lint; P4b enforcement relevance is explicitly unknown.",
+      "adapter": "adapters/self-action-convergence.mjs",
+      "guardFiles": [
+        "tests/unit/self-action-convergence.test.ts",
+        "scripts/lint-no-unregistered-self-action.js"
+      ],
+      "subjectFiles": [
+        "src/testing/selfActionRegistry.ts",
+        "scripts/lib/self-action-detect.mjs"
+      ],
+      "pipelineEntryPoint": ".github/workflows/ci.yml -> npm run test:push and npm run lint (unregistered-self-action lint is report-only at the pinned base)"
+    },
+    {
+      "id": "lint-llm-attribution",
+      "description": "B0.4 third-party known-hollow control: attribution lint silently skips an unreadable violating scanned input at pinned pre-S3 base.",
+      "adapter": "adapters/lint-llm-attribution.mjs",
+      "guardFiles": ["tests/unit/llm-attribution-ratchet.test.ts"],
+      "subjectFiles": ["scripts/lint-llm-attribution.js"],
+      "pipelineEntryPoint": "targeted attribution ratchet + direct lint invocation over generated scanned input"
+    },
+    {
+      "id": "guard-posture-probe",
+      "description": "B0.4 third-party known-hollow control: unavailable local posture is reported clean at pinned pre-S3 base; P4b is explicitly unknown because the real peer-posture source is enumerated.",
+      "adapter": "adapters/guard-posture-probe.mjs",
+      "guardFiles": ["tests/unit/monitoring/guard-posture-probe.test.ts"],
+      "subjectFiles": ["src/monitoring/probes/GuardPostureProbe.ts"],
+      "pipelineEntryPoint": "targeted GuardPostureProbe behavioral suite"
+    },
+    {
+      "id": "audit-convergence-validator",
+      "description": "B0.4 third-party strong control: audit-convergence validator plus merged-state CI ratchet.",
+      "adapter": "adapters/audit-convergence-validator.mjs",
+      "guardFiles": [
+        "tests/unit/audit-convergence-reports.test.ts",
+        "tests/unit/write-audit-convergence.test.ts"
+      ],
+      "subjectFiles": [
+        "scripts/write-audit-convergence.mjs",
+        "docs/STANDARDS-REGISTRY.md",
+        "docs/audits/full-decision-visibility-enactment.md"
+      ],
+      "pipelineEntryPoint": ".github/workflows/ci.yml -> npm run test:push"
+    },
+    {
+      "id": "topic-operator-evidence",
+      "description": "Evidence-bearing topic-operator bindings plus verified-reader refusal of assertions.",
+      "adapter": "adapters/topic-operator-evidence.mjs",
+      "guardFiles": [
+        "tests/unit/topic-operator-store.test.ts",
+        "tests/integration/topic-operator-routes.test.ts",
+        "tests/integration/topic-operator-autobind-route.test.ts"
+      ],
+      "subjectFiles": [
+        "src/users/TopicOperatorStore.ts",
+        "src/server/routes.ts",
+        "src/commands/server.ts"
+      ],
+      "pipeline": {
+        "protectedRemoteUrl": "https://github.com/JKHeadley/instar.git",
+        "protectedRef": "refs/heads/main",
+        "workflowPath": ".github/workflows/ci.yml",
+        "workflowJob": "unit",
+        "workflowCommandPrefix": "npm run test:push",
+        "invocationPrefix": ["npm", "run", "test:push"],
+        "commandIndex": 0,
+        "observer": {
+          "nodeEntry": "node_modules/vitest/vitest.mjs",
+          "requiredArgs": [
+            "tests/unit/topic-operator-store.test.ts",
+            "tests/integration/topic-operator-routes.test.ts",
+            "tests/integration/topic-operator-autobind-route.test.ts"
+          ]
+        }
+      },
+      "pipelineEntryPoint": ".github/workflows/ci.yml -> npm run test:push"
+    },
+    {
+      "id": "standards-direction-guard",
+      "description": "Protected-base article identity, continuity denominator, and independently ratified constitutional direction guard.",
+      "adapter": "adapters/standards-direction-guard.mjs",
+      "guardFiles": [
+        "scripts/standards-direction-guard.mjs",
+        "scripts/standards-coverage.mjs",
+        "tests/unit/standards-direction-guard.test.ts",
+        "tests/unit/standards-direction-guard-contract.test.ts"
+      ],
+      "subjectFiles": [
+        "docs/STANDARDS-REGISTRY.md",
+        "docs/standards-direction-approvals.json",
+        ".github/keyrings/telegram-principal-pub.pem"
+      ],
+      "pipeline": {
+        "protectedRemoteUrl": "https://github.com/JKHeadley/instar.git",
+        "protectedRef": "refs/heads/main",
+        "workflowPath": ".github/workflows/ci.yml",
+        "workflowJob": "standards-coverage",
+        "workflowCommandPrefix": "node scripts/standards-coverage.mjs --check",
+        "invocationPrefix": ["node", "scripts/standards-coverage.mjs", "--check"],
+        "commandIndex": 0,
+        "observer": {
+          "nodeEntry": "scripts/standards-coverage.mjs",
+          "requiredArgs": ["--check"]
+        }
+      },
+      "pipelineEntryPoint": ".github/workflows/ci.yml -> node scripts/standards-coverage.mjs --check"
+    },
+    {
+      "id": "testing-integrity-route-enforcement",
+      "description": "The changed-route Tier-3 execution guard and its real-AgentServer evidence oracle.",
+      "adapter": "adapters/testing-integrity-route-enforcement.mjs",
+      "guardFiles": [
+        "scripts/lint-testing-integrity.mjs",
+        "tests/helpers/testingIntegrity.ts",
+        "tests/unit/scripts/testing-integrity-enforcement.test.ts",
+        "tests/integration/testing-integrity-pipeline.test.ts",
+        "tests/e2e/testing-integrity-guard-lifecycle.test.ts"
+      ],
+      "subjectFiles": [
+        "src/server/routes.ts"
+      ],
+      "pipeline": {
+        "protectedRemoteUrl": "https://github.com/JKHeadley/instar.git",
+        "protectedRef": "refs/heads/main",
+        "workflowPath": ".github/workflows/ci.yml",
+        "workflowJob": "lint",
+        "workflowCommandPrefix": "npm run lint",
+        "invocationPrefix": ["npm", "run", "lint"],
+        "commandIndex": 0,
+        "observer": {
+          "nodeEntry": "scripts/lint-testing-integrity.mjs",
+          "requiredArgs": []
+        }
+      },
+      "pipelineEntryPoint": ".github/workflows/ci.yml -> npm run lint"
+    },
+    {
+      "id": "checker-blind-input-coverage",
+      "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+      "adapter": "adapters/checker-blind-input-coverage.mjs",
+      "guardFiles": [
+        "scripts/lint-checker-blind-input-coverage.mjs",
+        "scripts/lib/checker-blind-input-ratchet.mjs",
+        "tests/unit/checker-blind-input-ratchet.test.ts"
+      ],
+      "subjectFiles": [
+        "scripts/lint-llm-attribution.js",
+        "scripts/checker-blind-input-cases.mjs"
+      ],
+      "pipeline": {
+        "protectedRemoteUrl": "https://github.com/JKHeadley/instar.git",
+        "protectedRef": "refs/heads/main",
+        "workflowPath": ".github/workflows/ci.yml",
+        "workflowJob": "lint",
+        "workflowCommandPrefix": "npm run lint",
+        "invocationPrefix": ["npm", "run", "lint"],
+        "commandIndex": 0,
+        "observer": {
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        }
+      },
+      "pipelineEntryPoint": ".github/workflows/ci.yml -> npm run lint"
+    }
+  ]
+}

--- a/scratchpad/phaseB/fix-verifier.mjs
+++ b/scratchpad/phaseB/fix-verifier.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { load as parseYaml } from 'js-yaml';
 import {
   createAuthenticatedReceiptAuthority,
+  isLiveAuthenticatedObserverEvent,
   isLiveAuthenticatedReceipt,
 } from './authenticated-execution-receipt.mjs';
 
@@ -168,6 +169,8 @@ function streamingSpawn(argv, options = {}, onObserverEvent = () => {}) {
     let stdout = '';
     let stderr = '';
     let stdoutLines = '';
+    let observerCandidateLineCount = 0;
+    let observerEventChain = Promise.resolve();
     let observerError = null;
     let timedOut = false;
     let settled = false;
@@ -194,9 +197,17 @@ function streamingSpawn(argv, options = {}, onObserverEvent = () => {}) {
         const line = stdoutLines.slice(0, newline);
         stdoutLines = stdoutLines.slice(newline + 1);
         if (!line.startsWith('FIX_VERIFIER_OBSERVER_EVENT ')) continue;
-        try { onObserverEvent(JSON.parse(line.slice('FIX_VERIFIER_OBSERVER_EVENT '.length)), child.pid); }
-        catch (error) {
-          observerError = error instanceof Error ? error.message : String(error);
+        observerCandidateLineCount += 1;
+        try {
+          const event = JSON.parse(line.slice('FIX_VERIFIER_OBSERVER_EVENT '.length));
+          observerEventChain = observerEventChain
+            .then(() => onObserverEvent(event, child.pid))
+            .catch((error) => {
+              observerError ??= error instanceof Error ? error.message : String(error);
+              try { child.kill('SIGTERM'); } catch {}
+            });
+        } catch (error) {
+          observerError ??= error instanceof Error ? error.message : String(error);
           try { child.kill('SIGTERM'); } catch {}
         }
       }
@@ -214,17 +225,19 @@ function streamingSpawn(argv, options = {}, onObserverEvent = () => {}) {
       try { child.kill('SIGTERM'); } catch {}
       setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 2_000).unref();
     }, options.timeoutMs ?? 30_000);
-    child.once('exit', (code, signal) => {
+    child.once('exit', async (code, signal) => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
       consumeLines();
+      await observerEventChain;
       const combined = `${stdout}${stderr}`;
       resolve({
         argv, cwd: options.cwd, startedAt, endedAt: isoNow(), durationMs: Date.now() - startedMs,
         pid: child.pid, exitCode: typeof code === 'number' ? code : null, signal: signal ?? null,
         spawnError: null, timedOut, stdout: clip(stdout), stderr: clip(stderr),
         outputSha256: sha256(combined), observerError,
+        observerCandidateLineCount,
         exitProvenance: 'direct child status from spawn; shell=false; nested observer pids validated live with ps',
       });
     });
@@ -444,7 +457,7 @@ export function validatePipelineContract(contract, commandArgv, protectedWorkflo
 }
 
 function observerSource({ realNode, cwd, guardId, nodeEntry, requiredArgs, shortCircuit }) {
-  return `#!${realNode}\n`
+  return `import crypto from 'node:crypto';\n`
     + `import fs from 'node:fs';\n`
     + `import path from 'node:path';\n`
     + `import { spawn } from 'node:child_process';\n`
@@ -452,9 +465,14 @@ function observerSource({ realNode, cwd, guardId, nodeEntry, requiredArgs, short
     + `const cwd = ${JSON.stringify(cwd)};\n`
     + `const expected = ${JSON.stringify(path.resolve(cwd, nodeEntry))};\n`
     + `const required = ${JSON.stringify(requiredArgs)};\n`
+    + `const canonical = (value) => { if (Array.isArray(value)) return '[' + value.map(canonical).join(',') + ']'; if (value && typeof value === 'object') return '{' + Object.keys(value).sort().map((key) => JSON.stringify(key) + ':' + canonical(value[key])).join(',') + '}'; return JSON.stringify(value); };\n`
+    + `const keyPair = crypto.generateKeyPairSync('ed25519');\n`
+    + `const publicKey = keyPair.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');\n`
+    + `const observerSession = crypto.randomUUID();\n`
+    + `let sequence = 0;\n`
     + `const resolve = (value) => { try { return fs.realpathSync(path.resolve(cwd, value)); } catch { return path.resolve(cwd, value); } };\n`
     + `const target = argv.length > 0 && resolve(argv[0]) === resolve(expected) && required.every((item) => argv.includes(item));\n`
-    + `const emit = (kind, fields = {}) => process.stdout.write('FIX_VERIFIER_OBSERVER_EVENT ' + JSON.stringify({ source: 'fix-verifier-observer', kind, guardId: ${JSON.stringify(guardId)}, nodeEntry: ${JSON.stringify(nodeEntry)}, observerPid: process.pid, argv, ...fields }) + '\\n');\n`
+    + `const emit = (kind, fields = {}) => { const event = { eventSchema: 'phaseB-authenticated-observer-event/v1', source: 'fix-verifier-observer', observerSession, sequence: ++sequence, kind, guardId: ${JSON.stringify(guardId)}, nodeEntry: ${JSON.stringify(nodeEntry)}, observerPid: process.pid, argv, ...(kind === 'observer-ready' ? { publicKey } : {}), ...fields }; const signature = crypto.sign(null, Buffer.from(canonical(event)), keyPair.privateKey).toString('base64'); process.stdout.write('FIX_VERIFIER_OBSERVER_EVENT ' + JSON.stringify({ ...event, signature }) + '\\n'); };\n`
     + `if (target) {\n`
     + `  emit('observer-ready');\n`
     + `  process.kill(process.pid, 'SIGSTOP');\n`
@@ -487,14 +505,18 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
   const root = path.join(observerRoot, label);
   fs.mkdirSync(root, { recursive: true });
   const wrapper = path.join(root, 'node');
-  fs.writeFileSync(wrapper, observerSource({
+  const observerProgram = path.join(root, 'authenticated-observer.mjs');
+  fs.writeFileSync(observerProgram, observerSource({
     realNode: process.execPath,
     cwd,
     guardId,
     nodeEntry: contract.observer.nodeEntry,
     requiredArgs: contract.observer.requiredArgs,
     shortCircuit,
-  }), { mode: 0o755 });
+  }), { mode: 0o600 });
+  fs.writeFileSync(wrapper,
+    `#!/bin/sh\nunset NODE_OPTIONS\nexec "${process.execPath}" "${observerProgram}" "$@"\n`,
+    { mode: 0o755 });
   const events = [];
   let observerReady = null;
   let validatedChildStart = null;
@@ -506,23 +528,37 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
     cwd,
     timeoutMs: command.timeoutMs,
     env: { ...process.env, CI: '1', PATH: `${root}${path.delimiter}${process.env.PATH ?? ''}` },
-  }, (event, pipelinePid) => {
-    events.push(event);
+  }, async (event, pipelinePid) => {
     if (event?.source !== 'fix-verifier-observer' || event.guardId !== guardId || event.nodeEntry !== contract.observer.nodeEntry) {
       throw new Error('observer event identity is invalid');
     }
     if (event.kind === 'observer-ready') {
+      if (observerReady) throw new Error('duplicate observer-ready event is not allowed');
       const record = processRecord(event.observerPid);
       const argvValid = Array.isArray(event.argv)
         && event.argv.length > 0
         && (() => { try { return fs.realpathSync(path.resolve(cwd, event.argv[0])) === fs.realpathSync(expectedEntry); } catch { return false; } })()
         && contract.observer.requiredArgs.every((item) => event.argv.includes(item));
-      const valid = record?.command.includes(wrapper) && descendantOf(event.observerPid, pipelinePid) && argvValid;
-      observerReady = { event, valid, processRecord: record };
-      continueStopped(event.observerPid);
+      const valid = record?.command.includes(observerProgram) && descendantOf(event.observerPid, pipelinePid) && argvValid;
       if (!valid) throw new Error('observer-ready process identity was not the instrument wrapper in the pipeline descendant tree');
+      const authenticated = await authority.pinObserverEvent(event, {
+        kind: 'observer-ready', guardId, nodeEntry: contract.observer.nodeEntry, observerPid: event.observerPid,
+      });
+      if (!authenticated || !isLiveAuthenticatedObserverEvent(event)) throw new Error('observer-ready event was not authenticated by the private authority');
+      events.push(event);
+      observerReady = { event, valid, authenticated, processRecord: record };
+      continueStopped(event.observerPid);
       return;
     }
+    if (!observerReady?.authenticated) throw new Error('observer event arrived before an authenticated observer-ready event');
+    const authenticated = await authority.authenticateObserverEvent(event, {
+      guardId,
+      nodeEntry: contract.observer.nodeEntry,
+      observerPid: observerReady.event.observerPid,
+      observerSession: observerReady.event.observerSession,
+    });
+    if (!authenticated || !isLiveAuthenticatedObserverEvent(event)) throw new Error('observer event signature was not authenticated by the private authority');
+    events.push(event);
     if (event.kind === 'child-start') {
       const record = processRecord(event.childPid);
       const valid = observerReady?.valid === true
@@ -530,13 +566,21 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
         && descendantOf(event.childPid, pipelinePid)
         && record.command.includes(contract.observer.nodeEntry)
         && Array.isArray(event.argv)
-        && event.argv.length > 0;
-      validatedChildStart = { event, valid, processRecord: record };
-      continueStopped(event.childPid);
+        && event.argv.length > 0
+        && JSON.stringify(event.argv) === JSON.stringify(observerReady.event.argv);
       if (!valid) throw new Error('observed child pid was not the exact declared descendant process');
+      validatedChildStart = { event, valid, authenticated, processRecord: record };
+      continueStopped(event.childPid);
       return;
     }
-    if (event.kind === 'child-exit') childExit = event;
+    if (event.kind === 'child-exit') {
+      if (!validatedChildStart?.authenticated
+          || event.childPid !== validatedChildStart.event.childPid
+          || JSON.stringify(event.argv) !== JSON.stringify(validatedChildStart.event.argv)) {
+        throw new Error('child-exit event was not bound to the authenticated child-start event');
+      }
+      childExit = event;
+    }
     if (event.kind === 'short-circuit') shortCircuitEvent = event;
   });
   const receipts = [];
@@ -550,6 +594,9 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
       childPid: childExit.childPid, childExitCode: childExit.childExitCode, signal: childExit.signal,
       argv: childExit.argv, startedAt: childExit.startedAt, childExitedAt: childExit.childExitedAt,
       emittedAfterChildExit: true,
+      observerSession: childExit.observerSession,
+      observerEventSequence: childExit.sequence,
+      observerEventSignatureHash: sha256(childExit.signature),
     });
     if (await authority.authenticate(receipt, { guardId, kind: 'child-exit', childPid: childExit.childPid, childExitCode: 0 })) {
       receipts.push(receipt);
@@ -561,8 +608,11 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
     const receipt = await authority.issue({
       guardId, kind: 'short-circuit', observerPid: shortCircuitEvent.observerPid,
       childPid: shortCircuitEvent.observerPid, childExitCode: 0, signal: null,
-      argv: [wrapper, ...shortCircuitEvent.argv], startedAt: shortCircuitEvent.shortCircuitedAt,
+      argv: [observerProgram, ...shortCircuitEvent.argv], startedAt: shortCircuitEvent.shortCircuitedAt,
       childExitedAt: run.endedAt, emittedAfterChildExit: true,
+      observerSession: shortCircuitEvent.observerSession,
+      observerEventSequence: shortCircuitEvent.sequence,
+      observerEventSignatureHash: sha256(shortCircuitEvent.signature),
     });
     if (await authority.authenticate(receipt, { guardId, kind: 'short-circuit', childPid: shortCircuitEvent.observerPid })) {
       shortCircuitReceipt = receipt;
@@ -570,11 +620,15 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
   }
   return {
     run,
-    observer: { wrapper, nodeEntry: contract.observer.nodeEntry, requiredArgs: contract.observer.requiredArgs },
+    observer: { wrapper, observerProgram, nodeEntry: contract.observer.nodeEntry, requiredArgs: contract.observer.requiredArgs },
     receipts,
     shortCircuitEvents: shortCircuitEvent ? [shortCircuitEvent] : [],
     shortCircuitReceipt,
-    processObservations: { observerReady, validatedChildStart, childExit, eventCount: events.length },
+    processObservations: {
+      observerReady, validatedChildStart, childExit,
+      authenticatedEventCount: events.length,
+      stdoutCandidateEventLineCount: run.observerCandidateLineCount,
+    },
   };
 }
 
@@ -620,7 +674,7 @@ export async function runPipelineWiringControls({ command, cwd, guardId, contrac
     envelope: {
       source: 'fix-verifier-core',
       status,
-      mode: 'core-private-channel-hmac-receipt',
+      mode: 'core-authenticated-observer-events-hmac-receipt',
       authorityId: receipt?.authorityId ?? null,
       receipt,
       C3: {
@@ -634,7 +688,7 @@ export async function runPipelineWiringControls({ command, cwd, guardId, contrac
   };
 }
 
-const PIPELINE_MODES = new Set(['core-private-channel-hmac-receipt']);
+const PIPELINE_MODES = new Set(['core-authenticated-observer-events-hmac-receipt']);
 export function validatePipelineEvidence(evidence) {
   if (!evidence || typeof evidence !== 'object') return { valid: false, reason: 'pipeline evidence is not an object' };
   if (evidence.source !== 'fix-verifier-core' || evidence.status !== 'proven' || !PIPELINE_MODES.has(evidence.mode)) return { valid: false, reason: 'pipeline evidence is not a core-minted proven envelope' };
@@ -921,7 +975,7 @@ async function measure(args) {
         outcome: wiringOutcome,
         declaredEntryPoint: guard.pipelineEntryPoint,
         establishedBy: wired
-          ? 'the core authenticated the exact live manifest-pinned guard child after it exited through the protected workflow command; C3 wrapper success produced no guard receipt'
+          ? 'the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt'
           : 'no valid core-authenticated post-child receipt relationship was established',
         protectedBase: protectedBaseEvidence,
         contract: pipelineContractValidation,

--- a/scratchpad/phaseB/fix-verifier.mjs
+++ b/scratchpad/phaseB/fix-verifier.mjs
@@ -4,9 +4,13 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { load as parseYaml } from 'js-yaml';
+import {
+  createAuthenticatedReceiptAuthority,
+  isLiveAuthenticatedReceipt,
+} from './authenticated-execution-receipt.mjs';
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = path.dirname(SCRIPT_PATH);
@@ -132,6 +136,99 @@ function directSpawn(argv, options = {}) {
     outputSha256: sha256(combined),
     exitProvenance: 'direct child status from spawnSync; shell=false',
   };
+}
+
+function processRecord(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  const result = spawnSync('/bin/ps', ['-p', String(pid), '-o', 'ppid=', '-o', 'command='], {
+    encoding: 'utf8', timeout: 2_000, env: { PATH: '/usr/bin:/bin', LANG: 'C' },
+  });
+  if (result.status !== 0 || !result.stdout.trim()) return null;
+  const match = result.stdout.trim().match(/^(\d+)\s+([\s\S]+)$/);
+  return match ? { pid, ppid: Number(match[1]), command: match[2] } : null;
+}
+
+function descendantOf(pid, ancestorPid) {
+  let cursor = pid;
+  const seen = new Set();
+  for (let depth = 0; depth < 32 && cursor > 1 && !seen.has(cursor); depth++) {
+    if (cursor === ancestorPid) return true;
+    seen.add(cursor);
+    const record = processRecord(cursor);
+    if (!record) return false;
+    cursor = record.ppid;
+  }
+  return cursor === ancestorPid;
+}
+
+function streamingSpawn(argv, options = {}, onObserverEvent = () => {}) {
+  return new Promise((resolve) => {
+    const startedAt = isoNow();
+    const startedMs = Date.now();
+    let stdout = '';
+    let stderr = '';
+    let stdoutLines = '';
+    let observerError = null;
+    let timedOut = false;
+    let settled = false;
+    let child;
+    try {
+      child = spawn(argv[0], argv.slice(1), {
+        cwd: options.cwd,
+        env: options.env ?? process.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      resolve({
+        argv, cwd: options.cwd, startedAt, endedAt: isoNow(), durationMs: Date.now() - startedMs,
+        pid: null, exitCode: null, signal: null, spawnError: error.message, timedOut: false,
+        stdout: clip(''), stderr: clip(''), outputSha256: sha256(''), observerError: null,
+        exitProvenance: 'direct child spawn failed before a pid existed',
+      });
+      return;
+    }
+    const consumeLines = () => {
+      for (;;) {
+        const newline = stdoutLines.indexOf('\n');
+        if (newline < 0) break;
+        const line = stdoutLines.slice(0, newline);
+        stdoutLines = stdoutLines.slice(newline + 1);
+        if (!line.startsWith('FIX_VERIFIER_OBSERVER_EVENT ')) continue;
+        try { onObserverEvent(JSON.parse(line.slice('FIX_VERIFIER_OBSERVER_EVENT '.length)), child.pid); }
+        catch (error) {
+          observerError = error instanceof Error ? error.message : String(error);
+          try { child.kill('SIGTERM'); } catch {}
+        }
+      }
+    };
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      stdoutLines += text;
+      consumeLines();
+    });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.once('error', (error) => { observerError ??= error.message; });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      try { child.kill('SIGTERM'); } catch {}
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 2_000).unref();
+    }, options.timeoutMs ?? 30_000);
+    child.once('exit', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      consumeLines();
+      const combined = `${stdout}${stderr}`;
+      resolve({
+        argv, cwd: options.cwd, startedAt, endedAt: isoNow(), durationMs: Date.now() - startedMs,
+        pid: child.pid, exitCode: typeof code === 'number' ? code : null, signal: signal ?? null,
+        spawnError: null, timedOut, stdout: clip(stdout), stderr: clip(stderr),
+        outputSha256: sha256(combined), observerError,
+        exitProvenance: 'direct child status from spawn; shell=false; nested observer pids validated live with ps',
+      });
+    });
+  });
 }
 
 function requireSuccess(argv, options = {}) {
@@ -346,16 +443,7 @@ export function validatePipelineContract(contract, commandArgv, protectedWorkflo
   return { valid: problems.length === 0, reason: problems.join('; ') || null, checks, normalizedInvocation: normalized };
 }
 
-function readJsonLines(file) {
-  try {
-    return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map((line) => JSON.parse(line));
-  } catch (error) {
-    if (error?.code === 'ENOENT') return [];
-    return [{ malformed: true, error: error.message }];
-  }
-}
-
-function observerSource({ realNode, cwd, guardId, token, nodeEntry, requiredArgs, receiptFile, shortCircuitFile, shortCircuit }) {
+function observerSource({ realNode, cwd, guardId, nodeEntry, requiredArgs, shortCircuit }) {
   return `#!${realNode}\n`
     + `import fs from 'node:fs';\n`
     + `import path from 'node:path';\n`
@@ -366,118 +454,196 @@ function observerSource({ realNode, cwd, guardId, token, nodeEntry, requiredArgs
     + `const required = ${JSON.stringify(requiredArgs)};\n`
     + `const resolve = (value) => { try { return fs.realpathSync(path.resolve(cwd, value)); } catch { return path.resolve(cwd, value); } };\n`
     + `const target = argv.length > 0 && resolve(argv[0]) === resolve(expected) && required.every((item) => argv.includes(item));\n`
-    + `const append = (file, value) => fs.appendFileSync(file, JSON.stringify(value) + '\\n', 'utf8');\n`
+    + `const emit = (kind, fields = {}) => process.stdout.write('FIX_VERIFIER_OBSERVER_EVENT ' + JSON.stringify({ source: 'fix-verifier-observer', kind, guardId: ${JSON.stringify(guardId)}, nodeEntry: ${JSON.stringify(nodeEntry)}, observerPid: process.pid, argv, ...fields }) + '\\n');\n`
+    + `if (target) {\n`
+    + `  emit('observer-ready');\n`
+    + `  process.kill(process.pid, 'SIGSTOP');\n`
+    + `}\n`
     + `if (target && ${shortCircuit ? 'true' : 'false'}) {\n`
-    + `  const event = { source: 'fix-verifier-core', guardId: ${JSON.stringify(guardId)}, token: ${JSON.stringify(token)}, nodeEntry: ${JSON.stringify(nodeEntry)}, argv, shortCircuitedAt: new Date().toISOString() };\n`
-    + `  append(${JSON.stringify(shortCircuitFile)}, event);\n`
-    + `  process.stdout.write('[fix-verifier-C3] short-circuited guard=' + event.guardId + ' entry=' + event.nodeEntry + '\\n');\n`
+    + `  emit('short-circuit', { shortCircuitedAt: new Date().toISOString() });\n`
+    + `  process.stdout.write('[fix-verifier-C3] authenticated observer short-circuited guard=' + ${JSON.stringify(guardId)} + ' entry=' + ${JSON.stringify(nodeEntry)} + '\\n');\n`
     + `  process.exit(0);\n`
     + `}\n`
     + `const startedAt = new Date().toISOString();\n`
     + `const child = spawn(${JSON.stringify(realNode)}, argv, { cwd: process.cwd(), env: process.env, stdio: 'inherit' });\n`
+    + `if (target) {\n`
+    + `  try { child.kill('SIGSTOP'); } catch {}\n`
+    + `  emit('child-start', { childPid: child.pid, startedAt });\n`
+    + `}\n`
     + `const forward = (signal) => { try { child.kill(signal); } catch {} };\n`
     + `for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) process.on(signal, () => forward(signal));\n`
     + `child.once('error', (error) => { console.error(error.message); process.exit(1); });\n`
     + `child.once('exit', (code, signal) => {\n`
     + `  const childExitCode = typeof code === 'number' ? code : null;\n`
     + `  if (target) {\n`
-    + `    const receipt = { source: 'fix-verifier-core', guardId: ${JSON.stringify(guardId)}, token: ${JSON.stringify(token)}, tokenSha256: ${JSON.stringify(sha256(token))}, nodeEntry: ${JSON.stringify(nodeEntry)}, argv, startedAt, childExitedAt: new Date().toISOString(), childExitCode, signal: signal ?? null, emittedAfterChildExit: true };\n`
-    + `    append(${JSON.stringify(receiptFile)}, receipt);\n`
-    + `    process.stdout.write('[fix-verifier-wiring] token=' + receipt.token + ' guard=' + receipt.guardId + ' entry=' + receipt.nodeEntry + ' childExit=' + String(receipt.childExitCode) + '\\n');\n`
+    + `    emit('child-exit', { childPid: child.pid, startedAt, childExitedAt: new Date().toISOString(), childExitCode, signal: signal ?? null, emittedAfterChildExit: true });\n`
     + `  }\n`
     + `  process.exit(childExitCode ?? 1);\n`
     + `});\n`;
 }
 
-function runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, token, shortCircuit }) {
+async function runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, authority, shortCircuit }) {
   const label = shortCircuit ? 'c3' : 'positive';
   const root = path.join(observerRoot, label);
   fs.mkdirSync(root, { recursive: true });
-  const receiptFile = path.join(root, 'receipts.jsonl');
-  const shortCircuitFile = path.join(root, 'short-circuits.jsonl');
   const wrapper = path.join(root, 'node');
   fs.writeFileSync(wrapper, observerSource({
     realNode: process.execPath,
     cwd,
     guardId,
-    token,
     nodeEntry: contract.observer.nodeEntry,
     requiredArgs: contract.observer.requiredArgs,
-    receiptFile,
-    shortCircuitFile,
     shortCircuit,
   }), { mode: 0o755 });
-  const run = directSpawn(command.argv, {
+  const events = [];
+  let observerReady = null;
+  let validatedChildStart = null;
+  let childExit = null;
+  let shortCircuitEvent = null;
+  const expectedEntry = path.resolve(cwd, contract.observer.nodeEntry);
+  const continueStopped = (pid) => { try { process.kill(pid, 'SIGCONT'); } catch {} };
+  const run = await streamingSpawn(command.argv, {
     cwd,
     timeoutMs: command.timeoutMs,
     env: { ...process.env, CI: '1', PATH: `${root}${path.delimiter}${process.env.PATH ?? ''}` },
+  }, (event, pipelinePid) => {
+    events.push(event);
+    if (event?.source !== 'fix-verifier-observer' || event.guardId !== guardId || event.nodeEntry !== contract.observer.nodeEntry) {
+      throw new Error('observer event identity is invalid');
+    }
+    if (event.kind === 'observer-ready') {
+      const record = processRecord(event.observerPid);
+      const argvValid = Array.isArray(event.argv)
+        && event.argv.length > 0
+        && (() => { try { return fs.realpathSync(path.resolve(cwd, event.argv[0])) === fs.realpathSync(expectedEntry); } catch { return false; } })()
+        && contract.observer.requiredArgs.every((item) => event.argv.includes(item));
+      const valid = record?.command.includes(wrapper) && descendantOf(event.observerPid, pipelinePid) && argvValid;
+      observerReady = { event, valid, processRecord: record };
+      continueStopped(event.observerPid);
+      if (!valid) throw new Error('observer-ready process identity was not the instrument wrapper in the pipeline descendant tree');
+      return;
+    }
+    if (event.kind === 'child-start') {
+      const record = processRecord(event.childPid);
+      const valid = observerReady?.valid === true
+        && record?.ppid === event.observerPid
+        && descendantOf(event.childPid, pipelinePid)
+        && record.command.includes(contract.observer.nodeEntry)
+        && Array.isArray(event.argv)
+        && event.argv.length > 0;
+      validatedChildStart = { event, valid, processRecord: record };
+      continueStopped(event.childPid);
+      if (!valid) throw new Error('observed child pid was not the exact declared descendant process');
+      return;
+    }
+    if (event.kind === 'child-exit') childExit = event;
+    if (event.kind === 'short-circuit') shortCircuitEvent = event;
   });
+  const receipts = [];
+  let shortCircuitReceipt = null;
+  if (!shortCircuit && run.exitCode === 0 && !run.spawnError && !run.observerError
+      && validatedChildStart?.valid && childExit
+      && childExit.childPid === validatedChildStart.event.childPid
+      && childExit.childExitCode === 0 && childExit.emittedAfterChildExit === true) {
+    const receipt = await authority.issue({
+      guardId, kind: 'child-exit', observerPid: childExit.observerPid,
+      childPid: childExit.childPid, childExitCode: childExit.childExitCode, signal: childExit.signal,
+      argv: childExit.argv, startedAt: childExit.startedAt, childExitedAt: childExit.childExitedAt,
+      emittedAfterChildExit: true,
+    });
+    if (await authority.authenticate(receipt, { guardId, kind: 'child-exit', childPid: childExit.childPid, childExitCode: 0 })) {
+      receipts.push(receipt);
+      process.stdout.write(`[fix-verifier-wiring] authenticated guard=${guardId} entry=${contract.observer.nodeEntry} childPid=${childExit.childPid} childExit=0\n`);
+    }
+  }
+  if (shortCircuit && run.exitCode === 0 && !run.spawnError && !run.observerError
+      && observerReady?.valid && shortCircuitEvent?.observerPid === observerReady.event.observerPid) {
+    const receipt = await authority.issue({
+      guardId, kind: 'short-circuit', observerPid: shortCircuitEvent.observerPid,
+      childPid: shortCircuitEvent.observerPid, childExitCode: 0, signal: null,
+      argv: [wrapper, ...shortCircuitEvent.argv], startedAt: shortCircuitEvent.shortCircuitedAt,
+      childExitedAt: run.endedAt, emittedAfterChildExit: true,
+    });
+    if (await authority.authenticate(receipt, { guardId, kind: 'short-circuit', childPid: shortCircuitEvent.observerPid })) {
+      shortCircuitReceipt = receipt;
+    }
+  }
   return {
     run,
     observer: { wrapper, nodeEntry: contract.observer.nodeEntry, requiredArgs: contract.observer.requiredArgs },
-    receipts: readJsonLines(receiptFile),
-    shortCircuitEvents: readJsonLines(shortCircuitFile),
+    receipts,
+    shortCircuitEvents: shortCircuitEvent ? [shortCircuitEvent] : [],
+    shortCircuitReceipt,
+    processObservations: { observerReady, validatedChildStart, childExit, eventCount: events.length },
   };
 }
 
-export function runPipelineWiringControls({ command, cwd, guardId, contract, observerRoot }) {
-  const token = `${crypto.randomUUID()}-${crypto.randomBytes(16).toString('hex')}`;
-  const c3Token = `${crypto.randomUUID()}-${crypto.randomBytes(16).toString('hex')}`;
-  const positive = runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, token, shortCircuit: false });
-  const C3 = runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, token: c3Token, shortCircuit: true });
+export async function runPipelineWiringControls({ command, cwd, guardId, contract, observerRoot }) {
+  const authority = await createAuthenticatedReceiptAuthority({ issuer: `fix-verifier:${guardId}` });
+  let positive;
+  let C3;
+  try {
+    positive = await runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, authority, shortCircuit: false });
+    C3 = await runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, authority, shortCircuit: true });
+  } finally {
+    await authority.close();
+  }
   const receipt = positive.receipts.length === 1 ? positive.receipts[0] : null;
-  const positiveReceiptValid = receipt?.source === 'fix-verifier-core'
+  const positiveReceiptValid = isLiveAuthenticatedReceipt(receipt)
     && receipt.guardId === guardId
-    && receipt.token === token
-    && receipt.tokenSha256 === sha256(token)
-    && receipt.nodeEntry === contract.observer.nodeEntry
+    && receipt.kind === 'child-exit'
     && receipt.childExitCode === 0
     && receipt.emittedAfterChildExit === true;
   const c3Event = C3.shortCircuitEvents.length === 1 ? C3.shortCircuitEvents[0] : null;
   const c3Valid = C3.run.exitCode === 0 && !C3.run.spawnError && C3.receipts.length === 0
-    && c3Event?.source === 'fix-verifier-core'
+    && isLiveAuthenticatedReceipt(C3.shortCircuitReceipt)
+    && c3Event?.source === 'fix-verifier-observer'
     && c3Event.guardId === guardId
-    && c3Event.token === c3Token
     && c3Event.nodeEntry === contract.observer.nodeEntry;
   C3.outcome = c3Valid
     ? 'proven'
-    : !c3Event || C3.run.exitCode === null || C3.run.spawnError || C3.run.exitCode !== 0
+    : !c3Event || !C3.shortCircuitReceipt || C3.run.exitCode === null || C3.run.spawnError || C3.run.exitCode !== 0
       ? 'unknown'
       : 'not-proven';
   const checks = [
     { check: 'real declared pipeline wrapper exited successfully', passed: positive.run.exitCode === 0 && !positive.run.spawnError },
-    { check: 'core observer emitted exactly one post-child receipt', passed: positiveReceiptValid },
+    { check: 'private-channel authority authenticated exactly one post-child receipt', passed: positiveReceiptValid },
     { check: 'C3 wrapper still exited successfully', passed: C3.run.exitCode === 0 && !C3.run.spawnError },
-    { check: 'C3 short-circuited the exact guard child', passed: Boolean(c3Event) },
+    { check: 'C3 authenticated the instrument observer short-circuit', passed: Boolean(c3Event) && isLiveAuthenticatedReceipt(C3.shortCircuitReceipt) },
     { check: 'C3 produced no guard execution receipt', passed: C3.receipts.length === 0 },
   ];
   const status = checks.every((item) => item.passed) ? 'proven' : 'unknown';
   return {
-    token,
-    tokenSha256: sha256(token),
+    authorityId: receipt?.authorityId ?? C3.shortCircuitReceipt?.authorityId ?? null,
     positive,
     C3,
     envelope: {
       source: 'fix-verifier-core',
       status,
-      mode: 'core-minted-process-receipt',
-      tokenSha256: sha256(token),
+      mode: 'core-private-channel-hmac-receipt',
+      authorityId: receipt?.authorityId ?? null,
       receipt,
-      C3: { outcome: C3.outcome, receiptCount: C3.receipts.length, shortCircuitEvent: c3Event },
+      C3: {
+        outcome: C3.outcome,
+        receiptCount: C3.receipts.length,
+        shortCircuitEvent: c3Event,
+        shortCircuitReceipt: C3.shortCircuitReceipt,
+      },
       checks,
     },
   };
 }
 
-const PIPELINE_MODES = new Set(['core-minted-process-receipt']);
+const PIPELINE_MODES = new Set(['core-private-channel-hmac-receipt']);
 export function validatePipelineEvidence(evidence) {
   if (!evidence || typeof evidence !== 'object') return { valid: false, reason: 'pipeline evidence is not an object' };
   if (evidence.source !== 'fix-verifier-core' || evidence.status !== 'proven' || !PIPELINE_MODES.has(evidence.mode)) return { valid: false, reason: 'pipeline evidence is not a core-minted proven envelope' };
-  if (!/^[a-f0-9]{64}$/.test(evidence.tokenSha256 ?? '') || evidence.receipt?.tokenSha256 !== evidence.tokenSha256 || evidence.receipt?.emittedAfterChildExit !== true) {
-    return { valid: false, reason: 'pipeline receipt is missing or not bound to the minted token after child exit' };
+  if (!isLiveAuthenticatedReceipt(evidence.receipt) || evidence.receipt?.emittedAfterChildExit !== true) {
+    return { valid: false, reason: 'pipeline receipt was not authenticated live by the private-channel authority' };
   }
-  if (evidence.C3?.outcome !== 'proven' || evidence.C3?.receiptCount !== 0 || !evidence.C3?.shortCircuitEvent) {
-    return { valid: false, reason: 'C3 did not prove wrapper success without a guard receipt' };
+  if (evidence.C3?.outcome !== 'proven' || evidence.C3?.receiptCount !== 0
+      || !evidence.C3?.shortCircuitEvent || !isLiveAuthenticatedReceipt(evidence.C3?.shortCircuitReceipt)) {
+    return { valid: false, reason: 'C3 did not authenticate wrapper success without a guard receipt' };
   }
   if (!Array.isArray(evidence.checks) || evidence.checks.length === 0 || evidence.checks.some((check) => !check || check.passed !== true)) {
     return { valid: false, reason: 'pipeline checks must be non-empty and all pass' };
@@ -622,7 +788,7 @@ async function measure(args) {
     applyFixture(wiringRoot);
     const selectedPipelineCommand = guard.pipeline ? adapter.pipelineCommands[guard.pipeline.commandIndex ?? 0] : null;
     const wiringRun = selectedPipelineCommand && pipelineContractValidation.valid
-      ? runPipelineWiringControls({
+      ? await runPipelineWiringControls({
           command: selectedPipelineCommand,
           cwd: wiringRoot,
           guardId: guard.id,

--- a/scratchpad/phaseB/fix-verifier.mjs
+++ b/scratchpad/phaseB/fix-verifier.mjs
@@ -408,7 +408,9 @@ export function sameRealFile(left, right, cwd = process.cwd()) {
   try {
     const leftRealPath = fs.realpathSync(path.resolve(cwd, left));
     const rightRealPath = fs.realpathSync(path.resolve(cwd, right));
-    return leftRealPath === rightRealPath;
+    return fs.statSync(leftRealPath).isFile()
+      && fs.statSync(rightRealPath).isFile()
+      && leftRealPath === rightRealPath;
   } catch {
     return false;
   }
@@ -481,10 +483,10 @@ function observerSource({ realNode, cwd, guardId, nodeEntry, requiredArgs, short
     + `const publicKey = keyPair.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');\n`
     + `const observerSession = crypto.randomUUID();\n`
     + `let sequence = 0;\n`
-    + `const resolveReal = (value) => { try { return fs.realpathSync(path.resolve(cwd, value)); } catch { return null; } };\n`
-    + `const observedReal = argv.length > 0 ? resolveReal(argv[0]) : null;\n`
-    + `const expectedReal = resolveReal(expected);\n`
-    + `const target = observedReal !== null && expectedReal !== null && observedReal === expectedReal && required.every((item) => argv.includes(item));\n`
+    + `const resolveRealFile = (value) => { try { const real = fs.realpathSync(path.resolve(cwd, value)); return fs.statSync(real).isFile() ? real : null; } catch { return null; } };\n`
+    + `const observedRealFile = argv.length > 0 ? resolveRealFile(argv[0]) : null;\n`
+    + `const expectedRealFile = resolveRealFile(expected);\n`
+    + `const target = observedRealFile !== null && expectedRealFile !== null && observedRealFile === expectedRealFile && required.every((item) => argv.includes(item));\n`
     + `const emit = (kind, fields = {}) => { const event = { eventSchema: 'phaseB-authenticated-observer-event/v1', source: 'fix-verifier-observer', observerSession, sequence: ++sequence, kind, guardId: ${JSON.stringify(guardId)}, nodeEntry: ${JSON.stringify(nodeEntry)}, observerPid: process.pid, argv, ...(kind === 'observer-ready' ? { publicKey } : {}), ...fields }; const signature = crypto.sign(null, Buffer.from(canonical(event)), keyPair.privateKey).toString('base64'); process.stdout.write('FIX_VERIFIER_OBSERVER_EVENT ' + JSON.stringify({ ...event, signature }) + '\\n'); };\n`
     + `if (target) {\n`
     + `  emit('observer-ready');\n`

--- a/scratchpad/phaseB/fix-verifier.mjs
+++ b/scratchpad/phaseB/fix-verifier.mjs
@@ -921,8 +921,8 @@ async function measure(args) {
         outcome: wiringOutcome,
         declaredEntryPoint: guard.pipelineEntryPoint,
         establishedBy: wired
-          ? 'core-minted token received from the exact manifest-pinned guard child after it exited through the protected workflow command; C3 wrapper success produced no receipt'
-          : 'no valid core-minted post-child receipt relationship was established',
+          ? 'the core authenticated the exact live manifest-pinned guard child after it exited through the protected workflow command; C3 wrapper success produced no guard receipt'
+          : 'no valid core-authenticated post-child receipt relationship was established',
         protectedBase: protectedBaseEvidence,
         contract: pipelineContractValidation,
         pipelineEvidence: pipelineValidation.valid ? rawPipelineEvidence : { status: 'unknown', rejected: true, rejectionReason: pipelineValidation.reason },

--- a/scratchpad/phaseB/fix-verifier.mjs
+++ b/scratchpad/phaseB/fix-verifier.mjs
@@ -1,0 +1,840 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { load as parseYaml } from 'js-yaml';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const SCRIPT_DIR = path.dirname(SCRIPT_PATH);
+const DEFAULT_MANIFEST = path.join(SCRIPT_DIR, 'fix-verifier.manifest.json');
+const PROPERTY_IDS = ['P1', 'P2', 'P3', 'P4', 'P5'];
+const OUTPUT_LIMIT = 16_000;
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function clip(value, limit = OUTPUT_LIMIT) {
+  const text = String(value ?? '');
+  if (text.length <= limit) return { text, truncated: false, originalChars: text.length };
+  const half = Math.floor(limit / 2);
+  return {
+    text: `${text.slice(0, half)}\n...[${text.length - limit} chars omitted]...\n${text.slice(-half)}`,
+    truncated: true,
+    originalChars: text.length,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    manifest: DEFAULT_MANIFEST,
+    fixture: 'none',
+    keepTemp: false,
+    forceMutationFailure: [],
+    nodeModules: null,
+    output: null,
+    wiringOnly: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    if (key === '--guard') args.guard = argv[++i];
+    else if (key === '--repo') args.repo = argv[++i];
+    else if (key === '--commit') args.commit = argv[++i];
+    else if (key === '--manifest') args.manifest = argv[++i];
+    else if (key === '--fixture') args.fixture = argv[++i];
+    else if (key === '--force-mutation-failure') args.forceMutationFailure.push(...String(argv[++i] ?? '').split(',').filter(Boolean));
+    else if (key === '--node-modules') args.nodeModules = argv[++i];
+    else if (key === '--output') args.output = argv[++i];
+    else if (key === '--wiring-only') args.wiringOnly = true;
+    else if (key === '--keep-temp') args.keepTemp = true;
+    else throw new Error(`unknown argument: ${key}`);
+  }
+  for (const required of ['guard', 'repo', 'commit']) {
+    if (!args[required]) throw new Error(`missing required --${required}`);
+  }
+  if (!['none', 'deliberately-hollow-guard'].includes(args.fixture)) {
+    throw new Error(`unsupported --fixture ${args.fixture}`);
+  }
+  for (const forced of args.forceMutationFailure) {
+    if (!PROPERTY_IDS.includes(forced) && !/^p[1-5][a-z]?-/.test(forced)) {
+      throw new Error(`invalid forced mutation selector: ${forced}`);
+    }
+  }
+  return args;
+}
+
+export function validateManifestObject(manifest, manifestPath, { checkAdapters = true } = {}) {
+  const problems = [];
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) problems.push('manifest must be an object');
+  if (manifest?.schemaVersion !== 1) problems.push('schemaVersion must be 1');
+  if (!Array.isArray(manifest?.adapters)) problems.push('adapters must be an array');
+  else if (manifest.adapters.length === 0) problems.push('adapter registry is empty; no guard can be measured');
+  const ids = new Set();
+  for (const [index, guard] of (manifest?.adapters ?? []).entries()) {
+    const prefix = `adapters[${index}]`;
+    if (!guard || typeof guard !== 'object') { problems.push(`${prefix} must be an object`); continue; }
+    if (typeof guard.id !== 'string' || !/^[a-z0-9][a-z0-9-]*$/.test(guard.id)) problems.push(`${prefix}.id is invalid`);
+    else if (ids.has(guard.id)) problems.push(`${prefix}.id duplicates ${guard.id}`);
+    else ids.add(guard.id);
+    if (typeof guard.adapter !== 'string' || guard.adapter.length === 0) problems.push(`${prefix}.adapter is required`);
+    if (!Array.isArray(guard.guardFiles) || guard.guardFiles.length === 0) problems.push(`${prefix}.guardFiles must be non-empty`);
+    if (!Array.isArray(guard.subjectFiles) || guard.subjectFiles.length === 0) problems.push(`${prefix}.subjectFiles must be non-empty`);
+    for (const [field, values] of [['guardFiles', guard.guardFiles], ['subjectFiles', guard.subjectFiles]]) {
+      for (const rel of values ?? []) {
+        if (typeof rel !== 'string' || path.isAbsolute(rel) || rel.split('/').includes('..')) problems.push(`${prefix}.${field} contains unsafe path`);
+      }
+    }
+    if (checkAdapters && typeof guard.adapter === 'string') {
+      const adapter = path.resolve(path.dirname(manifestPath), guard.adapter);
+      if (!adapter.startsWith(`${path.dirname(manifestPath)}${path.sep}`) || !fs.existsSync(adapter)) {
+        problems.push(`${prefix}.adapter does not resolve inside the manifest directory`);
+      }
+    }
+  }
+  if (problems.length) throw new Error(`invalid checked adapter registry: ${problems.join('; ')}`);
+  return { count: manifest.adapters.length, ids: [...ids].sort() };
+}
+
+function directSpawn(argv, options = {}) {
+  const startedAt = isoNow();
+  const startedMs = Date.now();
+  const result = spawnSync(argv[0], argv.slice(1), {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    env: options.env ?? process.env,
+    timeout: options.timeoutMs ?? 30_000,
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const combined = `${stdout}${stderr}`;
+  return {
+    argv,
+    cwd: options.cwd,
+    startedAt,
+    endedAt: isoNow(),
+    durationMs: Date.now() - startedMs,
+    exitCode: typeof result.status === 'number' ? result.status : null,
+    signal: result.signal ?? null,
+    spawnError: result.error?.message ?? null,
+    timedOut: result.error?.code === 'ETIMEDOUT',
+    stdout: clip(stdout),
+    stderr: clip(stderr),
+    outputSha256: sha256(combined),
+    exitProvenance: 'direct child status from spawnSync; shell=false',
+  };
+}
+
+function requireSuccess(argv, options = {}) {
+  const run = directSpawn(argv, options);
+  if (run.exitCode !== 0 || run.spawnError) {
+    throw new Error(`${argv.join(' ')} failed: ${run.spawnError ?? run.stderr.text ?? run.stdout.text}`);
+  }
+  return run;
+}
+
+function gitText(repo, args) {
+  const run = requireSuccess(['git', ...args], { cwd: repo });
+  return run.stdout.text.trim();
+}
+
+function snapshotPath(root, rel) {
+  const abs = path.resolve(root, rel);
+  if (abs !== root && !abs.startsWith(`${root}${path.sep}`)) throw new Error(`snapshot path escapes isolated root: ${rel}`);
+  try {
+    const stat = fs.lstatSync(abs);
+    const type = stat.isFile() ? 'file' : stat.isDirectory() ? 'directory' : stat.isSymbolicLink() ? 'symlink' : 'other';
+    let contentSha256 = null;
+    let bytes = null;
+    if (stat.isFile()) {
+      const content = fs.readFileSync(abs);
+      contentSha256 = sha256(content);
+      bytes = content.length;
+    } else if (stat.isSymbolicLink()) {
+      const target = fs.readlinkSync(abs);
+      contentSha256 = sha256(target);
+      bytes = Buffer.byteLength(target);
+    }
+    return { exists: true, type, mode: (stat.mode & 0o777).toString(8).padStart(3, '0'), bytes, contentSha256 };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { exists: false, type: null, mode: null, bytes: null, contentSha256: null };
+    return { exists: null, error: error.message };
+  }
+}
+
+function snapshotPaths(root, paths) {
+  return Object.fromEntries([...new Set(paths)].sort().map((rel) => [rel, snapshotPath(root, rel)]));
+}
+
+function changedSnapshotPaths(before, after) {
+  return [...new Set([...Object.keys(before), ...Object.keys(after)])].filter((rel) => JSON.stringify(before[rel]) !== JSON.stringify(after[rel]));
+}
+
+function runGuardCommands(commands, cwd) {
+  const executionToken = crypto.randomUUID();
+  const runs = commands.map((command) => {
+    const run = directSpawn(command.argv, {
+      cwd,
+      timeoutMs: command.timeoutMs,
+      env: { ...process.env, CI: '1', B0_FIX_VERIFIER_EXECUTION_TOKEN: executionToken },
+    });
+    const combined = `${run.stdout.text}\n${run.stderr.text}`;
+    const observedBy = (command.observeAny ?? []).filter((token) => combined.includes(token));
+    const decidingLines = combined.split('\n').filter((line) =>
+      /Cannot find name|Test Files|Tests\s+\d+|AssertionError|expected|received|No test files found/.test(line),
+    ).slice(-12);
+    let decidingKind = 'no-deciding-output';
+    if (/Cannot find name|No test files found|Tests\s+0\s+passed|Tests\s+no tests/.test(combined)) decidingKind = 'compile-or-no-tests';
+    else if (run.exitCode === 0) decidingKind = 'suite-passed';
+    else if (/AssertionError|expected|received|(?:Test Files|Tests)\s+\d+\s+failed/.test(combined)) decidingKind = 'assertion-or-test-failure';
+    return {
+      ...run,
+      observed: observedBy.length > 0,
+      observedBy,
+      decidingOutput: { kind: decidingKind, lines: decidingLines },
+    };
+  });
+  const executable = runs.every((run) => run.spawnError === null && run.exitCode !== null && !run.timedOut);
+  const observed = runs.every((run) => run.observed);
+  let outcome = 'unknown';
+  if (executable && observed) outcome = runs.every((run) => run.exitCode === 0) ? 'pass' : 'fail';
+  return {
+    executionToken,
+    processProof: 'each argv was spawned directly with shell=false; the recorded exitCode is the child process status',
+    outcome,
+    executable,
+    observed,
+    runs,
+  };
+}
+
+function writeJsonAtomic(outputPath, record) {
+  const absolute = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  const temporary = `${absolute}.${process.pid}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+  fs.renameSync(temporary, absolute);
+}
+
+function shouldForce(selectorList, mutation) {
+  return selectorList.includes(mutation.property) || selectorList.includes(mutation.id);
+}
+
+export function summarizeProperties(mutationEvidence, positiveControlPassed) {
+  const properties = {};
+  for (const property of PROPERTY_IDS) {
+    const evidence = mutationEvidence.filter((item) => item.property === property);
+    if (evidence.length === 0) throw new Error(`${property} has an empty mutation population (0/0 is an error)`);
+    let outcome;
+    if (!positiveControlPassed) outcome = 'unknown';
+    else if (evidence.some((item) => !item.mutationApplied || item.mutationRelevant === false || item.guardOutcome === 'unknown')) outcome = 'unknown';
+    else if (evidence.every((item) => item.guardOutcome === 'fail')) outcome = 'proven';
+    else outcome = 'not-proven';
+    if (property === 'P3') {
+      const typePreserving = evidence.find((item) => item.id.includes('p3d'));
+      const substantive = typePreserving?.guardRun?.runs?.some((run) => run.decidingOutput?.kind === 'assertion-or-test-failure');
+      if (!substantive) outcome = 'not-proven';
+    }
+    properties[property] = { outcome, mutations: evidence.map((item) => item.id) };
+  }
+  return properties;
+}
+
+export function effectiveClasses(mutationEvidence, properties, positiveControlPassed) {
+  if (!positiveControlPassed) return [];
+  const classes = new Set();
+  for (const item of mutationEvidence) {
+    if (!item.mutationApplied || item.guardOutcome !== 'fail') continue;
+    if (item.property === 'P3') continue;
+    classes.add(item.violationClass);
+  }
+  if (properties.P3?.outcome === 'proven') classes.add('guard removal');
+  return [...classes].sort();
+}
+
+export function deriveRung({ exists, wired, positiveControlPassed, properties }) {
+  const outcomes = Object.values(properties).map((item) => item.outcome);
+  if (!exists) return 'not-proven';
+  if (outcomes.includes('unknown') || !positiveControlPassed) return 'not-proven';
+  if (wired && outcomes.every((value) => value === 'proven')) return 'effective';
+  if (wired) return 'wired';
+  return 'exists';
+}
+
+const RELEVANCE_MODES = new Set(['declared-load-bearing-input', 'outside-enumeration']);
+
+export function validateRelevanceEvidence(evidence) {
+  if (!evidence || typeof evidence !== 'object') return { valid: false, reason: 'relevance evidence is not an object' };
+  if (evidence.status !== 'proven' && evidence.status !== 'unknown') return { valid: false, reason: 'relevance status must be proven or unknown' };
+  if (!RELEVANCE_MODES.has(evidence.mode)) return { valid: false, reason: `relevance mode is not allowed: ${String(evidence.mode)}` };
+  if (!Array.isArray(evidence.checks) || evidence.checks.length === 0) return { valid: false, reason: 'relevance checks must be a non-empty array' };
+  if (evidence.checks.some((check) => !check || check.passed !== true)) return { valid: false, reason: 'every relevance check must pass' };
+  return { valid: true };
+}
+
+function normalizedInvocation(argv) {
+  if (!Array.isArray(argv)) return [];
+  if (argv[0] !== 'env') return argv;
+  let index = 1;
+  while (index < argv.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(argv[index])) index += 1;
+  return argv.slice(index);
+}
+
+function safeRelativeFile(value) {
+  return typeof value === 'string' && value.length > 0 && !path.isAbsolute(value) && !value.split('/').includes('..');
+}
+
+export function validatePipelineContract(contract, commandArgv, protectedWorkflowText) {
+  const problems = [];
+  if (!contract || typeof contract !== 'object' || Array.isArray(contract)) {
+    return { valid: false, reason: 'pipeline contract is not an object', checks: [] };
+  }
+  if (typeof contract.protectedRemoteUrl !== 'string' || !/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(contract.protectedRemoteUrl)) {
+    problems.push('protectedRemoteUrl must be a pinned GitHub repository URL');
+  }
+  if (typeof contract.protectedRef !== 'string' || !/^refs\/heads\/[A-Za-z0-9._/-]+$/.test(contract.protectedRef)) {
+    problems.push('protectedRef must be a full branch ref');
+  }
+  if (!safeRelativeFile(contract.workflowPath)) problems.push('workflowPath must be a safe relative file');
+  if (typeof contract.workflowJob !== 'string' || contract.workflowJob.length === 0) problems.push('workflowJob is required');
+  if (typeof contract.workflowCommandPrefix !== 'string' || contract.workflowCommandPrefix.trim().length === 0) problems.push('workflowCommandPrefix is required');
+  if (!Array.isArray(contract.invocationPrefix) || contract.invocationPrefix.length === 0 || contract.invocationPrefix.some((item) => typeof item !== 'string' || item.length === 0)) {
+    problems.push('invocationPrefix must be a non-empty argv array');
+  }
+  if (!contract.observer || typeof contract.observer !== 'object' || !safeRelativeFile(contract.observer.nodeEntry)) {
+    problems.push('observer.nodeEntry must be a safe relative file');
+  }
+  if (!Array.isArray(contract.observer?.requiredArgs) || contract.observer.requiredArgs.some((item) => typeof item !== 'string' || item.length === 0)) {
+    problems.push('observer.requiredArgs must be an array of non-empty strings');
+  }
+
+  const normalized = normalizedInvocation(commandArgv);
+  const invocationMatches = Array.isArray(contract.invocationPrefix)
+    && contract.invocationPrefix.every((item, index) => normalized[index] === item);
+  if (!invocationMatches) problems.push('adapter command does not invoke the manifest-pinned real pipeline entry');
+
+  let workflowCommandFound = false;
+  let workflowParseError = null;
+  try {
+    const parsed = parseYaml(protectedWorkflowText);
+    const steps = parsed?.jobs?.[contract.workflowJob]?.steps;
+    if (!Array.isArray(steps)) throw new Error(`workflow job ${contract.workflowJob} has no steps`);
+    workflowCommandFound = steps.some((step) => typeof step?.run === 'string'
+      && step.run.split('\n').some((line) => line.trim().startsWith(contract.workflowCommandPrefix)));
+  } catch (error) {
+    workflowParseError = error.message;
+  }
+  if (workflowParseError) problems.push(`protected workflow could not be parsed: ${workflowParseError}`);
+  else if (!workflowCommandFound) problems.push('protected workflow job does not declare the pinned pipeline command');
+
+  const checks = [
+    { check: 'protected remote URL is instrument-pinned', passed: !problems.some((item) => item.startsWith('protectedRemoteUrl')) },
+    { check: 'protected branch ref is instrument-pinned', passed: !problems.some((item) => item.startsWith('protectedRef')) },
+    { check: 'adapter command invokes the pinned real entry', passed: invocationMatches },
+    { check: 'protected workflow job declares the pinned command', passed: workflowCommandFound && !workflowParseError },
+    { check: 'observer target is a safe exact child entry', passed: safeRelativeFile(contract.observer?.nodeEntry) },
+  ];
+  return { valid: problems.length === 0, reason: problems.join('; ') || null, checks, normalizedInvocation: normalized };
+}
+
+function readJsonLines(file) {
+  try {
+    return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map((line) => JSON.parse(line));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    return [{ malformed: true, error: error.message }];
+  }
+}
+
+function observerSource({ realNode, cwd, guardId, token, nodeEntry, requiredArgs, receiptFile, shortCircuitFile, shortCircuit }) {
+  return `#!${realNode}\n`
+    + `import fs from 'node:fs';\n`
+    + `import path from 'node:path';\n`
+    + `import { spawn } from 'node:child_process';\n`
+    + `const argv = process.argv.slice(2);\n`
+    + `const cwd = ${JSON.stringify(cwd)};\n`
+    + `const expected = ${JSON.stringify(path.resolve(cwd, nodeEntry))};\n`
+    + `const required = ${JSON.stringify(requiredArgs)};\n`
+    + `const resolve = (value) => { try { return fs.realpathSync(path.resolve(cwd, value)); } catch { return path.resolve(cwd, value); } };\n`
+    + `const target = argv.length > 0 && resolve(argv[0]) === resolve(expected) && required.every((item) => argv.includes(item));\n`
+    + `const append = (file, value) => fs.appendFileSync(file, JSON.stringify(value) + '\\n', 'utf8');\n`
+    + `if (target && ${shortCircuit ? 'true' : 'false'}) {\n`
+    + `  const event = { source: 'fix-verifier-core', guardId: ${JSON.stringify(guardId)}, token: ${JSON.stringify(token)}, nodeEntry: ${JSON.stringify(nodeEntry)}, argv, shortCircuitedAt: new Date().toISOString() };\n`
+    + `  append(${JSON.stringify(shortCircuitFile)}, event);\n`
+    + `  process.stdout.write('[fix-verifier-C3] short-circuited guard=' + event.guardId + ' entry=' + event.nodeEntry + '\\n');\n`
+    + `  process.exit(0);\n`
+    + `}\n`
+    + `const startedAt = new Date().toISOString();\n`
+    + `const child = spawn(${JSON.stringify(realNode)}, argv, { cwd: process.cwd(), env: process.env, stdio: 'inherit' });\n`
+    + `const forward = (signal) => { try { child.kill(signal); } catch {} };\n`
+    + `for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) process.on(signal, () => forward(signal));\n`
+    + `child.once('error', (error) => { console.error(error.message); process.exit(1); });\n`
+    + `child.once('exit', (code, signal) => {\n`
+    + `  const childExitCode = typeof code === 'number' ? code : null;\n`
+    + `  if (target) {\n`
+    + `    const receipt = { source: 'fix-verifier-core', guardId: ${JSON.stringify(guardId)}, token: ${JSON.stringify(token)}, tokenSha256: ${JSON.stringify(sha256(token))}, nodeEntry: ${JSON.stringify(nodeEntry)}, argv, startedAt, childExitedAt: new Date().toISOString(), childExitCode, signal: signal ?? null, emittedAfterChildExit: true };\n`
+    + `    append(${JSON.stringify(receiptFile)}, receipt);\n`
+    + `    process.stdout.write('[fix-verifier-wiring] token=' + receipt.token + ' guard=' + receipt.guardId + ' entry=' + receipt.nodeEntry + ' childExit=' + String(receipt.childExitCode) + '\\n');\n`
+    + `  }\n`
+    + `  process.exit(childExitCode ?? 1);\n`
+    + `});\n`;
+}
+
+function runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, token, shortCircuit }) {
+  const label = shortCircuit ? 'c3' : 'positive';
+  const root = path.join(observerRoot, label);
+  fs.mkdirSync(root, { recursive: true });
+  const receiptFile = path.join(root, 'receipts.jsonl');
+  const shortCircuitFile = path.join(root, 'short-circuits.jsonl');
+  const wrapper = path.join(root, 'node');
+  fs.writeFileSync(wrapper, observerSource({
+    realNode: process.execPath,
+    cwd,
+    guardId,
+    token,
+    nodeEntry: contract.observer.nodeEntry,
+    requiredArgs: contract.observer.requiredArgs,
+    receiptFile,
+    shortCircuitFile,
+    shortCircuit,
+  }), { mode: 0o755 });
+  const run = directSpawn(command.argv, {
+    cwd,
+    timeoutMs: command.timeoutMs,
+    env: { ...process.env, CI: '1', PATH: `${root}${path.delimiter}${process.env.PATH ?? ''}` },
+  });
+  return {
+    run,
+    observer: { wrapper, nodeEntry: contract.observer.nodeEntry, requiredArgs: contract.observer.requiredArgs },
+    receipts: readJsonLines(receiptFile),
+    shortCircuitEvents: readJsonLines(shortCircuitFile),
+  };
+}
+
+export function runPipelineWiringControls({ command, cwd, guardId, contract, observerRoot }) {
+  const token = `${crypto.randomUUID()}-${crypto.randomBytes(16).toString('hex')}`;
+  const c3Token = `${crypto.randomUUID()}-${crypto.randomBytes(16).toString('hex')}`;
+  const positive = runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, token, shortCircuit: false });
+  const C3 = runObservedPipelinePass({ command, cwd, guardId, contract, observerRoot, token: c3Token, shortCircuit: true });
+  const receipt = positive.receipts.length === 1 ? positive.receipts[0] : null;
+  const positiveReceiptValid = receipt?.source === 'fix-verifier-core'
+    && receipt.guardId === guardId
+    && receipt.token === token
+    && receipt.tokenSha256 === sha256(token)
+    && receipt.nodeEntry === contract.observer.nodeEntry
+    && receipt.childExitCode === 0
+    && receipt.emittedAfterChildExit === true;
+  const c3Event = C3.shortCircuitEvents.length === 1 ? C3.shortCircuitEvents[0] : null;
+  const c3Valid = C3.run.exitCode === 0 && !C3.run.spawnError && C3.receipts.length === 0
+    && c3Event?.source === 'fix-verifier-core'
+    && c3Event.guardId === guardId
+    && c3Event.token === c3Token
+    && c3Event.nodeEntry === contract.observer.nodeEntry;
+  C3.outcome = c3Valid
+    ? 'proven'
+    : !c3Event || C3.run.exitCode === null || C3.run.spawnError || C3.run.exitCode !== 0
+      ? 'unknown'
+      : 'not-proven';
+  const checks = [
+    { check: 'real declared pipeline wrapper exited successfully', passed: positive.run.exitCode === 0 && !positive.run.spawnError },
+    { check: 'core observer emitted exactly one post-child receipt', passed: positiveReceiptValid },
+    { check: 'C3 wrapper still exited successfully', passed: C3.run.exitCode === 0 && !C3.run.spawnError },
+    { check: 'C3 short-circuited the exact guard child', passed: Boolean(c3Event) },
+    { check: 'C3 produced no guard execution receipt', passed: C3.receipts.length === 0 },
+  ];
+  const status = checks.every((item) => item.passed) ? 'proven' : 'unknown';
+  return {
+    token,
+    tokenSha256: sha256(token),
+    positive,
+    C3,
+    envelope: {
+      source: 'fix-verifier-core',
+      status,
+      mode: 'core-minted-process-receipt',
+      tokenSha256: sha256(token),
+      receipt,
+      C3: { outcome: C3.outcome, receiptCount: C3.receipts.length, shortCircuitEvent: c3Event },
+      checks,
+    },
+  };
+}
+
+const PIPELINE_MODES = new Set(['core-minted-process-receipt']);
+export function validatePipelineEvidence(evidence) {
+  if (!evidence || typeof evidence !== 'object') return { valid: false, reason: 'pipeline evidence is not an object' };
+  if (evidence.source !== 'fix-verifier-core' || evidence.status !== 'proven' || !PIPELINE_MODES.has(evidence.mode)) return { valid: false, reason: 'pipeline evidence is not a core-minted proven envelope' };
+  if (!/^[a-f0-9]{64}$/.test(evidence.tokenSha256 ?? '') || evidence.receipt?.tokenSha256 !== evidence.tokenSha256 || evidence.receipt?.emittedAfterChildExit !== true) {
+    return { valid: false, reason: 'pipeline receipt is missing or not bound to the minted token after child exit' };
+  }
+  if (evidence.C3?.outcome !== 'proven' || evidence.C3?.receiptCount !== 0 || !evidence.C3?.shortCircuitEvent) {
+    return { valid: false, reason: 'C3 did not prove wrapper success without a guard receipt' };
+  }
+  if (!Array.isArray(evidence.checks) || evidence.checks.length === 0 || evidence.checks.some((check) => !check || check.passed !== true)) {
+    return { valid: false, reason: 'pipeline checks must be non-empty and all pass' };
+  }
+  return { valid: true };
+}
+
+async function measure(args) {
+  const manifestPath = fs.realpathSync(path.resolve(args.manifest));
+  const manifestBytes = fs.readFileSync(manifestPath);
+  const manifest = JSON.parse(manifestBytes.toString('utf8'));
+  const adapterRegistry = validateManifestObject(manifest, manifestPath);
+  const guard = manifest.adapters.find((item) => item.id === args.guard);
+  if (!guard) throw new Error(`guard ${args.guard} has no entry in the checked adapter registry`);
+
+  const adapterPath = path.resolve(path.dirname(manifestPath), guard.adapter);
+  const adapter = await import(`${pathToFileURL(adapterPath).href}?v=${sha256(fs.readFileSync(adapterPath)).slice(0, 12)}`);
+  if (!Array.isArray(adapter.mutations) || adapter.mutations.length === 0) throw new Error('adapter mutation population is empty (0/0 is an error)');
+  for (const property of PROPERTY_IDS) {
+    if (!adapter.mutations.some((mutation) => mutation.property === property)) throw new Error(`adapter has no ${property} mutation`);
+  }
+  if (!Array.isArray(adapter.pipelineCommands) || adapter.pipelineCommands.length === 0) throw new Error('adapter pipeline command population is empty');
+  if (!Array.isArray(adapter.guardCommands) || adapter.guardCommands.length === 0) throw new Error('adapter guard command population is empty');
+
+  const inputRepo = fs.realpathSync(path.resolve(args.repo));
+  const targetRoot = fs.realpathSync(gitText(inputRepo, ['rev-parse', '--show-toplevel']));
+  const resolvedCommit = gitText(targetRoot, ['rev-parse', `${args.commit}^{commit}`]);
+  const targetStatusBefore = gitText(targetRoot, ['status', '--porcelain=v1']);
+  const targetRemote = (() => {
+    for (const name of ['upstream', 'origin']) {
+      const run = directSpawn(['git', 'remote', 'get-url', name], { cwd: targetRoot });
+      if (run.exitCode === 0) return { name, url: run.stdout.text.trim() };
+    }
+    return { name: null, url: null };
+  })();
+
+  const existenceRows = [...new Set([...guard.guardFiles, ...guard.subjectFiles])].map((rel) => {
+    const run = directSpawn(['git', 'cat-file', '-e', `${resolvedCommit}:${rel}`], { cwd: targetRoot });
+    return { path: rel, existsAtCommit: run.exitCode === 0, exitCode: run.exitCode, stderr: run.stderr };
+  });
+  const exists = existenceRows.every((item) => item.existsAtCommit);
+  if (!exists) throw new Error(`guard/subject path absent at target commit: ${existenceRows.filter((item) => !item.existsAtCommit).map((item) => item.path).join(', ')}`);
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-fix-verifier-'));
+  const copies = [];
+  let dependencyEvidence;
+  let nodeModulesPath;
+  let isolationSource;
+  let protectedBaseEvidence = null;
+  let pipelineContractValidation = { valid: false, reason: 'guard has no structured pipeline contract', checks: [] };
+
+  const cloneCase = (label, attachDependencies = true, workspaceKind = 'guard') => {
+    const safe = label.replace(/[^a-zA-Z0-9_-]/g, '-');
+    const root = path.join(tempRoot, `${String(copies.length + 1).padStart(2, '0')}-${safe}`);
+    requireSuccess(['git', 'clone', '--shared', '--no-checkout', '--quiet', isolationSource, root], { cwd: tempRoot, timeoutMs: 120_000 });
+    requireSuccess(['git', 'checkout', '--detach', '--quiet', resolvedCommit], { cwd: root, timeoutMs: 120_000 });
+    const actual = gitText(root, ['rev-parse', 'HEAD']);
+    if (actual !== resolvedCommit) throw new Error(`isolated clone commit mismatch: ${actual} != ${resolvedCommit}`);
+    if (protectedBaseEvidence?.commit) {
+      for (const ref of ['refs/remotes/origin/main', 'refs/remotes/upstream/main', 'refs/heads/main']) {
+        requireSuccess(['git', 'update-ref', ref, protectedBaseEvidence.commit], { cwd: root });
+      }
+      const mergeBase = gitText(root, ['merge-base', protectedBaseEvidence.commit, resolvedCommit]);
+      if (!mergeBase) throw new Error('isolated clone has no merge base with the protected branch');
+    }
+    if (attachDependencies) {
+      const destination = path.join(root, 'node_modules');
+      fs.symlinkSync(nodeModulesPath, destination, 'dir');
+      if (workspaceKind === 'pipeline' && typeof adapter.preparePipelineWorkspace === 'function') adapter.preparePipelineWorkspace(root, protectedBaseEvidence);
+      else if (typeof adapter.prepareWorkspace === 'function') adapter.prepareWorkspace(root, protectedBaseEvidence);
+    }
+    copies.push({ label, root, commit: actual });
+    return root;
+  };
+
+  try {
+    isolationSource = path.join(tempRoot, '00-isolation-source');
+    requireSuccess(['git', 'clone', '--shared', '--no-checkout', '--quiet', targetRoot, isolationSource], { cwd: tempRoot, timeoutMs: 120_000 });
+    if (guard.pipeline) {
+      const remote = directSpawn(['git', 'ls-remote', guard.pipeline.protectedRemoteUrl, guard.pipeline.protectedRef], { cwd: isolationSource, timeoutMs: 120_000 });
+      const line = remote.stdout.text.trim().split('\n').find((item) => item.endsWith(`\t${guard.pipeline.protectedRef}`));
+      const serverCommit = line?.split(/\s+/)[0] ?? null;
+      if (remote.exitCode !== 0 || !/^[a-f0-9]{40}$/.test(serverCommit ?? '')) {
+        throw new Error(`could not resolve protected base from server: ${remote.stderr.text || remote.stdout.text}`);
+      }
+      requireSuccess([
+        'git', 'fetch', '--quiet', '--no-tags', guard.pipeline.protectedRemoteUrl,
+        `${guard.pipeline.protectedRef}:refs/fix-verifier/protected-base`,
+      ], { cwd: isolationSource, timeoutMs: 120_000 });
+      const fetchedCommit = gitText(isolationSource, ['rev-parse', 'refs/fix-verifier/protected-base^{commit}']);
+      if (fetchedCommit !== serverCommit) throw new Error(`protected-base fetch mismatch: ${fetchedCommit} != ${serverCommit}`);
+      const protectedWorkflowText = gitText(isolationSource, ['show', `${fetchedCommit}:${guard.pipeline.workflowPath}`]);
+      const pipelineCommand = adapter.pipelineCommands[guard.pipeline.commandIndex ?? 0];
+      if (!pipelineCommand) throw new Error('pipeline contract selects a missing adapter command');
+      pipelineContractValidation = validatePipelineContract(guard.pipeline, pipelineCommand.argv, protectedWorkflowText);
+      if (!pipelineContractValidation.valid) throw new Error(`invalid protected pipeline contract: ${pipelineContractValidation.reason}`);
+      requireSuccess(['git', 'update-ref', 'refs/remotes/origin/main', fetchedCommit], { cwd: isolationSource });
+      requireSuccess(['git', 'update-ref', 'refs/remotes/upstream/main', fetchedCommit], { cwd: isolationSource });
+      requireSuccess(['git', 'update-ref', 'refs/heads/main', fetchedCommit], { cwd: isolationSource });
+      const mergeBase = gitText(isolationSource, ['merge-base', fetchedCommit, resolvedCommit]);
+      if (!mergeBase) throw new Error('candidate has no merge base with the server-resolved protected branch');
+      protectedBaseEvidence = {
+        remoteUrl: guard.pipeline.protectedRemoteUrl,
+        ref: guard.pipeline.protectedRef,
+        commit: fetchedCommit,
+        serverResolved: true,
+        fetchMatchesServer: true,
+        workflowPath: guard.pipeline.workflowPath,
+        workflowSha256: sha256(protectedWorkflowText),
+        mergeBase,
+      };
+    }
+
+    if (args.nodeModules) {
+      nodeModulesPath = fs.realpathSync(path.resolve(args.nodeModules));
+      if (!fs.statSync(nodeModulesPath).isDirectory()) throw new Error('--node-modules must name a directory');
+      dependencyEvidence = { mode: 'provided', path: nodeModulesPath, prepared: true };
+    } else {
+      const seed = cloneCase('dependency-seed', false);
+      const prepare = directSpawn(['npm', 'ci', '--ignore-scripts', '--no-audit', '--no-fund'], { cwd: seed, timeoutMs: 300_000 });
+      dependencyEvidence = { mode: 'npm-ci-isolated-seed', run: prepare, prepared: prepare.exitCode === 0 && !prepare.spawnError };
+      if (!dependencyEvidence.prepared) throw new Error(`dependency preparation failed: ${prepare.stderr.text || prepare.stdout.text}`);
+      nodeModulesPath = fs.realpathSync(path.join(seed, 'node_modules'));
+    }
+
+    const fixtureEvidence = [];
+    const applyFixture = (root) => {
+      if (args.fixture === 'none') return null;
+      if (typeof adapter.applyDeliberatelyHollowGuard !== 'function') throw new Error('adapter does not implement deliberately-hollow-guard fixture');
+      const before = snapshotPaths(root, guard.guardFiles);
+      const fixture = adapter.applyDeliberatelyHollowGuard(root);
+      const after = snapshotPaths(root, fixture.paths);
+      const verification = fixture.verify();
+      const changedPaths = changedSnapshotPaths(before, after);
+      const evidence = { root, before, after, changedPaths, verification, applied: verification.ok && changedPaths.length > 0 };
+      fixtureEvidence.push(evidence);
+      if (!evidence.applied) throw new Error('deliberately hollow guard fixture could not be verified');
+      return evidence;
+    };
+
+    const wiringRoot = cloneCase('pipeline-wiring', true, 'pipeline');
+    applyFixture(wiringRoot);
+    const selectedPipelineCommand = guard.pipeline ? adapter.pipelineCommands[guard.pipeline.commandIndex ?? 0] : null;
+    const wiringRun = selectedPipelineCommand && pipelineContractValidation.valid
+      ? runPipelineWiringControls({
+          command: selectedPipelineCommand,
+          cwd: wiringRoot,
+          guardId: guard.id,
+          contract: guard.pipeline,
+          observerRoot: path.join(tempRoot, 'pipeline-observer'),
+        })
+      : null;
+    const rawPipelineEvidence = wiringRun?.envelope;
+    const pipelineValidation = validatePipelineEvidence(rawPipelineEvidence);
+    const wired = pipelineContractValidation.valid && pipelineValidation.valid;
+    const wiringOutcome = wired
+      ? 'proven'
+      : !wiringRun
+        || wiringRun.positive.receipts.length === 0 && wiringRun.positive.run.exitCode !== 0
+        || wiringRun.positive.run.exitCode === null
+        || wiringRun.positive.run.spawnError
+        ? 'unknown'
+        : 'not-proven';
+
+    let positiveRun = null;
+    let positiveControlPassed = false;
+    const mutationEvidence = [];
+    if (!args.wiringOnly) {
+      const positiveRoot = cloneCase('positive-control');
+      applyFixture(positiveRoot);
+      positiveRun = runGuardCommands(adapter.guardCommands, positiveRoot);
+      positiveControlPassed = positiveRun.outcome === 'pass';
+
+      for (const mutation of adapter.mutations) {
+        const root = cloneCase(mutation.id);
+        applyFixture(root);
+        const before = snapshotPaths(root, mutation.paths);
+        let applyError = null;
+        let verification = { ok: false, checks: [] };
+        if (shouldForce(args.forceMutationFailure, mutation)) {
+          applyError = `forced mutation failure for ${mutation.id}`;
+        } else {
+          try {
+            mutation.apply(root);
+            verification = mutation.verify(root);
+          } catch (error) {
+            applyError = error.message;
+          }
+        }
+        const after = snapshotPaths(root, mutation.paths);
+        const changedPaths = changedSnapshotPaths(before, after);
+        const gitStatusRun = directSpawn(['git', 'status', '--porcelain=v1'], { cwd: root });
+        const rootIsIsolated = root.startsWith(`${tempRoot}${path.sep}`) && root !== targetRoot;
+        const mutationApplied = !applyError && verification.ok === true && changedPaths.length > 0 && rootIsIsolated;
+        const rawRelevanceEvidence = mutationApplied && typeof adapter.verifyMutationRelevant === 'function'
+          ? adapter.verifyMutationRelevant({ root, mutation, changedPaths, guard, guardFiles: guard.guardFiles, subjectFiles: guard.subjectFiles })
+          : { status: 'unknown', mode: 'declared-load-bearing-input', checks: [{ check: 'adapter supplied structured relevance evidence', passed: false }] };
+        const relevanceValidation = validateRelevanceEvidence(rawRelevanceEvidence);
+        const relevanceEvidence = relevanceValidation.valid
+          ? rawRelevanceEvidence
+          : { ...rawRelevanceEvidence, status: 'unknown', rejected: true, rejectionReason: relevanceValidation.reason };
+        const mutationRelevant = mutationApplied && relevanceValidation.valid && relevanceEvidence.status === 'proven';
+        let guardRun = null;
+        let guardOutcome = 'unknown';
+        if (mutationApplied && mutationRelevant) {
+          guardRun = runGuardCommands(adapter.guardCommands, root);
+          guardOutcome = guardRun.outcome;
+        }
+        mutationEvidence.push({
+          id: mutation.id,
+          property: mutation.property,
+          label: mutation.label,
+          violationClass: mutation.violationClass,
+          isolatedRoot: root,
+          rootIsIsolated,
+          applyError,
+          mutationApplied,
+          mutationRelevant,
+          relevanceEvidence,
+          proof: { before, after, changedPaths, adapterVerification: verification, gitStatus: gitStatusRun },
+          guardOutcome,
+          guardRun,
+        });
+      }
+    }
+
+    const properties = args.wiringOnly
+      ? Object.fromEntries(PROPERTY_IDS.map((property) => [property, { outcome: 'unknown', mutations: [] }]))
+      : summarizeProperties(mutationEvidence, positiveControlPassed);
+    const effectiveAgainst = args.wiringOnly ? [] : effectiveClasses(mutationEvidence, properties, positiveControlPassed);
+    const rung = args.wiringOnly ? (exists && wired ? 'wired' : exists ? 'exists' : 'not-proven') : deriveRung({ exists, wired, positiveControlPassed, properties });
+    const targetStatusAfter = gitText(targetRoot, ['status', '--porcelain=v1']);
+    const targetUntouched = targetStatusBefore === targetStatusAfter;
+    if (!targetUntouched) throw new Error('target working-tree porcelain changed during isolated measurement');
+
+    return {
+      schemaVersion: 1,
+      measuredAt: isoNow(),
+      instrument: {
+        path: SCRIPT_PATH,
+        sha256: sha256(fs.readFileSync(SCRIPT_PATH)),
+        manifest: { path: manifestPath, sha256: sha256(manifestBytes), adapterRegistryChecked: true, ...adapterRegistry },
+        adapter: { path: adapterPath, sha256: sha256(fs.readFileSync(adapterPath)) },
+      },
+      guardId: guard.id,
+      description: guard.description,
+      fixture: args.fixture,
+      measurementScope: args.wiringOnly ? 'wiring-only' : 'full-property-and-wiring',
+      target: {
+        tree: targetRoot,
+        requestedCommit: args.commit,
+        commit: resolvedCommit,
+        remote: targetRemote,
+        dirtyAtStart: targetStatusBefore.length > 0,
+        porcelainAtStart: targetStatusBefore.split('\n').filter(Boolean),
+      },
+      adapterRegistry: {
+        source: manifestPath,
+        sourceSha256: sha256(manifestBytes),
+        schemaChecked: true,
+        semanticRole: 'list of implemented adapters; never a guard census or coverage denominator',
+        nonEmpty: adapterRegistry.count > 0,
+        adaptedGuardCount: adapterRegistry.count,
+        ids: adapterRegistry.ids,
+      },
+      coverageAggregate: {
+        emitted: false,
+        ratio: null,
+        denominator: null,
+        notMeasured: null,
+        reason: 'this command verifies one requested guard; adapter registration is not the real guard census',
+      },
+      existence: { outcome: exists ? 'proven' : 'not-proven', files: existenceRows },
+      wiring: {
+        outcome: wiringOutcome,
+        declaredEntryPoint: guard.pipelineEntryPoint,
+        establishedBy: wired
+          ? 'core-minted token received from the exact manifest-pinned guard child after it exited through the protected workflow command; C3 wrapper success produced no receipt'
+          : 'no valid core-minted post-child receipt relationship was established',
+        protectedBase: protectedBaseEvidence,
+        contract: pipelineContractValidation,
+        pipelineEvidence: pipelineValidation.valid ? rawPipelineEvidence : { status: 'unknown', rejected: true, rejectionReason: pipelineValidation.reason },
+        run: wiringRun,
+      },
+      controls: {
+        C1: args.wiringOnly
+          ? { outcome: wired ? 'proven' : wiringOutcome, required: 'untouched guard passes through the real protected-workflow entry and emits the post-child receipt', run: wiringRun?.positive ?? null }
+          : { outcome: positiveControlPassed ? 'proven' : positiveRun.outcome === 'unknown' ? 'unknown' : 'not-proven', required: 'pristine guard passes', run: positiveRun },
+        C2: args.wiringOnly
+          ? {
+              outcome: wiringRun?.C3?.outcome === 'proven' ? 'proven' : 'unknown',
+              required: 'the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted',
+              perMutation: { 'C3-exact-child-short-circuit': wiringRun?.C3?.outcome === 'proven' ? 'proven' : 'unknown' },
+            }
+          : {
+              outcome: mutationEvidence.every((item) => item.mutationApplied && item.mutationRelevant) ? 'proven' : 'unknown',
+              required: 'every mutation is verified applied before guard output is interpreted',
+              perMutation: Object.fromEntries(mutationEvidence.map((item) => [item.id, item.mutationApplied && item.mutationRelevant ? 'proven' : 'unknown'])),
+            },
+        C3: {
+          outcome: wiringRun?.C3?.outcome ?? 'unknown',
+          required: 'the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists',
+          run: wiringRun?.C3 ?? null,
+        },
+      },
+      properties,
+      effectiveAgainst,
+      rung,
+      mutations: mutationEvidence,
+      isolation: {
+        method: 'throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink',
+        tempRoot,
+        copies,
+        fixtureEvidence,
+        protectedBase: protectedBaseEvidence,
+        targetPorcelainUnchanged: targetUntouched,
+        cleanup: args.keepTemp ? 'retained by explicit --keep-temp' : 'removed before record emission',
+      },
+      dependencies: dependencyEvidence,
+    };
+  } finally {
+    if (!args.keepTemp) fs.rmSync(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+}
+
+function fatalRecord(args, error) {
+  return {
+    schemaVersion: 1,
+    measuredAt: isoNow(),
+    guardId: args?.guard ?? null,
+    target: { tree: args?.repo ?? null, requestedCommit: args?.commit ?? null, commit: null },
+    rung: 'not-proven',
+    properties: Object.fromEntries(PROPERTY_IDS.map((property) => [property, { outcome: 'unknown', mutations: [] }])),
+    effectiveAgainst: [],
+    fatal: { name: error.name, message: error.message, stack: clip(error.stack ?? '').text },
+  };
+}
+
+async function main() {
+  let args;
+  let record;
+  let exitCode;
+  try {
+    args = parseArgs(process.argv.slice(2));
+    record = await measure(args);
+    const unknown = Object.values(record.properties).some((item) => item.outcome === 'unknown');
+    exitCode = args.wiringOnly
+      ? record.wiring?.outcome === 'proven' && record.controls?.C3?.outcome === 'proven' ? 0 : record.wiring?.outcome === 'unknown' ? 2 : 1
+      : record.rung === 'effective' ? 0 : unknown ? 2 : 1;
+  } catch (error) {
+    record = fatalRecord(args, error);
+    exitCode = 2;
+  }
+  if (args?.output) writeJsonAtomic(args.output, record);
+  process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
+  process.exit(exitCode);
+}
+
+const IS_MAIN = process.argv[1] && fs.existsSync(process.argv[1]) && fs.realpathSync(process.argv[1]) === fs.realpathSync(SCRIPT_PATH);
+if (IS_MAIN) main();

--- a/scratchpad/phaseB/fix-verifier.mjs
+++ b/scratchpad/phaseB/fix-verifier.mjs
@@ -403,6 +403,17 @@ function safeRelativeFile(value) {
   return typeof value === 'string' && value.length > 0 && !path.isAbsolute(value) && !value.split('/').includes('..');
 }
 
+export function sameRealFile(left, right, cwd = process.cwd()) {
+  if (typeof left !== 'string' || left.length === 0 || typeof right !== 'string' || right.length === 0) return false;
+  try {
+    const leftRealPath = fs.realpathSync(path.resolve(cwd, left));
+    const rightRealPath = fs.realpathSync(path.resolve(cwd, right));
+    return leftRealPath === rightRealPath;
+  } catch {
+    return false;
+  }
+}
+
 export function validatePipelineContract(contract, commandArgv, protectedWorkflowText) {
   const problems = [];
   if (!contract || typeof contract !== 'object' || Array.isArray(contract)) {
@@ -470,8 +481,10 @@ function observerSource({ realNode, cwd, guardId, nodeEntry, requiredArgs, short
     + `const publicKey = keyPair.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');\n`
     + `const observerSession = crypto.randomUUID();\n`
     + `let sequence = 0;\n`
-    + `const resolve = (value) => { try { return fs.realpathSync(path.resolve(cwd, value)); } catch { return path.resolve(cwd, value); } };\n`
-    + `const target = argv.length > 0 && resolve(argv[0]) === resolve(expected) && required.every((item) => argv.includes(item));\n`
+    + `const resolveReal = (value) => { try { return fs.realpathSync(path.resolve(cwd, value)); } catch { return null; } };\n`
+    + `const observedReal = argv.length > 0 ? resolveReal(argv[0]) : null;\n`
+    + `const expectedReal = resolveReal(expected);\n`
+    + `const target = observedReal !== null && expectedReal !== null && observedReal === expectedReal && required.every((item) => argv.includes(item));\n`
     + `const emit = (kind, fields = {}) => { const event = { eventSchema: 'phaseB-authenticated-observer-event/v1', source: 'fix-verifier-observer', observerSession, sequence: ++sequence, kind, guardId: ${JSON.stringify(guardId)}, nodeEntry: ${JSON.stringify(nodeEntry)}, observerPid: process.pid, argv, ...(kind === 'observer-ready' ? { publicKey } : {}), ...fields }; const signature = crypto.sign(null, Buffer.from(canonical(event)), keyPair.privateKey).toString('base64'); process.stdout.write('FIX_VERIFIER_OBSERVER_EVENT ' + JSON.stringify({ ...event, signature }) + '\\n'); };\n`
     + `if (target) {\n`
     + `  emit('observer-ready');\n`
@@ -537,7 +550,7 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
       const record = processRecord(event.observerPid);
       const argvValid = Array.isArray(event.argv)
         && event.argv.length > 0
-        && (() => { try { return fs.realpathSync(path.resolve(cwd, event.argv[0])) === fs.realpathSync(expectedEntry); } catch { return false; } })()
+        && sameRealFile(event.argv[0], expectedEntry, cwd)
         && contract.observer.requiredArgs.every((item) => event.argv.includes(item));
       const valid = record?.command.includes(observerProgram) && descendantOf(event.observerPid, pipelinePid) && argvValid;
       if (!valid) throw new Error('observer-ready process identity was not the instrument wrapper in the pipeline descendant tree');
@@ -564,9 +577,9 @@ async function runObservedPipelinePass({ command, cwd, guardId, contract, observ
       const valid = observerReady?.valid === true
         && record?.ppid === event.observerPid
         && descendantOf(event.childPid, pipelinePid)
-        && record.command.includes(contract.observer.nodeEntry)
         && Array.isArray(event.argv)
         && event.argv.length > 0
+        && sameRealFile(event.argv[0], expectedEntry, cwd)
         && JSON.stringify(event.argv) === JSON.stringify(observerReady.event.argv);
       if (!valid) throw new Error('observed child pid was not the exact declared descendant process');
       validatedChildStart = { event, valid, authenticated, processRecord: record };

--- a/scratchpad/phaseB/fix-verifier.test.mjs
+++ b/scratchpad/phaseB/fix-verifier.test.mjs
@@ -96,7 +96,7 @@ test('pipeline contract is anchored in a protected workflow job and exact real c
 test('wiring rejects adapter testimony and requires a core-minted runtime receipt', () => {
   assert.equal(validatePipelineEvidence(undefined).valid, false);
   assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'adapter-command-contract', checks: [{ passed: true }] }).valid, false);
-  assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'core-private-channel-hmac-receipt', checks: [{ passed: false }] }).valid, false);
+  assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'core-authenticated-observer-events-hmac-receipt', checks: [{ passed: false }] }).valid, false);
 });
 
 test('C3 short-circuits the exact guard child while the real wrapper succeeds and produces no receipt', async () => {
@@ -197,6 +197,51 @@ test('H1 C3 ignores a same-user disk receipt forged by a stand-in that never run
     assert.equal(validatePipelineEvidence(result.envelope).valid, false);
     assert.equal(fs.existsSync(path.join(root, '.observer', 'positive', 'receipts.jsonl')), true);
     console.log('H1_W1_C3 standInExit=0 realChildRan=false diskReceiptWritten=true authenticatedReceipts=0 verdict=UNKNOWN');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('H1 C4 rejects signed observer-event lines injected through aggregate stdout without the real child', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-h1-stdout-injection-'));
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-h1-stdout-injection',
+      private: true,
+      scripts: { injected: 'node standin.mjs' },
+    }));
+    fs.writeFileSync(path.join(root, 'guard.mjs'), "require('fs').writeFileSync('real-child-ran', 'yes'); throw new Error('the real child must not run in C4');\n");
+    fs.writeFileSync(path.join(root, 'standin.mjs'), `
+      import crypto from 'node:crypto';
+      const canonical = (value) => { if (Array.isArray(value)) return '[' + value.map(canonical).join(',') + ']'; if (value && typeof value === 'object') return '{' + Object.keys(value).sort().map((key) => JSON.stringify(key) + ':' + canonical(value[key])).join(',') + '}'; return JSON.stringify(value); };
+      const pair = crypto.generateKeyPairSync('ed25519');
+      const publicKey = pair.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+      const observerSession = crypto.randomUUID();
+      const argv = ['guard.mjs'];
+      const emit = (sequence, kind, fields = {}) => {
+        const event = { eventSchema: 'phaseB-authenticated-observer-event/v1', source: 'fix-verifier-observer', observerSession, sequence, kind, guardId: 'declared-real-child', nodeEntry: 'guard.mjs', observerPid: process.pid, argv, ...(kind === 'observer-ready' ? { publicKey } : {}), ...fields };
+        const signature = crypto.sign(null, Buffer.from(canonical(event)), pair.privateKey).toString('base64');
+        process.stdout.write('FIX_VERIFIER_OBSERVER_EVENT ' + JSON.stringify({ ...event, signature }) + '\\n');
+      };
+      const now = new Date().toISOString();
+      emit(1, 'observer-ready');
+      emit(2, 'child-start', { childPid: process.pid, startedAt: now });
+      emit(3, 'child-exit', { childPid: process.pid, startedAt: now, childExitedAt: now, childExitCode: 0, signal: null, emittedAfterChildExit: true });
+    `);
+    const result = await runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'injected'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'declared-real-child',
+      contract: { observer: { nodeEntry: 'guard.mjs', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+    assert.equal(result.positive.run.observerCandidateLineCount, 3);
+    assert.equal(result.positive.processObservations.authenticatedEventCount, 0);
+    assert.equal(result.positive.receipts.length, 0);
+    assert.equal(result.envelope.status, 'unknown');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+    assert.equal(fs.existsSync(path.join(root, 'real-child-ran')), false);
+    console.log(`H1_W1_C4 stdoutObserverLines=3 realChildRan=false authenticatedObserverEvents=0 authenticatedReceipts=0 verdict=UNKNOWN`);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scratchpad/phaseB/fix-verifier.test.mjs
+++ b/scratchpad/phaseB/fix-verifier.test.mjs
@@ -218,6 +218,79 @@ test('W4 negative refuses a shim to a same-named real file in another directory'
   }
 });
 
+test('W4-R negative refuses a declared directory even when Node executes its index file', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-w4r-directory-entry-'));
+  try {
+    const entryDir = path.join(root, 'entry-dir');
+    fs.mkdirSync(entryDir, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-w4r-directory-entry',
+      private: true,
+      scripts: { wired: 'node entry-dir' },
+    }));
+    fs.writeFileSync(path.join(entryDir, 'index.js'), "console.log('[w4r-directory] contained index ran');\n");
+
+    const result = await runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'wired'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'w4r-directory-entry',
+      contract: { observer: { nodeEntry: 'entry-dir', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+
+    assert.equal(sameRealFile('entry-dir', 'entry-dir', root), false);
+    assert.match(result.positive.run.stdout.text, /\[w4r-directory\] contained index ran/);
+    assert.equal(result.positive.run.exitCode, 0);
+    assert.equal(result.positive.processObservations.authenticatedEventCount, 0);
+    assert.equal(result.positive.receipts.length, 0);
+    assert.equal(result.C3.shortCircuitEvents.length, 0);
+    assert.equal(result.C3.receipts.length, 0);
+    assert.equal(result.envelope.status, 'unknown');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+    console.log('W4R_DIRECTORY executedContainedFile=true authenticatedEvents=0 authenticatedReceipts=0 verdict=UNKNOWN');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('W4-R negative refuses a symlink chain whose final target is a directory', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-w4r-directory-symlink-'));
+  try {
+    const entryDir = path.join(root, 'entry-dir');
+    fs.mkdirSync(entryDir, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-w4r-directory-symlink',
+      private: true,
+      scripts: { wired: 'node entry-link-a' },
+    }));
+    fs.writeFileSync(path.join(entryDir, 'index.js'), "console.log('[w4r-directory-symlink] contained index ran');\n");
+    fs.symlinkSync('entry-link-b', path.join(root, 'entry-link-a'));
+    fs.symlinkSync('entry-dir', path.join(root, 'entry-link-b'));
+
+    const result = await runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'wired'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'w4r-directory-symlink-entry',
+      contract: { observer: { nodeEntry: 'entry-link-a', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+
+    assert.equal(fs.realpathSync(path.join(root, 'entry-link-a')), fs.realpathSync(entryDir));
+    assert.equal(sameRealFile('entry-link-a', 'entry-link-a', root), false);
+    assert.match(result.positive.run.stdout.text, /\[w4r-directory-symlink\] contained index ran/);
+    assert.equal(result.positive.run.exitCode, 0);
+    assert.equal(result.positive.processObservations.authenticatedEventCount, 0);
+    assert.equal(result.positive.receipts.length, 0);
+    assert.equal(result.C3.shortCircuitEvents.length, 0);
+    assert.equal(result.C3.receipts.length, 0);
+    assert.equal(result.envelope.status, 'unknown');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+    console.log('W4R_DIRECTORY_SYMLINK chainEndsAtDirectory=true executedContainedFile=true authenticatedEvents=0 authenticatedReceipts=0 verdict=UNKNOWN');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('a pipeline that stops before the guard is UNKNOWN, including C3', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-wiring-blocked-'));
   try {

--- a/scratchpad/phaseB/fix-verifier.test.mjs
+++ b/scratchpad/phaseB/fix-verifier.test.mjs
@@ -96,10 +96,10 @@ test('pipeline contract is anchored in a protected workflow job and exact real c
 test('wiring rejects adapter testimony and requires a core-minted runtime receipt', () => {
   assert.equal(validatePipelineEvidence(undefined).valid, false);
   assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'adapter-command-contract', checks: [{ passed: true }] }).valid, false);
-  assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'core-minted-process-receipt', checks: [{ passed: false }] }).valid, false);
+  assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'core-private-channel-hmac-receipt', checks: [{ passed: false }] }).valid, false);
 });
 
-test('C3 short-circuits the exact guard child while the real wrapper succeeds and produces no receipt', () => {
+test('C3 short-circuits the exact guard child while the real wrapper succeeds and produces no receipt', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-wiring-test-'));
   try {
     fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
@@ -111,7 +111,7 @@ test('C3 short-circuits the exact guard child while the real wrapper succeeds an
     const contract = {
       observer: { nodeEntry: 'guard.mjs', requiredArgs: [] },
     };
-    const result = runPipelineWiringControls({
+    const result = await runPipelineWiringControls({
       command: { argv: ['npm', 'run', 'wired'], timeoutMs: 30_000 },
       cwd: root,
       guardId: 'fixture-guard',
@@ -120,7 +120,8 @@ test('C3 short-circuits the exact guard child while the real wrapper succeeds an
     });
     assert.equal(result.positive.run.exitCode, 0);
     assert.equal(result.positive.receipts.length, 1);
-    assert.equal(result.positive.receipts[0].token, result.token);
+    assert.match(result.positive.receipts[0].mac, /^[a-f0-9]{64}$/);
+    assert.equal(result.positive.receipts[0].childExitCode, 0);
     assert.equal(result.C3.run.exitCode, 0);
     assert.equal(result.C3.shortCircuitEvents.length, 1);
     assert.equal(result.C3.receipts.length, 0);
@@ -132,7 +133,7 @@ test('C3 short-circuits the exact guard child while the real wrapper succeeds an
   }
 });
 
-test('a pipeline that stops before the guard is UNKNOWN, including C3', () => {
+test('a pipeline that stops before the guard is UNKNOWN, including C3', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-wiring-blocked-'));
   try {
     fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
@@ -141,7 +142,7 @@ test('a pipeline that stops before the guard is UNKNOWN, including C3', () => {
       scripts: { blocked: "node -e \"console.error('upstream gate stopped'); process.exit(1)\" && node guard.mjs" },
     }));
     fs.writeFileSync(path.join(root, 'guard.mjs'), "console.log('[fixture-guard] PASS');\n");
-    const result = runPipelineWiringControls({
+    const result = await runPipelineWiringControls({
       command: { argv: ['npm', 'run', 'blocked'], timeoutMs: 30_000 },
       cwd: root,
       guardId: 'fixture-guard',
@@ -154,6 +155,48 @@ test('a pipeline that stops before the guard is UNKNOWN, including C3', () => {
     assert.equal(result.C3.outcome, 'unknown');
     assert.equal(result.envelope.status, 'unknown');
     assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('H1 C3 ignores a same-user disk receipt forged by a stand-in that never runs the declared child', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-h1-forgery-'));
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-h1-forgery',
+      private: true,
+      scripts: { standin: 'node standin.mjs' },
+    }));
+    fs.writeFileSync(path.join(root, 'guard.mjs'), "throw new Error('the real child must not run in C3');\n");
+    fs.writeFileSync(path.join(root, 'standin.mjs'), `
+      import fs from 'node:fs';
+      import path from 'node:path';
+      const visible = {
+        source: 'fix-verifier-core', status: 'proven',
+        mode: 'core-private-channel-hmac-receipt',
+        authorityId: 'candidate-readable', childPid: process.pid,
+        childExitCode: 0, emittedAfterChildExit: true,
+        mac: '0'.repeat(64),
+      };
+      const destination = path.join(process.cwd(), '.observer', 'positive', 'receipts.jsonl');
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, JSON.stringify(visible) + '\\n');
+      console.log('stand-in wrote candidate-shaped disk receipt without running guard.mjs');
+    `);
+    const result = await runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'standin'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'declared-real-child',
+      contract: { observer: { nodeEntry: 'guard.mjs', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+    assert.equal(result.positive.run.exitCode, 0);
+    assert.equal(result.positive.receipts.length, 0);
+    assert.equal(result.envelope.status, 'unknown');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+    assert.equal(fs.existsSync(path.join(root, '.observer', 'positive', 'receipts.jsonl')), true);
+    console.log('H1_W1_C3 standInExit=0 realChildRan=false diskReceiptWritten=true authenticatedReceipts=0 verdict=UNKNOWN');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scratchpad/phaseB/fix-verifier.test.mjs
+++ b/scratchpad/phaseB/fix-verifier.test.mjs
@@ -13,6 +13,7 @@ import {
   validateRelevanceEvidence,
   validatePipelineEvidence,
   runPipelineWiringControls,
+  sameRealFile,
 } from './fix-verifier.mjs';
 
 function evidence(overrides = {}) {
@@ -93,6 +94,18 @@ test('pipeline contract is anchored in a protected workflow job and exact real c
   assert.equal(validatePipelineContract(contract, ['npm', 'run', 'lint'], 'jobs:\n  lint:\n    steps:\n      - run: npm run test\n').valid, false);
 });
 
+test('declared-entry realpath equality refuses every resolution failure', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-w4-resolution-failure-'));
+  try {
+    fs.writeFileSync(path.join(root, 'present.mjs'), 'export {};\n');
+    assert.equal(sameRealFile('missing.mjs', 'missing.mjs', root), false);
+    assert.equal(sameRealFile('present.mjs', 'missing.mjs', root), false);
+    assert.equal(sameRealFile('', 'present.mjs', root), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('wiring rejects adapter testimony and requires a core-minted runtime receipt', () => {
   assert.equal(validatePipelineEvidence(undefined).valid, false);
   assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'adapter-command-contract', checks: [{ passed: true }] }).valid, false);
@@ -128,6 +141,78 @@ test('C3 short-circuits the exact guard child while the real wrapper succeeds an
     assert.equal(result.C3.outcome, 'proven');
     assert.equal(result.envelope.status, 'proven');
     assert.equal(validatePipelineEvidence(result.envelope).valid, true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('W4 positive accepts shim and module spellings only when they resolve to the same real entry', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-w4-same-entry-'));
+  try {
+    const binDir = path.join(root, 'node_modules', '.bin');
+    const moduleDir = path.join(root, 'node_modules', 'vitest');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(moduleDir, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-w4-same-entry',
+      private: true,
+      scripts: { wired: 'node node_modules/.bin/vitest' },
+    }));
+    fs.writeFileSync(path.join(moduleDir, 'vitest.mjs'), "console.log('[w4-positive] real module ran');\n");
+    fs.symlinkSync('../vitest/vitest.mjs', path.join(binDir, 'vitest'));
+
+    const result = await runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'wired'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'w4-same-real-entry',
+      contract: { observer: { nodeEntry: 'node_modules/vitest/vitest.mjs', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+
+    assert.equal(fs.realpathSync(path.join(binDir, 'vitest')), fs.realpathSync(path.join(moduleDir, 'vitest.mjs')));
+    assert.equal(result.positive.run.exitCode, 0);
+    assert.equal(result.positive.receipts.length, 1);
+    assert.equal(result.C3.outcome, 'proven');
+    assert.equal(result.envelope.status, 'proven');
+    console.log('W4_POSITIVE shimRealPathEqualsModule=true authenticatedReceipts=1 verdict=PROVEN');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('W4 negative refuses a shim to a same-named real file in another directory', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-w4-wrong-entry-'));
+  try {
+    const binDir = path.join(root, 'node_modules', '.bin');
+    const declaredDir = path.join(root, 'node_modules', 'vitest');
+    const wrongDir = path.join(root, 'node_modules', 'other');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(declaredDir, { recursive: true });
+    fs.mkdirSync(wrongDir, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-w4-wrong-entry',
+      private: true,
+      scripts: { wired: 'node node_modules/.bin/vitest' },
+    }));
+    fs.writeFileSync(path.join(declaredDir, 'vitest.mjs'), "throw new Error('declared entry must not run');\n");
+    fs.writeFileSync(path.join(wrongDir, 'vitest.mjs'), "console.log('[w4-negative] wrong same-named module ran');\n");
+    fs.symlinkSync('../other/vitest.mjs', path.join(binDir, 'vitest'));
+
+    const result = await runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'wired'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'w4-wrong-real-entry',
+      contract: { observer: { nodeEntry: 'node_modules/vitest/vitest.mjs', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+
+    assert.notEqual(fs.realpathSync(path.join(binDir, 'vitest')), fs.realpathSync(path.join(declaredDir, 'vitest.mjs')));
+    assert.equal(result.positive.run.exitCode, 0);
+    assert.equal(result.positive.receipts.length, 0);
+    assert.equal(result.C3.shortCircuitEvents.length, 0);
+    assert.equal(result.envelope.status, 'unknown');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+    console.log('W4_NEGATIVE symlinkTargetsDifferentSameNamedFile=true authenticatedReceipts=0 verdict=UNKNOWN');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scratchpad/phaseB/fix-verifier.test.mjs
+++ b/scratchpad/phaseB/fix-verifier.test.mjs
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  deriveRung,
+  effectiveClasses,
+  summarizeProperties,
+  validateManifestObject,
+  validatePipelineContract,
+  validateRelevanceEvidence,
+  validatePipelineEvidence,
+  runPipelineWiringControls,
+} from './fix-verifier.mjs';
+
+function evidence(overrides = {}) {
+  return {
+    id: 'mutation',
+    property: 'P1',
+    violationClass: 'hollowing',
+    mutationApplied: true,
+    guardOutcome: 'fail',
+    ...overrides,
+  };
+}
+
+function completeEvidence() {
+  return [
+    evidence({ id: 'p1', property: 'P1', violationClass: 'hollowing' }),
+    evidence({ id: 'p2', property: 'P2', violationClass: 'self-report / false testimony' }),
+    evidence({ id: 'p3a', property: 'P3', violationClass: 'guard removal' }),
+    evidence({ id: 'p3b', property: 'P3', violationClass: 'guard removal' }),
+    evidence({ id: 'p3c', property: 'P3', violationClass: 'guard removal' }),
+    evidence({ id: 'p3d', property: 'P3', violationClass: 'guard removal', guardRun: { runs: [{ decidingOutput: { kind: 'assertion-or-test-failure' } }] } }),
+    evidence({ id: 'p4a', property: 'P4', violationClass: 'vacuous measurement' }),
+    evidence({ id: 'p4b', property: 'P4', violationClass: 'population evasion' }),
+    evidence({ id: 'p5', property: 'P5', violationClass: 'blind input / fail-open' }),
+  ];
+}
+
+test('checked adapter registry refuses to claim it can measure zero adapters', () => {
+  assert.throws(
+    () => validateManifestObject({ schemaVersion: 1, adapters: [] }, '/tmp/manifest.json', { checkAdapters: false }),
+    /adapter registry is empty; no guard can be measured/,
+  );
+});
+
+test('checked adapter registry refuses duplicate guard identifiers', () => {
+  const guard = { id: 'same', adapter: 'a.mjs', guardFiles: ['g'], subjectFiles: ['s'] };
+  assert.throws(
+    () => validateManifestObject({ schemaVersion: 1, adapters: [guard, guard] }, '/tmp/manifest.json', { checkAdapters: false }),
+    /duplicates same/,
+  );
+});
+
+test('a mutation that did not verify applied makes its property unknown', () => {
+  const all = completeEvidence();
+  all[0] = evidence({ id: 'p1', mutationApplied: false, guardOutcome: 'unknown' });
+  const properties = summarizeProperties(all, true);
+  assert.equal(properties.P1.outcome, 'unknown');
+  assert.notEqual(properties.P1.outcome, 'not-proven');
+});
+
+test('an applied but irrelevant mutation makes its property unknown', () => {
+  const all = completeEvidence();
+  all[0] = evidence({ id: 'p1', mutationRelevant: false, guardOutcome: 'pass' });
+  const properties = summarizeProperties(all, true);
+  assert.equal(properties.P1.outcome, 'unknown');
+});
+
+test('relevance envelope rejects malformed proven evidence', () => {
+  assert.equal(validateRelevanceEvidence({ status: 'proven', mode: 'declared-load-bearing-input', checks: [] }).valid, false);
+  assert.equal(validateRelevanceEvidence({ status: 'proven', mode: 'path-overlap', checks: [{ passed: true }] }).valid, false);
+  assert.equal(validateRelevanceEvidence({ status: 'proven', mode: 'declared-load-bearing-input', checks: [{ passed: false }] }).valid, false);
+  assert.equal(validateRelevanceEvidence({ status: 'proven', mode: 'declared-load-bearing-input', checks: [{ passed: true }] }).valid, true);
+});
+
+test('pipeline contract is anchored in a protected workflow job and exact real command', () => {
+  const contract = {
+    protectedRemoteUrl: 'https://github.com/JKHeadley/instar.git',
+    protectedRef: 'refs/heads/main',
+    workflowPath: '.github/workflows/ci.yml',
+    workflowJob: 'lint',
+    workflowCommandPrefix: 'npm run lint',
+    invocationPrefix: ['npm', 'run', 'lint'],
+    observer: { nodeEntry: 'scripts/lint-testing-integrity.mjs', requiredArgs: [] },
+  };
+  const workflow = 'jobs:\n  lint:\n    steps:\n      - run: npm run lint\n';
+  assert.equal(validatePipelineContract(contract, ['npm', 'run', 'lint'], workflow).valid, true);
+  assert.equal(validatePipelineContract(contract, ['npm', 'run', 'test'], workflow).valid, false);
+  assert.equal(validatePipelineContract(contract, ['npm', 'run', 'lint'], 'jobs:\n  lint:\n    steps:\n      - run: npm run test\n').valid, false);
+});
+
+test('wiring rejects adapter testimony and requires a core-minted runtime receipt', () => {
+  assert.equal(validatePipelineEvidence(undefined).valid, false);
+  assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'adapter-command-contract', checks: [{ passed: true }] }).valid, false);
+  assert.equal(validatePipelineEvidence({ status: 'proven', mode: 'core-minted-process-receipt', checks: [{ passed: false }] }).valid, false);
+});
+
+test('C3 short-circuits the exact guard child while the real wrapper succeeds and produces no receipt', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-wiring-test-'));
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-wiring-fixture',
+      private: true,
+      scripts: { wired: 'node guard.mjs' },
+    }));
+    fs.writeFileSync(path.join(root, 'guard.mjs'), "console.log('[fixture-guard] PASS');\n");
+    const contract = {
+      observer: { nodeEntry: 'guard.mjs', requiredArgs: [] },
+    };
+    const result = runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'wired'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'fixture-guard',
+      contract,
+      observerRoot: path.join(root, '.observer'),
+    });
+    assert.equal(result.positive.run.exitCode, 0);
+    assert.equal(result.positive.receipts.length, 1);
+    assert.equal(result.positive.receipts[0].token, result.token);
+    assert.equal(result.C3.run.exitCode, 0);
+    assert.equal(result.C3.shortCircuitEvents.length, 1);
+    assert.equal(result.C3.receipts.length, 0);
+    assert.equal(result.C3.outcome, 'proven');
+    assert.equal(result.envelope.status, 'proven');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a pipeline that stops before the guard is UNKNOWN, including C3', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-verifier-wiring-blocked-'));
+  try {
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({
+      name: 'fix-verifier-wiring-blocked-fixture',
+      private: true,
+      scripts: { blocked: "node -e \"console.error('upstream gate stopped'); process.exit(1)\" && node guard.mjs" },
+    }));
+    fs.writeFileSync(path.join(root, 'guard.mjs'), "console.log('[fixture-guard] PASS');\n");
+    const result = runPipelineWiringControls({
+      command: { argv: ['npm', 'run', 'blocked'], timeoutMs: 30_000 },
+      cwd: root,
+      guardId: 'fixture-guard',
+      contract: { observer: { nodeEntry: 'guard.mjs', requiredArgs: [] } },
+      observerRoot: path.join(root, '.observer'),
+    });
+    assert.equal(result.positive.run.exitCode, 1);
+    assert.equal(result.positive.receipts.length, 0);
+    assert.equal(result.C3.shortCircuitEvents.length, 0);
+    assert.equal(result.C3.outcome, 'unknown');
+    assert.equal(result.envelope.status, 'unknown');
+    assert.equal(validatePipelineEvidence(result.envelope).valid, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a verified mutation followed by a passing guard is not-proven, not unknown', () => {
+  const all = completeEvidence();
+  all[0] = evidence({ id: 'p1', guardOutcome: 'pass' });
+  const properties = summarizeProperties(all, true);
+  assert.equal(properties.P1.outcome, 'not-proven');
+});
+
+test('P3 requires all four sabotages to fail, including the type-preserving hollow', () => {
+  const all = completeEvidence();
+  all.find((item) => item.id === 'p3d').guardOutcome = 'pass';
+  const properties = summarizeProperties(all, true);
+  assert.equal(properties.P3.outcome, 'not-proven');
+  assert.ok(!effectiveClasses(all, properties, true).includes('guard removal'));
+});
+
+test('P4 reports named classes independently but the property needs both mutations', () => {
+  const all = completeEvidence();
+  all.find((item) => item.id === 'p4b').guardOutcome = 'pass';
+  const properties = summarizeProperties(all, true);
+  const classes = effectiveClasses(all, properties, true);
+  assert.equal(properties.P4.outcome, 'not-proven');
+  assert.ok(classes.includes('vacuous measurement'));
+  assert.ok(!classes.includes('population evasion'));
+});
+
+test('effective requires wired, C1, and all five properties proven', () => {
+  const all = completeEvidence();
+  const properties = summarizeProperties(all, true);
+  assert.equal(deriveRung({ exists: true, wired: true, positiveControlPassed: true, properties }), 'effective');
+  assert.deepEqual(effectiveClasses(all, properties, true), [
+    'blind input / fail-open',
+    'guard removal',
+    'hollowing',
+    'population evasion',
+    'self-report / false testimony',
+    'vacuous measurement',
+  ]);
+});
+
+test('unknown forces the overall rung to not-proven even when wiring ran', () => {
+  const all = completeEvidence();
+  all[0] = evidence({ id: 'p1', mutationApplied: false, guardOutcome: 'unknown' });
+  const properties = summarizeProperties(all, true);
+  assert.equal(deriveRung({ exists: true, wired: true, positiveControlPassed: true, properties }), 'not-proven');
+});


### PR DESCRIPTION
## Summary

- Rebase PR #1922 onto current protected main and record the honest post-rebase coverage wiring result.
- Compare observed and declared verifier entries only when both resolve to the same regular file.
- Add authenticated positive/negative fixtures for the `.bin` shim case, wrong symlink targets, directories, symlink chains ending at directories, same-named files elsewhere, and resolution failures.
- Record the repaired operator-binding wiring proof without changing authentication or enforcement-evidence logic.

## ELI16

The verifier watches a real pipeline process and checks that the program which ran is the exact program declared in its manifest. Package managers often provide a shortcut under `node_modules/.bin` that is a symlink to the real module file, so the two path spellings may differ legitimately.

The first version resolved both names and required equal final paths, but an independent judge found that this still accepted a directory: Node could be given the directory name and silently execute an `index.js` inside it. The repaired comparison accepts equality only when both resolved operands are regular files. Directories and symlink chains ending at directories now execute in full negative fixtures but authenticate zero events/receipts and return `UNKNOWN`.

## Verification

- `node --test scratchpad/phaseB/authenticated-execution-receipt.test.mjs scratchpad/phaseB/fix-verifier.test.mjs` — 24 passed, 0 failed.
- Legitimate shim: `W4_POSITIVE shimRealPathEqualsModule=true authenticatedReceipts=1 verdict=PROVEN`.
- Wrong real file: `W4_NEGATIVE symlinkTargetsDifferentSameNamedFile=true authenticatedReceipts=0 verdict=UNKNOWN`.
- Directory: `W4R_DIRECTORY executedContainedFile=true authenticatedEvents=0 authenticatedReceipts=0 verdict=UNKNOWN`.
- Symlink chain to directory: `W4R_DIRECTORY_SYMLINK chainEndsAtDirectory=true executedContainedFile=true authenticatedEvents=0 authenticatedReceipts=0 verdict=UNKNOWN`.
- Repaired operator-binding proof: `[fix-verifier-wiring] authenticated guard=topic-operator-evidence entry=node_modules/vitest/vitest.mjs childPid=77868 childExit=0`.
- Proof evidence: `wiring.outcome=proven`, `rung=wired`, one positive receipt, zero C3 guard receipts.
- Full mandatory pre-commit lint chain passed for both repair commits.

## UX impact

No end-user UI change. This narrows an internal proof instrument's path identity check and adds evidence records.

## Boundaries

- Authentication, signing, sequencing, and receipt binding are unchanged.
- Enforcement-evidence logic is unchanged.
- Manifest and adapters are unchanged.
- Model-registry manifest/freshness gate and CI configuration are unchanged.
- No approver key was created.
- Do not merge or enable auto-merge; this PR is for review only.
