### PR TITLE
test: port certified structured checker results to F1

### DIFF
--- a/scratchpad/phaseB/REPORT-F2.md
+++ b/scratchpad/phaseB/REPORT-F2.md
@@ -1,0 +1,119 @@
+# REPORT F2 — reconciliation of the certified structured-output repair
+
+## 2026-08-18 12:02:24 -0700 (PDT) — identity
+
+```text
+builder: Instar-codey
+lane: F2 reconciliation
+measured line: phaseb/f1-blind-checker-ratchet
+measured commit: 3801aefe9825e1258f5f235c123c56bee9e6a98b
+certified source branch: phaseb/f3-checker-instrument-harness
+certified implementation: e64e3a2497d59a4d3aec0f8eb4e04589e4912f58
+independent certification: REPORT-J16, SOUND, 2026-08-18 07:21:03 -0700
+reconciliation branch: phaseb/f2-certified-summary-reconciliation
+reconciliation implementation: 859e90347555fec34ae5d9500752b058658ca507
+common protected base: 248ed7177f5bf416aa7bdad9763741478195e1fc
+Node: v22.18.0
+```
+
+I read `REPORT-J16.md` first and `REPORT-J14.md` second as directed. The history is decisive: J14 refused the earlier two-decoration allowlist because it still parsed presentation text; the branch then replaced it with schema-validated Node test-event records, and J16 independently certified that exact implementation SOUND. I found no defect in the certified approach and did not re-derive or improve it.
+
+## Reconciliation answer
+
+The correct integration is to carry the certified P3 harness bytes onto the measured F1 line. Re-pointing the battery at F3 is not equivalent: F3 and F1 diverged at protected main, and F3 does not contain the later F1 ratchet and authenticated-receipt work that the fourth-guard battery is meant to measure. Re-pointing would change the subject rather than repair the measured subject.
+
+The certified test-file change does **not** apply automatically without conflicts. A real no-commit cherry-pick of `e64e3a2` onto `3801aefe9` produced:
+
+```text
+CONFLICT (modify/delete): scratchpad/phaseB/REPORT-W5.md
+CONFLICT (content): tests/unit/checker-blind-input-ratchet.test.ts
+```
+
+The report conflict is historical evidence, not executable repair: F1 does not carry `REPORT-W5.md`, while `e64e3a2` modifies it. I kept that unrelated report absent.
+
+The test-file conflict had exactly two localized conflict regions:
+
+1. F1 still had the original `guardOwnSuite(modulePath, dir)` declaration, whereas the certified change arrives from a parent containing J14's intermediate `hasNodeTestSummary` repair and replaces that path with the structured result schema, parser, and dual-reporter helper.
+2. F1 still had the original `output.toContain('# tests 4')` / `output.toContain('# fail 3')` block, whereas the certified change arrives from the intermediate two-spelling assertions and replaces them with exact TAP/spec structured-record equality.
+
+Nothing in F1's additional ratchet, blind-case, protected-state, or authenticated-receipt work conflicts semantically with the certified P3 harness. Those additions are earlier in the same test file and remain byte-for-byte as they were on F1. The conflict is textual ancestry: both branches independently added this test file after their common protected base, and F1 never carried J14's intermediate allowlist commit.
+
+## What I did
+
+I created a clean worktree and branch at exact measured commit `3801aefe9`. I performed the no-commit cherry-pick trial, retained only the executable test-file port, resolved both content regions by selecting the certified side verbatim, and omitted the unrelated historical W5 report. I made no xmllint/JUnit changes and added no alternative parser, reporter, assertion, or control.
+
+The resulting implementation commit is:
+
+```text
+859e90347555fec34ae5d9500752b058658ca507  test: read checker results structurally
+```
+
+It changes only:
+
+```text
+tests/unit/checker-blind-input-ratchet.test.ts | 125 insertions, 11 deletions
+```
+
+## Exact-byte proof
+
+The full files cannot have the same digest because the measured F1 file contains 256 additional lines of later F1 work before P3. The certified unit of integration is the complete final P3 block, from `describe('P3 — ...')` through end of file. It is 233 lines in both trees and hashes identically:
+
+```text
+e64e3a2 P3 block: 363e23c30d25283f8bb3d9da303710c04a396d58b577bc2de37de35aa3cd3c8c
+859e903 P3 block: 363e23c30d25283f8bb3d9da303710c04a396d58b577bc2de37de35aa3cd3c8c
+```
+
+Whole-file identity records explain, rather than conceal, the retained F1 context:
+
+```text
+F1 before port:       339d2c0f8b84df1dce28e13bcbc3bf26b90917cf42f3e78c6dc3f99b373e0110
+F1 after port:        d0018f709d12ea0e8e974cacd142cefc95cdbe203a83bf62962854119f78add6
+F3 certified whole:   ab59cd790255325b1f6958ddbdb4c540b7d96a1b6bb6c00c5992df06d74f0847
+```
+
+No `xmllint`, JUnit, fake-rendered-line, or F2 reimplementation byte appears in the reconciled test file.
+
+## Integration verification
+
+I ran only the focused 3d test on the reconciled F1 tree, not the independent P3 property battery. It passed:
+
+```text
+Test Files  1 passed (1)
+Tests       1 passed | 17 skipped (18)
+tapChildExit=1
+specChildExit=1
+```
+
+The two real human reporters produced genuinely different output:
+
+```text
+TAP:  # tests 4 / # pass 1 / # fail 3
+spec: ℹ tests 4 / ℹ pass 1 / ℹ fail 3
+```
+
+Both structured destinations produced the same exact schema-validated record:
+
+```json
+{"schema":"checker-blind-input/guard-own-results-v1","tests":[{"testNumber":1,"identity":"empty population is not proof","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":2,"identity":"unknown coverage id is rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":3,"identity":"new uncovered checker is named and rejected","outcome":"fail","failureCode":"ERR_ASSERTION"},{"testNumber":4,"identity":"genuinely covered population passes","outcome":"pass","failureCode":null}]}
+```
+
+Compile-only verification also passed with `tsc --noEmit`. I intentionally did not invoke the aggregate pre-commit hook because its `npm run lint` path calls `lint-checker-blind-input-coverage.mjs`, which would violate the instruction not to run the P3 battery on this integration. The implementation commit was therefore made with Husky disabled after the focused test, TypeScript check, clean staged-diff check, and exact-byte comparison passed.
+
+J16's independent evidence remains the authority for the certified source bytes: it reports the complete 13/13 guard suite green and certifies the structured-event, decoration-independence, strengthened exact-identity, and wiring claims. This F2 record establishes only that those already-certified bytes now sit on and execute against the measured F1 line.
+
+## Abandoned build record preserved
+
+Per the corrected instruction, the earlier xmllint/JUnit attempt was not deleted or committed. It remains uncommitted in:
+
+```text
+/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f2-structured-summary-repair
+branch: phaseb/f2-structured-summary-repair
+status: staged modification to tests/unit/checker-blind-input-ratchet.test.ts
+        staged addition of scratchpad/phaseB/REPORT-F2.md
+```
+
+None of those bytes were copied into reconciliation commit `859e90347`.
+
+## Finding
+
+There is no genuine defect in the J16-certified mechanism. The defect was integration topology: the certified repair and the measured F1 subject were divergent descendants of protected main. The executable answer is the exact certified P3 block on an F1 descendant, not a new repair and not a battery re-point.

--- a/scratchpad/phaseB/REPORT-P3B.md
+++ b/scratchpad/phaseB/REPORT-P3B.md
@@ -1,0 +1,243 @@
+# P3B — fresh current-instrument property battery for the reconciled checker guard
+
+## PRE-C1 TARGET DECLARATION — 2026-08-18 12:28:53 -0700 (PDT)
+
+This target was declared in the durable run record before any C1 pristine control or property invocation:
+
+```text
+target branch: phaseb/f2-certified-summary-reconciliation
+target commit: 859e90347555fec34ae5d9500752b058658ca507
+target role: J16-certified structured-output implementation ported onto the measured F1 line
+runner: Instar-codey, lane P3B
+C1 status at declaration: NOT RUN
+property battery status at declaration: NOT RUN
+```
+
+This run is runner-authored evidence, not an implementation change or independent judgement. Every result is provisional pending independent judgement of both the port and this battery. If the port is refused, this battery is void. The original `REPORT-P3.md` remains the authoritative stopped result for target `3801aefe9825e1258f5f235c123c56bee9e6a98b` and will not be overwritten.
+
+## PRE-C1 MEASUREMENT BOUNDARY — 2026-08-18 12:36:38 -0700 (PDT)
+
+No C1 or property process had run when this section was written. The clean detached measurement checkout was created from the declared commit, not from working-tree bytes:
+
+```text
+measurement checkout: /private/tmp/instar-p3b-859e903-0ArROb/target
+HEAD: 859e90347555fec34ae5d9500752b058658ca507
+porcelain: []
+Node: v22.18.0
+live protected authority: https://github.com/JKHeadley/instar.git refs/heads/main
+live server resolution: 248ed7177f5bf416aa7bdad9763741478195e1fc
+```
+
+Pinned outer instrument identity:
+
+```text
+instrument worktree: phaseb-w4-r-regular-file-identity
+instrument commit: fee69a8eefe406ccf9062ac8fd4b41f58e084680
+instrument SHA-256: c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a
+instrument-test SHA-256: c38827b6ab50c245244e4ded34e20c1c421651a08f29b02bd37db499c26653fe
+receipt-authority SHA-256: 6534ed0983b733311d343c23b60bc70d13648ca9d911a136875504d20d6e4817
+manifest SHA-256: a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677
+checker adapter SHA-256: e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77
+```
+
+### J20 dependency and cache record — BEFORE
+
+```text
+outer instrument dependency argument: .../phaseb-w4-r-regular-file-identity/node_modules
+outer instrument dependency root after realpath: /Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules
+
+provided measurement dependency argument: /private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay
+provided measurement dependency root after realpath: /private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay
+resolved immutable package source: /Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f1-blind-checker-ratchet/node_modules
+
+committed instrument lockfile SHA-256: f08d38d0938c29b0c8302b25d2235e7d6629f108d6c415bcabeb3481d1a33663
+committed target lockfile SHA-256: f08d38d0938c29b0c8302b25d2235e7d6629f108d6c415bcabeb3481d1a33663
+outer installed .package-lock.json SHA-256: bd72886c1ba769e9c0b61a883f823ec9d9eac4b158761a39d5d0ef09b26f5133
+measurement installed .package-lock.json SHA-256: 86d75a245c2581a8b379587df320b1f62313f550314930d8312aef35ecbd14ff
+
+js-yaml approved version: 4.1.1
+js-yaml approved integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+outer js-yaml entry SHA-256: 7d1ebc0d9929b9124997b439d1a1fd9aff8feb6bb0a1b59e977ea638944f34ba
+measurement js-yaml entry SHA-256: 7d1ebc0d9929b9124997b439d1a1fd9aff8feb6bb0a1b59e977ea638944f34ba
+outer js-yaml package aggregate (32 regular files): 234377c610468a2365beb72e5eed934e8690e04c772630ea877153c02fec480b
+measurement js-yaml package aggregate (32 regular files): 234377c610468a2365beb72e5eed934e8690e04c772630ea877153c02fec480b
+
+Vitest approved version: 2.1.9
+Vitest approved integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+outer Vitest entry SHA-256: 39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6
+measurement Vitest entry SHA-256: 39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6
+outer Vitest package aggregate (116 regular files): a52603846c3f92f20446063cdc34f313e1c8d8ececdb0142408d64d3dd69635d
+measurement Vitest package aggregate (116 regular files): a52603846c3f92f20446063cdc34f313e1c8d8ececdb0142408d64d3dd69635d
+```
+
+Each package aggregate is SHA-256 over a lexically ordered list of `SHA256(file-bytes) + two spaces + package-relative-path + newline` for every regular file below the real package root. The same algorithm will be repeated after the measurement.
+
+Mutable-cache disposition: **isolated, not reused**. The provided measurement root is a per-proof overlay outside every shared dependency tree. Its package entries are symlinks to the resolved immutable source above, while `.vite/` is a new real directory at `/private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay/.vite`. `vitest/results.json` was absent before C1. Thus the run shares approved package bytes but neither reads nor writes the F1 tree's mutable Vitest cache. No reinstall occurred.
+
+### Pristine tracked-byte stamps — BEFORE
+
+```text
+409fbf5866541ea6899e15e562680d47476ab63f0b409bc96c26fa3a4ee67984  scripts/lint-llm-attribution.js
+e96cfa613a4b97a4334007546867f64bcae73169e9565450ab42d35e2d9c46ff  scripts/checker-blind-input-cases.mjs
+dfebb009ea3784eb1a006519461377d2820645701a029959cbacbdbfc357e4af  scripts/lint-checker-blind-input-coverage.mjs
+98907ead3be3171c946e343cad9b859475a27997b84670718362e7cfba8bc312  scripts/lib/checker-blind-input-ratchet.mjs
+d0018f709d12ea0e8e974cacd142cefc95cdbe203a83bf62962854119f78add6  tests/unit/checker-blind-input-ratchet.test.ts
+```
+
+C1 status at this boundary: **NOT RUN**. The admissibility rule is fixed in advance: one pristine attempt; any nonzero assertion mismatch voids the battery and is never relabeled environmental; no retry-until-green; no property credit for anything not actually measured.
+
+## C1 — PASS on the single pristine attempt
+
+The direct production command was run once at the declared detached target:
+
+```text
+node scripts/lint-checker-blind-input-coverage.mjs
+C1 exit: 0
+Test Files  1 passed (1)
+Tests  18 passed (18)
+checker-blind-input: population=96 execution-proven=5 legacy-uncovered=91/91 new-checkers=1 protected-base=248ed7177f5b
+checker-blind-input: executable blind cases passed
+```
+
+The repaired type-preserving control executed two real Node reporters. Both child processes exited 1 and yielded the same structured record: tests 1–3 failed with `ERR_ASSERTION`, while the named genuine control test 4 passed.
+
+```text
+P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1
+F4_DECORATION_CONTROL renderer=tap structuredVerdict=reject ...
+F4_DECORATION_CONTROL renderer=spec structuredVerdict=reject ...
+```
+
+This is a structured-event decision under genuinely different renderers, not a rendered-summary spelling check. Delete, comment-out, and superstring controls also each reported `mutationApplied=true` with a nonzero direct child.
+
+At 12:39:46 PDT immediately after C1, porcelain remained empty and all five tracked stamps were byte-identical to BEFORE. The isolated cache was newly created only inside the per-proof overlay:
+
+```text
+isolated cache SHA-256 after C1: efffb293f464d6b376c0e769a5ed94437cef603f488a61d2405a83f218880191
+isolated cache size: 123 bytes
+isolated cache mtime: 2026-08-18 12:39:26 -0700
+shared F1 cache touched by this run: NO
+```
+
+C1 is admissible. It was not retried. The full property verifier may now run once against the same target, protected authority, and provided dependency root.
+
+## Full current-instrument record
+
+The pinned verifier completed at `2026-08-18T19:51:11.722Z` with process exit `0`:
+
+```text
+measurement scope: full-property-and-wiring
+declared target: 859e90347555fec34ae5d9500752b058658ca507
+resolved target: 859e90347555fec34ae5d9500752b058658ca507
+target dirty at start: false
+target porcelain at start: []
+provided dependency root: /private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay
+record rung: effective
+```
+
+The verifier's own isolated C1 also passed once (`exitCode=0`, `timedOut=false`). This is the in-record positive control that the full verifier necessarily performs after the direct preflight gate above; neither control followed a failed guard assertion and neither was retried until green.
+
+Two setup failures preceded the successful full record and receive no evidentiary credit. First, an output path outside the subprocess sandbox was refused with `EPERM`; the requested directory did not exist and no usable record was emitted. After redirecting output to the isolated run root, the sandboxed process emitted a fatal record because DNS access to the pinned GitHub authority was denied before protected-base acquisition. It contained zero mutations and P1–P5 all `unknown`. The identical verifier invocation was then allowed network access because the failure was explicitly environmental (`Could not resolve host`), not an assertion mismatch. The successful record below is the only property measurement.
+
+### Wiring and controls
+
+The protected authority resolved and fetched one base for the whole record:
+
+```text
+remote: https://github.com/JKHeadley/instar.git
+ref: refs/heads/main
+server/fetched commit: 248ed7177f5bf416aa7bdad9763741478195e1fc
+workflow: .github/workflows/ci.yml
+workflow SHA-256: be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71
+merge base: 248ed7177f5bf416aa7bdad9763741478195e1fc
+```
+
+The real workflow command `npm run lint` exited `0`. Its authenticated observer bound the exact regular-file entry `scripts/lint-checker-blind-input-coverage.mjs` to child PID `10887`, child exit `0`, and one post-child HMAC receipt. C3 then ran the same wrapper with the guard short-circuited: the wrapper still exited `0`, the signed short-circuit event authenticated, and the guard receipt count was exactly zero.
+
+```text
+C1: proven
+C2: proven for every mutation
+C3: proven
+WIRING: proven
+isolated copies: 11
+target porcelain unchanged: true
+```
+
+### P1–P5 mutation audit
+
+There were nine declared mutations. For every row, the raw record has `rootIsIsolated=true`, `applyError=null`, `mutationApplied=true`, `mutationRelevant=true`, relevance status `proven`, direct guard exit `1`, `timedOut=false`, `spawnError=null`, and `signal=null`.
+
+| Property | Mutation | Applied/relevant result | Deciding guard observation |
+|---|---|---|---|
+| P1 | `p1-symbol-preserving-checker-hollow` | proven / proven | The preserved `runLint` API fabricated `blind: []`; the executable blind-case assertion named `blind-input-accepted`, outer test result was `1 failed / 17 passed`, and the guard returned NOT-PROVEN. |
+| P2 | `p2-subject-self-reports-clean` | proven / proven | The subject added false `all-inputs-readable` testimony while returning an empty blind set; the external execution check still named `blind-input-accepted`, with `1 failed / 17 passed`. |
+| P3 | `p3a-delete` | proven / proven | The real guard module was absent; direct child exit `1` with `ERR_MODULE_NOT_FOUND`. |
+| P3 | `p3b-comment-out` | proven / proven | Every executable line was inert; direct child exit `1` because required exports were absent. |
+| P3 | `p3c-superstring-rename` | proven / proven | The standalone evaluator symbol was absent; the suite executed and failed `4 / 18`. |
+| P3 | `p3d-type-preserving-hollow` | proven / proven | The exact export/signature remained but returned constant `passed:true`; behavioral assertions executed and failed `2 / 18`, naming the false `within-ratchet` results. |
+| P4 | `p4a-empty-population` | proven / proven | The production enumerator was forced to `[]`; the suite executed and failed `4 / 18`, including the non-empty population and missing-source controls. |
+| P4 | `p4b-planted-nested-checker` | proven / proven | A real nested checker outside the declared file set had no case ID; recursive enumeration found it and the ceiling assertion failed `1 / 18`. |
+| P5 | `p5-blind-production-checker` | proven / proven | The real production subject was mode `000`; the guard failed closed with `UNKNOWN ... EACCES`, exit `1`. |
+
+The adapter's P3d mutation is distinct from the repaired target's own P3d control. The adapter tests whether the production guard survives a type-preserving hollow; the target-owned control is what independently distinguishes the exact four named Node test results under two real renderers. Both directions bit in this run.
+
+No timeout, changing failure set, retry, or unobserved child contributes to any property. The effective set emitted by the instrument is exactly:
+
+```text
+P1: proven
+P2: proven
+P3: proven (delete, comment-out, superstring rename, type-preserving hollow)
+P4: proven (empty population, nested population evasion)
+P5: proven
+EFFECTIVE AGAINST {blind input / fail-open, guard removal, hollowing, population evasion, self-report / false testimony, vacuous measurement}
+```
+
+## J20 dependency and cache record — AFTER
+
+At `2026-08-18 12:52:43 -0700 (PDT)`, the identical digest procedure produced:
+
+```text
+outer instrument dependency root after realpath: /Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-h1-authenticated-execution-receipts/node_modules
+provided measurement dependency root after realpath: /private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay
+
+committed instrument lockfile SHA-256: f08d38d0938c29b0c8302b25d2235e7d6629f108d6c415bcabeb3481d1a33663  (unchanged)
+committed target lockfile SHA-256: f08d38d0938c29b0c8302b25d2235e7d6629f108d6c415bcabeb3481d1a33663  (unchanged)
+outer installed .package-lock.json SHA-256: bd72886c1ba769e9c0b61a883f823ec9d9eac4b158761a39d5d0ef09b26f5133  (unchanged)
+measurement installed .package-lock.json SHA-256: 86d75a245c2581a8b379587df320b1f62313f550314930d8312aef35ecbd14ff  (unchanged)
+
+outer js-yaml entry SHA-256: 7d1ebc0d9929b9124997b439d1a1fd9aff8feb6bb0a1b59e977ea638944f34ba  (unchanged)
+measurement js-yaml entry SHA-256: 7d1ebc0d9929b9124997b439d1a1fd9aff8feb6bb0a1b59e977ea638944f34ba  (unchanged)
+outer js-yaml package aggregate: 234377c610468a2365beb72e5eed934e8690e04c772630ea877153c02fec480b  (unchanged)
+measurement js-yaml package aggregate: 234377c610468a2365beb72e5eed934e8690e04c772630ea877153c02fec480b  (unchanged)
+
+outer Vitest entry SHA-256: 39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6  (unchanged)
+measurement Vitest entry SHA-256: 39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6  (unchanged)
+outer Vitest package aggregate: a52603846c3f92f20446063cdc34f313e1c8d8ececdb0142408d64d3dd69635d  (unchanged)
+measurement Vitest package aggregate: a52603846c3f92f20446063cdc34f313e1c8d8ececdb0142408d64d3dd69635d  (unchanged)
+```
+
+The target checkout remained porcelain-clean, and all five guard/subject stamps listed in BEFORE were unchanged. The per-proof cache changed as expected from scheduling metadata only:
+
+```text
+cache before C1: absent
+cache after direct C1: efffb293f464d6b376c0e769a5ed94437cef603f488a61d2405a83f218880191 (123 bytes)
+cache after full record: eb5d877ab29308e2c1cb49b41c26d8191d21995c7719653d20904c5b16f45fba (122 bytes)
+final cache mtime: 2026-08-18 12:51:04 -0700
+cache location: /private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay/.vite/vitest/results.json
+disposition: isolated; never reused from or written into a shared dependency tree
+```
+
+Thus executable parser/runner bytes and both committed lock identities were stable across the run, while the one mutable dependency-side input was confined to a fresh directory outside the shared tree. No install occurred.
+
+## Evidence and provisional ruling
+
+```text
+2b3e1335b18db572c3d84786a7376aca39a4856828a5a5409f4026cee0764b3d  scratchpad/phaseB/evidence/P3B-checker-blind-input-coverage.json
+raw record size: 276860 bytes
+runner: Instar-codey, lane P3B
+target: 859e90347555fec34ae5d9500752b058658ca507
+instrument: fee69a8eefe406ccf9062ac8fd4b41f58e084680 / c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a
+```
+
+**PROVISIONAL RUNNER RESULT:** `EFFECTIVE AGAINST {blind input / fail-open, guard removal, hollowing, population evasion, self-report / false testimony, vacuous measurement}` for exact target `859e90347555fec34ae5d9500752b058658ca507`.
+
+This is not independent judgement and grants no final credit by itself. Both the F2 port and this P3B battery still require independent review; if the port is refused, this entire battery is void. The original `REPORT-P3.md` and its stopped result for `3801aefe9825e1258f5f235c123c56bee9e6a98b` remain unchanged.

--- a/scratchpad/phaseB/evidence/P3B-checker-blind-input-coverage.json
+++ b/scratchpad/phaseB/evidence/P3B-checker-blind-input-coverage.json
@@ -1,0 +1,2168 @@
+{
+  "schemaVersion": 1,
+  "measuredAt": "2026-08-18T19:51:11.722Z",
+  "instrument": {
+    "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.mjs",
+    "sha256": "c9fab8034effc8f64c525073f85c7c04c1fd5cca9c0b2324203632ea34145b3a",
+    "manifest": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+      "sha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+      "adapterRegistryChecked": true,
+      "count": 8,
+      "ids": [
+        "audit-convergence-validator",
+        "checker-blind-input-coverage",
+        "guard-posture-probe",
+        "lint-llm-attribution",
+        "self-action-convergence",
+        "standards-direction-guard",
+        "testing-integrity-route-enforcement",
+        "topic-operator-evidence"
+      ]
+    },
+    "adapter": {
+      "path": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/adapters/checker-blind-input-coverage.mjs",
+      "sha256": "e3f66283ba3d265d0ebdc7fe56198200a45cbabbcc62369156c0c4d660c7fa77"
+    }
+  },
+  "guardId": "checker-blind-input-coverage",
+  "description": "Production-derived checker census, blind-input cases, and one-way legacy-debt ceiling.",
+  "fixture": "none",
+  "measurementScope": "full-property-and-wiring",
+  "target": {
+    "tree": "/private/tmp/instar-p3b-859e903-0ArROb/target",
+    "requestedCommit": "859e90347555fec34ae5d9500752b058658ca507",
+    "commit": "859e90347555fec34ae5d9500752b058658ca507",
+    "remote": {
+      "name": "origin",
+      "url": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-f2-certified-summary-reconciliation"
+    },
+    "dirtyAtStart": false,
+    "porcelainAtStart": []
+  },
+  "adapterRegistry": {
+    "source": "/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w4-r-regular-file-identity/scratchpad/phaseB/fix-verifier.manifest.json",
+    "sourceSha256": "a3ae19ae23bae375f48de04d51aa9f17e674e20783bdfd0d9dd5b5815b864677",
+    "schemaChecked": true,
+    "semanticRole": "list of implemented adapters; never a guard census or coverage denominator",
+    "nonEmpty": true,
+    "adaptedGuardCount": 8,
+    "ids": [
+      "audit-convergence-validator",
+      "checker-blind-input-coverage",
+      "guard-posture-probe",
+      "lint-llm-attribution",
+      "self-action-convergence",
+      "standards-direction-guard",
+      "testing-integrity-route-enforcement",
+      "topic-operator-evidence"
+    ]
+  },
+  "coverageAggregate": {
+    "emitted": false,
+    "ratio": null,
+    "denominator": null,
+    "notMeasured": null,
+    "reason": "this command verifies one requested guard; adapter registration is not the real guard census"
+  },
+  "existence": {
+    "outcome": "proven",
+    "files": [
+      {
+        "path": "scripts/lint-checker-blind-input-coverage.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lib/checker-blind-input-ratchet.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "tests/unit/checker-blind-input-ratchet.test.ts",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/lint-llm-attribution.js",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      },
+      {
+        "path": "scripts/checker-blind-input-cases.mjs",
+        "existsAtCommit": true,
+        "exitCode": 0,
+        "stderr": {
+          "text": "",
+          "truncated": false,
+          "originalChars": 0
+        }
+      }
+    ]
+  },
+  "wiring": {
+    "outcome": "proven",
+    "declaredEntryPoint": ".github/workflows/ci.yml -> npm run lint",
+    "establishedBy": "the core authenticated the signed, strictly sequenced observer events for the exact live manifest-pinned guard child, then bound the HMAC receipt to its signed exit event; C3 wrapper success produced no guard receipt",
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "contract": {
+      "valid": true,
+      "reason": null,
+      "checks": [
+        {
+          "check": "protected remote URL is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "protected branch ref is instrument-pinned",
+          "passed": true
+        },
+        {
+          "check": "adapter command invokes the pinned real entry",
+          "passed": true
+        },
+        {
+          "check": "protected workflow job declares the pinned command",
+          "passed": true
+        },
+        {
+          "check": "observer target is a safe exact child entry",
+          "passed": true
+        }
+      ],
+      "normalizedInvocation": [
+        "npm",
+        "run",
+        "lint"
+      ]
+    },
+    "pipelineEvidence": {
+      "source": "fix-verifier-core",
+      "status": "proven",
+      "mode": "core-authenticated-observer-events-hmac-receipt",
+      "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+      "receipt": {
+        "schema": "phaseB-authenticated-execution-receipt/v1",
+        "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+        "issuer": "fix-verifier:checker-blind-input-coverage",
+        "nonce": "09f9742b-59af-43c5-8fb6-c21b799017ab",
+        "guardId": "checker-blind-input-coverage",
+        "kind": "child-exit",
+        "observerPid": 10829,
+        "childPid": 10887,
+        "childExitCode": 0,
+        "signal": null,
+        "argv": [
+          "scripts/lint-checker-blind-input-coverage.mjs"
+        ],
+        "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+        "startedAt": "2026-08-18T19:43:16.853Z",
+        "childExitedAt": "2026-08-18T19:44:01.741Z",
+        "emittedAfterChildExit": true,
+        "observerSession": "dd911b4a-90e2-44ee-8395-b97fb6dfeceb",
+        "observerEventSequence": 3,
+        "observerEventSignatureHash": "19b2f4cba7a11d8d686ef3698956363b459faa692ac113c4d8981ccf3e401bdc",
+        "mac": "0b13deae3b0a754db68f0de6076701f9cbd3eaab8e5244f81d4792b6f2e8ac2d"
+      },
+      "C3": {
+        "outcome": "proven",
+        "receiptCount": 0,
+        "shortCircuitEvent": {
+          "eventSchema": "phaseB-authenticated-observer-event/v1",
+          "source": "fix-verifier-observer",
+          "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+          "sequence": 2,
+          "kind": "short-circuit",
+          "guardId": "checker-blind-input-coverage",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "observerPid": 93759,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "shortCircuitedAt": "2026-08-18T19:45:00.800Z",
+          "signature": "tkdQmR8o7aygy/m3/pLm6o2GNqFTkMSi4aGjZGZ4KCE5tNeVVWso13ek2acj4qABBjY6JUj0usPQ8D0E4+kGDA=="
+        },
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "21f2e0fc-d554-4f19-85ef-b8f1f7534a20",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 93759,
+          "childPid": 93759,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "59a734b0a204c458bbb204618d18df7685f6ec3da6fac1e7ade4e47ee457e1d7",
+          "startedAt": "2026-08-18T19:45:00.800Z",
+          "childExitedAt": "2026-08-18T19:45:00.809Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "7f3843f96bbc9424064b7b3e581ee815dbb661a021061745a9b27b166b0f44e9",
+          "mac": "ded8e83e57157157e9e5ae7a889d3d20cdcf6e44b8913e4049ab3558cb84e88f"
+        }
+      },
+      "checks": [
+        {
+          "check": "real declared pipeline wrapper exited successfully",
+          "passed": true
+        },
+        {
+          "check": "private-channel authority authenticated exactly one post-child receipt",
+          "passed": true
+        },
+        {
+          "check": "C3 wrapper still exited successfully",
+          "passed": true
+        },
+        {
+          "check": "C3 authenticated the instrument observer short-circuit",
+          "passed": true
+        },
+        {
+          "check": "C3 produced no guard execution receipt",
+          "passed": true
+        }
+      ]
+    },
+    "run": {
+      "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+      "positive": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring",
+          "startedAt": "2026-08-18T19:42:14.155Z",
+          "endedAt": "2026-08-18T19:44:01.746Z",
+          "durationMs": 107591,
+          "pid": 61369,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthr\n...[23466 chars omitted]...\n3cefb2f37a1f26aad3f9f094db429140abce9f5f57ddf76ba7d114a82daff\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"802db0db-3290-463b-80b4-000af6e6e1ba\",\"guardId\":\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"kind\":\"blind\",\"observerPid\":10887,\"childPid\":42793,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"blind\"],\"argvHash\":\"00adfa944521542258b0a58ef54a386f583c0a90bc04e088d4111420e37164e9\",\"startedAt\":\"2026-08-18T19:43:58.550Z\",\"childExitedAt\":\"2026-08-18T19:43:59.017Z\",\"emittedAfterChildExit\":true,\"mac\":\"526f7eaed509ac1c672a3cedd3f9a641e3caeb38b942b114f0145b01db603d5f\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"ba0f1ef3-0cce-441c-ae81-902d6311293b\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"control\",\"observerPid\":10887,\"childPid\":43122,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"control\"],\"argvHash\":\"df358e67d0d14babf54ccee64001f9f1ced6a2dbeaef2a69a32a44fec6effee8\",\"startedAt\":\"2026-08-18T19:43:59.018Z\",\"childExitedAt\":\"2026-08-18T19:43:59.461Z\",\"emittedAfterChildExit\":true,\"mac\":\"acd5e923209a0370f190be6cf099e070a9cd437ad6b4d97b14ad068978fcc5f1\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"52bf7de9-9c83-4e9c-a1c1-9ba754b6eb36\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"blind\",\"observerPid\":10887,\"childPid\":43461,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"blind\"],\"argvHash\":\"1bbcda275a3b9ef95551fcea4cd43cec1840c1baf7a858e5b93db4a01c5f3fb4\",\"startedAt\":\"2026-08-18T19:43:59.461Z\",\"childExitedAt\":\"2026-08-18T19:43:59.948Z\",\"emittedAfterChildExit\":true,\"mac\":\"61c705c92576e82f68cd884fb85314623534cedce1495b9f5220e8df4494f300\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"51822550-4839-4474-9d09-fa98e6f60286\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"control\",\"observerPid\":10887,\"childPid\":43815,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"control\"],\"argvHash\":\"37b040cfa5c1e00bd5c3556acd62801d08fc219881e360a26c25fcb434a16e64\",\"startedAt\":\"2026-08-18T19:43:59.949Z\",\"childExitedAt\":\"2026-08-18T19:44:00.421Z\",\"emittedAfterChildExit\":true,\"mac\":\"7d60a43fd36463a0786d33085d3741760439f5ee6702d2f60aba86ab7c0a5d37\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"d048dff3-95e3-43c8-9da9-68acf3bfde47\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"blind\",\"observerPid\":10887,\"childPid\":44121,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"blind\"],\"argvHash\":\"b3bb983dfd792516f274961b2b56c799e9b938fa7da142c11aff87e54eba78a1\",\"startedAt\":\"2026-08-18T19:44:00.421Z\",\"childExitedAt\":\"2026-08-18T19:44:00.880Z\",\"emittedAfterChildExit\":true,\"mac\":\"e670f36dae7221801bb813eb308e1ca0cdfa4c6ca830be720a2cba2241f3c6e5\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"e31d5456-0e87-4b89-8ef8-1a22aafa2436\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"control\",\"observerPid\":10887,\"childPid\":44387,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"control\"],\"argvHash\":\"f3adbc692beb33a46b0e50c58d9ff937f1644de4195ea675392b0da023dd9d15\",\"startedAt\":\"2026-08-18T19:44:00.881Z\",\"childExitedAt\":\"2026-08-18T19:44:01.322Z\",\"emittedAfterChildExit\":true,\"mac\":\"e672c1029ff70ec8a75058db63fa64e8f261356fc7ab855a711929cc4d6185d3\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"86388b11-bb66-4f0f-8a96-26fa982b4ba3\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"65d818da-dbbc-46f4-a519-2a2f7f3da216\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"blind\",\"observerPid\":10887,\"childPid\":44706,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"blind\"],\"argvHash\":\"9019d32cbbf87b4632386279b053d78d96c119be507bf2dc2084d1bc0a948012\",\"startedAt\":\"2026-08-18T19:44:01.323Z\",\"childExitedAt\":\"2026-08-18T19:44:01.736Z\",\"emittedAfterChildExit\":true,\"mac\":\"76020bf9453d7fdff1d7f414cbf388b9e3ffe6d97fba036f53e1d34485ed4576\"}\nchecker-blind-input: population=96 execution-proven=5 legacy-uncovered=91/91 new-checkers=1 protected-base=248ed7177f5b\nchecker-blind-input: executable blind cases passed\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"dd911b4a-90e2-44ee-8395-b97fb6dfeceb\",\"sequence\":3,\"kind\":\"child-exit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":10829,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"childPid\":10887,\"startedAt\":\"2026-08-18T19:43:16.853Z\",\"childExitedAt\":\"2026-08-18T19:44:01.741Z\",\"childExitCode\":0,\"signal\":null,\"emittedAfterChildExit\":true,\"signature\":\"U5XvOL9ezsTWZ27ZPCxa4fOA2n4L5PqRTpmFey23jyRAgqzj/cqQePYBekQwoDFh2l6HmMbB1F9+SFDn12NwCA==\"}\n",
+            "truncated": true,
+            "originalChars": 39466
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 11549)\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:57 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:43:58 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts \n...[16556 chars omitted]...\n0gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n12:44:01 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-huzPmO/core-generated-checker-case-worker.ts. Does the file exist?\n",
+            "truncated": true,
+            "originalChars": 32556
+          },
+          "outputSha256": "fee854db32f5a97c6c1ac835af80650ae04aa7b0370759ddd8394ad9002dd539",
+          "observerError": null,
+          "observerCandidateLineCount": 3,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/positive/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/positive/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [
+          {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "09f9742b-59af-43c5-8fb6-c21b799017ab",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "child-exit",
+            "observerPid": 10829,
+            "childPid": 10887,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+            "startedAt": "2026-08-18T19:43:16.853Z",
+            "childExitedAt": "2026-08-18T19:44:01.741Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "dd911b4a-90e2-44ee-8395-b97fb6dfeceb",
+            "observerEventSequence": 3,
+            "observerEventSignatureHash": "19b2f4cba7a11d8d686ef3698956363b459faa692ac113c4d8981ccf3e401bdc",
+            "mac": "0b13deae3b0a754db68f0de6076701f9cbd3eaab8e5244f81d4792b6f2e8ac2d"
+          }
+        ],
+        "shortCircuitEvents": [],
+        "shortCircuitReceipt": null,
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "dd911b4a-90e2-44ee-8395-b97fb6dfeceb",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 10829,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEACpGD8MjbbqSJJ+6yOx6jvnZwE3a8mfWGJEnbk10I+Zo=",
+              "signature": "P/pJEibgCjuZLkt4F/bVWZCc2PaiG28FfYQyffqZ5QbOuTF7W+ne5HcR4eiqiry2W/QIdsnEX7JespD2cVjgDw=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 10829,
+              "ppid": 61830,
+              "command": "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/positive/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "dd911b4a-90e2-44ee-8395-b97fb6dfeceb",
+              "sequence": 2,
+              "kind": "child-start",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 10829,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "childPid": 10887,
+              "startedAt": "2026-08-18T19:43:16.853Z",
+              "signature": "xBDlh2eKZMqUY54HqReGG1uQobKzBeAj+bXVxSsblRrAmMa8xcZehmUDF/M81MfHWFYoBf2VV9i31mm1qKVwBA=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 10887,
+              "ppid": 10829,
+              "command": "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "childExit": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "dd911b4a-90e2-44ee-8395-b97fb6dfeceb",
+            "sequence": 3,
+            "kind": "child-exit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 10829,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "childPid": 10887,
+            "startedAt": "2026-08-18T19:43:16.853Z",
+            "childExitedAt": "2026-08-18T19:44:01.741Z",
+            "childExitCode": 0,
+            "signal": null,
+            "emittedAfterChildExit": true,
+            "signature": "U5XvOL9ezsTWZ27ZPCxa4fOA2n4L5PqRTpmFey23jyRAgqzj/cqQePYBekQwoDFh2l6HmMbB1F9+SFDn12NwCA=="
+          },
+          "authenticatedEventCount": 3,
+          "stdoutCandidateEventLineCount": 3
+        }
+      },
+      "C3": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring",
+          "startedAt": "2026-08-18T19:44:01.748Z",
+          "endedAt": "2026-08-18T19:45:00.809Z",
+          "durationMs": 59061,
+          "pid": 45098,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ffb72504-f569-4732-9834-adcdf361f0d4\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93759,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAclBRqghyX5fMnyaPu7B4oRIZ1LM52PyHtYZJfGXwrK0=\",\"signature\":\"nYXqS2jBYKVXqLuu5qructEYdgFqX4cnixJP20uVCGWtn6C/nmAHdk+48idgabGc6CaZoqseyhDmBhqCgOaEAg==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ffb72504-f569-4732-9834-adcdf361f0d4\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93759,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T19:45:00.800Z\",\"signature\":\"tkdQmR8o7aygy/m3/pLm6o2GNqFTkMSi4aGjZGZ4KCE5tNeVVWso13ek2acj4qABBjY6JUj0usPQ8D0E4+kGDA==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "9127c493caf18499b34689a84827c16dfa4148ade41a0a8721866026ea284fdc",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 93759,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T19:45:00.800Z",
+            "signature": "tkdQmR8o7aygy/m3/pLm6o2GNqFTkMSi4aGjZGZ4KCE5tNeVVWso13ek2acj4qABBjY6JUj0usPQ8D0E4+kGDA=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "21f2e0fc-d554-4f19-85ef-b8f1f7534a20",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 93759,
+          "childPid": 93759,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "59a734b0a204c458bbb204618d18df7685f6ec3da6fac1e7ade4e47ee457e1d7",
+          "startedAt": "2026-08-18T19:45:00.800Z",
+          "childExitedAt": "2026-08-18T19:45:00.809Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "7f3843f96bbc9424064b7b3e581ee815dbb661a021061745a9b27b166b0f44e9",
+          "mac": "ded8e83e57157157e9e5ae7a889d3d20cdcf6e44b8913e4049ab3558cb84e88f"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 93759,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAclBRqghyX5fMnyaPu7B4oRIZ1LM52PyHtYZJfGXwrK0=",
+              "signature": "nYXqS2jBYKVXqLuu5qructEYdgFqX4cnixJP20uVCGWtn6C/nmAHdk+48idgabGc6CaZoqseyhDmBhqCgOaEAg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 93759,
+              "ppid": 45486,
+              "command": "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      },
+      "envelope": {
+        "source": "fix-verifier-core",
+        "status": "proven",
+        "mode": "core-authenticated-observer-events-hmac-receipt",
+        "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+        "receipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "09f9742b-59af-43c5-8fb6-c21b799017ab",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "child-exit",
+          "observerPid": 10829,
+          "childPid": 10887,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "ee8d981ca55fa9fbff4a431bffc2bd8c540e3d1cc95546b03c2c592206608fba",
+          "startedAt": "2026-08-18T19:43:16.853Z",
+          "childExitedAt": "2026-08-18T19:44:01.741Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "dd911b4a-90e2-44ee-8395-b97fb6dfeceb",
+          "observerEventSequence": 3,
+          "observerEventSignatureHash": "19b2f4cba7a11d8d686ef3698956363b459faa692ac113c4d8981ccf3e401bdc",
+          "mac": "0b13deae3b0a754db68f0de6076701f9cbd3eaab8e5244f81d4792b6f2e8ac2d"
+        },
+        "C3": {
+          "outcome": "proven",
+          "receiptCount": 0,
+          "shortCircuitEvent": {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 93759,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T19:45:00.800Z",
+            "signature": "tkdQmR8o7aygy/m3/pLm6o2GNqFTkMSi4aGjZGZ4KCE5tNeVVWso13ek2acj4qABBjY6JUj0usPQ8D0E4+kGDA=="
+          },
+          "shortCircuitReceipt": {
+            "schema": "phaseB-authenticated-execution-receipt/v1",
+            "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+            "issuer": "fix-verifier:checker-blind-input-coverage",
+            "nonce": "21f2e0fc-d554-4f19-85ef-b8f1f7534a20",
+            "guardId": "checker-blind-input-coverage",
+            "kind": "short-circuit",
+            "observerPid": 93759,
+            "childPid": 93759,
+            "childExitCode": 0,
+            "signal": null,
+            "argv": [
+              "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "argvHash": "59a734b0a204c458bbb204618d18df7685f6ec3da6fac1e7ade4e47ee457e1d7",
+            "startedAt": "2026-08-18T19:45:00.800Z",
+            "childExitedAt": "2026-08-18T19:45:00.809Z",
+            "emittedAfterChildExit": true,
+            "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+            "observerEventSequence": 2,
+            "observerEventSignatureHash": "7f3843f96bbc9424064b7b3e581ee815dbb661a021061745a9b27b166b0f44e9",
+            "mac": "ded8e83e57157157e9e5ae7a889d3d20cdcf6e44b8913e4049ab3558cb84e88f"
+          }
+        },
+        "checks": [
+          {
+            "check": "real declared pipeline wrapper exited successfully",
+            "passed": true
+          },
+          {
+            "check": "private-channel authority authenticated exactly one post-child receipt",
+            "passed": true
+          },
+          {
+            "check": "C3 wrapper still exited successfully",
+            "passed": true
+          },
+          {
+            "check": "C3 authenticated the instrument observer short-circuit",
+            "passed": true
+          },
+          {
+            "check": "C3 produced no guard execution receipt",
+            "passed": true
+          }
+        ]
+      }
+    }
+  },
+  "controls": {
+    "C1": {
+      "outcome": "proven",
+      "required": "pristine guard passes",
+      "run": {
+        "executionToken": "7b014a70-f393-4bd2-aced-ffa1b4dfce57",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "pass",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control",
+            "startedAt": "2026-08-18T19:45:07.667Z",
+            "endedAt": "2026-08-18T19:46:03.383Z",
+            "durationMs": 55716,
+            "exitCode": 0,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-sQD4B2/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-sQD4B2/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-sQD4B2/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-sQD4B2/guard-own.test.mjs (34.106042ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 44.94\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-sQD4B2/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-sQD4B2/guard-own.test.mjs (34.106042ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-wv0Pzr/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-wv0Pzr/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-wv0Pzr/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-wv0Pzr/guard-own.test.mjs (33.616917ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 45.79525\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-wv0Pzr/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-wv0Pzr/guard-own.test.mjs (33.616917ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-ebdYe3/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-ebdYe3/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-ebdYe3/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-ebdYe3/guard-own.test.mjs (34.8135ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 47.972291\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-ebdYe3/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-ebdYe3/guard-own.test.mjs (34.8135ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1\nF4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\nTAP version 13\n# Subtest: empty population is not proof\nnot ok 1 - empty population is not proof\n  ---\n  duration_ms: 1.960958\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-61nG1P/guard-own.test.mjs:5:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly deep-equal:\n    + actual - expected\n    \n      {\n        coveredCount: 0,\n    +   maxUncovered: 0,\n    +   passed: true,\n    -   passed: false,\n        populationCount: 0,\n    +   reason: 'within-ratchet',\n    -   reason: 'empty-population',\n        uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-61nG1P/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.start (node:internal/test_runner/test:944:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.181959\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-61nG1P/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-61nG1P/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/t\n...[8072 chars omitted]...\n\"childPid\":38537,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"control\"],\"argvHash\":\"685e71fed1025a6434f7f2bbf0e1b0d99f6a47ebafe0de67e3c9b3ccfca0c771\",\"startedAt\":\"2026-08-18T19:45:59.875Z\",\"childExitedAt\":\"2026-08-18T19:46:00.340Z\",\"emittedAfterChildExit\":true,\"mac\":\"98966ad0cde40acc18052a3e14eea25d9cc1d46ccb862527b0753a0a8afdde46\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"92187e92-2b0f-44f0-889e-1a2eda936ea5\",\"guardId\":\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"kind\":\"blind\",\"observerPid\":97365,\"childPid\":38859,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"probe:src/monitoring/probes/GuardPostureProbe.ts\",\"blind\"],\"argvHash\":\"a2e335b4735c28c4fa1938fbd8a77dce43bcfa3394ffd4019a8ec8343e6d95cf\",\"startedAt\":\"2026-08-18T19:46:00.345Z\",\"childExitedAt\":\"2026-08-18T19:46:00.809Z\",\"emittedAfterChildExit\":true,\"mac\":\"ba1c6977b9349b443276bc145a3e4de8a94422dbc98d1b6d9801916f297c8bf8\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"8424c95b-7fb7-4f40-8c5f-e4c6db6d1684\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"control\",\"observerPid\":97365,\"childPid\":39155,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"control\"],\"argvHash\":\"9e65de758b10b111b18e9e3843aa806b07c3ffc65b2d3b7923358d47becc8177\",\"startedAt\":\"2026-08-18T19:46:00.809Z\",\"childExitedAt\":\"2026-08-18T19:46:01.223Z\",\"emittedAfterChildExit\":true,\"mac\":\"a2439ebe85c3139c37d0aff4dbdbaeba219241f7957bb5d4f703bc2f5f3c80bf\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"724f7b6c-a1a2-4d38-90ef-99ceca234733\",\"guardId\":\"reviewer:src/core/reviewers/standards-conformance.ts\",\"kind\":\"blind\",\"observerPid\":97365,\"childPid\":39441,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"reviewer:src/core/reviewers/standards-conformance.ts\",\"blind\"],\"argvHash\":\"085138176f10f62984cd26cfa53d9c4e132050178444bad84f90dc76530509be\",\"startedAt\":\"2026-08-18T19:46:01.223Z\",\"childExitedAt\":\"2026-08-18T19:46:01.618Z\",\"emittedAfterChildExit\":true,\"mac\":\"0fc578099635fca157f65c12b23d7bc0e378324e896ab291fea221976438f23d\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"7db5cb2d-1c20-4985-b5cb-4b5b81864507\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"control\",\"observerPid\":97365,\"childPid\":39688,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"control\"],\"argvHash\":\"b017369782d21c974ea114af9498dcfa637d9ae95a1eadea9e07a58a55d6e212\",\"startedAt\":\"2026-08-18T19:46:01.618Z\",\"childExitedAt\":\"2026-08-18T19:46:02.068Z\",\"emittedAfterChildExit\":true,\"mac\":\"9b28f57218e3a98f62a05a35533367896d89050b50bd76ddcea67fb7a72164bf\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"bf9eb2fa-94c5-4ad8-87c8-4601096b076e\",\"guardId\":\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"kind\":\"blind\",\"observerPid\":97365,\"childPid\":39986,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"script:scripts/lint-checker-blind-input-coverage.mjs\",\"blind\"],\"argvHash\":\"c14cb72a0961a7f1af4f2b057e46839b01324527e73e2f4f44186c7948a13ce2\",\"startedAt\":\"2026-08-18T19:46:02.069Z\",\"childExitedAt\":\"2026-08-18T19:46:02.486Z\",\"emittedAfterChildExit\":true,\"mac\":\"6b358ddbf755d3ae08c8cbab7064989c1dc0193c01c1a0e4d7539422dc495bd5\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"eae6a847-fb65-45bb-8cd3-53834e36d32f\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"control\",\"observerPid\":97365,\"childPid\":40275,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"control\"],\"argvHash\":\"8d6ab0fa6c3494a2fd7d881feb9fbe27bce9be7c30b1bc48292396caf15122aa\",\"startedAt\":\"2026-08-18T19:46:02.487Z\",\"childExitedAt\":\"2026-08-18T19:46:02.949Z\",\"emittedAfterChildExit\":true,\"mac\":\"c1c3d53c5d5c6e7902c0f79662e14564e106789a088c7fa61b0ea5d67252715b\"}\nCHECKER_BLIND_CORE_RECEIPT {\"schema\":\"phaseB-authenticated-execution-receipt/v1\",\"authorityId\":\"77ddc5a3-df80-4081-8691-e10f25621951\",\"issuer\":\"checker-blind-input-core\",\"nonce\":\"e56a5381-3567-4ff5-80f0-5921734fe73c\",\"guardId\":\"script:scripts/lint-llm-attribution.js\",\"kind\":\"blind\",\"observerPid\":97365,\"childPid\":40532,\"childExitCode\":0,\"signal\":null,\"argv\":[\"/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node\",\"/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/node_modules/vite-node/vite-node.mjs\",\"--script\",\"/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts\",\"script:scripts/lint-llm-attribution.js\",\"blind\"],\"argvHash\":\"f7b877e966b0a45e8a29d5c0f49512accb7876bd582a8450ea6ae76158399ef3\",\"startedAt\":\"2026-08-18T19:46:02.950Z\",\"childExitedAt\":\"2026-08-18T19:46:03.372Z\",\"emittedAfterChildExit\":true,\"mac\":\"0083062c912a7bd0a538ef10bb785dea4eb9fff11cdfa6bd45b790cfc553857c\"}\nchecker-blind-input: population=96 execution-proven=5 legacy-uncovered=91/91 new-checkers=1 protected-base=248ed7177f5b\nchecker-blind-input: executable blind cases passed\n",
+              "truncated": true,
+              "originalChars": 24072
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 98152)\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:45:59 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:00 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/s\n...[15147 chars omitted]...\nj/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:02 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:03 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/SafeFsExecutor.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:03 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lint-llm-attribution.js) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:03 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/probes/GuardPostureProbe.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:03 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/core/reviewers/standards-conformance.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:03 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/src/monitoring/HumanAsDetectorLog.ts) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n12:46:03 PM [vite] Pre-transform error: Failed to load url file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs (resolved id: file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control/scripts/lib/checker-blind-input-ratchet.mjs) in /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-blind-core-xQWr2Q/core-generated-checker-case-worker.ts. Does the file exist?\n",
+              "truncated": true,
+              "originalChars": 31147
+            },
+            "outputSha256": "f0d7ec52adfeb21a842aa90546efc1f09f679d5955306e4d2d13d7d0bbd89d2e",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input"
+            ],
+            "decidingOutput": {
+              "kind": "suite-passed",
+              "lines": [
+                "    + actual - expected",
+                "  name: 'AssertionError'",
+                "  expected:",
+                "  name: 'AssertionError'",
+                "  expected: false"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "C2": {
+      "outcome": "proven",
+      "required": "every mutation is verified applied before guard output is interpreted",
+      "perMutation": {
+        "p1-symbol-preserving-checker-hollow": "proven",
+        "p2-subject-self-reports-clean": "proven",
+        "p3a-delete": "proven",
+        "p3b-comment-out": "proven",
+        "p3c-superstring-rename": "proven",
+        "p3d-type-preserving-hollow": "proven",
+        "p4a-empty-population": "proven",
+        "p4b-planted-nested-checker": "proven",
+        "p5-blind-production-checker": "proven"
+      }
+    },
+    "C3": {
+      "outcome": "proven",
+      "required": "the real wrapper succeeds while the exact guard child is skipped, and no execution receipt exists",
+      "run": {
+        "run": {
+          "argv": [
+            "npm",
+            "run",
+            "lint"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring",
+          "startedAt": "2026-08-18T19:44:01.748Z",
+          "endedAt": "2026-08-18T19:45:00.809Z",
+          "durationMs": 59061,
+          "pid": 45098,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "\n> instar@1.3.1180 lint\n> tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/lint-no-unfunneled-topic-creation.js && node scripts/lint-no-unfunneled-headless-launch.js && node scripts/lint-no-unfunneled-tmux-literal-send.js && node scripts/lint-no-unbounded-llm-spawn.js && node scripts/lint-no-unregistered-self-action.js && node scripts/lint-no-unfunneled-credential-write.js && node scripts/lint-state-registry.js && node scripts/lint-store-retention-declared.js && node scripts/lint-no-wholefile-sync-read.js && node scripts/lint-cas-emit-placement.js && node scripts/lint-journal-actuation-ban.js && node scripts/lint-no-blocking-process-scans.js && node scripts/lint-sync-subprocess-chokepoint.js && node scripts/lint-dev-agent-dark-gate.js && node scripts/lint-guard-manifest.js && node scripts/lint-llm-attribution.js && node scripts/lint-no-mainthread-cartographer-walk.js && node scripts/lint-scrape-fixture-realness.js && node scripts/check-codex-rule1-drift.js && node scripts/lint-routing-registry-freshness.js && node scripts/lint-no-opus-claude-cli-gating.js && node scripts/lint-model-registry-freshness.mjs && node scripts/lint-no-unreachable-messaging-gate.js && node scripts/lint-telegram-egress-boundary.mjs && node scripts/lint-nature-chains.mjs && node scripts/lint-emit-without-admit.js && node scripts/lint-migration-consumer-completeness.js && node scripts/lint-canonical-pipeline-completeness.mjs && node scripts/lint-expected-capacity-degradations.js && node scripts/lint-rollout-evidence-resolvable.js && node scripts/lint-no-direct-standards-registry-path.mjs && node scripts/lint-blocking-decisions-declared.mjs && node scripts/lint-no-duplicate-definitions.mjs && node scripts/lint-dispatch-withholds-answer.mjs && node scripts/lint-recall-surface-names-match-mechanism.mjs && node scripts/lint-registry-insertion-placement.mjs && node scripts/lint-standard-code-backreference.mjs && node scripts/lint-registry-tree-parentage.mjs && node scripts/lint-single-governing-obligation.mjs && node scripts/lint-documented-only-countdown.mjs && node scripts/lint-deferral-carrier-resolvable.mjs --staged --enforce && node scripts/generate-standards-hierarchy.mjs --check && node scripts/lint-framework-list-completeness.mjs && node scripts/lint-checker-blind-input-coverage.mjs\n\n[lint-no-direct-url-log] ✓ no credentialed-URL logging found\nlint-no-unfunneled-topic-creation: clean\nlint-no-unfunneled-headless-launch: clean\n✓ tmux literal sends funnelled (scanned 1660 files, 0 unfunneled)\nlint-no-unbounded-llm-spawn: clean\nlint-no-unregistered-self-action: report-only — 25 controller-shape emitter(s) scanned, 19 unregistered.\n  src/core/CaffeinateManager.ts:97 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/UpgradeNotifyManager.ts:123 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/core/WorktreeManager.ts:506 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/messaging/SpawnRequestManager.ts:1051 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ActiveWorkSilenceSentinel.ts:203 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/AgentWorktreeReaper.ts:196 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/CollaborationRedriveEngine.ts:322 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ContextWedgeSentinel.ts:321 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/McpProcessReaper.ts:158 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/OrphanProcessReaper.ts:547 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/QuotaManager.ts:419 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/RateLimitSentinel.ts:295 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/ReleaseReadinessSentinel.ts:289 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionMonitor.ts:335 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SessionWatchdog.ts:429 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/SocketDisconnectSentinel.ts:175 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/monitoring/WorktreeReaper.ts:72 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/threadline/HeartbeatWatchdog.ts:259 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  src/tunnel/TunnelManager.ts:128 — a self-action controller with an unregistered emit — add /* @self-action-controller: <id> */ and register <id> in SELF_ACTION_CONTROLLERS (or allowlist it with a one-shot/user-driven reason)\n  (report-only — no build failure; the enforcing flip is gated on prGate.classClosure.dryRun:false after a measured clean soak.)\nlint-no-unfunneled-credential-write: clean\nlint-state-registry: clean (104 registry categories)\nlint-store-retention-declared: OK — 29 stores retentioned, 75 grandfathered (retrofit backlog, may only shrink).\nlint-no-wholefile-sync-read: OK — 0 literal hit(s), all grandfathered (0 baselined).\nlint-cas-emit-placement: clean (14 CAS call site(s), all paired)\nlint-journal-actuation-ban: clean (8 actuator modules, none load the reader)\nlint-no-blocking-process-scans: clean\nlint-sync-subprocess-chokepoint: clean — 95 raw sync spawn(s), all grandfathered (142 baselined).\nlint-dev-agent-dark-gate: clean\nlint-guard-manifest: clean\nlint-no-mainthread-cartographer-walk: clean\n  ✅ parseGroqPricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL groq.com/pricing table bytes)\n  ✅ parseGooglePricingHtml — realness fixture + feeds-and-asserts test OK (parses the REAL ai.google.dev/pricing flash-lite card bytes (PAID text rate, never audio/free))\n  ✅ FrameworkLoginDriver.parseArtifact — realness fixture + feeds-and-asserts test OK (parses the REAL wrapped Mac Mini login pane)\n  ✅ parseProcTable — realness fixture + feeds-and-asserts test OK (parses the REAL captured ps process table byte-for-byte)\n  ✅ parseProbeResponse — realness fixture + feeds-and-asserts test OK (classifies the REAL captured /mesh/rpc probe responses byte-for-byte)\n  ✅ parseTailscaleStatus — realness fixture + feeds-and-asserts test OK (parses the REAL captured tailscale status --json byte-for-byte)\n  ✅ parseReceivePathMessage — realness fixture + feeds-and-asserts test OK (parses the REAL captured Telegram receive-path message objects)\n  ✅ parseRatificationConfirmation — realness fixture + feeds-and-asserts test OK (binds a REAL reply-anchored confirmation to the enumerated set (message-id chain))\n  ✅ parseDeferTrigger — realness fixture + feeds-and-asserts test OK (matches defer-intent vocabulary in the REAL captured trigger message)\n  ✅ parseDeclaredDeliverables — realness fixture + feeds-and-asserts test OK (a REAL pathless condition text declares NOTHING)\n  ✅ parsePorcelainStatus — realness fixture + feeds-and-asserts test OK (maps REAL git status --porcelain output per the R42 mapping)\n  ✅ runLayerBScan — realness fixture + feeds-and-asserts test OK (flags the REAL incident prose and stays silent on the REAL fenced clean tail)\n[codex-rule1-drift] ✓ config.ts is compliant with spec 12 Rule 1 (Phase A)\nlint-routing-registry-freshness: OK — every COMPONENT_CATEGORY key has a registry row.\nlint-no-opus-claude-cli-gating: OK — R1/R2 clamp intact; no config routes a gating call to Opus×claude-CLI.\n\u001b[1m[lint-model-registry-freshness]\u001b[0m enforcement=strict\n  \u001b[32mok\u001b[0m   Staleness OK: reviewed 2026-08-18 (0d ago, window 45d).\n  \u001b[32mok\u001b[0m   Drift OK: gemini-cli 'gemini-capable-tier' -> 'gemini-3.1-pro-preview' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: codex-cli 'codex-capable-tier' -> 'gpt-5.5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: anthropic-headless 'anthropic-headless-capable-tier' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-opus-4-8' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-tier-escalation-default-escalated' -> 'claude-fable-5' (in derived frontier set).\n  \u001b[32mok\u001b[0m   Drift OK: claude-code 'claude-clean-door-reviewer-default' -> 'claude-fable-5' (in derived frontier set).\n\u001b[32mPASS\u001b[0m — model registry pins fresh and in-allowlist.\nlint-no-unreachable-messaging-gate: clean\nlint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to src/messaging/telegram-egress.ts, which checks the serialised body before sending.\nlint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve 'claude-sonnet-4-6', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.\n[lint-emit-without-admit] OK — 1659 file(s) scanned, 0 violations.\nlint-migration-consumer-completeness: clean\nlint-canonical-pipeline-completeness: clean (structural coverage evidence only)\n[capacity-enforcement-contracts] PASS\nlint-rollout-evidence-resolvable: clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved.\n✓ lint-no-direct-standards-registry-path: the resolver is the only path constructor.\nlint-blocking-decisions-declared: clean — 26 file(s) in the population, 12/12 declared blocking (shrink-only), 14 content-pinned as non-blocking.\nlint-no-duplicate-definitions: clean — 15 family heading(s), 88 article(s), 2 article ID(s), no duplicate definitions.\nlint-dispatch-withholds-answer: clean — 7 templated dispatch(es) carry the complete withhold-the-answer protocol. (Ad-hoc dispatches are out of scope; see the header.)\nlint-recall-surface-names-match-mechanism: clean — 2 advertised recall surface(s); /semantic/search/hybrid → .searchHybrid (meaning), /semantic/search → .search (literal).\nlint-registry-insertion-placement: clean — 88 article(s), 77 declaring a placement, 11 grandfathered (shrink-only).\nlint-standard-code-backreference: clean — 50 cited file(s), 23 naming a standard back, 27 grandfathered (shrink-only).\nlint-registry-tree-parentage: clean — 88 article(s), 39 declared parent-child relation(s), all resolving and bidirectional.\nlint-single-governing-obligation: clean — 8 obligation(s), each with one declared governing article and 10 deferring article(s).\nlint-documented-only-countdown: clean — 3 article countdown(s) + 36 sub-obligation countdown(s), all unexpired; soonest 2026-09-07 (\"The Body and the Mind\").\nlint-deferral-carrier-resolvable: clean — 0 marker(s), each resolving to an inlined carrier excerpt. NOTE: this verifies the carrier is CHECKABLE, not that it COVERS the deferral — semantic coverage is the reviewer's job (see the header for why no similarity metric was shippable).\ngenerate-standards-hierarchy --check: clean — 39 declared relation(s) rendered, block current.\n[framework-list] self-test passed (both detectors fire on a known-stale list; the subset marker suppresses); compared 5 framework list(s) (0 literal-union, 2 named-type, 3 declared-subset) across 1660 files.\n[framework-list] OK — every annotated list covers its own declared type.\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ffb72504-f569-4732-9834-adcdf361f0d4\",\"sequence\":1,\"kind\":\"observer-ready\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93759,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"publicKey\":\"MCowBQYDK2VwAyEAclBRqghyX5fMnyaPu7B4oRIZ1LM52PyHtYZJfGXwrK0=\",\"signature\":\"nYXqS2jBYKVXqLuu5qructEYdgFqX4cnixJP20uVCGWtn6C/nmAHdk+48idgabGc6CaZoqseyhDmBhqCgOaEAg==\"}\nFIX_VERIFIER_OBSERVER_EVENT {\"eventSchema\":\"phaseB-authenticated-observer-event/v1\",\"source\":\"fix-verifier-observer\",\"observerSession\":\"ffb72504-f569-4732-9834-adcdf361f0d4\",\"sequence\":2,\"kind\":\"short-circuit\",\"guardId\":\"checker-blind-input-coverage\",\"nodeEntry\":\"scripts/lint-checker-blind-input-coverage.mjs\",\"observerPid\":93759,\"argv\":[\"scripts/lint-checker-blind-input-coverage.mjs\"],\"shortCircuitedAt\":\"2026-08-18T19:45:00.800Z\",\"signature\":\"tkdQmR8o7aygy/m3/pLm6o2GNqFTkMSi4aGjZGZ4KCE5tNeVVWso13ek2acj4qABBjY6JUj0usPQ8D0E4+kGDA==\"}\n[fix-verifier-C3] authenticated observer short-circuited guard=checker-blind-input-coverage entry=scripts/lint-checker-blind-input-coverage.mjs\n",
+            "truncated": false,
+            "originalChars": 14882
+          },
+          "stderr": {
+            "text": "  ⚠️  register-or-justify: 70 exported parse*/scrape* symbol(s) in src/ are not in SCRAPE_PARSERS.\n      If they consume untrusted real-world text, register them (spec change) or justify out-of-scope in the PR:\n        • parseWorktreeGitPointer (src/core/AgentWorktreeDetector.ts)\n        • parseCapabilityDigest (src/core/CapabilityRegistry.ts)\n        • parseJsonResult (src/core/ClaudeCliIntelligenceProvider.ts)\n        • parseContinuationTasks (src/core/CodexTaskContinuationStore.ts)\n        • parseHlc (src/core/HybridLogicalClock.ts)\n        • parseHlcKey (src/core/HybridLogicalClock.ts)\n        • parseInstrumentAssessment (src/core/InstrumentAssessment.ts)\n        • parseMoveIntentResponse (src/core/MoveIntentClassifier.ts)\n        • parseIdentityLayer (src/core/OrgIntentIdentityLayer.ts)\n        • parsePlanDoc (src/core/PlanDocParser.ts)\n        • parseProfileIntentResponse (src/core/ProfileIntentClassifier.ts)\n        • parseSafeYaml (src/core/SafeYaml.ts)\n        • parseProcTimeToSeconds (src/core/SessionManager.ts)\n        • parseSlackRoutingKey (src/core/SlackForwardBridge.ts)\n        • parseStandardsRegistryDetailed (src/core/StandardsRegistryParser.ts)\n        • parseStandardsRegistry (src/core/StandardsRegistryParser.ts)\n        • parseArcCheckResponse (src/core/TopicIntentArcCheck.ts)\n        • parseExtractorResponse (src/core/TopicIntentExtractor.ts)\n        • parseExtractorAnalysis (src/core/TopicIntentExtractor.ts)\n        • parseUsherResponse (src/core/Usher.ts)\n        • ...and 50 more\n\n",
+            "truncated": false,
+            "originalChars": 1529
+          },
+          "outputSha256": "9127c493caf18499b34689a84827c16dfa4148ade41a0a8721866026ea284fdc",
+          "observerError": null,
+          "observerCandidateLineCount": 2,
+          "exitProvenance": "direct child status from spawn; shell=false; nested observer pids validated live with ps"
+        },
+        "observer": {
+          "wrapper": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/node",
+          "observerProgram": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs",
+          "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+          "requiredArgs": []
+        },
+        "receipts": [],
+        "shortCircuitEvents": [
+          {
+            "eventSchema": "phaseB-authenticated-observer-event/v1",
+            "source": "fix-verifier-observer",
+            "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+            "sequence": 2,
+            "kind": "short-circuit",
+            "guardId": "checker-blind-input-coverage",
+            "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+            "observerPid": 93759,
+            "argv": [
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "shortCircuitedAt": "2026-08-18T19:45:00.800Z",
+            "signature": "tkdQmR8o7aygy/m3/pLm6o2GNqFTkMSi4aGjZGZ4KCE5tNeVVWso13ek2acj4qABBjY6JUj0usPQ8D0E4+kGDA=="
+          }
+        ],
+        "shortCircuitReceipt": {
+          "schema": "phaseB-authenticated-execution-receipt/v1",
+          "authorityId": "cae0dc8e-ebc3-4e22-a546-f1346590e401",
+          "issuer": "fix-verifier:checker-blind-input-coverage",
+          "nonce": "21f2e0fc-d554-4f19-85ef-b8f1f7534a20",
+          "guardId": "checker-blind-input-coverage",
+          "kind": "short-circuit",
+          "observerPid": 93759,
+          "childPid": 93759,
+          "childExitCode": 0,
+          "signal": null,
+          "argv": [
+            "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs",
+            "scripts/lint-checker-blind-input-coverage.mjs"
+          ],
+          "argvHash": "59a734b0a204c458bbb204618d18df7685f6ec3da6fac1e7ade4e47ee457e1d7",
+          "startedAt": "2026-08-18T19:45:00.800Z",
+          "childExitedAt": "2026-08-18T19:45:00.809Z",
+          "emittedAfterChildExit": true,
+          "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+          "observerEventSequence": 2,
+          "observerEventSignatureHash": "7f3843f96bbc9424064b7b3e581ee815dbb661a021061745a9b27b166b0f44e9",
+          "mac": "ded8e83e57157157e9e5ae7a889d3d20cdcf6e44b8913e4049ab3558cb84e88f"
+        },
+        "processObservations": {
+          "observerReady": {
+            "event": {
+              "eventSchema": "phaseB-authenticated-observer-event/v1",
+              "source": "fix-verifier-observer",
+              "observerSession": "ffb72504-f569-4732-9834-adcdf361f0d4",
+              "sequence": 1,
+              "kind": "observer-ready",
+              "guardId": "checker-blind-input-coverage",
+              "nodeEntry": "scripts/lint-checker-blind-input-coverage.mjs",
+              "observerPid": 93759,
+              "argv": [
+                "scripts/lint-checker-blind-input-coverage.mjs"
+              ],
+              "publicKey": "MCowBQYDK2VwAyEAclBRqghyX5fMnyaPu7B4oRIZ1LM52PyHtYZJfGXwrK0=",
+              "signature": "nYXqS2jBYKVXqLuu5qructEYdgFqX4cnixJP20uVCGWtn6C/nmAHdk+48idgabGc6CaZoqseyhDmBhqCgOaEAg=="
+            },
+            "valid": true,
+            "authenticated": true,
+            "processRecord": {
+              "pid": 93759,
+              "ppid": 45486,
+              "command": "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/pipeline-observer/c3/authenticated-observer.mjs scripts/lint-checker-blind-input-coverage.mjs"
+            }
+          },
+          "validatedChildStart": null,
+          "childExit": null,
+          "authenticatedEventCount": 2,
+          "stdoutCandidateEventLineCount": 2
+        },
+        "outcome": "proven"
+      }
+    }
+  },
+  "properties": {
+    "P1": {
+      "outcome": "proven",
+      "mutations": [
+        "p1-symbol-preserving-checker-hollow"
+      ]
+    },
+    "P2": {
+      "outcome": "proven",
+      "mutations": [
+        "p2-subject-self-reports-clean"
+      ]
+    },
+    "P3": {
+      "outcome": "proven",
+      "mutations": [
+        "p3a-delete",
+        "p3b-comment-out",
+        "p3c-superstring-rename",
+        "p3d-type-preserving-hollow"
+      ]
+    },
+    "P4": {
+      "outcome": "proven",
+      "mutations": [
+        "p4a-empty-population",
+        "p4b-planted-nested-checker"
+      ]
+    },
+    "P5": {
+      "outcome": "proven",
+      "mutations": [
+        "p5-blind-production-checker"
+      ]
+    }
+  },
+  "effectiveAgainst": [
+    "blind input / fail-open",
+    "guard removal",
+    "hollowing",
+    "population evasion",
+    "self-report / false testimony",
+    "vacuous measurement"
+  ],
+  "rung": "effective",
+  "mutations": [
+    {
+      "id": "p1-symbol-preserving-checker-hollow",
+      "property": "P1",
+      "label": "SYMBOL-PRESERVING HOLLOW",
+      "violationClass": "hollowing",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/03-p1-symbol-preserving-checker-hollow",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "semantic mutation marker S3 adapter P1 is present",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lint-llm-attribution.js": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 16253,
+            "contentSha256": "409fbf5866541ea6899e15e562680d47476ab63f0b409bc96c26fa3a4ee67984"
+          }
+        },
+        "after": {
+          "scripts/lint-llm-attribution.js": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 15165,
+            "contentSha256": "39def5fd2c3d81b19011ae47a553df4a7e3c3bd623f37a638e7e87fc569438bc"
+          }
+        },
+        "changedPaths": [
+          "scripts/lint-llm-attribution.js"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "runLint export and signature remain",
+              "passed": true
+            },
+            {
+              "check": "constant clean result replaced implementation",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/03-p1-symbol-preserving-checker-hollow",
+          "startedAt": "2026-08-18T19:46:06.765Z",
+          "endedAt": "2026-08-18T19:46:06.937Z",
+          "durationMs": 172,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lint-llm-attribution.js\n",
+            "truncated": false,
+            "originalChars": 35
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4e2b2f0087549b0e161d77e53780ad5d01c8073ed2facb36acc0c9dd10302c79",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "aca3a16e-b04c-4425-aa84-48754f2e5063",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/03-p1-symbol-preserving-checker-hollow",
+            "startedAt": "2026-08-18T19:46:06.937Z",
+            "endedAt": "2026-08-18T19:46:54.354Z",
+            "durationMs": 47417,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/03-p1-symbol-preserving-checker-hollow\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-cHHjgZ/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-cHHjgZ/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-cHHjgZ/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-cHHjgZ/guard-own.test.mjs (82.288625ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 92.911958\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-cHHjgZ/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-cHHjgZ/guard-own.test.mjs (82.288625ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-383zBE/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-383zBE/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-383zBE/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-383zBE/guard-own.test.mjs (27.25375ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 36.383\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-383zBE/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-383zBE/guard-own.test.mjs (27.25375ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-Yj70iA/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-Yj70iA/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-Yj70iA/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-Yj70iA/guard-own.test.mjs (23.799166ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 30.494417\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-Yj70iA/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-Yj70iA/guard-own.test.mjs (23.799166ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1\nF4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\nTAP version 13\n# Subtest: empty population is not proof\nnot ok 1 - empty population is not proof\n  ---\n  duration_ms: 1.096334\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:5:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly deep-equal:\n    + actual - expected\n    \n      {\n        coveredCount: 0,\n    +   maxUncovered: 0,\n    +   passed: true,\n    -   passed: false,\n        populationCount: 0,\n    +   reason: 'within-ratchet',\n    -   reason: 'empty-population',\n        uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.start (node:internal/test_runner/test:944:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.30975\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.136666\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.116625\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 62.198208\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (1.122583ms)\n✖ unknown coverage id is rejected (0.160459ms)\n✖ new uncovered checker is named and rejected (0.068ms)\n✔ genuinely covered population passes (0.065375ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 51.752167\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-g0JyoZ/guard-own.test.mjs:5:1\n✖ empty population is not proof (1.122583ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.start (node:internal/test_runner/test:944:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual'\n  }\n\ntest at ../../checker-p3-hollow-g0JyoZ/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.160459ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\ntest at ../../checker-p3-hollow-g0JyoZ/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.068ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-g0JyoZ/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 1 failed) 6413ms\n   × checker blind-input class ratchet > executes every declared blind case and none reports clean 4390ms\n     → expected [ { …(4) } ] to deeply equal []\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 846ms\n   ✓ checker blind-input class ratchet > derives bootstrap authority from canonical protected main, never a local tracking ref 423ms\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  12:46:08\n   Duration  45.71s (transform 417ms, setup 3ms, collect 181ms, tests 6.41s, environment 0ms, prepare 35ms)\n\n",
+              "truncated": false,
+              "originalChars": 13953
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 44332)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > executes every declared blind case and none reports clean\nAssertionError: expected [ { …(4) } ] to deeply equal []\n\n- Expected\n+ Received\n\n- Array []\n+ Array [\n+   Object {\n+     \"evidence\": Object {\n+       \"exitCode\": 1,\n+       \"output\": \"CHECKER_CHILD_RESULT {\\\"id\\\":\\\"script:scripts/lint-llm-attribution.js\\\",\\\"phase\\\":\\\"blind\\\",\\\"passed\\\":false,\\\"evidence\\\":{\\\"real\\\":[],\\\"stale\\\":[],\\\"blind\\\":[]}}\",\n+       \"passed\": false,\n+       \"spawnError\": null,\n+     },\n+     \"id\": \"script:scripts/lint-llm-attribution.js\",\n+     \"phase\": \"blind\",\n+     \"reason\": \"blind-input-accepted\",\n+   },\n+ ]\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:289:32\n    287|     expect([...CASES.keys()].sort()).toEqual([...BLIND_INPUT_CASE_IDS]…\n    288|     const execution = await executeBlindCases(CASES);\n    289|     expect(execution.failures).toEqual([]);\n       |                                ^\n    290|     expect(execution.provenIds.sort()).toEqual([...BLIND_INPUT_CASE_ID…\n    291|   });\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+              "truncated": false,
+              "originalChars": 1301
+            },
+            "outputSha256": "5871663b85229676a6575b37d9c7d5afd00bc732a5bd4a725f1dea2d192f903c",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input",
+              "checker blind-input class ratchet",
+              "Test Files"
+            ],
+            "decidingOutput": {
+              "kind": "assertion-or-test-failure",
+              "lines": [
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:",
+                "  + actual - expected",
+                "    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "     → expected [ { …(4) } ] to deeply equal []",
+                " Test Files  1 failed (1)",
+                "      Tests  1 failed | 17 passed (18)",
+                "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯",
+                "AssertionError: expected [ { …(4) } ] to deeply equal []"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p2-subject-self-reports-clean",
+      "property": "P2",
+      "label": "SUBJECT SELF-REPORTS CLEAN",
+      "violationClass": "self-report / false testimony",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/04-p2-subject-self-reports-clean",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "semantic mutation marker S3 adapter P2 is present",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lint-llm-attribution.js": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 16253,
+            "contentSha256": "409fbf5866541ea6899e15e562680d47476ab63f0b409bc96c26fa3a4ee67984"
+          }
+        },
+        "after": {
+          "scripts/lint-llm-attribution.js": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 15200,
+            "contentSha256": "85f039e39dfc4452bdf83579fd1f78a4278ab7117cfd120736b51908ce765602"
+          }
+        },
+        "changedPaths": [
+          "scripts/lint-llm-attribution.js"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "subject emits explicit false testimony",
+              "passed": true
+            },
+            {
+              "check": "independent blind field is falsely empty",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/04-p2-subject-self-reports-clean",
+          "startedAt": "2026-08-18T19:46:57.488Z",
+          "endedAt": "2026-08-18T19:46:57.644Z",
+          "durationMs": 156,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lint-llm-attribution.js\n",
+            "truncated": false,
+            "originalChars": 35
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4e2b2f0087549b0e161d77e53780ad5d01c8073ed2facb36acc0c9dd10302c79",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "cc31f5ef-4b18-4a8a-807d-76718ad105c5",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/04-p2-subject-self-reports-clean",
+            "startedAt": "2026-08-18T19:46:57.644Z",
+            "endedAt": "2026-08-18T19:47:45.795Z",
+            "durationMs": 48151,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/04-p2-subject-self-reports-clean\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-ib1AkR/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-ib1AkR/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-ib1AkR/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-ib1AkR/guard-own.test.mjs (62.978667ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 133.945916\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-ib1AkR/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-ib1AkR/guard-own.test.mjs (62.978667ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-96L7d3/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-96L7d3/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-96L7d3/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-96L7d3/guard-own.test.mjs (24.271625ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 33.919292\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-96L7d3/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-96L7d3/guard-own.test.mjs (24.271625ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-wos7LX/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-wos7LX/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-wos7LX/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-wos7LX/guard-own.test.mjs (26.269ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 35.2265\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-wos7LX/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-wos7LX/guard-own.test.mjs (26.269ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1\nF4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\nTAP version 13\n# Subtest: empty population is not proof\nnot ok 1 - empty population is not proof\n  ---\n  duration_ms: 1.109834\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:5:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly deep-equal:\n    + actual - expected\n    \n      {\n        coveredCount: 0,\n    +   maxUncovered: 0,\n    +   passed: true,\n    -   passed: false,\n        populationCount: 0,\n    +   reason: 'within-ratchet',\n    -   reason: 'empty-population',\n        uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.start (node:internal/test_runner/test:944:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.190459\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.199708\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.171958\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 109.007458\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (2.612875ms)\n✖ unknown coverage id is rejected (0.23175ms)\n✖ new uncovered checker is named and rejected (0.08975ms)\n✔ genuinely covered population passes (0.07825ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 80.969167\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-sKY9JD/guard-own.test.mjs:5:1\n✖ empty population is not proof (2.612875ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.start (node:internal/test_runner/test:944:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual'\n  }\n\ntest at ../../checker-p3-hollow-sKY9JD/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.23175ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\ntest at ../../checker-p3-hollow-sKY9JD/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.08975ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-sKY9JD/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 1 failed) 8323ms\n   × checker blind-input class ratchet > executes every declared blind case and none reports clean 6190ms\n     → expected [ { …(4) } ] to deeply equal []\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 1014ms\n   ✓ P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 324ms\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  12:46:59\n   Duration  46.56s (transform 502ms, setup 2ms, collect 185ms, tests 8.32s, environment 0ms, prepare 52ms)\n\n",
+              "truncated": false,
+              "originalChars": 13945
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 78257)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > executes every declared blind case and none reports clean\nAssertionError: expected [ { …(4) } ] to deeply equal []\n\n- Expected\n+ Received\n\n- Array []\n+ Array [\n+   Object {\n+     \"evidence\": Object {\n+       \"exitCode\": 1,\n+       \"output\": \"CHECKER_CHILD_RESULT {\\\"id\\\":\\\"script:scripts/lint-llm-attribution.js\\\",\\\"phase\\\":\\\"blind\\\",\\\"passed\\\":false,\\\"evidence\\\":{\\\"real\\\":[],\\\"stale\\\":[],\\\"blind\\\":[],\\\"subjectClaim\\\":\\\"all-inputs-readable\\\"}}\",\n+       \"passed\": false,\n+       \"spawnError\": null,\n+     },\n+     \"id\": \"script:scripts/lint-llm-attribution.js\",\n+     \"phase\": \"blind\",\n+     \"reason\": \"blind-input-accepted\",\n+   },\n+ ]\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:289:32\n    287|     expect([...CASES.keys()].sort()).toEqual([...BLIND_INPUT_CASE_IDS]…\n    288|     const execution = await executeBlindCases(CASES);\n    289|     expect(execution.failures).toEqual([]);\n       |                                ^\n    290|     expect(execution.provenIds.sort()).toEqual([...BLIND_INPUT_CASE_ID…\n    291|   });\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+              "truncated": false,
+              "originalChars": 1342
+            },
+            "outputSha256": "ede6b84ebf158720709ed9f410b44ecf24ef86be67d6e50050d408775bdf9104",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input",
+              "checker blind-input class ratchet",
+              "Test Files"
+            ],
+            "decidingOutput": {
+              "kind": "assertion-or-test-failure",
+              "lines": [
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:",
+                "  + actual - expected",
+                "    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "     → expected [ { …(4) } ] to deeply equal []",
+                " Test Files  1 failed (1)",
+                "      Tests  1 failed | 17 passed (18)",
+                "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯",
+                "AssertionError: expected [ { …(4) } ] to deeply equal []"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p3a-delete",
+      "property": "P3",
+      "label": "DELETE",
+      "violationClass": "guard removal",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "exact structural mutation verified",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7646,
+            "contentSha256": "98907ead3be3171c946e343cad9b859475a27997b84670718362e7cfba8bc312"
+          }
+        },
+        "after": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": false,
+            "type": null,
+            "mode": null,
+            "bytes": null,
+            "contentSha256": null
+          }
+        },
+        "changedPaths": [
+          "scripts/lib/checker-blind-input-ratchet.mjs"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "scripts/lib/checker-blind-input-ratchet.mjs is absent",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete",
+          "startedAt": "2026-08-18T19:47:49.664Z",
+          "endedAt": "2026-08-18T19:47:49.787Z",
+          "durationMs": 123,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " D scripts/lib/checker-blind-input-ratchet.mjs\n",
+            "truncated": false,
+            "originalChars": 47
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "9438d15de7a141174eb8e2641dad0d210eadb724bf61cfad2966f105b2a15a4f",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "53a8c731-4eb5-4d3e-9ff1-8f15b8438e5e",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete",
+            "startedAt": "2026-08-18T19:47:49.788Z",
+            "endedAt": "2026-08-18T19:47:49.827Z",
+            "durationMs": 39,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "",
+              "truncated": false,
+              "originalChars": 0
+            },
+            "stderr": {
+              "text": "node:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete/scripts/lib/checker-blind-input-ratchet.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete/scripts/lint-checker-blind-input-coverage.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete/scripts/lib/checker-blind-input-ratchet.mjs'\n}\n\nNode.js v22.18.0\n",
+              "truncated": false,
+              "originalChars": 1219
+            },
+            "outputSha256": "0e361adf1bda2a352599f81348a468332bafe8ead1d242956d865c60f64014c7",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input"
+            ],
+            "decidingOutput": {
+              "kind": "no-deciding-output",
+              "lines": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p3b-comment-out",
+      "property": "P3",
+      "label": "COMMENT OUT",
+      "violationClass": "guard removal",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/06-p3b-comment-out",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "exact structural mutation verified",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7646,
+            "contentSha256": "98907ead3be3171c946e343cad9b859475a27997b84670718362e7cfba8bc312"
+          }
+        },
+        "after": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 8225,
+            "contentSha256": "aeb732c4dacefe44944d5711d935f13983f0235ecb1dd98d234ce9c382d7b599"
+          }
+        },
+        "changedPaths": [
+          "scripts/lib/checker-blind-input-ratchet.mjs"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "guard has no executable lines",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/06-p3b-comment-out",
+          "startedAt": "2026-08-18T19:47:53.471Z",
+          "endedAt": "2026-08-18T19:47:53.526Z",
+          "durationMs": 55,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lib/checker-blind-input-ratchet.mjs\n",
+            "truncated": false,
+            "originalChars": 47
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4bd2e689678bc8f5f172f183027a5343da30cbd4ed1c8870804974266311c113",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "c91f29fd-f92d-41e1-90c4-e77502e1fed2",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/06-p3b-comment-out",
+            "startedAt": "2026-08-18T19:47:53.526Z",
+            "endedAt": "2026-08-18T19:47:53.548Z",
+            "durationMs": 22,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "",
+              "truncated": false,
+              "originalChars": 0
+            },
+            "stderr": {
+              "text": "file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/06-p3b-comment-out/scripts/lint-checker-blind-input-coverage.mjs:10\n  checkerIdForCandidatePath,\n  ^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module './lib/checker-blind-input-ratchet.mjs' does not provide an export named 'checkerIdForCandidatePath'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n",
+              "truncated": false,
+              "originalChars": 688
+            },
+            "outputSha256": "874bb086eec1fd9e7d0d1e49e0dbfd9f38e2d00f24b00f658f26d73370e3559c",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input"
+            ],
+            "decidingOutput": {
+              "kind": "no-deciding-output",
+              "lines": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p3c-superstring-rename",
+      "property": "P3",
+      "label": "SUPERSTRING RENAME",
+      "violationClass": "guard removal",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/07-p3c-superstring-rename",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "exact structural mutation verified",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7646,
+            "contentSha256": "98907ead3be3171c946e343cad9b859475a27997b84670718362e7cfba8bc312"
+          }
+        },
+        "after": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7662,
+            "contentSha256": "c48ac31accbc925f626f213e9e1fc72a61455ccb66ac784f454f6b2120bd803b"
+          }
+        },
+        "changedPaths": [
+          "scripts/lib/checker-blind-input-ratchet.mjs"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "longer symbol exists",
+              "passed": true
+            },
+            {
+              "check": "standalone original is absent",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/07-p3c-superstring-rename",
+          "startedAt": "2026-08-18T19:47:56.274Z",
+          "endedAt": "2026-08-18T19:47:56.370Z",
+          "durationMs": 96,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lib/checker-blind-input-ratchet.mjs\n",
+            "truncated": false,
+            "originalChars": 47
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4bd2e689678bc8f5f172f183027a5343da30cbd4ed1c8870804974266311c113",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "3000a9c4-e28d-4cd7-9a42-e72aeaaca3c4",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/07-p3c-superstring-rename",
+            "startedAt": "2026-08-18T19:47:56.370Z",
+            "endedAt": "2026-08-18T19:48:37.793Z",
+            "durationMs": 41423,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/07-p3c-superstring-rename\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-PWyd6U/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-PWyd6U/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-PWyd6U/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-PWyd6U/guard-own.test.mjs (26.415ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 36.774708\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-PWyd6U/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-PWyd6U/guard-own.test.mjs (26.415ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-Astn37/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-Astn37/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-Astn37/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-Astn37/guard-own.test.mjs (27.070792ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 33.936917\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-Astn37/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-Astn37/guard-own.test.mjs (27.070792ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-eBnRl0/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-eBnRl0/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-eBnRl0/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-eBnRl0/guard-own.test.mjs (65.350542ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 76.131333\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-eBnRl0/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-eBnRl0/guard-own.test.mjs (65.350542ms)\n  'test failed'\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 4 failed) 5468ms\n   × checker blind-input class ratchet > derives a non-empty production population and holds legacy exceptions at the pinned ceiling 107ms\n     → evaluateBlindInputCoverage is not a function\n   ✓ checker blind-input class ratchet > executes every declared blind case and none reports clean 3868ms\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 899ms\n   × checker blind-input class ratchet > P4a empty population is an error, never 0/0 clean 1ms\n     → evaluateBlindInputCoverage is not a function\n   × checker blind-input class ratchet > P4b recursively catches planted checkers outside top-level globs 4ms\n     → evaluateBlindInputCoverage is not a function\n   × P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 3ms\n     → expected null not to be null\n\n Test Files  1 failed (1)\n      Tests  4 failed | 14 passed (18)\n   Start at  12:47:57\n   Duration  39.99s (transform 333ms, setup 4ms, collect 215ms, tests 5.47s, environment 0ms, prepare 50ms)\n\n",
+              "truncated": false,
+              "originalChars": 6153
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 14480)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > derives a non-empty production population and holds legacy exceptions at the pinned ceiling\nTypeError: evaluateBlindInputCoverage is not a function\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:275:20\n    273|   it('derives a non-empty production population and holds legacy excep…\n    274|     const population = deriveCheckerPopulation(ROOT);\n    275|     const result = evaluateBlindInputCoverage({\n       |                    ^\n    276|       population,\n    277|       coverageIds: BLIND_INPUT_CASE_IDS,\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > P4a empty population is an error, never 0/0 clean\nTypeError: evaluateBlindInputCoverage is not a function\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:383:20\n    381| \n    382|   it('P4a empty population is an error, never 0/0 clean', () => {\n    383|     const result = evaluateBlindInputCoverage({ population: [], covera…\n       |                    ^\n    384|     expect(result).toMatchObject({ passed: false, reason: 'empty-popul…\n    385|   });\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > P4b recursively catches planted checkers outside top-level globs\nTypeError: evaluateBlindInputCoverage is not a function\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:397:22\n    395|         'script:scripts/nested/lint-planted.mjs',\n    396|       ]);\n    397|       const result = evaluateBlindInputCoverage({ population, coverage…\n       |                      ^\n    398|       expect(result).toMatchObject({ passed: false, reason: 'uncovered…\n    399|     } finally {\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nAssertionError: expected null not to be null\n ❯ replaceGuardBody tests/unit/checker-blind-input-ratchet.test.ts:597:23\n    595|     const signature = /export function evaluateBlindInputCoverage\\(\\{ …\n    596|     const match = signature.exec(body);\n    597|     expect(match).not.toBeNull();\n       |                       ^\n    598|     const open = (match?.index ?? 0) + (match?.[0].length ?? 0) - 1;\n    599|     let depth = 0;\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:667:22\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+              "truncated": false,
+              "originalChars": 2698
+            },
+            "outputSha256": "2fd1b997864a5faee505cf76351c37957b5ab121329032676b29418a6669f48c",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input",
+              "checker blind-input class ratchet",
+              "Test Files"
+            ],
+            "decidingOutput": {
+              "kind": "assertion-or-test-failure",
+              "lines": [
+                "     → expected null not to be null",
+                " Test Files  1 failed (1)",
+                "      Tests  4 failed | 14 passed (18)",
+                "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯",
+                "AssertionError: expected null not to be null"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p3d-type-preserving-hollow",
+      "property": "P3",
+      "label": "TYPE-PRESERVING HOLLOW",
+      "violationClass": "guard removal",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/08-p3d-type-preserving-hollow",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "semantic mutation marker S3 adapter P3d is present",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7646,
+            "contentSha256": "98907ead3be3171c946e343cad9b859475a27997b84670718362e7cfba8bc312"
+          }
+        },
+        "after": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 6738,
+            "contentSha256": "c2b6f6bd95ce4182199c8b3c44a34db95c3d5c7a450c205d12826986ecaa0540"
+          }
+        },
+        "changedPaths": [
+          "scripts/lib/checker-blind-input-ratchet.mjs"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "exact exported evaluator signature remains",
+              "passed": true
+            },
+            {
+              "check": "constant passing body is present",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/08-p3d-type-preserving-hollow",
+          "startedAt": "2026-08-18T19:48:41.006Z",
+          "endedAt": "2026-08-18T19:48:41.209Z",
+          "durationMs": 203,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lib/checker-blind-input-ratchet.mjs\n",
+            "truncated": false,
+            "originalChars": 47
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4bd2e689678bc8f5f172f183027a5343da30cbd4ed1c8870804974266311c113",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "7faf6761-1b5b-4ea1-895d-bd87cb1a19c9",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/08-p3d-type-preserving-hollow",
+            "startedAt": "2026-08-18T19:48:41.209Z",
+            "endedAt": "2026-08-18T19:49:21.147Z",
+            "durationMs": 39938,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/08-p3d-type-preserving-hollow\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-QdYttx/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-QdYttx/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-QdYttx/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-QdYttx/guard-own.test.mjs (40.463041ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 48.732708\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-QdYttx/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-QdYttx/guard-own.test.mjs (40.463041ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-GFesmy/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-GFesmy/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-GFesmy/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-GFesmy/guard-own.test.mjs (32.231375ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 41.885291\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-GFesmy/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-GFesmy/guard-own.test.mjs (32.231375ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-sukmE4/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-sukmE4/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-sukmE4/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-sukmE4/guard-own.test.mjs (37.651625ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 51.095166\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-sukmE4/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-sukmE4/guard-own.test.mjs (37.651625ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1\nF4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\nTAP version 13\n# Subtest: empty population is not proof\nnot ok 1 - empty population is not proof\n  ---\n  duration_ms: 1.104084\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:5:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly deep-equal:\n    + actual - expected\n    \n      {\n        coveredCount: 0,\n    +   maxUncovered: 0,\n    +   passed: true,\n    -   passed: false,\n        populationCount: 0,\n    +   reason: 'within-ratchet',\n    -   reason: 'empty-population',\n        uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.start (node:internal/test_runner/test:944:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.225791\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.084708\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.073167\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 41.815292\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (1.106334ms)\n✖ unknown coverage id is rejected (0.221083ms)\n✖ new uncovered checker is named and rejected (0.080417ms)\n✔ genuinely covered population passes (0.071417ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 44.540541\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-PyFvCG/guard-own.test.mjs:5:1\n✖ empty population is not proof (1.106334ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.start (node:internal/test_runner/test:944:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual'\n  }\n\ntest at ../../checker-p3-hollow-PyFvCG/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.221083ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\ntest at ../../checker-p3-hollow-PyFvCG/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.080417ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-PyFvCG/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 2 failed) 5306ms\n   ✓ checker blind-input class ratchet > executes every declared blind case and none reports clean 3689ms\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 793ms\n   × checker blind-input class ratchet > P4a empty population is an error, never 0/0 clean 2ms\n     → expected { passed: true, …(5) } to match object { passed: false, …(1) }\n(4 matching properties omitted from actual)\n   × checker blind-input class ratchet > P4b recursively catches planted checkers outside top-level globs 3ms\n     → expected { passed: true, …(5) } to match object { passed: false, …(1) }\n(4 matching properties omitted from actual)\n\n Test Files  1 failed (1)\n      Tests  2 failed | 16 passed (18)\n   Start at  12:48:42\n   Duration  38.64s (transform 388ms, setup 3ms, collect 171ms, tests 5.31s, environment 0ms, prepare 39ms)\n\n",
+              "truncated": false,
+              "originalChars": 14226
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 46382)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > P4a empty population is an error, never 0/0 clean\nAssertionError: expected { passed: true, …(5) } to match object { passed: false, …(1) }\n(4 matching properties omitted from actual)\n\n- Expected\n+ Received\n\n  Object {\n-   \"passed\": false,\n-   \"reason\": \"empty-population\",\n+   \"passed\": true,\n+   \"reason\": \"within-ratchet\",\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:384:20\n    382|   it('P4a empty population is an error, never 0/0 clean', () => {\n    383|     const result = evaluateBlindInputCoverage({ population: [], covera…\n    384|     expect(result).toMatchObject({ passed: false, reason: 'empty-popul…\n       |                    ^\n    385|   });\n    386| \n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > P4b recursively catches planted checkers outside top-level globs\nAssertionError: expected { passed: true, …(5) } to match object { passed: false, …(1) }\n(4 matching properties omitted from actual)\n\n- Expected\n+ Received\n\n  Object {\n-   \"passed\": false,\n-   \"reason\": \"uncovered-checker-count-increased\",\n+   \"passed\": true,\n+   \"reason\": \"within-ratchet\",\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:398:22\n    396|       ]);\n    397|       const result = evaluateBlindInputCoverage({ population, coverage…\n    398|       expect(result).toMatchObject({ passed: false, reason: 'uncovered…\n       |                      ^\n    399|     } finally {\n    400|       SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, …\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+              "truncated": false,
+              "originalChars": 1850
+            },
+            "outputSha256": "5dacfc6117fc74f3d510d1491a9a95b05c615cc590d5f5d71aa189f8aaf789f3",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input",
+              "checker blind-input class ratchet",
+              "Test Files"
+            ],
+            "decidingOutput": {
+              "kind": "assertion-or-test-failure",
+              "lines": [
+                "    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "     → expected { passed: true, …(5) } to match object { passed: false, …(1) }",
+                "     → expected { passed: true, …(5) } to match object { passed: false, …(1) }",
+                " Test Files  1 failed (1)",
+                "      Tests  2 failed | 16 passed (18)",
+                "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯",
+                "AssertionError: expected { passed: true, …(5) } to match object { passed: false, …(1) }",
+                "AssertionError: expected { passed: true, …(5) } to match object { passed: false, …(1) }"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p4a-empty-population",
+      "property": "P4",
+      "label": "EMPTY THE POPULATION",
+      "violationClass": "vacuous measurement",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/09-p4a-empty-population",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "semantic mutation marker S3 adapter P4a is present",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7646,
+            "contentSha256": "98907ead3be3171c946e343cad9b859475a27997b84670718362e7cfba8bc312"
+          }
+        },
+        "after": {
+          "scripts/lib/checker-blind-input-ratchet.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 7039,
+            "contentSha256": "740354b4c602e67bae477cff48698578e71a4ca2b6778f97e06820f09851132f"
+          }
+        },
+        "changedPaths": [
+          "scripts/lib/checker-blind-input-ratchet.mjs"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "enumerator is forced empty",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/09-p4a-empty-population",
+          "startedAt": "2026-08-18T19:49:23.970Z",
+          "endedAt": "2026-08-18T19:49:24.190Z",
+          "durationMs": 220,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lib/checker-blind-input-ratchet.mjs\n",
+            "truncated": false,
+            "originalChars": 47
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4bd2e689678bc8f5f172f183027a5343da30cbd4ed1c8870804974266311c113",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "50c3d3c7-6543-4407-9775-f73b4453bd4b",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/09-p4a-empty-population",
+            "startedAt": "2026-08-18T19:49:24.190Z",
+            "endedAt": "2026-08-18T19:50:05.578Z",
+            "durationMs": 41388,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/09-p4a-empty-population\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-pyyNat/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-pyyNat/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-pyyNat/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-pyyNat/guard-own.test.mjs (174.715125ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 185.720166\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-pyyNat/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-pyyNat/guard-own.test.mjs (174.715125ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-tpMiIr/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-tpMiIr/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-tpMiIr/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-tpMiIr/guard-own.test.mjs (121.896125ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 129.981542\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-tpMiIr/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-tpMiIr/guard-own.test.mjs (121.896125ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-l9noXA/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-l9noXA/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-l9noXA/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-l9noXA/guard-own.test.mjs (69.961416ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 81.018042\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-l9noXA/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-l9noXA/guard-own.test.mjs (69.961416ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1\nF4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\nTAP version 13\n# Subtest: empty population is not proof\nnot ok 1 - empty population is not proof\n  ---\n  duration_ms: 2.591708\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:5:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly deep-equal:\n    + actual - expected\n    \n      {\n        coveredCount: 0,\n    +   maxUncovered: 0,\n    +   passed: true,\n    -   passed: false,\n        populationCount: 0,\n    +   reason: 'within-ratchet',\n    -   reason: 'empty-population',\n        uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.start (node:internal/test_runner/test:944:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.224792\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.079042\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.074709\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 58.978333\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (2.39175ms)\n✖ unknown coverage id is rejected (0.463833ms)\n✖ new uncovered checker is named and rejected (0.323333ms)\n✔ genuinely covered population passes (0.22025ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 139.629792\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-LCYFjg/guard-own.test.mjs:5:1\n✖ empty population is not proof (2.39175ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.start (node:internal/test_runner/test:944:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual'\n  }\n\ntest at ../../checker-p3-hollow-LCYFjg/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.463833ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\ntest at ../../checker-p3-hollow-LCYFjg/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.323333ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-LCYFjg/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 4 failed) 9343ms\n   × checker blind-input class ratchet > derives a non-empty production population and holds legacy exceptions at the pinned ceiling 6ms\n     → expected false to be true // Object.is equality\n   × checker blind-input class ratchet > executes every declared blind case and none reports clean 4809ms\n     → expected [ { …(4) }, { …(4) } ] to deeply equal []\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 3291ms\n   × checker blind-input class ratchet > P4b recursively catches planted checkers outside top-level globs 17ms\n     → expected [] to deeply equal [ …(2) ]\n   × checker blind-input class ratchet > P5 missing population source is unavailable evidence, never a clean result 35ms\n     → expected [Function] to throw an error\n   ✓ P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 354ms\n\n Test Files  1 failed (1)\n      Tests  4 failed | 14 passed (18)\n   Start at  12:49:25\n   Duration  40.36s (transform 287ms, setup 4ms, collect 137ms, tests 9.34s, environment 0ms, prepare 37ms)\n\n",
+              "truncated": false,
+              "originalChars": 14474
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 76689)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > derives a non-empty production population and holds legacy exceptions at the pinned ceiling\nAssertionError: expected false to be true // Object.is equality\n\n- Expected\n+ Received\n\n- true\n+ false\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:280:27\n    278|       maxUncovered: MAX_UNCOVERED_CHECKERS,\n    279|     });\n    280|     expect(result.passed).toBe(true);\n       |                           ^\n    281|     expect(result.populationCount).toBeGreaterThan(90);\n    282|     expect(result.coveredCount).toBe(CASES.size);\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > executes every declared blind case and none reports clean\nAssertionError: expected [ { …(4) }, { …(4) } ] to deeply equal []\n\n- Expected\n+ Received\n\n- Array []\n+ Array [\n+   Object {\n+     \"evidence\": Object {\n+       \"exitCode\": 1,\n+       \"output\": \"CHECKER_CHILD_RESULT {\\\"id\\\":\\\"script:scripts/lint-checker-blind-input-coverage.mjs\\\",\\\"phase\\\":\\\"control\\\",\\\"passed\\\":false,\\\"evidence\\\":{\\\"population\\\":0}}\",\n+       \"passed\": false,\n+       \"spawnError\": null,\n+     },\n+     \"id\": \"script:scripts/lint-checker-blind-input-coverage.mjs\",\n+     \"phase\": \"control\",\n+     \"reason\": \"control-not-clean\",\n+   },\n+   Object {\n+     \"evidence\": Object {\n+       \"exitCode\": 1,\n+       \"output\": \"CHECKER_CHILD_RESULT {\\\"id\\\":\\\"script:scripts/lint-checker-blind-input-coverage.mjs\\\",\\\"phase\\\":\\\"blind\\\",\\\"passed\\\":false,\\\"evidence\\\":{\\\"rejectedMissingRoot\\\":false}}\",\n+       \"passed\": false,\n+       \"spawnError\": null,\n+     },\n+     \"id\": \"script:scripts/lint-checker-blind-input-coverage.mjs\",\n+     \"phase\": \"blind\",\n+     \"reason\": \"blind-input-accepted\",\n+   },\n+ ]\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:289:32\n    287|     expect([...CASES.keys()].sort()).toEqual([...BLIND_INPUT_CASE_IDS]…\n    288|     const execution = await executeBlindCases(CASES);\n    289|     expect(execution.failures).toEqual([]);\n       |                                ^\n    290|     expect(execution.provenIds.sort()).toEqual([...BLIND_INPUT_CASE_ID…\n    291|   });\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > P4b recursively catches planted checkers outside top-level globs\nAssertionError: expected [] to deeply equal [ …(2) ]\n\n- Expected\n+ Received\n\n- Array [\n-   \"reviewer:src/core/reviewers/nested/FifthReviewer.ts\",\n-   \"script:scripts/nested/lint-planted.mjs\",\n- ]\n+ Array []\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:393:43\n    391|       fs.writeFileSync(path.join(root, 'src', 'core', 'reviewers', 'ne…\n    392|       const population = deriveCheckerPopulation(root);\n    393|       expect(population.map((p) => p.id)).toEqual([\n       |                                           ^\n    394|         'reviewer:src/core/reviewers/nested/FifthReviewer.ts',\n    395|         'script:scripts/nested/lint-planted.mjs',\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > P5 missing population source is unavailable evidence, never a clean result\nAssertionError: expected [Function] to throw an error\n\n- Expected: \nnull\n\n+ Received: \nundefined\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:431:75\n    429| \n    430|   it('P5 missing population source is unavailable evidence, never a cl…\n    431|     expect(() => deriveCheckerPopulation(path.join(ROOT, '__missing__'…\n       |                                                                           ^\n    432|   });\n    433| \n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+              "truncated": false,
+              "originalChars": 3912
+            },
+            "outputSha256": "30fe4acb00485b523eb003931bebb8dc6e214d839140a39b3fa8d973eecc320b",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input",
+              "checker blind-input class ratchet",
+              "Test Files"
+            ],
+            "decidingOutput": {
+              "kind": "assertion-or-test-failure",
+              "lines": [
+                "    expected: false,",
+                "     → expected false to be true // Object.is equality",
+                "     → expected [ { …(4) }, { …(4) } ] to deeply equal []",
+                "     → expected [] to deeply equal [ …(2) ]",
+                "     → expected [Function] to throw an error",
+                " Test Files  1 failed (1)",
+                "      Tests  4 failed | 14 passed (18)",
+                "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯",
+                "AssertionError: expected false to be true // Object.is equality",
+                "AssertionError: expected [ { …(4) }, { …(4) } ] to deeply equal []",
+                "AssertionError: expected [] to deeply equal [ …(2) ]",
+                "AssertionError: expected [Function] to throw an error"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p4b-planted-nested-checker",
+      "property": "P4",
+      "label": "PLANT A NESTED CHECKER",
+      "violationClass": "population evasion",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/10-p4b-planted-nested-checker",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "outside-enumeration",
+        "checks": [
+          {
+            "check": "new nested lint is a real recursively enumerated checker candidate",
+            "passed": true
+          },
+          {
+            "check": "new checker has no blind-case coverage id",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/phase-b/deep/lint-s3-uncovered.mjs": {
+            "exists": false,
+            "type": null,
+            "mode": null,
+            "bytes": null,
+            "contentSha256": null
+          }
+        },
+        "after": {
+          "scripts/phase-b/deep/lint-s3-uncovered.mjs": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 38,
+            "contentSha256": "d77295b8f5dae46ad129d47ae9b49d3b41dc97ef1858ae50f8ed171d49517c33"
+          }
+        },
+        "changedPaths": [
+          "scripts/phase-b/deep/lint-s3-uncovered.mjs"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "nested production checker exists",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/10-p4b-planted-nested-checker",
+          "startedAt": "2026-08-18T19:50:09.043Z",
+          "endedAt": "2026-08-18T19:50:09.237Z",
+          "durationMs": 194,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": "?? scripts/phase-b/\n",
+            "truncated": false,
+            "originalChars": 20
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "c530820beee4522268e59e620697faf720653114c5fd2ec4e4073bc6ee5614f8",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "c2ca7634-8b8e-4033-b3ed-50652326a013",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/10-p4b-planted-nested-checker",
+            "startedAt": "2026-08-18T19:50:09.237Z",
+            "endedAt": "2026-08-18T19:51:05.122Z",
+            "durationMs": 55885,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "\n RUN  v2.1.9 /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/10-p4b-planted-nested-checker\n\n✓ standards registry asset: 88 articles, registry 1b96011a057a…, guards 7574cf213f8b… → src/data + dist/data\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3a DELETE\nP3_3a_DELETE mutationApplied=true guardOwnTestExit=1\nnode:internal/modules/esm/resolve:274\n    throw new ERR_MODULE_NOT_FOUND(\n          ^\n\nError [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qSUy7n/guard.mjs' imported from /private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qSUy7n/guard-own.test.mjs\n    at finalizeResolution (node:internal/modules/esm/resolve:274:11)\n    at moduleResolve (node:internal/modules/esm/resolve:859:10)\n    at defaultResolve (node:internal/modules/esm/resolve:983:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)\n    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)\n    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {\n  code: 'ERR_MODULE_NOT_FOUND',\n  url: 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qSUy7n/guard.mjs'\n}\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qSUy7n/guard-own.test.mjs (97.04525ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 105.701041\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qSUy7n/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-delete-qSUy7n/guard-own.test.mjs (97.04525ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3b COMMENT OUT every executable line\nP3_3b_COMMENT_OUT mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-oCDi5y/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-oCDi5y/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-oCDi5y/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-oCDi5y/guard-own.test.mjs (69.729209ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 83.161208\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-oCDi5y/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-comment-oCDi5y/guard-own.test.mjs (69.729209ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3c SUPERSTRING RENAME of the exact guard symbol\nP3_3c_SUPERSTRING_RENAME mutationApplied=true guardOwnTestExit=1\nfile:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-rOhW9V/guard-own.test.mjs:4\nimport { evaluateBlindInputCoverage } from \"file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-rOhW9V/guard.mjs\";\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^\nSyntaxError: The requested module 'file:///var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-rOhW9V/guard.mjs' does not provide an export named 'evaluateBlindInputCoverage'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:228:21)\n    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:647:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)\n\nNode.js v22.18.0\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-rOhW9V/guard-own.test.mjs (116.657917ms)\nℹ tests 1\nℹ suites 0\nℹ pass 0\nℹ fail 1\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 125.737208\n\n✖ failing tests:\n\ntest at ../../../../../../../../var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-rOhW9V/guard-own.test.mjs:1:1\n✖ /var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-rename-rOhW9V/guard-own.test.mjs (116.657917ms)\n  'test failed'\n\nstdout | tests/unit/checker-blind-input-ratchet.test.ts > P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict\nP3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=1 specChildExit=1\nF4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\nTAP version 13\n# Subtest: empty population is not proof\nnot ok 1 - empty population is not proof\n  ---\n  duration_ms: 6.555041\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:5:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly deep-equal:\n    + actual - expected\n    \n      {\n        coveredCount: 0,\n    +   maxUncovered: 0,\n    +   passed: true,\n    -   passed: false,\n        populationCount: 0,\n    +   reason: 'within-ratchet',\n    -   reason: 'empty-population',\n        uncovered: []\n      }\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected:\n    passed: false\n    reason: 'empty-population'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n  actual:\n    passed: true\n    reason: 'within-ratchet'\n    populationCount: 0\n    coveredCount: 0\n    uncovered:\n    maxUncovered: 0\n  operator: 'deepStrictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:6:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.start (node:internal/test_runner/test:944:17)\n    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)\n  ...\n# Subtest: unknown coverage id is rejected\nnot ok 2 - unknown coverage id is rejected\n  ---\n  duration_ms: 0.565208\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:10:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:11:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)\n  ...\n# Subtest: new uncovered checker is named and rejected\nnot ok 3 - new uncovered checker is named and rejected\n  ---\n  duration_ms: 0.237375\n  type: 'test'\n  location: '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:13:1'\n  failureType: 'testCodeFailure'\n  error: |-\n    Expected values to be strictly equal:\n    \n    true !== false\n    \n  code: 'ERR_ASSERTION'\n  name: 'AssertionError'\n  expected: false\n  actual: true\n  operator: 'strictEqual'\n  stack: |-\n    TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:15:10)\n    Test.runInAsyncScope (node:async_hooks:214:14)\n    Test.run (node:internal/test_runner/test:1047:25)\n    Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n    Test.postRun (node:internal/test_runner/test:1173:19)\n    Test.run (node:internal/test_runner/test:1101:12)\n    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)\n  ...\n# Subtest: genuinely covered population passes\nok 4 - genuinely covered population passes\n  ---\n  duration_ms: 0.248\n  type: 'test'\n  ...\n1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 3\n# cancelled 0\n# skipped 0\n# todo 0\n# duration_ms 145.230458\nF4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured={\"schema\":\"checker-blind-input/guard-own-results-v1\",\"tests\":[{\"testNumber\":1,\"identity\":\"empty population is not proof\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":2,\"identity\":\"unknown coverage id is rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":3,\"identity\":\"new uncovered checker is named and rejected\",\"outcome\":\"fail\",\"failureCode\":\"ERR_ASSERTION\"},{\"testNumber\":4,\"identity\":\"genuinely covered population passes\",\"outcome\":\"pass\",\"failureCode\":null}]}\n✖ empty population is not proof (1.126ms)\n✖ unknown coverage id is rejected (0.216167ms)\n✖ new uncovered checker is named and rejected (0.087292ms)\n✔ genuinely covered population passes (0.074583ms)\nℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 3\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 60.209333\n\n✖ failing tests:\n\ntest at ../../checker-p3-hollow-1Qk4be/guard-own.test.mjs:5:1\n✖ empty population is not proof (1.126ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:\n  + actual - expected\n  \n    {\n      coveredCount: 0,\n  +   maxUncovered: 0,\n  +   passed: true,\n  -   passed: false,\n      populationCount: 0,\n  +   reason: 'within-ratchet',\n  -   reason: 'empty-population',\n      uncovered: []\n    }\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:6:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.start (node:internal/test_runner/test:944:17)\n      at startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: { passed: true, reason: 'within-ratchet', populationCount: 0, coveredCount: 0, uncovered: [], maxUncovered: 0 },\n    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },\n    operator: 'deepStrictEqual'\n  }\n\ntest at ../../checker-p3-hollow-1Qk4be/guard-own.test.mjs:10:1\n✖ unknown coverage id is rejected (0.216167ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:11:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\ntest at ../../checker-p3-hollow-1Qk4be/guard-own.test.mjs:13:1\n✖ new uncovered checker is named and rejected (0.087292ms)\n  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n  \n  true !== false\n  \n      at TestContext.<anonymous> (file:///private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/checker-p3-hollow-1Qk4be/guard-own.test.mjs:15:10)\n      at Test.runInAsyncScope (node:async_hooks:214:14)\n      at Test.run (node:internal/test_runner/test:1047:25)\n      at Test.processPendingSubtests (node:internal/test_runner/test:744:18)\n      at Test.postRun (node:internal/test_runner/test:1173:19)\n      at Test.run (node:internal/test_runner/test:1101:12)\n      at async Test.processPendingSubtests (node:internal/test_runner/test:744:7) {\n    generatedMessage: true,\n    code: 'ERR_ASSERTION',\n    actual: true,\n    expected: false,\n    operator: 'strictEqual'\n  }\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts (18 tests | 1 failed) 9307ms\n   × checker blind-input class ratchet > derives a non-empty production population and holds legacy exceptions at the pinned ceiling 135ms\n     → expected false to be true // Object.is equality\n   ✓ checker blind-input class ratchet > executes every declared blind case and none reports clean 6813ms\n   ✓ checker blind-input class ratchet > refuses a never-invoked checker even when candidate testimony says invocations 1 1160ms\n   ✓ checker blind-input class ratchet > derives bootstrap authority from canonical protected main, never a local tracking ref 311ms\n   ✓ P3 — the ratchet own test rejects all four guard sabotages > 3d TYPE-PRESERVING HOLLOW BODY returns a passing verdict 321ms\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  12:50:10\n   Duration  54.29s (transform 388ms, setup 5ms, collect 168ms, tests 9.31s, environment 0ms, prepare 103ms)\n\n",
+              "truncated": false,
+              "originalChars": 14227
+            },
+            "stderr": {
+              "text": "[test-runner-bound] targeted-lane slot acquired (posture: enforcing, cap 6, pid 9906)\n⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯\n\n FAIL  tests/unit/checker-blind-input-ratchet.test.ts > checker blind-input class ratchet > derives a non-empty production population and holds legacy exceptions at the pinned ceiling\nAssertionError: expected false to be true // Object.is equality\n\n- Expected\n+ Received\n\n- true\n+ false\n\n ❯ tests/unit/checker-blind-input-ratchet.test.ts:280:27\n    278|       maxUncovered: MAX_UNCOVERED_CHECKERS,\n    279|     });\n    280|     expect(result.passed).toBe(true);\n       |                           ^\n    281|     expect(result.populationCount).toBeGreaterThan(90);\n    282|     expect(result.coveredCount).toBe(CASES.size);\n\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯\n\nchecker-blind-input: NOT-PROVEN — executable blind cases exited 1\n",
+              "truncated": false,
+              "originalChars": 840
+            },
+            "outputSha256": "27f81f0ccfad70d0dc294362e5e1baf94674fa27373fd55ba29b4fdb1cf56252",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input",
+              "checker blind-input class ratchet",
+              "Test Files"
+            ],
+            "decidingOutput": {
+              "kind": "assertion-or-test-failure",
+              "lines": [
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:",
+                "  + actual - expected",
+                "    expected: { passed: false, reason: 'empty-population', populationCount: 0, coveredCount: 0, uncovered: [] },",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:",
+                "    expected: false,",
+                "     → expected false to be true // Object.is equality",
+                " Test Files  1 failed (1)",
+                "      Tests  1 failed | 17 passed (18)",
+                "⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯",
+                "AssertionError: expected false to be true // Object.is equality"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "p5-blind-production-checker",
+      "property": "P5",
+      "label": "BLIND A POPULATION MEMBER",
+      "violationClass": "blind input / fail-open",
+      "isolatedRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/11-p5-blind-production-checker",
+      "rootIsIsolated": true,
+      "applyError": null,
+      "mutationApplied": true,
+      "mutationRelevant": true,
+      "relevanceEvidence": {
+        "status": "proven",
+        "mode": "declared-load-bearing-input",
+        "checks": [
+          {
+            "check": "changed path is a declared guard or production subject",
+            "passed": true
+          },
+          {
+            "check": "exact structural mutation verified",
+            "passed": true
+          }
+        ]
+      },
+      "proof": {
+        "before": {
+          "scripts/lint-llm-attribution.js": {
+            "exists": true,
+            "type": "file",
+            "mode": "644",
+            "bytes": 16253,
+            "contentSha256": "409fbf5866541ea6899e15e562680d47476ab63f0b409bc96c26fa3a4ee67984"
+          }
+        },
+        "after": {
+          "scripts/lint-llm-attribution.js": {
+            "exists": null,
+            "error": "EACCES: permission denied, open '/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/11-p5-blind-production-checker/scripts/lint-llm-attribution.js'"
+          }
+        },
+        "changedPaths": [
+          "scripts/lint-llm-attribution.js"
+        ],
+        "adapterVerification": {
+          "ok": true,
+          "checks": [
+            {
+              "check": "scripts/lint-llm-attribution.js mode is 000",
+              "passed": true
+            }
+          ]
+        },
+        "gitStatus": {
+          "argv": [
+            "git",
+            "status",
+            "--porcelain=v1"
+          ],
+          "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/11-p5-blind-production-checker",
+          "startedAt": "2026-08-18T19:51:10.014Z",
+          "endedAt": "2026-08-18T19:51:10.283Z",
+          "durationMs": 269,
+          "exitCode": 0,
+          "signal": null,
+          "spawnError": null,
+          "timedOut": false,
+          "stdout": {
+            "text": " M scripts/lint-llm-attribution.js\n",
+            "truncated": false,
+            "originalChars": 35
+          },
+          "stderr": {
+            "text": "",
+            "truncated": false,
+            "originalChars": 0
+          },
+          "outputSha256": "4e2b2f0087549b0e161d77e53780ad5d01c8073ed2facb36acc0c9dd10302c79",
+          "exitProvenance": "direct child status from spawnSync; shell=false"
+        }
+      },
+      "guardOutcome": "fail",
+      "guardRun": {
+        "executionToken": "57edeffd-6add-4ec0-a14f-dcfac2835bf4",
+        "processProof": "each argv was spawned directly with shell=false; the recorded exitCode is the child process status",
+        "outcome": "fail",
+        "executable": true,
+        "observed": true,
+        "runs": [
+          {
+            "argv": [
+              "/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node",
+              "scripts/lint-checker-blind-input-coverage.mjs"
+            ],
+            "cwd": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/11-p5-blind-production-checker",
+            "startedAt": "2026-08-18T19:51:10.283Z",
+            "endedAt": "2026-08-18T19:51:11.386Z",
+            "durationMs": 1103,
+            "exitCode": 1,
+            "signal": null,
+            "spawnError": null,
+            "timedOut": false,
+            "stdout": {
+              "text": "",
+              "truncated": false,
+              "originalChars": 0
+            },
+            "stderr": {
+              "text": "checker-blind-input: UNKNOWN — checker population unavailable: cannot read scripts/lint-llm-attribution.js: EACCES: permission denied, open '/private/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/11-p5-blind-production-checker/scripts/lint-llm-attribution.js'\n",
+              "truncated": false,
+              "originalChars": 289
+            },
+            "outputSha256": "6102bb591681dc1af1d21fef7b83b8e03e8013ccd552df5736fc2e8a98c551ae",
+            "exitProvenance": "direct child status from spawnSync; shell=false",
+            "observed": true,
+            "observedBy": [
+              "checker-blind-input"
+            ],
+            "decidingOutput": {
+              "kind": "no-deciding-output",
+              "lines": []
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "isolation": {
+    "method": "throwaway clones from an isolation seed; server-resolved protected base installed as origin/main, upstream/main, and main; dependency-only node_modules symlink",
+    "tempRoot": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j",
+    "copies": [
+      {
+        "label": "pipeline-wiring",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/01-pipeline-wiring",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "positive-control",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/02-positive-control",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p1-symbol-preserving-checker-hollow",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/03-p1-symbol-preserving-checker-hollow",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p2-subject-self-reports-clean",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/04-p2-subject-self-reports-clean",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p3a-delete",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/05-p3a-delete",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p3b-comment-out",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/06-p3b-comment-out",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p3c-superstring-rename",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/07-p3c-superstring-rename",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p3d-type-preserving-hollow",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/08-p3d-type-preserving-hollow",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p4a-empty-population",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/09-p4a-empty-population",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p4b-planted-nested-checker",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/10-p4b-planted-nested-checker",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      },
+      {
+        "label": "p5-blind-production-checker",
+        "root": "/var/folders/7s/y2tbdryn5jl10h7n_0y2vr700000gn/T/instar-fix-verifier-F00B7j/11-p5-blind-production-checker",
+        "commit": "859e90347555fec34ae5d9500752b058658ca507"
+      }
+    ],
+    "fixtureEvidence": [],
+    "protectedBase": {
+      "remoteUrl": "https://github.com/JKHeadley/instar.git",
+      "ref": "refs/heads/main",
+      "commit": "248ed7177f5bf416aa7bdad9763741478195e1fc",
+      "serverResolved": true,
+      "fetchMatchesServer": true,
+      "workflowPath": ".github/workflows/ci.yml",
+      "workflowSha256": "be9f8f5393854f15793424613fa46da4701b4808219cb173a0d9da1aa649ef71",
+      "mergeBase": "248ed7177f5bf416aa7bdad9763741478195e1fc"
+    },
+    "targetPorcelainUnchanged": true,
+    "cleanup": "removed before record emission"
+  },
+  "dependencies": {
+    "mode": "provided",
+    "path": "/private/tmp/instar-p3b-859e903-0ArROb/node_modules-overlay",
+    "prepared": true
+  }
+}

--- a/tests/unit/checker-blind-input-ratchet.test.ts
+++ b/tests/unit/checker-blind-input-ratchet.test.ts
@@ -461,9 +461,78 @@ describe('checker blind-input class ratchet', () => {
 describe('P3 — the ratchet own test rejects all four guard sabotages', () => {
   const sourcePath = path.join(ROOT, 'scripts', 'lib', 'checker-blind-input-ratchet.mjs');
   const source = fs.readFileSync(sourcePath, 'utf8');
+  const guardResultSchema = 'checker-blind-input/guard-own-results-v1';
+  const hollowExpectedResults = [
+    { testNumber: 1, identity: 'empty population is not proof', outcome: 'fail', failureCode: 'ERR_ASSERTION' },
+    { testNumber: 2, identity: 'unknown coverage id is rejected', outcome: 'fail', failureCode: 'ERR_ASSERTION' },
+    { testNumber: 3, identity: 'new uncovered checker is named and rejected', outcome: 'fail', failureCode: 'ERR_ASSERTION' },
+    { testNumber: 4, identity: 'genuinely covered population passes', outcome: 'pass', failureCode: null },
+  ] as const;
 
-  function guardOwnSuite(modulePath: string, dir: string) {
+  interface GuardOwnResult {
+    schema: typeof guardResultSchema;
+    tests: Array<{
+      testNumber: number;
+      identity: string;
+      outcome: 'pass' | 'fail';
+      failureCode: string | null;
+    }>;
+  }
+
+  function parseGuardOwnResult(raw: string): GuardOwnResult {
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      throw new Error('guard-own result is not JSON');
+    }
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('guard-own result must be an object');
+    }
+    const record = value as Record<string, unknown>;
+    if (record.schema !== guardResultSchema || !Array.isArray(record.tests)) {
+      throw new Error('guard-own result does not match schema v1');
+    }
+    const rootKeys = Object.keys(record).sort();
+    if (rootKeys.length !== 2 || rootKeys[0] !== 'schema' || rootKeys[1] !== 'tests') {
+      throw new Error('guard-own result has unknown root fields');
+    }
+    const tests = record.tests.map((entry, index) => {
+      if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error(`guard-own test result ${index} must be an object`);
+      }
+      const item = entry as Record<string, unknown>;
+      const keys = Object.keys(item).sort();
+      if (keys.join(',') !== 'failureCode,identity,outcome,testNumber') {
+        throw new Error(`guard-own test result ${index} has the wrong fields`);
+      }
+      if (!Number.isInteger(item.testNumber) || (item.testNumber as number) < 1) {
+        throw new Error(`guard-own test result ${index} has an invalid test number`);
+      }
+      if (typeof item.identity !== 'string' || item.identity.length === 0) {
+        throw new Error(`guard-own test result ${index} has an invalid identity`);
+      }
+      if (item.outcome !== 'pass' && item.outcome !== 'fail') {
+        throw new Error(`guard-own test result ${index} has an invalid outcome`);
+      }
+      if (item.failureCode !== null && typeof item.failureCode !== 'string') {
+        throw new Error(`guard-own test result ${index} has an invalid failure code`);
+      }
+      return {
+        testNumber: item.testNumber as number,
+        identity: item.identity,
+        outcome: item.outcome,
+        failureCode: item.failureCode,
+      };
+    });
+    return { schema: guardResultSchema, tests };
+  }
+
+  function guardOwnSuite(modulePath: string, dir: string, renderer: 'tap' | 'spec' = 'spec') {
     const suite = path.join(dir, 'guard-own.test.mjs');
+    const reporter = path.join(dir, 'guard-own-results-reporter.mjs');
+    const structuredDestination = path.join(dir, `guard-own-${renderer}-results.json`);
+    const renderedDestination = path.join(dir, `guard-own-${renderer}-rendered.txt`);
     fs.writeFileSync(suite, `
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -485,7 +554,41 @@ test('genuinely covered population passes', () => {
   assert.equal(evaluateBlindInputCoverage({population:['known'],coverageIds:['known'],maxUncovered:0}).passed, true);
 });
 `);
-    return spawnSync(process.execPath, ['--test', suite], { encoding: 'utf8' });
+    fs.writeFileSync(reporter, `
+export default async function* guardOwnResults(source) {
+  const tests = [];
+  for await (const event of source) {
+    if (event.type !== 'test:complete' || event.data.details.type === 'suite' || event.data.skip || event.data.todo) continue;
+    if (typeof event.data.file === 'string' && event.data.name === event.data.file) continue;
+    const error = event.data.details.error;
+    const cause = error && typeof error === 'object' ? error.cause : undefined;
+    const failureCode = cause && typeof cause === 'object' && typeof cause.code === 'string'
+      ? cause.code
+      : error && typeof error === 'object' && typeof error.code === 'string' ? error.code : null;
+    tests.push({
+      testNumber: event.data.testNumber,
+      identity: event.data.name,
+      outcome: event.data.details.passed ? 'pass' : 'fail',
+      failureCode,
+    });
+  }
+  yield JSON.stringify({ schema: ${JSON.stringify(guardResultSchema)}, tests });
+}
+`);
+    const child = spawnSync(process.execPath, [
+      '--test',
+      '--test-reporter', renderer,
+      '--test-reporter-destination', renderedDestination,
+      '--test-reporter', reporter,
+      '--test-reporter-destination', structuredDestination,
+      suite,
+    ], { encoding: 'utf8' });
+    return {
+      ...child,
+      renderer,
+      renderedOutput: fs.existsSync(renderedDestination) ? fs.readFileSync(renderedDestination, 'utf8').trim() : '',
+      structuredOutput: fs.existsSync(structuredDestination) ? fs.readFileSync(structuredDestination, 'utf8').trim() : '',
+    };
   }
 
   function replaceGuardBody(body: string): string {
@@ -504,8 +607,8 @@ test('genuinely covered population passes', () => {
     throw new Error('guard body did not close');
   }
 
-  function decidingOutput(result: ReturnType<typeof spawnSync>): string {
-    return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  function decidingOutput(result: ReturnType<typeof guardOwnSuite>): string {
+    return `${result.renderedOutput}\n${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
   }
 
   it('3a DELETE', () => {
@@ -565,13 +668,24 @@ test('genuinely covered population passes', () => {
       fs.writeFileSync(file, hollow);
       expect(hollow).toContain("return { passed: true, reason: 'within-ratchet'");
       expect(hollow).toContain('export function evaluateBlindInputCoverage');
-      const result = guardOwnSuite(file, dir);
-      const output = decidingOutput(result);
-      console.log(`P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true guardOwnTestExit=${result.status}\n${output}`);
-      expect(result.status).not.toBe(0);
-      expect(output).toContain('# tests 4');
-      expect(output).toContain('# fail 3');
-      expect(output).toMatch(/AssertionError|Expected values to be strictly equal/);
+      const tapResult = guardOwnSuite(file, dir, 'tap');
+      const specResult = guardOwnSuite(file, dir, 'spec');
+      const tapStructured = parseGuardOwnResult(tapResult.structuredOutput);
+      const specStructured = parseGuardOwnResult(specResult.structuredOutput);
+      expect(tapResult.status).not.toBe(0);
+      expect(specResult.status).not.toBe(0);
+      expect(tapStructured.tests).toEqual(hollowExpectedResults);
+      expect(specStructured.tests).toEqual(hollowExpectedResults);
+      expect(tapStructured).toEqual(specStructured);
+      console.log(
+        `P3_3d_TYPE_PRESERVING_HOLLOW mutationApplied=true tapChildExit=${tapResult.status} specChildExit=${specResult.status}`,
+      );
+      console.log(
+        `F4_DECORATION_CONTROL renderer=tap structuredVerdict=reject structured=${JSON.stringify(tapStructured)}\n${tapResult.renderedOutput}`,
+      );
+      console.log(
+        `F4_DECORATION_CONTROL renderer=spec structuredVerdict=reject structured=${JSON.stringify(specStructured)}\n${specResult.renderedOutput}`,
+      );
     } finally {
       SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'checker-p3:hollow' });
     }


### PR DESCRIPTION
## Summary

- ports the J16-certified structured Node test-event harness from implementation e64e3a2497d59a4d3aec0f8eb4e04589e4912f58 onto measured F1 commit 3801aefe9825e1258f5f235c123c56bee9e6a98b
- preserves the complete certified 233-line P3 block byte-for-byte (matching SHA-256: 363e23c30d25283f8bb3d9da303710c04a396d58b577bc2de37de35aa3cd3c8c) while retaining F1 ratchet and authenticated-receipt work
- records why direct cherry-pick conflicts textually and why re-pointing the battery at F3 would measure the wrong line

## Verification

- focused 3d integration test: 1 passed, 17 skipped; real TAP/spec renderings differed while structured records matched
- TypeScript compile-only check passed
- independent P3 property battery intentionally not run
- pre-push affected-test listing timed out and skipped local smoke; CI remains authority

## Evidence

- implementation port: 859e90347555fec34ae5d9500752b058658ca507
- reconciliation report: scratchpad/phaseB/REPORT-F2.md
- report commit: 3e5e5c5d1
- J16 source verdict: SOUND

The abandoned xmllint/JUnit attempt remains uncommitted in its original worktree and none of its bytes are included here.