### PR TITLE
test: make blind-case harness reporter-portable

### DIFF
--- a/scratchpad/phaseB/REPORT-F2.md
+++ b/scratchpad/phaseB/REPORT-F2.md
@@ -1,0 +1,102 @@
+# Phase B Lane F2 — blind-input case diagnosis
+
+> **Append-only chronology:** diagnosis was recorded before any checker, case, or harness source was changed.
+
+## 2026-08-18 05:46:09 -0700 (PDT) — diagnosis before repair
+
+### Cause in one sentence
+
+The five executable blind cases all run and correctly refuse their blind inputs; the suite exits 1 because the coverage harness's separate P3 type-preserving-hollow self-test hard-codes legacy Node test-summary text (`# tests 4` / `# fail 3`), while Node `v25.6.1` emits semantically equivalent spec-reporter lines (`ℹ tests 4` / `ℹ fail 3`).
+
+### Classification and scope
+
+This is **HARNESS failing to run/interpret its case**, not a checker accepting blindness and not an unrelated dependency/environment failure. The process, Vitest, `vite-node`, production checker imports, filesystem fixtures, and all ten control/blind child executions work. The environment exposes a portability bug in the coverage change's own assertion, but does not fail independently of it. The cause is inside `tests/unit/checker-blind-input-ratchet.test.ts`, so the brief permits a repair. It is not a finding: the property does hold in every declared blind case.
+
+The targeted Vitest case `executes every declared blind case and none reports clean` passed with one test passed and 17 skipped. A contemporaneous `better-sqlite3` native-module notice explicitly said it was non-gating; none of these cases uses sqlite and no deciding output names it.
+
+### Declared cases and direct deciding output
+
+Every case has a clean control and an intentionally blind input. A child exit 0 means the independent oracle saw clean for the control or non-clean for the blind phase.
+
+1. `detector:src/monitoring/HumanAsDetectorLog.ts`
+   - Demonstrates: a writable capture sink is clean; a persistence-write failure must be recorded rather than silently accepted.
+   - Control actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"detector:src/monitoring/HumanAsDetectorLog.ts","phase":"control","passed":true,"evidence":[]}
+     EXIT=0
+     ```
+   - Blind actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"detector:src/monitoring/HumanAsDetectorLog.ts","phase":"blind","passed":true,"evidence":[{"source":"test","topicId":29723,"messageId":null,"category":"factual-correction","reason":"persistence-write-failed"}]}
+     EXIT=0
+     ```
+
+2. `probe:src/monitoring/probes/GuardPostureProbe.ts`
+   - Demonstrates: readable local/peer posture is clean; unavailable local posture plus a failed peer deep read must return NOT-PROVEN rather than no anomaly.
+   - Control actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"probe:src/monitoring/probes/GuardPostureProbe.ts","phase":"control","passed":true,"evidence":{"passed":true,"description":"No guard-posture anomalies across machines","diagnostics":{"unknownSources":[]}}}
+     EXIT=0
+     ```
+   - Blind actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"probe:src/monitoring/probes/GuardPostureProbe.ts","phase":"blind","passed":true,"evidence":{"passed":false,"description":"Guard-posture NOT-PROVEN — 2 source(s) could not be inspected","error":"local: posture unavailable; blind-peer: deep read failed: unreachable"}}
+     EXIT=0
+     ```
+
+3. `reviewer:src/core/reviewers/standards-conformance.ts`
+   - Demonstrates: valid provider results may conclude fit; provider failure must degrade both review and fit judgment to not-proven.
+   - Control actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"reviewer:src/core/reviewers/standards-conformance.ts","phase":"control","passed":true,"evidence":{"report":{"conclusion":"fits","degraded":false},"fit":{"verdict":"fit","reason":"control","degraded":false}}}
+     EXIT=0
+     ```
+   - Blind actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"reviewer:src/core/reviewers/standards-conformance.ts","phase":"blind","passed":true,"evidence":{"report":{"conclusion":"not-proven","degraded":true,"degradeReason":"error"},"fit":{"verdict":"not-proven","reason":"fit judgment errored — not proven","degraded":true,"degradeReason":"error"}}}
+     EXIT=0
+     ```
+
+4. `script:scripts/lint-checker-blind-input-coverage.mjs`
+   - Demonstrates: a readable repository yields a non-empty checker population; a missing repository root must be rejected rather than treated as empty/clean.
+   - Control actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"script:scripts/lint-checker-blind-input-coverage.mjs","phase":"control","passed":true,"evidence":{"population":96}}
+     EXIT=0
+     ```
+   - Blind actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"script:scripts/lint-checker-blind-input-coverage.mjs","phase":"blind","passed":true,"evidence":{"rejectedMissingRoot":true}}
+     EXIT=0
+     ```
+
+5. `script:scripts/lint-llm-attribution.js`
+   - Demonstrates: a readable clean file yields no findings; an unreadable/missing input must be classified as blind rather than omitted as clean.
+   - Control actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"script:scripts/lint-llm-attribution.js","phase":"control","passed":true,"evidence":{"real":[],"allowlisted":[],"stale":[],"blind":[]}}
+     EXIT=0
+     ```
+   - Blind actual:
+     ```text
+     CHECKER_CHILD_RESULT {"id":"script:scripts/lint-llm-attribution.js","phase":"blind","passed":true,"evidence":{"real":[],"allowlisted":[],"stale":[],"blind":[{"reason":"file-unreadable: ENOENT"}]}}
+     EXIT=0
+     ```
+
+### Actual failing boundary
+
+The failure is in the later P3 harness fixture, not in `CASES`:
+
+```text
+P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1
+ℹ tests 4
+ℹ pass 1
+ℹ fail 3
+AssertionError: expected '✖ empty population is not proof ...' to contain '# tests 4'
+```
+
+The isolated hollow guard was correctly rejected: its own test process exited 1, three assertions failed, and assertion-failure output was present. Only the reporter-prefix assertion failed. Therefore the pre-repair coverage verdict remains:
+
+```text
+checker-blind-input: NOT-PROVEN — executable blind cases exited 1
+```

--- a/scratchpad/phaseB/REPORT-F2.md
+++ b/scratchpad/phaseB/REPORT-F2.md
@@ -100,3 +100,33 @@ The isolated hollow guard was correctly rejected: its own test process exited 1,
 ```text
 checker-blind-input: NOT-PROVEN — executable blind cases exited 1
 ```
+
+## 2026-08-18 05:53:23 -0700 (PDT) — repair and authenticated rerun
+
+The only source repair is in the coverage harness: its P3 type-preserving-hollow fixture now recognizes both TAP (`# tests` / `# fail`) and Node spec-reporter (`ℹ tests` / `ℹ fail`) summary lines while still requiring the isolated guard-own process to exit nonzero and expose assertion failures. No checker behavior, declared blind case, authentication, instrument, enforcement-evidence logic, model registry, CI configuration, or approver key changed.
+
+Post-repair verification:
+
+- `tests/unit/checker-blind-input-ratchet.test.ts`: 18/18 passed, including all five declared executable blind cases and all four P3 guard sabotages.
+- Normal commit gate: passed, including TypeScript and the repository lint chain.
+- Original certified H1 instrument SHA-256: `584a0a0b7248c4bede3f99e58f369db2183ca298fc5c1209862a6e3dc41edd72`.
+- Target commit: `f7cd56fdf5abd1289022499a124421e7ca622ca0`.
+- Protected base resolved to `upstream/main` at `248ed7177f5bf416aa7bdad9763741478195e1fc`.
+- Evidence: `scratchpad/phaseB/evidence/F2-checker-blind-input-coverage.json` (SHA-256 `b7a9ab3c6a5e295a343a27bb20ab0559be389fe479bde7380a0ba0fa0cbdc749`).
+- Positive run authenticated exactly one post-child receipt; C3 authenticated its short-circuit and minted zero guard receipts; the target worktree remained unchanged by measurement.
+
+Before verdict:
+
+```text
+checker-blind-input: NOT-PROVEN — executable blind cases exited 1
+```
+
+After deciding verdict line, verbatim:
+
+```text
+[fix-verifier-wiring] authenticated guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs childPid=32717 childExit=0
+```
+
+After evidence verdict: `wiring.outcome=proven`, `rung=wired`.
+
+Final classification: **HARNESS BUG FIXED**. The blind-input property itself held before and after the repair; the earlier `NOT-PROVEN` was caused solely by reporter-specific interpretation in the coverage test harness.

--- a/scratchpad/phaseB/evidence/F2-checker-blind-input-coverage.json
+++ b/scratchpad/phaseB/evidence/F2-checker-blind-input-coverage.json
@@ -1,0 +1,929 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T12:53:12.146Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "584a0a0b7248c4bede3f99e58f369db2183ca298fc5c1209862a6e3dc41edd72",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs",
+      "sha256": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77"
+    }
+  },
+  "guardId": "checker-blind-input-coverage",
+  "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f2-blind-case-harness",
+    "requestedCommit": "f7cd56fdf5abd1289022499a124421e7ca622ca0",
+    "commit": "f7cd56fdf5abd1289022499a124421e7ca622ca0",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-checker-blind-input-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lib/checker-blind-input-ratchet.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/checker-blind-input-ratchet.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lint-llm-attribution.js",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/checker-blind-input-cases.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-authenticated-observer-events-hmac-receipt",
+      "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+      "receipt": {
+        "schema": "phaseB-authenticated-execution-receipt/v1",
+        "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+        "issuer": "fix-verifier:checker-blind-input-coverage",
+        "nonce": "fad46f31-c9a7-499c-bed6-eb723d75836c",
+        "guardId": "checker-blind-input-coverage",
+        "kind": "child-exit",
+        "observerPid": 32669,
+        "childPid": 32717,
+        "childExitCode": 0,
+        "signal": null,
+        "argv": [
+          "scripts/lint-checker-blind-input-coverage.mjs"
+        ],
+        "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+        "startedAt": "2026-08-18T12:51:25.618Z",
+        "childExitedAt": "2026-08-18T12:52:05.965Z",
+        "emittedAfterChildExit": true,
+        "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+        "observerEventSequence": 3,
+        "observerEventSignatureHash": "898067ab123a0d1123c5722f8fc3573c7ebe98c66ae0fd61ff5ec4879398b47d",
+        "mac": "3835296256e369cf511f8a71773c51694cf5e43c8d43734842c4de381d9a7c68"
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "eventSchema": "phaseB-authenticated-observer-event/v1",
+          "source": "fix-verifier-observer",
+          "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+          "sequence": 2,
+          "kind": "short-circuit",
+          "guardId": "checker-blind-input-coverage",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "observerPid": 81395,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "shortCircuitedAt": "2026-08-18T12:53:11.868Z",
+          "signature": "ECWnjLQpk4oGgZ+CTBJc3OdxzSVW8TRRlEeZLzTfO2Lc0PX1sYPSQJhYLhM0zCQZny5LQQlNM59OYi+AwAHeBw=="
+        },
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "b5a2d485-bfc4-4309-9acb-f77c3c732713",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 81395,
+          "childPid": 81395,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "24d6df69c066dea788e6c4da1803279d7a94d4946cce9db52a1b59940a16fd0d",
+          "startedAt": "2026-08-18T12:53:11.868Z",
+          "childExitedAt": "2026-08-18T12:53:11.879Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "778b01ba955f864e7e4f0107a5a5b7e9fa9074f9ed60771850ccff397abbe96f",
+          "mac": "5dd0d9863d0f040542b1fcbb71cdcb60f5be642e4e356aad700fd397b5254c27"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "private-channel authority authenticated exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 authenticated the instrument observer short-circuit",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:50:41.474Z",
+          "endedAt": "2026-08-18T12:52:05.974Z",
+          "durationMs": 84500,
+          "pid": 8025,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[18759 chars omitted]...\ndExitedAt\":\"2026-08-18T12:52:03.887Z\",\"emittedAfterChildExit\":true,\"mac\":\"a3f9a3434f7873eac4224a7866f206aa9fd5d07bce37b32eb52508f9110fc01c\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"f89fa5a8-8d7a-4148-ba4f-e3a931396ecb\",\"guardId\":\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49122,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"blind\"],\"argvHash\":\"9019f437d015c054afb7297e5bad2ae62de46171484207d5addb9970c2a57b59\",\"startedAt\":\"2026-08-18T12:52:03.888Z\",\"childExitedAt\":\"2026-08-18T12:52:04.202Z\",\"emittedAfterChildExit\":true,\"mac\":\"afde7a60cdcd5592c330480d906df52fd0f18af70f2191ac3a502381b04d2500\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"092d70de-a350-48a1-896a-cd6e302c00b5\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"control\",\"observerPid\":32717,\"childPid\":49147,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"control\"],\"argvHash\":\"b48b4a4900bdf814ba37e297d2093f209b358b2df5179f80ec61ef246952e459\",\"startedAt\":\"2026-08-18T12:52:04.202Z\",\"childExitedAt\":\"2026-08-18T12:52:04.502Z\",\"emittedAfterChildExit\":true,\"mac\":\"f1abe6b9064c4edcb7f029dfcc0ef138bcca53b1e98f9f140ba3d9fb4328a81b\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"fc504f24-0845-45cb-81c6-7fed218d49d5\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49157,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"blind\"],\"argvHash\":\"c86eb1c9c62606c3201fa57ffc182b62b5761ee4a440e5ea035dd2f287ae57fc\",\"startedAt\":\"2026-08-18T12:52:04.502Z\",\"childExitedAt\":\"2026-08-18T12:52:04.790Z\",\"emittedAfterChildExit\":true,\"mac\":\"0a15c64bb3cd39c9505facfac06a048ca2c671368b501c88bf0c5b380a5ff707\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"f64a6baa-10fc-453f-9474-25eb65c3bf0b\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"control\",\"observerPid\":32717,\"childPid\":49177,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"control\"],\"argvHash\":\"778ac8ca876edfba91e4edbf2f67f36f96c1c7b47b024e6f36a8a87853cc0eb6\",\"startedAt\":\"2026-08-18T12:52:04.791Z\",\"childExitedAt\":\"2026-08-18T12:52:05.083Z\",\"emittedAfterChildExit\":true,\"mac\":\"4175bd5e1cdaa0795ab9365798e857522215862b0bfbc6f0e2fd56d9fa694883\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"b63c003a-0294-485f-bdc1-f6b101fecce4\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49275,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"blind\"],\"argvHash\":\"12e12b76b7ffb84aa0226b7d29da2f21b2142b872f54c6a2f94ac2036da013d7\",\"startedAt\":\"2026-08-18T12:52:05.084Z\",\"childExitedAt\":\"2026-08-18T12:52:05.374Z\",\"emittedAfterChildExit\":true,\"mac\":\"5ef69cc75d984e705fc013a953dcc704307fd724cbf3589ee84b6e31c4c45658\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"668fb81b-bca9-48dc-a60f-436b308d8f74\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"control\",\"observerPid\":32717,\"childPid\":49356,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"control\"],\"argvHash\":\"a67de6ff637da44aa80020b5d9b6898d1ceff9d49dd2eff5d52a8df3b3fedc70\",\"startedAt\":\"2026-08-18T12:52:05.374Z\",\"childExitedAt\":\"2026-08-18T12:52:05.677Z\",\"emittedAfterChildExit\":true,\"mac\":\"9e7cf654ff662c001ef66e03ee8cef29b9fbbc9ecf618661617ee22d1965b3ae\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"f63094b6-48ea-44ba-88a5-1e11e269f8af\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49434,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"blind\"],\"argvHash\":\"4c7325f45763f837a92ee25cd51b43f322a9c36209a7cc77db2004f58ad0e3d7\",\"startedAt\":\"2026-08-18T12:52:05.678Z\",\"childExitedAt\":\"2026-08-18T12:52:05.958Z\",\"emittedAfterChildExit\":true,\"mac\":\"520175f7e09fb5879100449ac321b3b76ccb5a34dcdbef9b4910631e5cd6367e\"}\nchecker-blind-input: population=96 execution-proven=5 legacy-uncovered=91/91 new-checkers=1 protected-base=248ed7177f5b\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"956786ba-f8b7-48ef-aabe-41bf304c1136\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":32669,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":32717,\"startedAt\":\"2026-08-18T12:51:25.618Z\",\"childExitedAt\":\"2026-08-18T12:52:05.965Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"Nx1toET3n32NUJMMQHLzwkHt5/BdbAMaMixYiNWZs1iuZeQT8S6qviG+Ig4aNVQWhtbHNcfYyZmPeYXYQfnrAw==\"}\n",
+            "truncated": true,
+            "originalChars": 34759
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 33285)\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id:\n...[16496 chars omitted]...\n0h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n",
+            "truncated": true,
+            "originalChars": 32496
+          },
+          "outputSha256": "5f5df78a563465d4388222777322fe2e97e9b6922b729e1c2710a0aa3f7e8766",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "fad46f31-c9a7-499c-bed6-eb723d75836c",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 32669,
+            "childPid": 32717,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T12:51:25.618Z",
+            "childExitedAt": "2026-08-18T12:52:05.965Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "898067ab123a0d1123c5722f8fc3573c7ebe98c66ae0fd61ff5ec4879398b47d",
+            "mac": "3835296256e369cf511f8a71773c51694cf5e43c8d43734842c4de381d9a7c68"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 32669,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAHD6IJ9APK8Wqks/dWuAGuKEeCMIKGd/fu/X42wbglDE=",
+              "signature": "nFTS9ls5Xs6KLmnRAl/NgkBw2V/ABCv0kHo7yPJrVaSSQ3v9E2MGfiuEmFMOXyBpCS5jD9je7OpsWjwDXHeuDA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 32669,
+              "ppid": 8261,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 32669,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 32717,
+              "startedAt": "2026-08-18T12:51:25.618Z",
+              "signature": "co7g1MtYlVG+k3ffjWlhvkLDU2ML8CVgDwOTF6GLDkhTmesncKd1/jXkaPM/Wct4ce/cfXWjRfWcCTOBK9FmCA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 32717,
+              "ppid": 32669,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 32669,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 32717,
+            "startedAt": "2026-08-18T12:51:25.618Z",
+            "childExitedAt": "2026-08-18T12:52:05.965Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "Nx1toET3n32NUJMMQHLzwkHt5/BdbAMaMixYiNWZs1iuZeQT8S6qviG+Ig4aNVQWhtbHNcfYyZmPeYXYQfnrAw=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:52:05.976Z",
+          "endedAt": "2026-08-18T12:53:11.879Z",
+          "durationMs": 65903,
+          "pid": 49566,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ee8a0678-c034-41df-8f26-0ea7a0cd6ba4\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":81395,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAhBuTYvXriL8FVP7BPdXFDNlD00/KtDfeQRnAdlxtTtg=\",\"signature\":\"+XXDHBzWBTzzXEC2oB2DMuCo4qh0SruZpQkG9U8E1GAb08KMgDT4letAZqsmDCzAupJiqOpUsUk4SfTKRn9tAw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ee8a0678-c034-41df-8f26-0ea7a0cd6ba4\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":81395,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T12:53:11.868Z\",\"signature\":\"ECWnjLQpk4oGgZ+CTBJc3OdxzSVW8TRRlEeZLzTfO2Lc0PX1sYPSQJhYLhM0zCQZny5LQQlNM59OYi+AwAHeBw==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "5cf2295d14a3f9c210d1fd4a375a682465367b57fc785ee42ce67bbad1fae292",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 81395,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:53:11.868Z",
+            "signature": "ECWnjLQpk4oGgZ+CTBJc3OdxzSVW8TRRlEeZLzTfO2Lc0PX1sYPSQJhYLhM0zCQZny5LQQlNM59OYi+AwAHeBw=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "b5a2d485-bfc4-4309-9acb-f77c3c732713",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 81395,
+          "childPid": 81395,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "24d6df69c066dea788e6c4da1803279d7a94d4946cce9db52a1b59940a16fd0d",
+          "startedAt": "2026-08-18T12:53:11.868Z",
+          "childExitedAt": "2026-08-18T12:53:11.879Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "778b01ba955f864e7e4f0107a5a5b7e9fa9074f9ed60771850ccff397abbe96f",
+          "mac": "5dd0d9863d0f040542b1fcbb71cdcb60f5be642e4e356aad700fd397b5254c27"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 81395,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAhBuTYvXriL8FVP7BPdXFDNlD00/KtDfeQRnAdlxtTtg=",
+              "signature": "+XXDHBzWBTzzXEC2oB2DMuCo4qh0SruZpQkG9U8E1GAb08KMgDT4letAZqsmDCzAupJiqOpUsUk4SfTKRn9tAw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 81395,
+              "ppid": 49776,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+        "receipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "fad46f31-c9a7-499c-bed6-eb723d75836c",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "child-exit",
+          "observerPid": 32669,
+          "childPid": 32717,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+          "startedAt": "2026-08-18T12:51:25.618Z",
+          "childExitedAt": "2026-08-18T12:52:05.965Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+          "observerEventSequence": 3,
+          "observerEventSignatureHash": "898067ab123a0d1123c5722f8fc3573c7ebe98c66ae0fd61ff5ec4879398b47d",
+          "mac": "3835296256e369cf511f8a71773c51694cf5e43c8d43734842c4de381d9a7c68"
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 81395,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:53:11.868Z",
+            "signature": "ECWnjLQpk4oGgZ+CTBJc3OdxzSVW8TRRlEeZLzTfO2Lc0PX1sYPSQJhYLhM0zCQZny5LQQlNM59OYi+AwAHeBw=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "b5a2d485-bfc4-4309-9acb-f77c3c732713",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "short-circuit",
+            "observerPid": 81395,
+            "childPid": 81395,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "24d6df69c066dea788e6c4da1803279d7a94d4946cce9db52a1b59940a16fd0d",
+            "startedAt": "2026-08-18T12:53:11.868Z",
+            "childExitedAt": "2026-08-18T12:53:11.879Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "778b01ba955f864e7e4f0107a5a5b7e9fa9074f9ed60771850ccff397abbe96f",
+            "mac": "5dd0d9863d0f040542b1fcbb71cdcb60f5be642e4e356aad700fd397b5254c27"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:50:41.474Z",
+          "endedAt": "2026-08-18T12:52:05.974Z",
+          "durationMs": 84500,
+          "pid": 8025,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[18759 chars omitted]...\ndExitedAt\":\"2026-08-18T12:52:03.887Z\",\"emittedAfterChildExit\":true,\"mac\":\"a3f9a3434f7873eac4224a7866f206aa9fd5d07bce37b32eb52508f9110fc01c\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"f89fa5a8-8d7a-4148-ba4f-e3a931396ecb\",\"guardId\":\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49122,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"blind\"],\"argvHash\":\"9019f437d015c054afb7297e5bad2ae62de46171484207d5addb9970c2a57b59\",\"startedAt\":\"2026-08-18T12:52:03.888Z\",\"childExitedAt\":\"2026-08-18T12:52:04.202Z\",\"emittedAfterChildExit\":true,\"mac\":\"afde7a60cdcd5592c330480d906df52fd0f18af70f2191ac3a502381b04d2500\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"092d70de-a350-48a1-896a-cd6e302c00b5\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"control\",\"observerPid\":32717,\"childPid\":49147,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"control\"],\"argvHash\":\"b48b4a4900bdf814ba37e297d2093f209b358b2df5179f80ec61ef246952e459\",\"startedAt\":\"2026-08-18T12:52:04.202Z\",\"childExitedAt\":\"2026-08-18T12:52:04.502Z\",\"emittedAfterChildExit\":true,\"mac\":\"f1abe6b9064c4edcb7f029dfcc0ef138bcca53b1e98f9f140ba3d9fb4328a81b\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"fc504f24-0845-45cb-81c6-7fed218d49d5\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49157,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"blind\"],\"argvHash\":\"c86eb1c9c62606c3201fa57ffc182b62b5761ee4a440e5ea035dd2f287ae57fc\",\"startedAt\":\"2026-08-18T12:52:04.502Z\",\"childExitedAt\":\"2026-08-18T12:52:04.790Z\",\"emittedAfterChildExit\":true,\"mac\":\"0a15c64bb3cd39c9505facfac06a048ca2c671368b501c88bf0c5b380a5ff707\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"f64a6baa-10fc-453f-9474-25eb65c3bf0b\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"control\",\"observerPid\":32717,\"childPid\":49177,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"control\"],\"argvHash\":\"778ac8ca876edfba91e4edbf2f67f36f96c1c7b47b024e6f36a8a87853cc0eb6\",\"startedAt\":\"2026-08-18T12:52:04.791Z\",\"childExitedAt\":\"2026-08-18T12:52:05.083Z\",\"emittedAfterChildExit\":true,\"mac\":\"4175bd5e1cdaa0795ab9365798e857522215862b0bfbc6f0e2fd56d9fa694883\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"b63c003a-0294-485f-bdc1-f6b101fecce4\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49275,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"blind\"],\"argvHash\":\"12e12b76b7ffb84aa0226b7d29da2f21b2142b872f54c6a2f94ac2036da013d7\",\"startedAt\":\"2026-08-18T12:52:05.084Z\",\"childExitedAt\":\"2026-08-18T12:52:05.374Z\",\"emittedAfterChildExit\":true,\"mac\":\"5ef69cc75d984e705fc013a953dcc704307fd724cbf3589ee84b6e31c4c45658\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"668fb81b-bca9-48dc-a60f-436b308d8f74\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"control\",\"observerPid\":32717,\"childPid\":49356,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"control\"],\"argvHash\":\"a67de6ff637da44aa80020b5d9b6898d1ceff9d49dd2eff5d52a8df3b3fedc70\",\"startedAt\":\"2026-08-18T12:52:05.374Z\",\"childExitedAt\":\"2026-08-18T12:52:05.677Z\",\"emittedAfterChildExit\":true,\"mac\":\"9e7cf654ff662c001ef66e03ee8cef29b9fbbc9ecf618661617ee22d1965b3ae\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"9f488a0b-7658-4ab7-b56e-79d668ad5992\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"f63094b6-48ea-44ba-88a5-1e11e269f8af\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"blind\",\"observerPid\":32717,\"childPid\":49434,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/opt/homebrew/Cellar/node/25.6.1/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"blind\"],\"argvHash\":\"4c7325f45763f837a92ee25cd51b43f322a9c36209a7cc77db2004f58ad0e3d7\",\"startedAt\":\"2026-08-18T12:52:05.678Z\",\"childExitedAt\":\"2026-08-18T12:52:05.958Z\",\"emittedAfterChildExit\":true,\"mac\":\"520175f7e09fb5879100449ac321b3b76ccb5a34dcdbef9b4910631e5cd6367e\"}\nchecker-blind-input: population=96 execution-proven=5 legacy-uncovered=91/91 new-checkers=1 protected-base=248ed7177f5b\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"956786ba-f8b7-48ef-aabe-41bf304c1136\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":32669,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":32717,\"startedAt\":\"2026-08-18T12:51:25.618Z\",\"childExitedAt\":\"2026-08-18T12:52:05.965Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"Nx1toET3n32NUJMMQHLzwkHt5/BdbAMaMixYiNWZs1iuZeQT8S6qviG+Ig4aNVQWhtbHNcfYyZmPeYXYQfnrAw==\"}\n",
+            "truncated": true,
+            "originalChars": 34759
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 33285)\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:03 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id:\n...[16496 chars omitted]...\n0h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n5:52:05 AM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-dkptwA/core-generated-checker-case-worker.ts. Does the file exist?\n",
+            "truncated": true,
+            "originalChars": 32496
+          },
+          "outputSha256": "5f5df78a563465d4388222777322fe2e97e9b6922b729e1c2710a0aa3f7e8766",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "fad46f31-c9a7-499c-bed6-eb723d75836c",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 32669,
+            "childPid": 32717,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T12:51:25.618Z",
+            "childExitedAt": "2026-08-18T12:52:05.965Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "898067ab123a0d1123c5722f8fc3573c7ebe98c66ae0fd61ff5ec4879398b47d",
+            "mac": "3835296256e369cf511f8a71773c51694cf5e43c8d43734842c4de381d9a7c68"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 32669,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAHD6IJ9APK8Wqks/dWuAGuKEeCMIKGd/fu/X42wbglDE=",
+              "signature": "nFTS9ls5Xs6KLmnRAl/NgkBw2V/ABCv0kHo7yPJrVaSSQ3v9E2MGfiuEmFMOXyBpCS5jD9je7OpsWjwDXHeuDA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 32669,
+              "ppid": 8261,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 32669,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 32717,
+              "startedAt": "2026-08-18T12:51:25.618Z",
+              "signature": "co7g1MtYlVG+k3ffjWlhvkLDU2ML8CVgDwOTF6GLDkhTmesncKd1/jXkaPM/Wct4ce/cfXWjRfWcCTOBK9FmCA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 32717,
+              "ppid": 32669,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "956786ba-f8b7-48ef-aabe-41bf304c1136",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 32669,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 32717,
+            "startedAt": "2026-08-18T12:51:25.618Z",
+            "childExitedAt": "2026-08-18T12:52:05.965Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "Nx1toET3n32NUJMMQHLzwkHt5/BdbAMaMixYiNWZs1iuZeQT8S6qviG+Ig4aNVQWhtbHNcfYyZmPeYXYQfnrAw=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring",
+          "startedAt": "2026-08-18T12:52:05.976Z",
+          "endedAt": "2026-08-18T12:53:11.879Z",
+          "durationMs": 65903,
+          "pid": 49566,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ee8a0678-c034-41df-8f26-0ea7a0cd6ba4\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":81395,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAhBuTYvXriL8FVP7BPdXFDNlD00/KtDfeQRnAdlxtTtg=\",\"signature\":\"+XXDHBzWBTzzXEC2oB2DMuCo4qh0SruZpQkG9U8E1GAb08KMgDT4letAZqsmDCzAupJiqOpUsUk4SfTKRn9tAw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ee8a0678-c034-41df-8f26-0ea7a0cd6ba4\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":81395,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T12:53:11.868Z\",\"signature\":\"ECWnjLQpk4oGgZ+CTBJc3OdxzSVW8TRRlEeZLzTfO2Lc0PX1sYPSQJhYLhM0zCQZny5LQQlNM59OYi+AwAHeBw==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "5cf2295d14a3f9c210d1fd4a375a682465367b57fc785ee42ce67bbad1fae292",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 81395,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T12:53:11.868Z",
+            "signature": "ECWnjLQpk4oGgZ+CTBJc3OdxzSVW8TRRlEeZLzTfO2Lc0PX1sYPSQJhYLhM0zCQZny5LQQlNM59OYi+AwAHeBw=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "c70688aa-e360-4322-a119-63f9d6f2aad5",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "b5a2d485-bfc4-4309-9acb-f77c3c732713",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 81395,
+          "childPid": 81395,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "24d6df69c066dea788e6c4da1803279d7a94d4946cce9db52a1b59940a16fd0d",
+          "startedAt": "2026-08-18T12:53:11.868Z",
+          "childExitedAt": "2026-08-18T12:53:11.879Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "778b01ba955f864e7e4f0107a5a5b7e9fa9074f9ed60771850ccff397abbe96f",
+          "mac": "5dd0d9863d0f040542b1fcbb71cdcb60f5be642e4e356aad700fd397b5254c27"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "ee8a0678-c034-41df-8f26-0ea7a0cd6ba4",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 81395,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAhBuTYvXriL8FVP7BPdXFDNlD00/KtDfeQRnAdlxtTtg=",
+              "signature": "+XXDHBzWBTzzXEC2oB2DMuCo4qh0SruZpQkG9U8E1GAb08KMgDT4letAZqsmDCzAupJiqOpUsUk4SfTKRn9tAw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 81395,
+              "ppid": 49776,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-4oWJs0/01-pipeline-wiring",
+        "commit": "f7cd56fdf5abd1289022499a124421e7ca622ca0"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules",
+    "prepared": true
+  }
+}

--- a/tests/unit/checker-blind-input-ratchet.test.ts
+++ b/tests/unit/checker-blind-input-ratchet.test.ts
@@ -462,6 +462,12 @@ describe('P3 — the ratchet own test rejects all four guard sabotages', () => {
   const sourcePath = path.join(ROOT, 'scripts', 'lib', 'checker-blind-input-ratchet.mjs');
   const source = fs.readFileSync(sourcePath, 'utf8');
 
+  function hasNodeTestSummary(output: string, label: 'tests' | 'fail', count: number): boolean {
+    const tap = `# ${label} ${count}`;
+    const spec = `ℹ ${label} ${count}`;
+    return output.split(/\r?\n/).some((line) => line.trim() === tap || line.trim() === spec);
+  }
+
   function guardOwnSuite(modulePath: string, dir: string) {
     const suite = path.join(dir, 'guard-own.test.mjs');
     fs.writeFileSync(suite, `
@@ -569,8 +575,8 @@ test('genuinely covered population passes', () => {
       const output = decidingOutput(result);
       console.log(`P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=${result.status}\n${output}`);
       expect(result.status).not.toBe(0);
-      expect(output).toContain('# tests 4');
-      expect(output).toContain('# fail 3');
+      expect(hasNodeTestSummary(output, 'tests', 4)).toBe(true);
+      expect(hasNodeTestSummary(output, 'fail', 3)).toBe(true);
       expect(output).toMatch(/AssertionError|Expected values to be strictly equal/);
     } finally {
       SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'checker-p3:hollow' });


### PR DESCRIPTION
## Summary

- diagnose why the checker-blind-input coverage suite exited 1 even though each declared blind case behaved correctly
- make the P3 hollow-body harness recognize both TAP and Node spec-reporter summary lines
- record the before/after diagnosis and an authenticated wiring-only rerun using the original certified H1 instrument

## ELI16

The safety checks were working, but one test expected Node to spell its summary in exactly one format. Newer Node printed the same counts with a different prefix, so the outer harness mislabeled a successful sabotage rejection as a failure. This change accepts both reporter formats while still requiring the sabotaged guard to fail for the real reasons.

## Verification

- `tests/unit/checker-blind-input-ratchet.test.ts`: 18/18 passed
- normal commit lint gate passed twice
- all five control/blind pairs exited 0 under their independent oracle
- original certified H1 instrument SHA-256: `584a0a0b7248c4bede3f99e58f369db2183ca298fc5c1209862a6e3dc41edd72`
- post-repair deciding line: `[fix-verifier-wiring] authenticated guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs childPid=32717 childExit=0`
- evidence records `wiring.outcome=proven`, `rung=wired`, one positive guard receipt, and zero C3 guard receipts

## UX impact

No end-user UI or runtime behavior changes. Test output interpretation is portable across supported Node reporter formats.

## Boundaries

- stacked on `phaseb/f1-blind-checker-ratchet`
- no checker behavior or declared blind case changed
- no authentication, instrument, enforcement-evidence, model-registry, CI, or approver-key changes
- pull request only; do not merge or enable auto-merge
