### PR TITLE
test: read checker results structurally

### DIFF
--- a/scratchpad/phaseB/REPORT-W5.md
+++ b/scratchpad/phaseB/REPORT-W5.md
@@ -1,0 +1,399 @@
+# Phase B Lane W5 — the two previously unrun wiring proofs
+
+> **Append-only chronology:** entries are recorded in execution order.
+
+## 2026-08-18 05:53:42 -0700 (PDT) — wiring-only measurement
+
+### Measurement identity and dependency
+
+Both measurements ran from branch `phaseb/w4-convert-wiring-proofs` at head
+`97e3ccb878463229745a98607213dc0933ed1381`. This is the unmerged W4 amendment
+that resolves both declared and observed entry spellings with `fs.realpathSync`
+and requires exact equality of the resulting paths.
+
+```text
+e49d10fd4d98a93a8011efa6807d180cab56fdf5a7745744879bad7c0afb4897  scratchpad/phaseB/fix-verifier.mjs
+6534ed0983b733311d343c23b60bc70d13648ca9d911a136875504d20d6e4817  scratchpad/phaseB/authenticated-execution-receipt.mjs
+a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677  scratchpad/phaseB/fix-verifier.manifest.json
+```
+
+The instrument and the W4 comparison amendment are both under independent
+judgement. These results are provisional on both; this report does not claim
+that either has passed.
+
+For both measurements, the instrument server-resolved and fetched protected
+`refs/heads/main` at
+`248ed7177f5bf416aa7bdad9763741478195e1fc`, with workflow SHA-256
+`be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71`.
+Both target worktrees were clean at measurement start. The scope was
+`wiring-only`.
+
+### Fail-open guard — `testing-integrity-route-enforcement`
+
+Target head:
+`fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf`. The protected merge base was
+`24f1bb4f76d8303f2124131743aa3b3d90bc972d`.
+
+The positive and C3 pipeline passes each exited 1 before the declared
+`scripts/lint-testing-integrity.mjs` child ran. Each pass produced zero observer
+candidate lines, zero authenticated observer events, and zero receipts.
+
+The instrument verdict line was, verbatim:
+
+```text
+    "outcome": "unknown",
+```
+
+The deciding pipeline line was the same in both passes (terminal color codes
+removed, text otherwise verbatim):
+
+```text
+  FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.
+```
+
+Result: **UNKNOWN**. The instrument could not observe the declared guard child,
+so this is not promoted to NOT-PROVEN. Per the lane brief, the run stopped on
+this guard; nothing was changed to make the pipeline proceed.
+
+### Checker-instrument guard — `checker-blind-input-coverage`
+
+Target head:
+`2f3cd8e16c7608fcd75c12f51623783f3da8824d`. The protected merge base was
+`e5085f969d604cf067383ab3446f5f49c7dccf74`.
+
+The positive and C3 pipeline passes each exited 1 before the declared
+`scripts/lint-checker-blind-input-coverage.mjs` child ran. Each pass produced
+zero observer candidate lines, zero authenticated observer events, and zero
+receipts.
+
+The instrument verdict line was, verbatim:
+
+```text
+    "outcome": "unknown",
+```
+
+The deciding pipeline line was the same in both passes (terminal color codes
+removed, text otherwise verbatim):
+
+```text
+  FIND STALENESS: model registry last reviewed 2026-07-03 (46d ago) exceeds the 45d window. Re-review each capable/latest pin against current frontier, update frontierAllowlist if a model has moved, then bump lastReviewedAt.
+```
+
+Result: **UNKNOWN**. The instrument could not observe the declared guard child,
+so this is not promoted to NOT-PROVEN. Per the lane brief, the run stopped on
+this guard; nothing was changed to make the pipeline proceed.
+
+The protected-main copy of the model registry is current, but neither guard is
+present at protected main; the measurements necessarily execute their lane
+heads, whose candidate trees still carry the stale review metadata shown by the
+real lint pipeline. No approver key was created, no CI configuration, registry
+manifest, gate, guard, instrument, adapter, or test was modified, and no branch,
+commit, pull request, or merge was created.
+
+### Evidence stamps
+
+```text
+50993c7f3255ae23115b8fb5fe6433ff097a22a6332876ded8d0527507736742  scratchpad/phaseB/evidence/W5-testing-integrity-route-enforcement.json
+319e9bf70af676e47823db39ab28b468b2420b425362e6434545cda8552bea2b  scratchpad/phaseB/evidence/W5-checker-blind-input-coverage.json
+```
+
+## 2026-08-18 06:12:13 -0700 (PDT) — W5-B branch refresh and rerun
+
+### Branch refreshes
+
+The server-resolved protected base remained
+`248ed7177f5bf416aa7bdad9763741478195e1fc`. Both guard worktrees were clean.
+Each branch rebased cleanly onto that exact protected-main commit; no conflict
+was resolved and no content edit was made.
+
+- `phase-b1.2-testing-integrity` rebased from observed upstream head
+  `fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf` to
+  `e5a6eebad7fb04bfaac0f8e168dbf7e833ccfe32`. Its one stable patch ID remained
+  `115510504fab0747fd289f32c93c3bd52cac3aca`. The push used
+  `--force-with-lease=refs/heads/phase-b1.2-testing-integrity:fbb4ec9d0e68a9a80d23f4df2413a7ac8e5c10cf`,
+  and a post-push `ls-remote` resolved the upstream branch to the new head.
+- `phaseb/s3-no-blind-clean` rebased from observed upstream head
+  `2f3cd8e16c7608fcd75c12f51623783f3da8824d` to
+  `e1937a91aa2000b36a2c2177417125394b020263`. Its three stable patch IDs remained,
+  in order, `c6b4db0ffb0bfef757d8f2d75bb2d095d2b9950c`,
+  `971037a815fabb056de528b9568bf0ceb73cb629`, and
+  `4b277be55bfffc6fe4a8d8f689b166914f809a49`. The push used
+  `--force-with-lease=refs/heads/phaseb/s3-no-blind-clean:2f3cd8e16c7608fcd75c12f51623783f3da8824d`,
+  and a post-push `ls-remote` resolved the upstream branch to the new head.
+
+No manifest, freshness gate, CI configuration, guard, test, adapter, or
+instrument was edited. No merge or new pull request was created.
+
+### Unchanged measurement identity
+
+Both reruns were `wiring-only` under W4 amendment branch head
+`97e3ccb878463229745a98607213dc0933ed1381`, instrument SHA-256
+`e49d10fd4d98a93a8011efa6807d180cab56fdf5a7745744879bad7c0afb4897`,
+authenticated-receipt SHA-256
+`6534ed0983b733311d343c23b60bc70d13648ca9d911a136875504d20d6e4817`,
+and manifest SHA-256
+`a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677`.
+The instrument and W4 comparison amendment remain under independent judgement;
+these results are provisional on both and do not claim either has passed.
+
+### Fail-open guard after rebase — `testing-integrity-route-enforcement`
+
+Target head: `e5a6eebad7fb04bfaac0f8e168dbf7e833ccfe32`. Protected base and
+merge base: `248ed7177f5bf416aa7bdad9763741478195e1fc`.
+
+The positive real lint wrapper exited 0. The exact declared
+`scripts/lint-testing-integrity.mjs` child emitted three authenticated observer
+events, exited 0, and produced exactly one authenticated child-exit receipt. C3
+kept the real wrapper at exit 0, authenticated the exact-child short circuit,
+and produced zero guard execution receipts.
+
+The instrument verdict line was, verbatim:
+
+```text
+[fix-verifier-wiring] authenticated guard=testing-integrity-route-enforcement entry=scripts/lint-testing-integrity.mjs childPid=79986 childExit=0
+```
+
+Result: wiring **PROVEN**, wiring-only rung **WIRED**.
+
+### Checker-instrument guard after rebase — `checker-blind-input-coverage`
+
+Target head: `e1937a91aa2000b36a2c2177417125394b020263`. Protected base and
+merge base: `248ed7177f5bf416aa7bdad9763741478195e1fc`.
+
+The positive real lint wrapper reached the exact declared
+`scripts/lint-checker-blind-input-coverage.mjs` child. All three observer events
+authenticated, including its signed child exit 1, but a successful child-exit
+receipt could not be minted. C3 exited 0, authenticated the exact-child short
+circuit, and produced zero guard execution receipts.
+
+The instrument verdict line was, verbatim:
+
+```text
+    "outcome": "unknown",
+```
+
+The deciding checker line was, verbatim:
+
+```text
+checker-blind-input: NOT-PROVEN — executable blind cases exited 1
+```
+
+The named fixture failure was:
+
+```text
+     → expected '✖ empty population is not proof (11.2…' to contain '# tests 4'
+```
+
+Node 25 rendered the test-runner summary with `ℹ tests 4`, not the fixture's
+legacy `# tests 4` spelling. Result: wiring **UNKNOWN**, wiring-only rung
+**EXISTS**. The declared checker did run and authenticate, but exited 1; the
+pipeline and checker were not adjusted, and the verdict is not promoted.
+
+### W5-B evidence stamps
+
+```text
+184472d6ec3c6a3f28a2bd9e44fccd6fbbbdc30d5b48c5f9eeb5c72fc61b0c91  scratchpad/phaseB/evidence/W5B-testing-integrity-route-enforcement.json
+fedc4a633edc0db816f923a4478b6247944532d192ed8fbee00c8c1114b5d31b  scratchpad/phaseB/evidence/W5B-checker-blind-input-coverage.json
+```
+
+## 2026-08-18 06:17:47 -0700 (PDT) — F3 diagnosis before repair
+
+F3 independently reproduced the checker-instrument child failure at rebased target
+`e1937a91aa2000b36a2c2177417125394b020263` before changing source. The focused
+P3d case exited 1.
+
+### Candidate 1 — genuine checker refusal because the property does not hold: ruled out
+
+The P3d fixture deliberately hollows the guard into always returning a passing
+verdict. The independent guard-own process correctly rejected that hollow: its
+process exited 1, the three cases that must reject the hollow failed, and the one
+genuinely covered control passed:
+
+```text
+P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1
+✖ empty population is not proof
+✖ unknown coverage id is rejected
+✖ new uncovered checker is named and rejected
+✔ genuinely covered population passes
+ℹ tests 4
+ℹ pass 1
+ℹ fail 3
+```
+
+The outer test also accepted the required nonzero status before reaching its
+summary assertions. This is the evidence that the checker property held; there
+is no genuine guard finding to preserve as a red result.
+
+### Candidate 2 — checker/harness output-format disagreement: ruled in
+
+The only outer assertion failure was the legacy reporter spelling:
+
+```text
+AssertionError: expected '✖ empty population is not proof ...' to contain '# tests 4'
+- # tests 4
++ ℹ tests 4
+```
+
+Source deciding lines:
+
+```text
+expect(result.status).not.toBe(0);
+expect(output).toContain('# tests 4');
+expect(output).toContain('# fail 3');
+```
+
+Node `v25.6.1` emitted the semantically identical counts as `ℹ tests 4` and
+`ℹ fail 3`. The harness therefore could not read a successful P3 rejection.
+
+### Candidate 3 — environment/dependency failure: ruled out
+
+The W5-B full child run reached the declared checker, authenticated all three
+observer events, executed the entire targeted file, and reported exactly one
+failed outer test with twelve passed:
+
+```text
+Test Files  1 failed (1)
+Tests  1 failed | 12 passed (13)
+FIX_VERIFIER_OBSERVER_EVENT ... "kind":"child-exit" ... "childExitCode":1
+```
+
+The only environment notice was explicitly non-gating:
+
+```text
+This is a notice, not a gate: nothing was blocked or skipped because of it.
+```
+
+No deciding output named SQLite, an import failure, a missing dependency, a
+timeout, or an observer/authentication error.
+
+### Classification and scope decision
+
+Classification: **guard-owned harness-format bug**. The cause is the reporter-
+specific assertions in `tests/unit/checker-blind-input-ratchet.test.ts`, which
+belongs to this guard's own harness. Repair is in scope. The pre-repair wiring
+result remains honest:
+
+```text
+checker-blind-input: NOT-PROVEN — executable blind cases exited 1
+    "outcome": "unknown",
+```
+
+F3 will not change the checker predicate, declared cases, verifier instrument,
+path comparison, authentication, signing, sequencing, receipt binding,
+manifest, adapter, model registry, CI configuration, or another lane's work.
+
+## 2026-08-18 06:21:34 -0700 (PDT) — F3 capacity checkpoint
+
+The operator directed F3 to stand down because concurrent proof-lane test load
+was repeatedly destabilizing the server and outbound messaging. This is a
+capacity pause, not a code or diagnosis blocker.
+
+Completed and durable in worktree branch `phaseb/f3-checker-instrument-harness`:
+
+- Pre-repair diagnosis above is recorded.
+- The only source edit is in the guard-owned
+  `tests/unit/checker-blind-input-ratchet.test.ts` harness.
+- It adds exact-line recognition for both TAP (`# tests 4`, `# fail 3`) and
+  Node spec-reporter (`ℹ tests 4`, `ℹ fail 3`) summaries.
+- It still requires the hollow guard-own process to exit nonzero and still
+  requires assertion-failure output. The checker predicate and cases are
+  unchanged.
+
+Post-repair verification had entered the repository's single suite-lane queue
+but never acquired the slot. The queue reported an active holder and explicitly
+said it was not hung. At the operator's direction the waiting process was
+interrupted with Ctrl-C before either the focused or full post-repair run began.
+Therefore no post-repair pass claim is made.
+
+Remaining work after an explicit restart:
+
+1. Run the focused P3d fixture and the full checker-blind-input ratchet test.
+2. If green, run normal lint/commit gates without bypass.
+3. Re-run the checker-instrument wiring-only proof using the repaired W4-R
+   verifier and the same target, record the verdict line verbatim, and append
+   the evidence hash here.
+4. Open a pull request only; do not merge or enable auto-merge.
+
+No commit, push, pull request, merge, or new proof run was started after the
+stand-down instruction.
+
+## 2026-08-18 06:37:40 -0700 (PDT) — F3-R repair and property control
+
+### Reader choice
+
+F3-R chose exact dual-spelling recognition rather than changing the child
+protocol: the harness now accepts either a complete TAP count line (`# tests 4`
+and `# fail 3`) or the current Node spec-reporter equivalent (`ℹ tests 4` and
+`ℹ fail 3`). It splits output into lines, trims each line, and requires exact
+line equality; substrings, arbitrary prefixes, missing counts, and different
+counts do not satisfy it.
+
+This is the smallest guard-owned repair. A new structured child protocol would
+change more of the independent control surface and create a second result
+channel to authenticate. The dual exact-line reader handles the two observed
+Node renderers while preserving the existing child process, four real tests,
+exit status, expected failure count, and assertion evidence.
+
+### WHAT-did-not-weaken control
+
+The existing P3d control replaces the guard body with an always-passing verdict,
+so the underlying blind-input property genuinely does not hold. After the
+reader repair, that isolated guard-own process still failed exactly the three
+required refusal cases and passed only the genuinely covered control. Deciding
+output, verbatim apart from timing values omitted from the individual case
+labels:
+
+```text
+P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1
+✖ empty population is not proof
+✖ unknown coverage id is rejected
+✖ new uncovered checker is named and rejected
+✔ genuinely covered population passes
+ℹ tests 4
+ℹ pass 1
+ℹ fail 3
+```
+
+The output also retained the three underlying `AssertionError
+[ERR_ASSERTION]` records. The repaired outer harness passed because it correctly
+read this failed child; the child itself did not become green.
+
+### Local verification before proof
+
+```text
+focused P3d: Test Files 1 passed (1); Tests 1 passed | 12 skipped (13)
+full guard suite: Test Files 1 passed (1); Tests 13 passed (13)
+```
+
+The non-gating `better-sqlite3` notice remained unrelated and explicitly stated
+that nothing was blocked or skipped because of it.
+
+## 2026-08-18 06:38:16 -0700 (PDT) — F3-R second capacity checkpoint
+
+The operator again directed all controlled proof work to stand down because the
+server supervisor was restarting the server before boot could complete under
+concurrent load. This is solely a capacity pause.
+
+Durable state on branch `phaseb/f3-checker-instrument-harness`:
+
+- Diagnosis, reader choice, and the WHAT-did-not-weaken control are recorded
+  above.
+- The guard-owned dual-spelling repair is complete.
+- Focused P3d verification passed 1/1; its intentionally hollow child still
+  exited 1 with `ℹ tests 4`, `ℹ pass 1`, `ℹ fail 3`, and three assertion errors.
+- The full guard suite passed 13/13.
+- The repair and this existing W5 record were staged for commit.
+- The normal commit gate had started but was interrupted with Ctrl-C immediately
+  on the stand-down instruction. No commit was created and no hook was bypassed.
+
+Remaining work after another explicit restart:
+
+1. Re-run the normal commit gate to completion without bypass.
+2. Run the checker-instrument wiring-only proof against the committed F3-R head
+   using the current repaired W4-R instrument.
+3. Append the exact proof verdict line and evidence hash to this report, then
+   commit through normal hooks.
+4. Push and open a pull request only; do not merge or enable auto-merge.
+
+No wiring proof, push, pull request, merge, or auto-merge action was started in
+this resumed interval.

--- a/scratchpad/phaseB/REPORT-W5.md
+++ b/scratchpad/phaseB/REPORT-W5.md
@@ -486,3 +486,29 @@ full guard suite: Test Files 1 passed (1); Tests 13 passed (13)
 
 The non-gating `better-sqlite3` notice remained unrelated and explicitly said
 nothing was blocked or skipped because of it.
+
+## 2026-08-18 07:12:35 -0700 (PDT) — F4 authenticated wiring result
+
+F4 measured clean committed target
+`e64e3a2497d59a4d3aec0f8eb4e04589e4912f58` with the current W4-R
+regular-file instrument SHA-256
+`c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a`.
+Protected main remained
+`248ed7177f5bf416aa7bdad9763741478195e1fc`, and target porcelain was
+unchanged by measurement.
+
+The real protected-workflow lint exited 0. Its observer authenticated the
+ordered ready, child-start, and child-exit events for the declared regular-file
+entry and minted exactly one post-child receipt. The C3 wrapper authenticated
+its own short-circuit event, exited 0, and minted zero guard-execution receipts.
+The verdict line, verbatim, was:
+
+```text
+[fix-verifier-wiring] authenticated guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs childPid=27613 childExit=0
+```
+
+After verdict: wiring **PROVEN**, wiring-only rung **WIRED**.
+
+Evidence:
+`scratchpad/phaseB/evidence/F4-checker-blind-input-coverage.json`, SHA-256
+`9e4c5b82810b06792fafe3d1b85fe0a0a86d49b1ba110ba8841ee4a3fcbb9627`.

--- a/scratchpad/phaseB/REPORT-W5.md
+++ b/scratchpad/phaseB/REPORT-W5.md
@@ -397,3 +397,35 @@ Remaining work after another explicit restart:
 
 No wiring proof, push, pull request, merge, or auto-merge action was started in
 this resumed interval.
+
+## 2026-08-18 06:46:07 -0700 (PDT) — F3-R authenticated wiring result
+
+The normal commit gate completed without bypass and ran the real guard lint to
+success:
+
+```text
+checker-blind-input: executable blind cases passed
+```
+
+F3-R then ran the checker-instrument wiring-only proof against clean committed
+target `52bc14b6b26044a431d22e8608f017d05c7d95cf`, using the current repaired W4-R
+instrument SHA-256
+`c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a`.
+Protected main resolved to
+`248ed7177f5bf416aa7bdad9763741478195e1fc`, and the target remained unchanged
+by measurement.
+
+The real positive lint run authenticated three signed observer events, exited
+0, and minted exactly one authenticated post-child receipt. C3 authenticated
+the observer short-circuit and minted zero guard execution receipts. The proof
+verdict line, verbatim, was:
+
+```text
+[fix-verifier-wiring] authenticated guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs childPid=6097 childExit=0
+```
+
+After verdict: wiring **PROVEN**, wiring-only rung **WIRED**.
+
+Evidence:
+`scratchpad/phaseB/evidence/F3R-checker-blind-input-coverage.json`, SHA-256
+`f800130157168f2d3871e8d6c2e140b94cd1b734c61730b234aa9ddefa83d35d`.

--- a/scratchpad/phaseB/REPORT-W5.md
+++ b/scratchpad/phaseB/REPORT-W5.md
@@ -429,3 +429,60 @@ After verdict: wiring **PROVEN**, wiring-only rung **WIRED**.
 Evidence:
 `scratchpad/phaseB/evidence/F3R-checker-blind-input-coverage.json`, SHA-256
 `f800130157168f2d3871e8d6c2e140b94cd1b734c61730b234aa9ddefa83d35d`.
+
+## 2026-08-18 07:05:36 -0700 (PDT) — F4 structured reader repair
+
+The independent F4 judgment accepted the F3-R scope, negative control, and
+repaired-boundary wiring, but found the reader still coupled to cosmetic Node
+test-runner decoration. F4 removed all TAP/spec summary-line matching from the
+decision path.
+
+The guard-owned child now runs with two independent reporters. A custom
+machine reporter emits schema `checker-blind-input/guard-own-results-v1` from
+Node's `test:complete` events; TAP or spec remains a human-only presentation
+channel. The reader rejects malformed JSON, the wrong schema, unknown root or
+test fields, invalid test numbers, missing identities, invalid outcomes, and
+invalid failure codes. Node also emits a synthetic file aggregate to custom
+reporters; it is excluded by its structural event identity (`name === file`),
+leaving the complete leaf-test population. No rendered text participates in
+the verdict.
+
+The hollow-body control requires exact ordered identity and outcome equality:
+
+```json
+{"schema":"checker-blind-input/guard-own-results-v1","tests":[{"testNumber":1,"identity":"empty population is not proof","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":2,"identity":"unknown coverage id is rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":3,"identity":"new uncovered checker is named and rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":4,"identity":"genuinely covered population passes","outcome":"pass","failureCode":null}]}
+```
+
+This preserves and strengthens all three substantive checks: both real child
+runs exit 1; the exact array contains four tests; and exactly the three named
+refusal tests fail with `ERR_ASSERTION`. An unrelated added, removed, renamed,
+reordered, or outcome-changed test makes exact equality fail.
+
+### Decoration-invariance control
+
+The same hollow guard ran once with the old TAP renderer and once with the
+current spec renderer. Both independent structured results were byte-for-byte
+equivalent after schema validation and produced the same rejection verdict.
+Deciding excerpts, verbatim:
+
+```text
+P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1
+F4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={"schema":"checker-blind-input/guard-own-results-v1","tests":[{"testNumber":1,"identity":"empty population is not proof","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":2,"identity":"unknown coverage id is rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":3,"identity":"new uncovered checker is named and rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":4,"identity":"genuinely covered population passes","outcome":"pass","failureCode":null}]}
+# tests 4
+# pass 1
+# fail 3
+F4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={"schema":"checker-blind-input/guard-own-results-v1","tests":[{"testNumber":1,"identity":"empty population is not proof","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":2,"identity":"unknown coverage id is rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":3,"identity":"new uncovered checker is named and rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":4,"identity":"genuinely covered population passes","outcome":"pass","failureCode":null}]}
+ℹ tests 4
+ℹ pass 1
+ℹ fail 3
+```
+
+Local verification:
+
+```text
+focused decoration control: Test Files 1 passed (1); Tests 1 passed | 12 skipped (13)
+full guard suite: Test Files 1 passed (1); Tests 13 passed (13)
+```
+
+The non-gating `better-sqlite3` notice remained unrelated and explicitly said
+nothing was blocked or skipped because of it.

--- a/scratchpad/phaseB/evidence/F3R-checker-blind-input-coverage.json
+++ b/scratchpad/phaseB/evidence/F3R-checker-blind-input-coverage.json
@@ -1,0 +1,929 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T13:45:54.769Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs",
+      "sha256": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77"
+    }
+  },
+  "guardId": "checker-blind-input-coverage",
+  "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f3-checker-instrument-harness",
+    "requestedCommit": "52bc14b6b26044a431d22e8608f017d05c7d95cf",
+    "commit": "52bc14b6b26044a431d22e8608f017d05c7d95cf",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-checker-blind-input-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lib/checker-blind-input-ratchet.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/checker-blind-input-ratchet.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lint-llm-attribution.js",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/checker-blind-input-cases.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-authenticated-observer-events-hmac-receipt",
+      "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+      "receipt": {
+        "schema": "phaseB-authenticated-execution-receipt/v1",
+        "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+        "issuer": "fix-verifier:checker-blind-input-coverage",
+        "nonce": "b2190c48-b73a-4765-9196-55031bfdf972",
+        "guardId": "checker-blind-input-coverage",
+        "kind": "child-exit",
+        "observerPid": 6020,
+        "childPid": 6097,
+        "childExitCode": 0,
+        "signal": null,
+        "argv": [
+          "scripts/lint-checker-blind-input-coverage.mjs"
+        ],
+        "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+        "startedAt": "2026-08-18T13:44:16.073Z",
+        "childExitedAt": "2026-08-18T13:44:52.032Z",
+        "emittedAfterChildExit": true,
+        "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+        "observerEventSequence": 3,
+        "observerEventSignatureHash": "068de2daa262a58ae4549af785c9a954d42228dae708ee76411b4c62f10d6a59",
+        "mac": "6f6af71e6ad0624e376f37c26b4efbedee6a4ac9d7751445b0a545200910f8c6"
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "eventSchema": "phaseB-authenticated-observer-event/v1",
+          "source": "fix-verifier-observer",
+          "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+          "sequence": 2,
+          "kind": "short-circuit",
+          "guardId": "checker-blind-input-coverage",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "observerPid": 62917,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "shortCircuitedAt": "2026-08-18T13:45:54.576Z",
+          "signature": "lpnOPPSKAN8c0gg2CWhGjlursU+7MPxDJx4oMdg1z+WKRzCTQKSYKgkNIhAxtLjZo2vraArvNLsfi1qcZ+vVDg=="
+        },
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "d02ac889-b5c2-4042-aff1-f0c2a84f2169",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 62917,
+          "childPid": 62917,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "0bd892c2b6c9d8cb06fe204b3a789c99035121f344cabc3063cdcbde4e719d5d",
+          "startedAt": "2026-08-18T13:45:54.576Z",
+          "childExitedAt": "2026-08-18T13:45:54.585Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "4526a5b4cbef1e467cfe4d57ddd08adf42985efc54aa778a54a2b07b06993321",
+          "mac": "01fed297e384d1444d9de0f6041fce73d936c7a10f35228bd3826e459759ed69"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "private-channel authority authenticated exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 authenticated the instrument observer short-circuit",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:43:18.842Z",
+          "endedAt": "2026-08-18T13:44:52.040Z",
+          "durationMs": 93198,
+          "pid": 67964,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[8429 chars omitted]...\nders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qw3sXz/guard-own.test.mjs (122.072042ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 133.044542\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qw3sXz/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qw3sXz/guard-own.test.mjs (122.072042ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs (142.123125ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 153.32575\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs (142.123125ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs (151.643417ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 162.829542\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs (151.643417ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1\n✖ empty population is not proof (4.84775ms)\n✖ unknown coverage id is rejected (0.310875ms)\n✖ new uncovered checker is named and rejected (0.184042ms)\n✔ genuinely covered population passes (0.171875ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 171.46825\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-4IXvEG/guard-own.test.mjs:5:1\n✖ empty population is not proof (4.84775ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-4IXvEG/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.start (node:internal/test_runner/test:1015:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-4IXvEG/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.310875ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-4IXvEG/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-4IXvEG/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.184042ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-4IXvEG/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\n ✓ tests/unit/checker-blind-input-ratchet.test.ts (13 tests) 1264ms\n\n Test Files  1 passed (1)\n      Tests  13 passed (13)\n   Start at  06:44:17\n   Duration  34.78s (transform 365ms, setup 4ms, collect 133ms, tests 1.26s, environment 0ms, prepare 90ms)\n\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"6beb4263-77b5-4c47-82c0-80a16365cbed\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":6020,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":6097,\"startedAt\":\"2026-08-18T13:44:16.073Z\",\"childExitedAt\":\"2026-08-18T13:44:52.032Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"lRlPTzfX2gSs51EL/rHjgejSWPXkZohQcTKzwfO237b1hvut8t5HUzYPF2SWJijKas8XIoMi/xAi7jdBmvW3AA==\"}\n",
+            "truncated": true,
+            "originalChars": 24429
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 6370)\n",
+            "truncated": false,
+            "originalChars": 1615
+          },
+          "outputSha256": "d053ade55be1022c27f79ef32f1823e1a275e5561419d5a3dedc1474c04cf23f",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "b2190c48-b73a-4765-9196-55031bfdf972",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 6020,
+            "childPid": 6097,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T13:44:16.073Z",
+            "childExitedAt": "2026-08-18T13:44:52.032Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "068de2daa262a58ae4549af785c9a954d42228dae708ee76411b4c62f10d6a59",
+            "mac": "6f6af71e6ad0624e376f37c26b4efbedee6a4ac9d7751445b0a545200910f8c6"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 6020,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAsAX1hKsBrkahhGIilHsv44IOriY79jOv0zT9IaI/k1w=",
+              "signature": "SUwt633cMn/R2nhNloNXNHdKVqdCUmjpc8vGPJwP8odxUp7Y/IARigD+9R3OCz7iuLxIl/GYziLBtHoRigCKDg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 6020,
+              "ppid": 68288,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 6020,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 6097,
+              "startedAt": "2026-08-18T13:44:16.073Z",
+              "signature": "4NNVvrJxISwK8P6b88HHH9rMDyNiXsa3vXTCQgALRPNRRaaFK/AgSgRS44KcE/ABul6XVY5ewp1JKNWFQaRwBg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 6097,
+              "ppid": 6020,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 6020,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 6097,
+            "startedAt": "2026-08-18T13:44:16.073Z",
+            "childExitedAt": "2026-08-18T13:44:52.032Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "lRlPTzfX2gSs51EL/rHjgejSWPXkZohQcTKzwfO237b1hvut8t5HUzYPF2SWJijKas8XIoMi/xAi7jdBmvW3AA=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:44:52.042Z",
+          "endedAt": "2026-08-18T13:45:54.585Z",
+          "durationMs": 62543,
+          "pid": 27100,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"e0b7de1c-5ef2-4930-a90c-b070e8dde062\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":62917,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAn1If3oS4HEeyOmMyHuDNg9rKfHZoolN0zLuJc6vwGqQ=\",\"signature\":\"j/srClQUfYT5dpCzr2OXVoD8Es8sYC/Zd1GbegPivZom1ODJB7qXBxBKrhygWZC+ukBw2d6G9pWfZLO7UdGsDw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"e0b7de1c-5ef2-4930-a90c-b070e8dde062\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":62917,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T13:45:54.576Z\",\"signature\":\"lpnOPPSKAN8c0gg2CWhGjlursU+7MPxDJx4oMdg1z+WKRzCTQKSYKgkNIhAxtLjZo2vraArvNLsfi1qcZ+vVDg==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "da449880e673cfb642623f4b058b03978f4002f77402bbc49682bbf59e25e486",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 62917,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T13:45:54.576Z",
+            "signature": "lpnOPPSKAN8c0gg2CWhGjlursU+7MPxDJx4oMdg1z+WKRzCTQKSYKgkNIhAxtLjZo2vraArvNLsfi1qcZ+vVDg=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "d02ac889-b5c2-4042-aff1-f0c2a84f2169",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 62917,
+          "childPid": 62917,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "0bd892c2b6c9d8cb06fe204b3a789c99035121f344cabc3063cdcbde4e719d5d",
+          "startedAt": "2026-08-18T13:45:54.576Z",
+          "childExitedAt": "2026-08-18T13:45:54.585Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "4526a5b4cbef1e467cfe4d57ddd08adf42985efc54aa778a54a2b07b06993321",
+          "mac": "01fed297e384d1444d9de0f6041fce73d936c7a10f35228bd3826e459759ed69"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 62917,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAn1If3oS4HEeyOmMyHuDNg9rKfHZoolN0zLuJc6vwGqQ=",
+              "signature": "j/srClQUfYT5dpCzr2OXVoD8Es8sYC/Zd1GbegPivZom1ODJB7qXBxBKrhygWZC+ukBw2d6G9pWfZLO7UdGsDw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 62917,
+              "ppid": 27367,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+        "receipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "b2190c48-b73a-4765-9196-55031bfdf972",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "child-exit",
+          "observerPid": 6020,
+          "childPid": 6097,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+          "startedAt": "2026-08-18T13:44:16.073Z",
+          "childExitedAt": "2026-08-18T13:44:52.032Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+          "observerEventSequence": 3,
+          "observerEventSignatureHash": "068de2daa262a58ae4549af785c9a954d42228dae708ee76411b4c62f10d6a59",
+          "mac": "6f6af71e6ad0624e376f37c26b4efbedee6a4ac9d7751445b0a545200910f8c6"
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 62917,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T13:45:54.576Z",
+            "signature": "lpnOPPSKAN8c0gg2CWhGjlursU+7MPxDJx4oMdg1z+WKRzCTQKSYKgkNIhAxtLjZo2vraArvNLsfi1qcZ+vVDg=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "d02ac889-b5c2-4042-aff1-f0c2a84f2169",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "short-circuit",
+            "observerPid": 62917,
+            "childPid": 62917,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "0bd892c2b6c9d8cb06fe204b3a789c99035121f344cabc3063cdcbde4e719d5d",
+            "startedAt": "2026-08-18T13:45:54.576Z",
+            "childExitedAt": "2026-08-18T13:45:54.585Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "4526a5b4cbef1e467cfe4d57ddd08adf42985efc54aa778a54a2b07b06993321",
+            "mac": "01fed297e384d1444d9de0f6041fce73d936c7a10f35228bd3826e459759ed69"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:43:18.842Z",
+          "endedAt": "2026-08-18T13:44:52.040Z",
+          "durationMs": 93198,
+          "pid": 67964,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[8429 chars omitted]...\nders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qw3sXz/guard-own.test.mjs (122.072042ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 133.044542\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qw3sXz/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qw3sXz/guard-own.test.mjs (122.072042ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs (142.123125ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 153.32575\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-TfoSmI/guard-own.test.mjs (142.123125ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at #asyncInstantiate (node:internal/modules/esm/module_job:319:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:422:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:655:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)\n\nNode.js v25.6.1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs (151.643417ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 162.829542\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-S5gzBK/guard-own.test.mjs (151.643417ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=1\n✖ empty population is not proof (4.84775ms)\n✖ unknown coverage id is rejected (0.310875ms)\n✖ new uncovered checker is named and rejected (0.184042ms)\n✔ genuinely covered population passes (0.171875ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 171.46825\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-4IXvEG/guard-own.test.mjs:5:1\n✖ empty population is not proof (4.84775ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-4IXvEG/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.start (node:internal/test_runner/test:1015:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-4IXvEG/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.310875ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-4IXvEG/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-4IXvEG/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.184042ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-4IXvEG/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\n ✓ tests/unit/checker-blind-input-ratchet.test.ts (13 tests) 1264ms\n\n Test Files  1 passed (1)\n      Tests  13 passed (13)\n   Start at  06:44:17\n   Duration  34.78s (transform 365ms, setup 4ms, collect 133ms, tests 1.26s, environment 0ms, prepare 90ms)\n\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"6beb4263-77b5-4c47-82c0-80a16365cbed\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":6020,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":6097,\"startedAt\":\"2026-08-18T13:44:16.073Z\",\"childExitedAt\":\"2026-08-18T13:44:52.032Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"lRlPTzfX2gSs51EL/rHjgejSWPXkZohQcTKzwfO237b1hvut8t5HUzYPF2SWJijKas8XIoMi/xAi7jdBmvW3AA==\"}\n",
+            "truncated": true,
+            "originalChars": 24429
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 6370)\n",
+            "truncated": false,
+            "originalChars": 1615
+          },
+          "outputSha256": "d053ade55be1022c27f79ef32f1823e1a275e5561419d5a3dedc1474c04cf23f",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "b2190c48-b73a-4765-9196-55031bfdf972",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 6020,
+            "childPid": 6097,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T13:44:16.073Z",
+            "childExitedAt": "2026-08-18T13:44:52.032Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "068de2daa262a58ae4549af785c9a954d42228dae708ee76411b4c62f10d6a59",
+            "mac": "6f6af71e6ad0624e376f37c26b4efbedee6a4ac9d7751445b0a545200910f8c6"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 6020,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAsAX1hKsBrkahhGIilHsv44IOriY79jOv0zT9IaI/k1w=",
+              "signature": "SUwt633cMn/R2nhNloNXNHdKVqdCUmjpc8vGPJwP8odxUp7Y/IARigD+9R3OCz7iuLxIl/GYziLBtHoRigCKDg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 6020,
+              "ppid": 68288,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 6020,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 6097,
+              "startedAt": "2026-08-18T13:44:16.073Z",
+              "signature": "4NNVvrJxISwK8P6b88HHH9rMDyNiXsa3vXTCQgALRPNRRaaFK/AgSgRS44KcE/ABul6XVY5ewp1JKNWFQaRwBg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 6097,
+              "ppid": 6020,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "6beb4263-77b5-4c47-82c0-80a16365cbed",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 6020,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 6097,
+            "startedAt": "2026-08-18T13:44:16.073Z",
+            "childExitedAt": "2026-08-18T13:44:52.032Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "lRlPTzfX2gSs51EL/rHjgejSWPXkZohQcTKzwfO237b1hvut8t5HUzYPF2SWJijKas8XIoMi/xAi7jdBmvW3AA=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/01-pipeline-wiring",
+          "startedAt": "2026-08-18T13:44:52.042Z",
+          "endedAt": "2026-08-18T13:45:54.585Z",
+          "durationMs": 62543,
+          "pid": 27100,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"e0b7de1c-5ef2-4930-a90c-b070e8dde062\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":62917,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAn1If3oS4HEeyOmMyHuDNg9rKfHZoolN0zLuJc6vwGqQ=\",\"signature\":\"j/srClQUfYT5dpCzr2OXVoD8Es8sYC/Zd1GbegPivZom1ODJB7qXBxBKrhygWZC+ukBw2d6G9pWfZLO7UdGsDw==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"e0b7de1c-5ef2-4930-a90c-b070e8dde062\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":62917,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T13:45:54.576Z\",\"signature\":\"lpnOPPSKAN8c0gg2CWhGjlursU+7MPxDJx4oMdg1z+WKRzCTQKSYKgkNIhAxtLjZo2vraArvNLsfi1qcZ+vVDg==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "da449880e673cfb642623f4b058b03978f4002f77402bbc49682bbf59e25e486",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 62917,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T13:45:54.576Z",
+            "signature": "lpnOPPSKAN8c0gg2CWhGjlursU+7MPxDJx4oMdg1z+WKRzCTQKSYKgkNIhAxtLjZo2vraArvNLsfi1qcZ+vVDg=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "71c443b8-c95f-464a-86cf-4f5f07be173f",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "d02ac889-b5c2-4042-aff1-f0c2a84f2169",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 62917,
+          "childPid": 62917,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "0bd892c2b6c9d8cb06fe204b3a789c99035121f344cabc3063cdcbde4e719d5d",
+          "startedAt": "2026-08-18T13:45:54.576Z",
+          "childExitedAt": "2026-08-18T13:45:54.585Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "4526a5b4cbef1e467cfe4d57ddd08adf42985efc54aa778a54a2b07b06993321",
+          "mac": "01fed297e384d1444d9de0f6041fce73d936c7a10f35228bd3826e459759ed69"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "e0b7de1c-5ef2-4930-a90c-b070e8dde062",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 62917,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAn1If3oS4HEeyOmMyHuDNg9rKfHZoolN0zLuJc6vwGqQ=",
+              "signature": "j/srClQUfYT5dpCzr2OXVoD8Es8sYC/Zd1GbegPivZom1ODJB7qXBxBKrhygWZC+ukBw2d6G9pWfZLO7UdGsDw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 62917,
+              "ppid": 27367,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-IPxCMe/01-pipeline-wiring",
+        "commit": "52bc14b6b26044a431d22e8608f017d05c7d95cf"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules",
+    "prepared": true
+  }
+}

--- a/scratchpad/phaseB/evidence/F4-checker-blind-input-coverage.json
+++ b/scratchpad/phaseB/evidence/F4-checker-blind-input-coverage.json
@@ -1,0 +1,929 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T14:10:32.549Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs",
+      "sha256": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77"
+    }
+  },
+  "guardId": "checker-blind-input-coverage",
+  "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+  "fixture": "none",
+  "measurementScope": "wiring-only",
+  "target": {
+    "tree": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f3-checker-instrument-harness",
+    "requestedCommit": "e64e3a249",
+    "commit": "e64e3a2497d59a4d3aec0f8eb4e04589e4912f58",
+    "remote": {
+      "name": "upstream",
+      "url": "https://github.com/JKHeadley/instar.git"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-checker-blind-input-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lib/checker-blind-input-ratchet.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/checker-blind-input-ratchet.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lint-llm-attribution.js",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/checker-blind-input-cases.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-authenticated-observer-events-hmac-receipt",
+      "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+      "receipt": {
+        "schema": "phaseB-authenticated-execution-receipt/v1",
+        "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+        "issuer": "fix-verifier:checker-blind-input-coverage",
+        "nonce": "8e0cc5cb-d772-47f6-af75-2f32b6d563cd",
+        "guardId": "checker-blind-input-coverage",
+        "kind": "child-exit",
+        "observerPid": 27533,
+        "childPid": 27613,
+        "childExitCode": 0,
+        "signal": null,
+        "argv": [
+          "scripts/lint-checker-blind-input-coverage.mjs"
+        ],
+        "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+        "startedAt": "2026-08-18T14:08:49.468Z",
+        "childExitedAt": "2026-08-18T14:09:32.948Z",
+        "emittedAfterChildExit": true,
+        "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+        "observerEventSequence": 3,
+        "observerEventSignatureHash": "fa2bfb83afc6920c98b106e1ab913ff6f87f4d2f3cd2f737d07ddaf897e3bdcc",
+        "mac": "6fc50dfefb7599abbb3b8f887e2acd82a0994ab2d5c42e700b2fcd164b230125"
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "eventSchema": "phaseB-authenticated-observer-event/v1",
+          "source": "fix-verifier-observer",
+          "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+          "sequence": 2,
+          "kind": "short-circuit",
+          "guardId": "checker-blind-input-coverage",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "observerPid": 67226,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "shortCircuitedAt": "2026-08-18T14:10:32.310Z",
+          "signature": "Kg7B4y3CEwP+0EOik8Q93TSL/3HkFCfgHtfk4Yz1AeIlOPNMTzjVyr9SKTOvuJeSQOhKV6Eh5+xcTgmGQd7hAg=="
+        },
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "760e3969-137f-4c52-ba75-6ebdae1a293e",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 67226,
+          "childPid": 67226,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "f79d58880b2e34fcbe7739149b521f85c5cb6b5a63c3666b67d3cdf796f84f78",
+          "startedAt": "2026-08-18T14:10:32.310Z",
+          "childExitedAt": "2026-08-18T14:10:32.319Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "0c2e780526ae0ee665c526ef5dbc2fc2164a6b160fb7475c5a0ce30ad97b1a9e",
+          "mac": "239743d7fc680906d0d8ab65ef25ca568cae88e6e7eb82e07da9d842a8529844"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "private-channel authority authenticated exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 authenticated the instrument observer short-circuit",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/01-pipeline-wiring",
+          "startedAt": "2026-08-18T14:07:54.157Z",
+          "endedAt": "2026-08-18T14:09:32.960Z",
+          "durationMs": 98803,
+          "pid": 93892,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[13339 chars omitted]...\n  uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:226:14)\n    Test.run (node:internal/test_runner/test:1118:25)\n    Test.start (node:internal/test_runner/test:1015:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.124584\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:226:14)\n    Test.run (node:internal/test_runner/test:1118:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n    Test.postRun (node:internal/test_runner/test:1247:19)\n    Test.run (node:internal/test_runner/test:1175:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.072792\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:226:14)\n    Test.run (node:internal/test_runner/test:1118:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n    Test.postRun (node:internal/test_runner/test:1247:19)\n    Test.run (node:internal/test_runner/test:1175:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:787:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.067875\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 87.095584\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (2.526042ms)\n✖ unknown coverage id is rejected (0.124292ms)\n✖ new uncovered checker is named and rejected (0.070792ms)\n✔ genuinely covered population passes (0.068542ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 88.395834\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-iaQEaw/guard-own.test.mjs:5:1\n✖ empty population is not proof (2.526042ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.start (node:internal/test_runner/test:1015:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-iaQEaw/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.124292ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-iaQEaw/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.070792ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\n ✓ tests/unit/checker-blind-input-ratchet.test.ts (13 tests) 1081ms\n   ✓ P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 329ms\n\n Test Files  1 passed (1)\n      Tests  13 passed (13)\n   Start at  07:08:50\n   Duration  42.18s (transform 329ms, setup 5ms, collect 98ms, tests 1.08s, environment 0ms, prepare 116ms)\n\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"b2c366e3-022a-45bf-b00d-84ee39dadc02\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":27533,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":27613,\"startedAt\":\"2026-08-18T14:08:49.468Z\",\"childExitedAt\":\"2026-08-18T14:09:32.948Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"Vs3qMkKCTPkZ8Dl8dAbcz0OBfYFljrlE0iPPD3VGvQa4DaiwwNggqg+941Io6gYK6sSqNvqJomnwKoKtZXTABA==\"}\n",
+            "truncated": true,
+            "originalChars": 29339
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 27993)\n[native-module-health] better-sqlite3 unavailable — a banner will follow the run summary.\n\n════════════════════════════════════════════════════════════════════════\n  better-sqlite3 could NOT load in this checkout for this run.\n\n  Could not locate the bindings file. Tried:\n\n  Every sqlite-backed subsystem degraded for the whole run. Test failures\n  above that mention bindings, sqlite, or a store failing to open are most\n  likely DOWNSTREAM of this one fact, not separate defects.\n\n  Fix:  npm rebuild better-sqlite3        (or reinstall WITHOUT --ignore-scripts,\n                                           which skips the postinstall that\n                                           builds the native binary)\n\n  This is a notice, not a gate: nothing was blocked or skipped because of it.\n════════════════════════════════════════════════════════════════════════\n",
+            "truncated": false,
+            "originalChars": 2479
+          },
+          "outputSha256": "00f3ab952c4b9d90b51d140363baf47d8aee75617d34083d7967801793202269",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "8e0cc5cb-d772-47f6-af75-2f32b6d563cd",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 27533,
+            "childPid": 27613,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T14:08:49.468Z",
+            "childExitedAt": "2026-08-18T14:09:32.948Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "fa2bfb83afc6920c98b106e1ab913ff6f87f4d2f3cd2f737d07ddaf897e3bdcc",
+            "mac": "6fc50dfefb7599abbb3b8f887e2acd82a0994ab2d5c42e700b2fcd164b230125"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 27533,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAssODSKAf43kthIj+ujVx0GYxMtVDNfSiWC1CzMiSiE8=",
+              "signature": "rIqgDTJTNuubn3LSDJ2aKPst7QSkYuM+8He7hdw8vjOdnsUpj0asr3L+rD3xipmVj+RF+/uxh2YJxfGi00uaDg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 27533,
+              "ppid": 94311,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 27533,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 27613,
+              "startedAt": "2026-08-18T14:08:49.468Z",
+              "signature": "UWT4Ff0VCewf8YelTCjSpOwC0/czRnTAZD8ISz3PK/1ayRHPcSt5/68e6omupuUekwhE6mhJaIqcRfIdeTovDA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 27613,
+              "ppid": 27533,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 27533,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 27613,
+            "startedAt": "2026-08-18T14:08:49.468Z",
+            "childExitedAt": "2026-08-18T14:09:32.948Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "Vs3qMkKCTPkZ8Dl8dAbcz0OBfYFljrlE0iPPD3VGvQa4DaiwwNggqg+941Io6gYK6sSqNvqJomnwKoKtZXTABA=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/01-pipeline-wiring",
+          "startedAt": "2026-08-18T14:09:32.962Z",
+          "endedAt": "2026-08-18T14:10:32.319Z",
+          "durationMs": 59357,
+          "pid": 40853,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"86af5593-dcb1-4cc4-8dcf-542455eba6ac\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":67226,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAjg2LNWVDw2RkKPxXbrxVwcIB8rrUd9iLKVZEoCn26Z4=\",\"signature\":\"VSZwtNqrDH+wn/TDvT05gaysvqrx0B/Hkl3RRaxbwAPfxDaTBpd6ewIlHF60CUC5xtPsWfRuH39RKurGYheUDQ==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"86af5593-dcb1-4cc4-8dcf-542455eba6ac\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":67226,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T14:10:32.310Z\",\"signature\":\"Kg7B4y3CEwP+0EOik8Q93TSL/3HkFCfgHtfk4Yz1AeIlOPNMTzjVyr9SKTOvuJeSQOhKV6Eh5+xcTgmGQd7hAg==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "1dedc68b7986b95e815a185837cf61bb835a3849c0c923780fd24e1de59bb3bb",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 67226,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T14:10:32.310Z",
+            "signature": "Kg7B4y3CEwP+0EOik8Q93TSL/3HkFCfgHtfk4Yz1AeIlOPNMTzjVyr9SKTOvuJeSQOhKV6Eh5+xcTgmGQd7hAg=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "760e3969-137f-4c52-ba75-6ebdae1a293e",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 67226,
+          "childPid": 67226,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "f79d58880b2e34fcbe7739149b521f85c5cb6b5a63c3666b67d3cdf796f84f78",
+          "startedAt": "2026-08-18T14:10:32.310Z",
+          "childExitedAt": "2026-08-18T14:10:32.319Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "0c2e780526ae0ee665c526ef5dbc2fc2164a6b160fb7475c5a0ce30ad97b1a9e",
+          "mac": "239743d7fc680906d0d8ab65ef25ca568cae88e6e7eb82e07da9d842a8529844"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 67226,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAjg2LNWVDw2RkKPxXbrxVwcIB8rrUd9iLKVZEoCn26Z4=",
+              "signature": "VSZwtNqrDH+wn/TDvT05gaysvqrx0B/Hkl3RRaxbwAPfxDaTBpd6ewIlHF60CUC5xtPsWfRuH39RKurGYheUDQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 67226,
+              "ppid": 41251,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+        "receipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "8e0cc5cb-d772-47f6-af75-2f32b6d563cd",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "child-exit",
+          "observerPid": 27533,
+          "childPid": 27613,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+          "startedAt": "2026-08-18T14:08:49.468Z",
+          "childExitedAt": "2026-08-18T14:09:32.948Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+          "observerEventSequence": 3,
+          "observerEventSignatureHash": "fa2bfb83afc6920c98b106e1ab913ff6f87f4d2f3cd2f737d07ddaf897e3bdcc",
+          "mac": "6fc50dfefb7599abbb3b8f887e2acd82a0994ab2d5c42e700b2fcd164b230125"
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 67226,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T14:10:32.310Z",
+            "signature": "Kg7B4y3CEwP+0EOik8Q93TSL/3HkFCfgHtfk4Yz1AeIlOPNMTzjVyr9SKTOvuJeSQOhKV6Eh5+xcTgmGQd7hAg=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "760e3969-137f-4c52-ba75-6ebdae1a293e",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "short-circuit",
+            "observerPid": 67226,
+            "childPid": 67226,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "f79d58880b2e34fcbe7739149b521f85c5cb6b5a63c3666b67d3cdf796f84f78",
+            "startedAt": "2026-08-18T14:10:32.310Z",
+            "childExitedAt": "2026-08-18T14:10:32.319Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "0c2e780526ae0ee665c526ef5dbc2fc2164a6b160fb7475c5a0ce30ad97b1a9e",
+            "mac": "239743d7fc680906d0d8ab65ef25ca568cae88e6e7eb82e07da9d842a8529844"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "untouched guard passes through the real protected-workflow entry and emits the post-child receipt",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/01-pipeline-wiring",
+          "startedAt": "2026-08-18T14:07:54.157Z",
+          "endedAt": "2026-08-18T14:09:32.960Z",
+          "durationMs": 98803,
+          "pid": 93892,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[13339 chars omitted]...\n  uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:226:14)\n    Test.run (node:internal/test_runner/test:1118:25)\n    Test.start (node:internal/test_runner/test:1015:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.124584\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:226:14)\n    Test.run (node:internal/test_runner/test:1118:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n    Test.postRun (node:internal/test_runner/test:1247:19)\n    Test.run (node:internal/test_runner/test:1175:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.072792\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:226:14)\n    Test.run (node:internal/test_runner/test:1118:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n    Test.postRun (node:internal/test_runner/test:1247:19)\n    Test.run (node:internal/test_runner/test:1175:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:787:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.067875\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 87.095584\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (2.526042ms)\n✖ unknown coverage id is rejected (0.124292ms)\n✖ new uncovered checker is named and rejected (0.070792ms)\n✔ genuinely covered population passes (0.068542ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 88.395834\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-iaQEaw/guard-own.test.mjs:5:1\n✖ empty population is not proof (2.526042ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.start (node:internal/test_runner/test:1015:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:358:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-iaQEaw/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.124292ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\ntest at ../../checker-p3-hollow-iaQEaw/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.070792ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-iaQEaw/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:226:14)\n      at Test.run (node:internal/test_runner/test:1118:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)\n      at Test.postRun (node:internal/test_runner/test:1247:19)\n      at Test.run (node:internal/test_runner/test:1175:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual',\n    diff: 'simple'\n  }\n\n ✓ tests/unit/checker-blind-input-ratchet.test.ts (13 tests) 1081ms\n   ✓ P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 329ms\n\n Test Files  1 passed (1)\n      Tests  13 passed (13)\n   Start at  07:08:50\n   Duration  42.18s (transform 329ms, setup 5ms, collect 98ms, tests 1.08s, environment 0ms, prepare 116ms)\n\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"b2c366e3-022a-45bf-b00d-84ee39dadc02\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":27533,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":27613,\"startedAt\":\"2026-08-18T14:08:49.468Z\",\"childExitedAt\":\"2026-08-18T14:09:32.948Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"Vs3qMkKCTPkZ8Dl8dAbcz0OBfYFljrlE0iPPD3VGvQa4DaiwwNggqg+941Io6gYK6sSqNvqJomnwKoKtZXTABA==\"}\n",
+            "truncated": true,
+            "originalChars": 29339
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 27993)\n[native-module-health] better-sqlite3 unavailable — a banner will follow the run summary.\n\n════════════════════════════════════════════════════════════════════════\n  better-sqlite3 could NOT load in this checkout for this run.\n\n  Could not locate the bindings file. Tried:\n\n  Every sqlite-backed subsystem degraded for the whole run. Test failures\n  above that mention bindings, sqlite, or a store failing to open are most\n  likely DOWNSTREAM of this one fact, not separate defects.\n\n  Fix:  npm rebuild better-sqlite3        (or reinstall WITHOUT --ignore-scripts,\n                                           which skips the postinstall that\n                                           builds the native binary)\n\n  This is a notice, not a gate: nothing was blocked or skipped because of it.\n════════════════════════════════════════════════════════════════════════\n",
+            "truncated": false,
+            "originalChars": 2479
+          },
+          "outputSha256": "00f3ab952c4b9d90b51d140363baf47d8aee75617d34083d7967801793202269",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "8e0cc5cb-d772-47f6-af75-2f32b6d563cd",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 27533,
+            "childPid": 27613,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T14:08:49.468Z",
+            "childExitedAt": "2026-08-18T14:09:32.948Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "fa2bfb83afc6920c98b106e1ab913ff6f87f4d2f3cd2f737d07ddaf897e3bdcc",
+            "mac": "6fc50dfefb7599abbb3b8f887e2acd82a0994ab2d5c42e700b2fcd164b230125"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 27533,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAssODSKAf43kthIj+ujVx0GYxMtVDNfSiWC1CzMiSiE8=",
+              "signature": "rIqgDTJTNuubn3LSDJ2aKPst7QSkYuM+8He7hdw8vjOdnsUpj0asr3L+rD3xipmVj+RF+/uxh2YJxfGi00uaDg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 27533,
+              "ppid": 94311,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 27533,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 27613,
+              "startedAt": "2026-08-18T14:08:49.468Z",
+              "signature": "UWT4Ff0VCewf8YelTCjSpOwC0/czRnTAZD8ISz3PK/1ayRHPcSt5/68e6omupuUekwhE6mhJaIqcRfIdeTovDA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 27613,
+              "ppid": 27533,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "b2c366e3-022a-45bf-b00d-84ee39dadc02",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 27533,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 27613,
+            "startedAt": "2026-08-18T14:08:49.468Z",
+            "childExitedAt": "2026-08-18T14:09:32.948Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "Vs3qMkKCTPkZ8Dl8dAbcz0OBfYFljrlE0iPPD3VGvQa4DaiwwNggqg+941Io6gYK6sSqNvqJomnwKoKtZXTABA=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "the C3 short-circuit is independently recorded against the exact observed child before its result is interpreted",
+      "perMutation": {
+        "C3-exact-child-short-circuit": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/01-pipeline-wiring",
+          "startedAt": "2026-08-18T14:09:32.962Z",
+          "endedAt": "2026-08-18T14:10:32.319Z",
+          "durationMs": 59357,
+          "pid": 40853,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"86af5593-dcb1-4cc4-8dcf-542455eba6ac\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":67226,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAjg2LNWVDw2RkKPxXbrxVwcIB8rrUd9iLKVZEoCn26Z4=\",\"signature\":\"VSZwtNqrDH+wn/TDvT05gaysvqrx0B/Hkl3RRaxbwAPfxDaTBpd6ewIlHF60CUC5xtPsWfRuH39RKurGYheUDQ==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"86af5593-dcb1-4cc4-8dcf-542455eba6ac\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":67226,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T14:10:32.310Z\",\"signature\":\"Kg7B4y3CEwP+0EOik8Q93TSL/3HkFCfgHtfk4Yz1AeIlOPNMTzjVyr9SKTOvuJeSQOhKV6Eh5+xcTgmGQd7hAg==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "1dedc68b7986b95e815a185837cf61bb835a3849c0c923780fd24e1de59bb3bb",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 67226,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T14:10:32.310Z",
+            "signature": "Kg7B4y3CEwP+0EOik8Q93TSL/3HkFCfgHtfk4Yz1AeIlOPNMTzjVyr9SKTOvuJeSQOhKV6Eh5+xcTgmGQd7hAg=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "ad086846-c663-403c-be40-9aeb5c5040eb",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "760e3969-137f-4c52-ba75-6ebdae1a293e",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 67226,
+          "childPid": 67226,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "f79d58880b2e34fcbe7739149b521f85c5cb6b5a63c3666b67d3cdf796f84f78",
+          "startedAt": "2026-08-18T14:10:32.310Z",
+          "childExitedAt": "2026-08-18T14:10:32.319Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "0c2e780526ae0ee665c526ef5dbc2fc2164a6b160fb7475c5a0ce30ad97b1a9e",
+          "mac": "239743d7fc680906d0d8ab65ef25ca568cae88e6e7eb82e07da9d842a8529844"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "86af5593-dcb1-4cc4-8dcf-542455eba6ac",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 67226,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAjg2LNWVDw2RkKPxXbrxVwcIB8rrUd9iLKVZEoCn26Z4=",
+              "signature": "VSZwtNqrDH+wn/TDvT05gaysvqrx0B/Hkl3RRaxbwAPfxDaTBpd6ewIlHF60CUC5xtPsWfRuH39RKurGYheUDQ=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 67226,
+              "ppid": 41251,
+              "command": "/opt/homebrew/Cellar/node/25.6.1/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P2": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P3": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P4": {
+      "outcome": "unknown",
+      "mutations": []
+    },
+    "P5": {
+      "outcome": "unknown",
+      "mutations": []
+    }
+  },
+  "effectiveAgainst": [],
+  "rung": "wired",
+  "mutations": [],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-D6SQ3M/01-pipeline-wiring",
+        "commit": "e64e3a2497d59a4d3aec0f8eb4e04589e4912f58"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-s3-no-blind-clean/node_modules",
+    "prepared": true
+  }
+}

--- a/tests/unit/checker-blind-input-ratchet.test.ts
+++ b/tests/unit/checker-blind-input-ratchet.test.ts
@@ -205,15 +205,78 @@ describe('checker blind-input class ratchet', () => {
 describe('P3 — the ratchet own test rejects all four guard sabotages', () => {
   const sourcePath = path.join(ROOT, 'scripts', 'lib', 'checker-blind-input-ratchet.mjs');
   const source = fs.readFileSync(sourcePath, 'utf8');
+  const guardResultSchema = 'checker-blind-input/guard-own-results-v1';
+  const hollowExpectedResults = [
+    { testNumber: 1, identity: 'empty population is not proof', outcome: 'fail', failureCode: 'ERR_ASSERTION' },
+    { testNumber: 2, identity: 'unknown coverage id is rejected', outcome: 'fail', failureCode: 'ERR_ASSERTION' },
+    { testNumber: 3, identity: 'new uncovered checker is named and rejected', outcome: 'fail', failureCode: 'ERR_ASSERTION' },
+    { testNumber: 4, identity: 'genuinely covered population passes', outcome: 'pass', failureCode: null },
+  ] as const;
 
-  function hasNodeTestSummary(output: string, label: 'tests' | 'fail', count: number): boolean {
-    const tap = `# ${label} ${count}`;
-    const spec = `ℹ ${label} ${count}`;
-    return output.split(/\r?\n/).some((line) => line.trim() === tap || line.trim() === spec);
+  interface GuardOwnResult {
+    schema: typeof guardResultSchema;
+    tests: Array<{
+      testNumber: number;
+      identity: string;
+      outcome: 'pass' | 'fail';
+      failureCode: string | null;
+    }>;
   }
 
-  function guardOwnSuite(modulePath: string, dir: string) {
+  function parseGuardOwnResult(raw: string): GuardOwnResult {
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      throw new Error('guard-own result is not JSON');
+    }
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('guard-own result must be an object');
+    }
+    const record = value as Record<string, unknown>;
+    if (record.schema !== guardResultSchema || !Array.isArray(record.tests)) {
+      throw new Error('guard-own result does not match schema v1');
+    }
+    const rootKeys = Object.keys(record).sort();
+    if (rootKeys.length !== 2 || rootKeys[0] !== 'schema' || rootKeys[1] !== 'tests') {
+      throw new Error('guard-own result has unknown root fields');
+    }
+    const tests = record.tests.map((entry, index) => {
+      if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error(`guard-own test result ${index} must be an object`);
+      }
+      const item = entry as Record<string, unknown>;
+      const keys = Object.keys(item).sort();
+      if (keys.join(',') !== 'failureCode,identity,outcome,testNumber') {
+        throw new Error(`guard-own test result ${index} has the wrong fields`);
+      }
+      if (!Number.isInteger(item.testNumber) || (item.testNumber as number) < 1) {
+        throw new Error(`guard-own test result ${index} has an invalid test number`);
+      }
+      if (typeof item.identity !== 'string' || item.identity.length === 0) {
+        throw new Error(`guard-own test result ${index} has an invalid identity`);
+      }
+      if (item.outcome !== 'pass' && item.outcome !== 'fail') {
+        throw new Error(`guard-own test result ${index} has an invalid outcome`);
+      }
+      if (item.failureCode !== null && typeof item.failureCode !== 'string') {
+        throw new Error(`guard-own test result ${index} has an invalid failure code`);
+      }
+      return {
+        testNumber: item.testNumber as number,
+        identity: item.identity,
+        outcome: item.outcome,
+        failureCode: item.failureCode,
+      };
+    });
+    return { schema: guardResultSchema, tests };
+  }
+
+  function guardOwnSuite(modulePath: string, dir: string, renderer: 'tap' | 'spec' = 'spec') {
     const suite = path.join(dir, 'guard-own.test.mjs');
+    const reporter = path.join(dir, 'guard-own-results-reporter.mjs');
+    const structuredDestination = path.join(dir, `guard-own-${renderer}-results.json`);
+    const renderedDestination = path.join(dir, `guard-own-${renderer}-rendered.txt`);
     fs.writeFileSync(suite, `
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -235,7 +298,41 @@ test('genuinely covered population passes', () => {
   assert.equal(evaluateBlindInputCoverage({population:['known'],coverageIds:['known'],maxUncovered:0}).passed, true);
 });
 `);
-    return spawnSync(process.execPath, ['--test', suite], { encoding: 'utf8' });
+    fs.writeFileSync(reporter, `
+export default async function* guardOwnResults(source) {
+  const tests = [];
+  for await (const event of source) {
+    if (event.type !== 'test:complete' || event.data.details.type === 'suite' || event.data.skip || event.data.todo) continue;
+    if (typeof event.data.file === 'string' && event.data.name === event.data.file) continue;
+    const error = event.data.details.error;
+    const cause = error && typeof error === 'object' ? error.cause : undefined;
+    const failureCode = cause && typeof cause === 'object' && typeof cause.code === 'string'
+      ? cause.code
+      : error && typeof error === 'object' && typeof error.code === 'string' ? error.code : null;
+    tests.push({
+      testNumber: event.data.testNumber,
+      identity: event.data.name,
+      outcome: event.data.details.passed ? 'pass' : 'fail',
+      failureCode,
+    });
+  }
+  yield JSON.stringify({ schema: ${JSON.stringify(guardResultSchema)}, tests });
+}
+`);
+    const child = spawnSync(process.execPath, [
+      '--test',
+      '--test-reporter', renderer,
+      '--test-reporter-destination', renderedDestination,
+      '--test-reporter', reporter,
+      '--test-reporter-destination', structuredDestination,
+      suite,
+    ], { encoding: 'utf8' });
+    return {
+      ...child,
+      renderer,
+      renderedOutput: fs.existsSync(renderedDestination) ? fs.readFileSync(renderedDestination, 'utf8').trim() : '',
+      structuredOutput: fs.existsSync(structuredDestination) ? fs.readFileSync(structuredDestination, 'utf8').trim() : '',
+    };
   }
 
   function replaceGuardBody(body: string): string {
@@ -254,8 +351,8 @@ test('genuinely covered population passes', () => {
     throw new Error('guard body did not close');
   }
 
-  function decidingOutput(result: ReturnType<typeof spawnSync>): string {
-    return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  function decidingOutput(result: ReturnType<typeof guardOwnSuite>): string {
+    return `${result.renderedOutput}\n${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
   }
 
   it('3a DELETE', () => {
@@ -315,13 +412,24 @@ test('genuinely covered population passes', () => {
       fs.writeFileSync(file, hollow);
       expect(hollow).toContain("return { passed: true, reason: 'within-ratchet'");
       expect(hollow).toContain('export function evaluateBlindInputCoverage');
-      const result = guardOwnSuite(file, dir);
-      const output = decidingOutput(result);
-      console.log(`P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=${result.status}\n${output}`);
-      expect(result.status).not.toBe(0);
-      expect(hasNodeTestSummary(output, 'tests', 4)).toBe(true);
-      expect(hasNodeTestSummary(output, 'fail', 3)).toBe(true);
-      expect(output).toMatch(/AssertionError|Expected values to be strictly equal/);
+      const tapResult = guardOwnSuite(file, dir, 'tap');
+      const specResult = guardOwnSuite(file, dir, 'spec');
+      const tapStructured = parseGuardOwnResult(tapResult.structuredOutput);
+      const specStructured = parseGuardOwnResult(specResult.structuredOutput);
+      expect(tapResult.status).not.toBe(0);
+      expect(specResult.status).not.toBe(0);
+      expect(tapStructured.tests).toEqual(hollowExpectedResults);
+      expect(specStructured.tests).toEqual(hollowExpectedResults);
+      expect(tapStructured).toEqual(specStructured);
+      console.log(
+        `P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=${tapResult.status} specChildExit=${specResult.status}`,
+      );
+      console.log(
+        `F4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured=${JSON.stringify(tapStructured)}\n${tapResult.renderedOutput}`,
+      );
+      console.log(
+        `F4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured=${JSON.stringify(specStructured)}\n${specResult.renderedOutput}`,
+      );
     } finally {
       SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'checker-p3:hollow' });
     }

--- a/tests/unit/checker-blind-input-ratchet.test.ts
+++ b/tests/unit/checker-blind-input-ratchet.test.ts
@@ -206,6 +206,12 @@ describe('P3 — the ratchet own test rejects all four guard sabotages', () => {
   const sourcePath = path.join(ROOT, 'scripts', 'lib', 'checker-blind-input-ratchet.mjs');
   const source = fs.readFileSync(sourcePath, 'utf8');
 
+  function hasNodeTestSummary(output: string, label: 'tests' | 'fail', count: number): boolean {
+    const tap = `# ${label} ${count}`;
+    const spec = `ℹ ${label} ${count}`;
+    return output.split(/\r?\n/).some((line) => line.trim() === tap || line.trim() === spec);
+  }
+
   function guardOwnSuite(modulePath: string, dir: string) {
     const suite = path.join(dir, 'guard-own.test.mjs');
     fs.writeFileSync(suite, `
@@ -313,8 +319,8 @@ test('genuinely covered population passes', () => {
       const output = decidingOutput(result);
       console.log(`P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=${result.status}\n${output}`);
       expect(result.status).not.toBe(0);
-      expect(output).toContain('# tests 4');
-      expect(output).toContain('# fail 3');
+      expect(hasNodeTestSummary(output, 'tests', 4)).toBe(true);
+      expect(hasNodeTestSummary(output, 'fail', 3)).toBe(true);
       expect(output).toMatch(/AssertionError|Expected values to be strictly equal/);
     } finally {
       SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'checker-p3:hollow' });


### PR DESCRIPTION
## Summary

- replace Node test-summary decoration matching with a schema-validated machine reporter over `test:complete` events
- require the exact four guard-own test identities, ordered outcomes, and three `ERR_ASSERTION` failure codes
- run the hollow-property control under both TAP and spec renderers and prove identical structured rejection verdicts
- record the authenticated checker-instrument wiring proof under the repaired regular-file boundary

## ELI16

The checker was catching sabotage correctly, but its outer harness judged that result by reading punctuation intended for humans. This change gives the harness a small JSON report containing each test's name, outcome, and failure code. TAP and spec can decorate the display however they want; both runs now produce the same machine verdict, while any added, removed, renamed, reordered, or outcome-changed test fails the exact identity check.

## Verification

- focused decoration control: 1 passed, 12 skipped
- full guard suite: 13 passed
- TAP control: child exit 1; exact four identities; three named `ERR_ASSERTION` failures; structured verdict `reject`
- spec control: child exit 1; identical schema result and structured verdict `reject`
- authenticated wiring verdict: `[fix-verifier-wiring] authenticated guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs childPid=27613 childExit=0`
- wiring evidence: `wiring.outcome=proven`, `rung=wired`, three authenticated positive observer events, one child-exit receipt, zero C3 guard receipts
- normal commit hooks passed twice; no hook bypass

## UX impact

No user-facing behavior changes. This removes a test-harness dependency on Node's human-readable reporter decoration.

## Boundaries

- stacked on `phaseb/s3-no-blind-clean`
- changes only the guard-owned harness and Phase B proof records
- does not change the checker predicate, checker cases, instrument, authentication/signing/sequencing, receipt binding, path boundary, model registry, or CI configuration
- pull request only; no merge or auto-merge
