### PR TITLE
fix(standards): authenticate structured observations

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-18T19-52-28-703Z-w37-authenticated-structured-observation.json
+++ b/.instar/instar-dev-decisions/2026-08-18T19-52-28-703Z-w37-authenticated-structured-observation.json
@@ -1,0 +1,37 @@
+{
+  "ts": "2026-08-18T19:52:28.703Z",
+  "slug": "w37-authenticated-structured-observation",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 367,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lib/standards-enforcement-execution-verifier.mjs",
+      "scripts/lib/standards-enforcement-measurement.mjs",
+      "scripts/lib/standards-enforcement-node-test-runner.mjs"
+    ],
+    "addedLines": 276,
+    "deletedLines": 91
+  },
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [1933],
+    "notes": "J18 found that W3.6's branch-owned structured-event collector authored promotion facts while H1 authenticated only child-exit metadata; its recorded runner digest was not an authority comparison."
+  },
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "gate",
+      "citation": "tests/unit/standards-enforcement-measurement.test.ts",
+      "howCaught": "An exact-schema collector forgery with a marker write is rejected by a protected expected-digest mismatch before execution, returns UNKNOWN, and mints no artifact; the genuine receipt-bound collector still preserves C1/C3 discrimination and both renderer-forgery controls."
+    },
+    "component": "standards-enforcement-measurement"
+  },
+  "verdict": "pass"
+}

--- a/scratchpad/phaseB/REPORT-W37.md
+++ b/scratchpad/phaseB/REPORT-W37.md
@@ -7,9 +7,10 @@
 ```text
 branch: phaseb/w37-authenticated-structured-observation
 base:   6f4d6599ea7c601f917c8db5cd1b6b3c1a3266b9 (phaseb/w36-structured-test-counts)
+implementation commit: aac1ea4d6eee1d69f833115ec1d8f2579cdbb49d
 brief:  scratchpad/phaseB/lane-W37-brief.md
 brief sha256: 4b84ff2fe89ade27cb683268ffed804a4748aa93d27b9518a1ca187c7a6820e0
-pull request: pending at report authoring; appended after publication
+pull request: https://github.com/JKHeadley/instar/pull/1936
 ```
 
 ## What changed
@@ -116,6 +117,17 @@ Tests       4 passed | 34 skipped (38)
 Duration    100.66s
 shared entrypoint preflight: match
 shared entrypoint postflight: match
+```
+
+The normal non-force push gate then ran the complete affected set against its resolved main base:
+
+```text
+Test Files  2 passed (2)
+Tests       54 passed (54)
+Duration    1128.90s
+W37_C2 ... runnerExecuted=false outcome=UNKNOWN artifact=null
+W36_C1 ... misleadingRendererCounts=ignored ... verdict=ratchet
+W37_C1 ... digestCompared=true protectedRunnerMaterialized=true observationsReceiptBound=true verdict=ratchet
 ```
 
 ## Mutation identity and relevance

--- a/scratchpad/phaseB/REPORT-W37.md
+++ b/scratchpad/phaseB/REPORT-W37.md
@@ -1,0 +1,169 @@
+# W3.7 — authenticated structured observation
+
+## Status
+
+**BUILT WITH HAND EVIDENCE; independent b03 judgement pending.** This report does not grade the repair. No merge was performed.
+
+```text
+branch: phaseb/w37-authenticated-structured-observation
+base:   6f4d6599ea7c601f917c8db5cd1b6b3c1a3266b9 (phaseb/w36-structured-test-counts)
+brief:  scratchpad/phaseB/lane-W37-brief.md
+brief sha256: 4b84ff2fe89ade27cb683268ffed804a4748aa93d27b9518a1ca187c7a6820e0
+pull request: pending at report authoring; appended after publication
+```
+
+## What changed
+
+The structured event collector is no longer executed from the candidate checkout merely because it has a digest-shaped identity.
+
+1. A protected schema-v3 execution plan must carry the exact expected SHA-256 of `scripts/lib/standards-enforcement-node-test-runner.mjs`.
+2. The verifier reads those runner bytes from the protected snapshot, compares them with that protected expected digest, and returns UNKNOWN with no artifact on mismatch.
+3. The compared protected bytes are materialized into each isolated clean, mutated, and pristine-confirmation workspace. The runner is checked again immediately before each execution as a regular non-symlink file with the exact expected digest.
+4. Each materialized runner creates an ephemeral Ed25519 identity and signs a ready event followed by the exact structured observation event. H1 pins the ready identity, authenticates the sequenced observation, and issues the child-exit receipt only when its observer session, event sequence, event kind, and event-signature hash match the last authenticated event.
+5. A promotable artifact retains the authenticated event, its recomputed observation digest, and the receipt linkage. Live-artifact validation rechecks every link.
+
+The independently protected expected runner digest is:
+
+```text
+04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2
+```
+
+The H1 receipt core was not modified. Its SHA-256 remained:
+
+```text
+6534ed0983b733311d343c23b60bc70d13648ca9d911a136875504d20d6e4817
+```
+
+## Can `node --test --test-reporter=json` remove the collector?
+
+**No on both exercised supported runtimes.** `json` is not a built-in Node test reporter in Node 22.18.0 or Node 25.6.1. Both commands treated `json` as a custom reporter package and exited 7 with `ERR_MODULE_NOT_FOUND: Cannot find package 'json'`.
+
+```text
+Node 25.6.1: node --test --test-reporter=json <probe> -> exit 7, ERR_MODULE_NOT_FOUND
+Node 22.18.0: node --test --test-reporter=json <probe> -> exit 7, ERR_MODULE_NOT_FOUND
+```
+
+Supplying a local custom JSON reporter would merely move the authorship fault into another branch-owned collector. Node's programmatic `node:test.run()` `TestsStream` remains the native structured source, so W3.7 keeps the small collector but makes its exact protected bytes authoritative and receipt-binds its output.
+
+## Rider: shared `node_modules` route
+
+**Route A was used. No install or rebuild was run.** The W3.7 `node_modules` symlink resolves to:
+
+```text
+/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w35-observed-enforcement-proof/node_modules
+```
+
+The production evidence collector does not resolve through that tree: it is read from the protected repository snapshot and copied into a fresh isolated workspace. The structured reporter is Node core. The outer Vitest test harness and its transitive dependencies do resolve through the shared tree.
+
+Named entrypoint pins:
+
+| Element | Resolved path / identity | SHA-256 |
+|---|---|---|
+| Node 25 runner + built-in `node:test` | `/opt/homebrew/Cellar/node/25.6.1/bin/node` | `f739e02b8e68d8accc60f15308c0d1dbe9cde2dfdb15463ba7389103b1b450e1` |
+| Node 22 runner + built-in `node:test` | `/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node` | `9187ad22c98cea5b635a79db52fa32ab3f6aa9d41e3abf5da71437cfef1ca9de` |
+| protected collector/runner | protected `scripts/lib/standards-enforcement-node-test-runner.mjs`, then isolated copy | `04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2` |
+| Vitest entry | shared `node_modules/vitest/vitest.mjs` | `39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6` |
+| Vitest CLI | shared `node_modules/vitest/dist/cli.js` | `88e96cc0817e9248dadf452c0db5f543dc25ec9ce1c801c2310ca3ac8ffdf48d` |
+| Vite CJS entry | shared `node_modules/vite/index.cjs` | `9f3d9f0d380bb14380fe3cd9c64be336ae0b892613229b07d837ab44784cbb96` |
+| Vite Node entry | shared `node_modules/vite/dist/node/index.js` | `2b295e9da790eb9d1b02b167a4678bd9106253d97e07a75f774cd2f3b1930476` |
+| TypeScript verifier | shared `node_modules/typescript/lib/typescript.js` | `3ae902c92cc44dace175c0e69e13a4b0899f6983c6121d76b9ab8dd5795e7675` |
+| YAML config dependency | shared `node_modules/js-yaml/index.js` | `7d1ebc0d9929b9124997b439d1a1fd9aff8feb6bb0a1b59e977ea638944f34ba` |
+
+To cover transitive harness inputs rather than only named entrypoints, the final run hashed the resolved shared tree deterministically as sorted entry type + relative path + file SHA-256 (or symlink target). With Vitest cache disabled, the preflight and postflight values were identical:
+
+```text
+shared input tree sha256: 0a73b6e90809f117f3134e94061f27aaa2133cf1b2c8dbee4d9e15508f93f6de
+regular files: 13,966
+symlinks: 30
+regular-file bytes: 572,000,653
+excluded runtime output: .vite/vitest/results.json
+```
+
+The exclusion is not silent. An earlier full-tree run correctly failed its postflight because Vitest changed only `.vite/vitest/results.json` from 123 to 129 bytes. That file is a runtime result cache, not collector/reporter/runner input. The deciding run used `--no-cache`; its mtime remained at 12:22:04 PDT while the run started at 12:24:13 PDT, and every other byte in the resolved tree matched before and after. A later attempt to include that disabled output in an all-byte pin correctly refused at preflight because a concurrent lane had changed it again (129 to 125 bytes); no tests ran. That confirms why the evidence manifest excludes exactly this non-input runtime output while pinning every transitive input. Nothing in the shared tree was installed, rebuilt, restored, or otherwise rewritten by hand.
+
+## Decisive observed controls
+
+Final Node 25.6.1 run, with full shared-input-tree preflight/postflight and `--no-cache`:
+
+```text
+W37_ROUTE_A_FINAL_PREFLIGHT ... sharedInputTreeSha256=0a73... files=13966 links=30 bytes=572000653
+W37_C2 expectedRunnerSha256=04795... actualRunnerSha256=c2e947... runnerExecuted=false outcome=UNKNOWN artifact=null
+W36_C1 source="node:test TestsStream" misleadingRendererCounts=ignored mutationLanded=true cleanExit=0 cleanTests=1 mutatedExit=1 mutatedTests=1 confirmationExit=0 confirmationTests=1 failureKind=assertion artifact=authenticated verdict=ratchet
+W37_C1 protectedRunnerSha256=04795... digestCompared=true protectedRunnerMaterialized=true observationsReceiptBound=true verdict=ratchet
+Test Files  1 passed (1)
+Tests       16 passed (16)
+W37_ROUTE_A_FINAL_POSTFLIGHT ... sharedInputTreeSha256=0a73... files=13966 links=30 bytes=572000653
+```
+
+The C2 forged runner contains an exact-schema summary claiming 999 passing tests and writes a per-test absolute marker supplied through a stable environment variable. Its protected bytes hash to `c2e947b7cecad6cd60afa3f77399a781258a8e0b5f2d54f8a6ec5e3e742b52b0`, not the protected expected digest. The verifier refused before execution; the marker did not exist, the result was UNKNOWN, and the artifact was null.
+
+The accepted two-way discrimination remained intact:
+
+- C1 genuine observer: clean pass, mutated assertion failure, pristine confirmation pass -> ratchet.
+- C3a vacuous `expect(true)`: mutation survives -> NOT-PROVEN.
+- C3b mutation-insensitive subject import: mutation survives -> NOT-PROVEN.
+- C3c stateful hollow observer: confirmation does not reset -> NOT-PROVEN.
+- C3d inherited-pipe descendant: bounded timeout -> UNKNOWN.
+- Both forged renderer summaries (`# tests 999` and `ℹ tests 999`) remain present and ignored.
+
+Node 22.18.0 independently ran all 16 measurement tests with the same C1/C2/C3 outcomes before the marker-path tightening. After that test-only tightening, Node 22 reran the decisive C1 and C2 controls: 2 passed, 14 skipped. Its Node binary and complete shared input-tree digests matched before and after.
+
+The affected coverage path also remained green:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed | 34 skipped (38)
+Duration    100.66s
+shared entrypoint preflight: match
+shared entrypoint postflight: match
+```
+
+## Mutation identity and relevance
+
+C1 mutates the independently declared subject imported by the observer, not the observer or collector:
+
+```text
+subject: src/certified-subject.mjs
+before: export const guarded = true;
+before sha256: c6b3e0ed964e1a5590db6e19bfe7a1811e0f0a285455868c5250c49551890001
+after:  export const guarded = false;
+after sha256: f2f4e1d6a3c6521262e7b8fa84d2ead164e0d2594f0f47d2801c619ebe68539c
+```
+
+The hashes are distinct, the observer imports `guarded`, the mutated run fails with structured `ERR_ASSERTION`, and the independently materialized pristine confirmation passes.
+
+## Failure classification during construction
+
+- Worktree creation first stopped after creating the worktree because the setup hook could not find `husky`; the sanctioned setup was completed without an install. Setup failure, before assertions.
+- A sandboxed Vitest invocation could not create its temporary config in the sanctioned worktree. Permission/setup failure, before assertions; the identical permitted run was then used.
+- The first positive W3.7 assertion run failed because the old guard ID contained NUL separators and could not be transported as child argv. This was a real implementation defect, not environmental; the guard ID is now the SHA-256 of the canonical protected identity tuple.
+- The first full shared-tree postflight detected Vitest's six-byte `results.json` cache change. This was treated as real shared-state drift. Cache was disabled and the complete remaining input tree was pinned; no shared install or manual repair was performed.
+- A later all-byte preflight refused before tests because a concurrent lane changed that same disabled results cache. This was a successful pre-execution refusal, not retried as evidence; the cache-disabled input manifest remained the deciding Route A proof.
+- Final source audit found that the first C2 marker path was relative to the disposable isolated workspace, so it did not independently prove non-execution. The control now uses a per-test absolute marker through a stable environment variable; the corrected C2 passed on Node 25 and Node 22.
+- The longer coverage command was twice cut off by tool transport before a result; neither partial run was counted. A persistent terminal run completed once and supplied the recorded evidence.
+- The first Node 22 aggregate wrapper had a JavaScript syntax error and exited before preflight or tests. The wrapper was corrected once; the resulting C1/C2 run passed with matching pre/post digests.
+
+No assertion mismatch was retried unchanged until green.
+
+## Changed-file identities
+
+| File | Before SHA-256 | After SHA-256 |
+|---|---|---|
+| `scripts/lib/standards-enforcement-node-test-runner.mjs` | `0b67bd259c7cd078ab4feba10a814e9c6007a210c40b98a2382042b2feb36cc1` | `04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2` |
+| `scripts/lib/standards-enforcement-execution-verifier.mjs` | `bb3662dcc3c31d9aff6aa0074388294f9d54f0d05249d19c693366f511f492d5` | `0cf6fbb303a49c664bd1587bdf852e58fde02b85408167b984bb07e9c7fadde4` |
+| `scripts/lib/standards-enforcement-measurement.mjs` | `ebdd8047399c41560c6214ed4f62269264585466acec22830b676d696b8e5646` | `0c34eeb22e49602c7fba2315a1de75a160cf3bb82628d7654f4bd2a8b97332f0` |
+| `tests/unit/standards-enforcement-measurement.test.ts` | `9f1470269337bacb29ede637c1bf0ee687d96ff60b0ac8c7def6f368e32238dc` | `7345c2c879c991d34101238b17c5e6c3833efa75809d64e41824d8fb31d14bb2` |
+| `tests/unit/standards-coverage-ratchet.test.ts` | `4a1e0efe7c08efa50f9d2a6b7c88c18f04b85fbb199f3829562aba9a8de7e33c` | `a9f60fca2d219efac9ae7585fab0096cb547aa2ca426f06833d0ee4cf88b4e60` |
+
+The new report, upgrade notes, and decision record have no pre-change bytes.
+
+## Other verification
+
+```text
+Node: v25.6.1 (primary), v22.18.0 (compatibility)
+node --check (three changed .mjs files): exit 0
+tsc --noEmit: exit 0; Node and TypeScript digests matched pre/post
+git diff --check: exit 0
+```
+
+No approver key was created. No CI file was changed. No force-push or merge was performed.

--- a/scripts/lib/standards-enforcement-execution-verifier.mjs
+++ b/scripts/lib/standards-enforcement-execution-verifier.mjs
@@ -3,19 +3,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import {
   createAuthenticatedReceiptAuthority,
+  isLiveAuthenticatedObserverEvent,
   isLiveAuthenticatedReceipt,
 } from "../../scratchpad/phaseB/authenticated-execution-receipt.mjs";
 import { SafeFsExecutor } from "../../dist/core/SafeFsExecutor.js";
 
-const ARTIFACT_SCHEMA = "standards-enforcement-observed-execution/v2";
+const ARTIFACT_SCHEMA = "standards-enforcement-observed-execution/v3";
 const RUNNER = "node-test-events-v1";
 const RUNNER_REF = "scripts/lib/standards-enforcement-node-test-runner.mjs";
-const RUNNER_PATH = fileURLToPath(
-  new URL("./standards-enforcement-node-test-runner.mjs", import.meta.url),
-);
 const OBSERVATION_SCHEMA = "standards-enforcement-node-test-events/v1";
 const DEFAULT_OBSERVER_TIMEOUT_MS = 15_000;
 const SHA256_RE = /^[a-f0-9]{64}$/;
@@ -23,16 +20,6 @@ const liveArtifacts = new WeakSet();
 
 const sha256 = (value) =>
   crypto.createHash("sha256").update(value).digest("hex");
-
-function runnerDigest() {
-  const stat = fs.lstatSync(RUNNER_PATH);
-  if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error("structured test runner must be a regular non-symlink file");
-  }
-  return sha256(fs.readFileSync(RUNNER_PATH));
-}
-
-const RUNNER_SHA256 = runnerDigest();
 
 function canonical(value) {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
@@ -120,12 +107,41 @@ function runObserver(
   observerRef,
   guardId,
   kind,
+  expectedRunnerSha256,
   timeoutMs = DEFAULT_OBSERVER_TIMEOUT_MS,
 ) {
+  const runnerPath = path.join(workspace, RUNNER_REF);
+  try {
+    const stat = fs.lstatSync(runnerPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error("protected structured test runner is not a regular file");
+    }
+    const actualRunnerSha256 = sha256(fs.readFileSync(runnerPath));
+    if (actualRunnerSha256 !== expectedRunnerSha256) {
+      throw new Error(
+        `protected structured test runner digest changed before execution: expected=${expectedRunnerSha256} actual=${actualRunnerSha256}`,
+      );
+    }
+  } catch (error) {
+    return Promise.resolve({
+      guardId,
+      kind,
+      observerRef,
+      runnerError: error instanceof Error ? error.message : String(error),
+      timedOut: false,
+    });
+  }
   return new Promise((resolve) => {
-    const argv = [process.execPath, RUNNER_PATH, observerRef];
+    const argv = [
+      process.execPath,
+      runnerPath,
+      observerRef,
+      guardId,
+      kind,
+      RUNNER_REF,
+    ];
     const startedAt = new Date().toISOString();
-    const child = spawn(process.execPath, [RUNNER_PATH, observerRef], {
+    const child = spawn(process.execPath, argv.slice(1), {
       cwd: workspace,
       env: scrubbedChildEnv(),
       stdio: ["ignore", "pipe", "pipe", "ipc"],
@@ -136,7 +152,7 @@ function runObserver(
     let spawnError = null;
     let timedOut = false;
     let settled = false;
-    const observations = [];
+    const events = [];
     const finish = (exitCode, signal, emittedAfterChildExit) => {
       if (settled) return;
       settled = true;
@@ -148,6 +164,7 @@ function runObserver(
       resolve({
         guardId,
         kind,
+        observerRef,
         childPid: child.pid,
         childExitCode: exitCode,
         signal,
@@ -157,11 +174,8 @@ function runObserver(
         emittedAfterChildExit,
         output,
         outputSha256: sha256(output),
-        observation:
-          observations.length === 1 &&
-          validObservation(observations[0], observerRef)
-            ? observations[0]
-            : null,
+        events,
+        runnerError: null,
         spawnError,
         timedOut,
       });
@@ -185,7 +199,7 @@ function runObserver(
     timer.unref();
     child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
     child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
-    child.on("message", (message) => observations.push(message));
+    child.on("message", (message) => events.push(message));
     child.on("error", (error) => {
       spawnError = error;
     });
@@ -195,6 +209,7 @@ function runObserver(
 
 async function authenticateRun(authority, run) {
   if (
+    run.runnerError ||
     run.spawnError ||
     !Number.isSafeInteger(run.childPid) ||
     run.childPid <= 0 ||
@@ -202,15 +217,61 @@ async function authenticateRun(authority, run) {
     run.childExitCode < 0
   )
     return null;
+  if (run.events.length !== 2) return null;
+  const [readyEvent, observationEvent] = run.events;
+  if (
+    readyEvent?.kind !== "observer-ready" ||
+    readyEvent?.runKind !== run.kind ||
+    observationEvent?.kind !== run.kind ||
+    !validObservation(observationEvent?.observation, run.observerRef) ||
+    observationEvent.observationSha256 !==
+      sha256(canonical(observationEvent.observation))
+  )
+    return null;
+  const readyExpected = {
+    kind: "observer-ready",
+    guardId: run.guardId,
+    nodeEntry: RUNNER_REF,
+    observerPid: run.childPid,
+    runKind: run.kind,
+    argv: run.argv.slice(1),
+  };
+  if (
+    !(await authority.pinObserverEvent(readyEvent, readyExpected)) ||
+    !isLiveAuthenticatedObserverEvent(readyEvent)
+  )
+    return null;
+  const observationExpected = {
+    kind: run.kind,
+    guardId: run.guardId,
+    nodeEntry: RUNNER_REF,
+    observerPid: run.childPid,
+    observerSession: readyEvent.observerSession,
+    argv: run.argv.slice(1),
+    observation: observationEvent.observation,
+    observationSha256: observationEvent.observationSha256,
+  };
+  if (
+    !(await authority.authenticateObserverEvent(
+      observationEvent,
+      observationExpected,
+    )) ||
+    !isLiveAuthenticatedObserverEvent(observationEvent)
+  )
+    return null;
   const expected = {
     guardId: run.guardId,
     kind: run.kind,
+    observerPid: run.childPid,
     childPid: run.childPid,
     childExitCode: run.childExitCode,
     argv: run.argv,
     startedAt: run.startedAt,
     childExitedAt: run.childExitedAt,
     emittedAfterChildExit: true,
+    observerSession: observationEvent.observerSession,
+    observerEventSequence: observationEvent.sequence,
+    observerEventSignatureHash: sha256(observationEvent.signature),
   };
   const receipt = await authority.issue(expected);
   if (
@@ -218,7 +279,12 @@ async function authenticateRun(authority, run) {
     !isLiveAuthenticatedReceipt(receipt)
   )
     return null;
-  return receipt;
+  return Object.freeze({
+    receipt,
+    observation: Object.freeze({ ...observationEvent.observation }),
+    observationEvent,
+    observationSha256: observationEvent.observationSha256,
+  });
 }
 
 function validatePlan(record) {
@@ -227,6 +293,7 @@ function validatePlan(record) {
   const relevance = record.proof.relevance;
   if (
     execution.runner !== RUNNER ||
+    !SHA256_RE.test(execution.runnerSha256) ||
     JSON.stringify(execution.argv) !==
       JSON.stringify(["node", RUNNER_REF, record.ref])
   ) {
@@ -239,6 +306,7 @@ function validatePlan(record) {
     new Set(execution.workspaceRefs).size !== execution.workspaceRefs.length ||
     JSON.stringify([...execution.workspaceRefs].sort()) !==
       JSON.stringify(execution.workspaceRefs) ||
+    execution.workspaceRefs.includes(RUNNER_REF) ||
     !execution.workspaceRefs.includes(record.ref) ||
     !execution.workspaceRefs.includes(relevance.subjectRef)
   ) {
@@ -259,7 +327,7 @@ function validatePlan(record) {
   return null;
 }
 
-function materialize(snapshot, refs) {
+function materialize(snapshot, refs, trustedRunnerContent) {
   const workspace = fs.mkdtempSync(
     path.join(os.tmpdir(), "standards-enforcement-observed-"),
   );
@@ -272,6 +340,9 @@ function materialize(snapshot, refs) {
       fs.mkdirSync(path.dirname(full), { recursive: true });
       fs.writeFileSync(full, content, { flag: "wx" });
     }
+    const runnerPath = path.join(workspace, RUNNER_REF);
+    fs.mkdirSync(path.dirname(runnerPath), { recursive: true });
+    fs.writeFileSync(runnerPath, trustedRunnerContent, { flag: "wx" });
     return { workspace, error: null };
   } catch (error) {
     return {
@@ -302,9 +373,9 @@ function artifactFor(
   clean,
   mutated,
   confirmation,
-  cleanReceipt,
-  mutatedReceipt,
-  confirmationReceipt,
+  cleanAuthentication,
+  mutatedAuthentication,
+  confirmationAuthentication,
   mutationLanded,
 ) {
   const payload = {
@@ -313,7 +384,7 @@ function artifactFor(
       ref: record.ref,
       sha256: record.sha256,
       runner: RUNNER,
-      runnerSha256: RUNNER_SHA256,
+      runnerSha256: record.proof.execution.runnerSha256,
       structuredSource: "node:test TestsStream",
       argv: clean.argv,
     },
@@ -325,29 +396,35 @@ function artifactFor(
       mutationLanded,
     },
     clean: {
-      receipt: cleanReceipt,
+      receipt: cleanAuthentication.receipt,
+      observationEvent: cleanAuthentication.observationEvent,
+      observationSha256: cleanAuthentication.observationSha256,
       exitCode: clean.childExitCode,
-      testsRun: clean.observation.testsRun,
-      passed: clean.observation.passed,
-      failed: clean.observation.failed,
+      testsRun: cleanAuthentication.observation.testsRun,
+      passed: cleanAuthentication.observation.passed,
+      failed: cleanAuthentication.observation.failed,
       outputSha256: clean.outputSha256,
     },
     mutated: {
-      receipt: mutatedReceipt,
+      receipt: mutatedAuthentication.receipt,
+      observationEvent: mutatedAuthentication.observationEvent,
+      observationSha256: mutatedAuthentication.observationSha256,
       exitCode: mutated.childExitCode,
-      testsRun: mutated.observation.testsRun,
-      passed: mutated.observation.passed,
-      failed: mutated.observation.failed,
-      assertionFailures: mutated.observation.assertionFailures,
+      testsRun: mutatedAuthentication.observation.testsRun,
+      passed: mutatedAuthentication.observation.passed,
+      failed: mutatedAuthentication.observation.failed,
+      assertionFailures: mutatedAuthentication.observation.assertionFailures,
       outputSha256: mutated.outputSha256,
-      decidingOutput: mutated.observation.decidingMessage,
+      decidingOutput: mutatedAuthentication.observation.decidingMessage,
     },
     confirmation: {
-      receipt: confirmationReceipt,
+      receipt: confirmationAuthentication.receipt,
+      observationEvent: confirmationAuthentication.observationEvent,
+      observationSha256: confirmationAuthentication.observationSha256,
       exitCode: confirmation.childExitCode,
-      testsRun: confirmation.observation.testsRun,
-      passed: confirmation.observation.passed,
-      failed: confirmation.observation.failed,
+      testsRun: confirmationAuthentication.observation.testsRun,
+      passed: confirmationAuthentication.observation.passed,
+      failed: confirmationAuthentication.observation.failed,
       outputSha256: confirmation.outputSha256,
     },
   };
@@ -377,11 +454,30 @@ export async function verifyProtectedExecutionProof({
   let mutatedWorkspace = null;
   let confirmationWorkspace = null;
   let authority = null;
-  const guardId = `${record.articleId}\0${record.ref}\0${record.proof.mutation.mutationId}`;
+  const guardId = sha256(canonical({
+    articleId: record.articleId,
+    mutationId: record.proof.mutation.mutationId,
+    ref: record.ref,
+  }));
   try {
+    const trustedRunnerContent = snapshot.readFile(RUNNER_REF);
+    if (trustedRunnerContent === null)
+      return {
+        status: "unknown",
+        reason: "protected structured test runner is unavailable",
+        artifact: null,
+      };
+    const actualRunnerSha256 = sha256(trustedRunnerContent);
+    if (actualRunnerSha256 !== record.proof.execution.runnerSha256)
+      return {
+        status: "unknown",
+        reason: `protected structured test runner digest mismatch: expected=${record.proof.execution.runnerSha256} actual=${actualRunnerSha256}`,
+        artifact: null,
+      };
     const cleanMaterialization = materialize(
       snapshot,
       record.proof.execution.workspaceRefs,
+      trustedRunnerContent,
     );
     cleanWorkspace = cleanMaterialization.workspace;
     if (cleanMaterialization.error)
@@ -394,6 +490,7 @@ export async function verifyProtectedExecutionProof({
     const mutatedMaterialization = materialize(
       snapshot,
       record.proof.execution.workspaceRefs,
+      trustedRunnerContent,
     );
     mutatedWorkspace = mutatedMaterialization.workspace;
     if (mutatedMaterialization.error)
@@ -406,6 +503,7 @@ export async function verifyProtectedExecutionProof({
     const confirmationMaterialization = materialize(
       snapshot,
       record.proof.execution.workspaceRefs,
+      trustedRunnerContent,
     );
     confirmationWorkspace = confirmationMaterialization.workspace;
     if (confirmationMaterialization.error)
@@ -423,25 +521,22 @@ export async function verifyProtectedExecutionProof({
       record.ref,
       guardId,
       "clean-observer-exit",
+      record.proof.execution.runnerSha256,
       observerTimeoutMs,
     );
+    if (clean.runnerError)
+      return { status: "unknown", reason: clean.runnerError, artifact: null };
     if (clean.timedOut)
       return {
         status: "unknown",
         reason: "clean observer execution timed out",
         artifact: null,
       };
-    const cleanReceipt = await authenticateRun(authority, clean);
-    if (!cleanReceipt)
+    const cleanAuthentication = await authenticateRun(authority, clean);
+    if (!cleanAuthentication)
       return {
         status: "unknown",
-        reason: "clean observer execution could not be authenticated",
-        artifact: null,
-      };
-    if (clean.observation === null)
-      return {
-        status: "unknown",
-        reason: "clean structured test observation unavailable",
+        reason: "clean structured test observation could not be authenticated",
         artifact: null,
       };
 
@@ -485,25 +580,22 @@ export async function verifyProtectedExecutionProof({
       record.ref,
       guardId,
       "mutated-observer-exit",
+      record.proof.execution.runnerSha256,
       observerTimeoutMs,
     );
+    if (mutated.runnerError)
+      return { status: "unknown", reason: mutated.runnerError, artifact: null };
     if (mutated.timedOut)
       return {
         status: "unknown",
         reason: "mutated observer execution timed out",
         artifact: null,
       };
-    const mutatedReceipt = await authenticateRun(authority, mutated);
-    if (!mutatedReceipt)
+    const mutatedAuthentication = await authenticateRun(authority, mutated);
+    if (!mutatedAuthentication)
       return {
         status: "unknown",
-        reason: "mutated observer execution could not be authenticated",
-        artifact: null,
-      };
-    if (mutated.observation === null)
-      return {
-        status: "unknown",
-        reason: "mutated structured test observation unavailable",
+        reason: "mutated structured test observation could not be authenticated",
         artifact: null,
       };
 
@@ -512,25 +604,29 @@ export async function verifyProtectedExecutionProof({
       record.ref,
       guardId,
       "confirmation-clean-observer-exit",
+      record.proof.execution.runnerSha256,
       observerTimeoutMs,
     );
+    if (confirmation.runnerError)
+      return {
+        status: "unknown",
+        reason: confirmation.runnerError,
+        artifact: null,
+      };
     if (confirmation.timedOut)
       return {
         status: "unknown",
         reason: "confirmation observer execution timed out",
         artifact: null,
       };
-    const confirmationReceipt = await authenticateRun(authority, confirmation);
-    if (!confirmationReceipt)
+    const confirmationAuthentication = await authenticateRun(
+      authority,
+      confirmation,
+    );
+    if (!confirmationAuthentication)
       return {
         status: "unknown",
-        reason: "confirmation observer execution could not be authenticated",
-        artifact: null,
-      };
-    if (confirmation.observation === null)
-      return {
-        status: "unknown",
-        reason: "confirmation structured test observation unavailable",
+        reason: "confirmation structured test observation could not be authenticated",
         artifact: null,
       };
 
@@ -539,28 +635,31 @@ export async function verifyProtectedExecutionProof({
       clean,
       mutated,
       confirmation,
-      cleanReceipt,
-      mutatedReceipt,
-      confirmationReceipt,
+      cleanAuthentication,
+      mutatedAuthentication,
+      confirmationAuthentication,
       mutationLanded,
     );
+    const cleanObservation = cleanAuthentication.observation;
+    const mutatedObservation = mutatedAuthentication.observation;
+    const confirmationObservation = confirmationAuthentication.observation;
     const cleanPassed =
       clean.childExitCode === 0 &&
-      clean.observation.testsRun > 0 &&
-      clean.observation.failed === 0;
+      cleanObservation.testsRun > 0 &&
+      cleanObservation.failed === 0;
     const sameTestsRan =
-      Number.isInteger(clean.observation.testsRun) &&
-      clean.observation.testsRun === mutated.observation.testsRun &&
-      clean.observation.testsRun === confirmation.observation.testsRun;
+      Number.isInteger(cleanObservation.testsRun) &&
+      cleanObservation.testsRun === mutatedObservation.testsRun &&
+      cleanObservation.testsRun === confirmationObservation.testsRun;
     const confirmationPassed =
       confirmation.childExitCode === 0 &&
-      confirmation.observation.testsRun > 0 &&
-      confirmation.observation.failed === 0;
+      confirmationObservation.testsRun > 0 &&
+      confirmationObservation.failed === 0;
     const assertionFailure =
       mutated.childExitCode !== 0 &&
-      mutated.observation.testsRun > 0 &&
-      mutated.observation.failed > 0 &&
-      mutated.observation.assertionFailures > 0;
+      mutatedObservation.testsRun > 0 &&
+      mutatedObservation.failed > 0 &&
+      mutatedObservation.assertionFailures > 0;
     if (!cleanPassed)
       return {
         status: "not-proven",
@@ -618,13 +717,30 @@ export async function verifyProtectedExecutionProof({
 }
 
 export function isLiveAuthenticatedExecutionArtifact(artifact) {
+  const liveRun = (run) => {
+    const event = run?.observationEvent;
+    const receipt = run?.receipt;
+    return Boolean(
+      event &&
+      receipt &&
+      isLiveAuthenticatedObserverEvent(event) &&
+      isLiveAuthenticatedReceipt(receipt) &&
+      validObservation(event.observation, artifact.observer?.ref) &&
+      run.observationSha256 === sha256(canonical(event.observation)) &&
+      event.observationSha256 === run.observationSha256 &&
+      receipt.observerSession === event.observerSession &&
+      receipt.observerEventSequence === event.sequence &&
+      receipt.observerEventSignatureHash === sha256(event.signature) &&
+      receipt.kind === event.kind
+    );
+  };
   return Boolean(
     artifact &&
     typeof artifact === "object" &&
     liveArtifacts.has(artifact) &&
-    isLiveAuthenticatedReceipt(artifact.clean?.receipt) &&
-    isLiveAuthenticatedReceipt(artifact.mutated?.receipt) &&
-    isLiveAuthenticatedReceipt(artifact.confirmation?.receipt),
+    liveRun(artifact.clean) &&
+    liveRun(artifact.mutated) &&
+    liveRun(artifact.confirmation),
   );
 }
 

--- a/scripts/lib/standards-enforcement-measurement.mjs
+++ b/scripts/lib/standards-enforcement-measurement.mjs
@@ -278,8 +278,9 @@ function validProofRecord(record, index) {
     return `record ${index} proof envelope is malformed`;
   }
   const execution = proof.execution;
-  if (!exactKeys(execution, ['runner', 'argv', 'workspaceRefs']) ||
+  if (!exactKeys(execution, ['runner', 'runnerSha256', 'argv', 'workspaceRefs']) ||
     execution.runner !== STANDARDS_EXECUTION_RUNNER ||
+    !SHA256_RE.test(execution.runnerSha256) ||
     JSON.stringify(execution.argv) !== JSON.stringify([
       'node',
       'scripts/lib/standards-enforcement-node-test-runner.mjs',
@@ -501,6 +502,10 @@ export async function measureAnchoredEnforcement({
                     execution: {
                       observationSource: artifact.observer.structuredSource,
                       runnerSha256: artifact.observer.runnerSha256,
+                      observationsReceiptBound: true,
+                      cleanObservationSha256: artifact.clean.observationSha256,
+                      mutatedObservationSha256: artifact.mutated.observationSha256,
+                      confirmationObservationSha256: artifact.confirmation.observationSha256,
                       cleanExitCode: artifact.clean.exitCode,
                       cleanTestsRun: artifact.clean.testsRun,
                       mutatedExitCode: artifact.mutated.exitCode,
@@ -523,6 +528,10 @@ export async function measureAnchoredEnforcement({
                       execution: {
                         observationSource: artifact.observer.structuredSource,
                         runnerSha256: artifact.observer.runnerSha256,
+                        observationsReceiptBound: true,
+                        cleanObservationSha256: artifact.clean.observationSha256,
+                        mutatedObservationSha256: artifact.mutated.observationSha256,
+                        confirmationObservationSha256: artifact.confirmation.observationSha256,
                         cleanExitCode: artifact.clean.exitCode,
                         cleanTestsRun: artifact.clean.testsRun,
                         mutatedExitCode: artifact.mutated.exitCode,

--- a/scripts/lib/standards-enforcement-node-test-runner.mjs
+++ b/scripts/lib/standards-enforcement-node-test-runner.mjs
@@ -1,7 +1,23 @@
+import crypto from "node:crypto";
 import path from "node:path";
 import { run } from "node:test";
 
 const SCHEMA = "standards-enforcement-node-test-events/v1";
+const EVENT_SCHEMA = "phaseB-authenticated-observer-event/v1";
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+const sha256 = (value) =>
+  crypto.createHash("sha256").update(value).digest("hex");
 
 function assertionError(error, seen = new Set()) {
   if (!error || typeof error !== "object" || seen.has(error)) return null;
@@ -30,20 +46,60 @@ function countedTest(data) {
   );
 }
 
-async function send(summary) {
+async function send(message) {
   if (typeof process.send !== "function") {
     throw new Error("structured observation IPC is unavailable");
   }
   await new Promise((resolve, reject) => {
-    process.send(summary, (error) => (error ? reject(error) : resolve()));
+    process.send(message, (error) => (error ? reject(error) : resolve()));
   });
-  if (process.connected) process.disconnect();
 }
 
 const observerRef = process.argv[2];
+const guardId = process.argv[3];
+const runKind = process.argv[4];
+const nodeEntry = process.argv[5];
 if (typeof observerRef !== "string" || observerRef.length === 0) {
   throw new Error("observer reference is required");
 }
+if (typeof guardId !== "string" || guardId.length === 0) {
+  throw new Error("guard identity is required");
+}
+if (typeof runKind !== "string" || runKind.length === 0) {
+  throw new Error("run kind is required");
+}
+if (typeof nodeEntry !== "string" || nodeEntry.length === 0) {
+  throw new Error("runner entry identity is required");
+}
+
+const keyPair = crypto.generateKeyPairSync("ed25519");
+const publicKey = keyPair.publicKey
+  .export({ type: "spki", format: "der" })
+  .toString("base64");
+const observerSession = crypto.randomUUID();
+const argv = process.argv.slice(1);
+let sequence = 0;
+async function emit(kind, fields = {}) {
+  const event = {
+    eventSchema: EVENT_SCHEMA,
+    source: "fix-verifier-observer",
+    observerSession,
+    sequence: ++sequence,
+    kind,
+    guardId,
+    nodeEntry,
+    observerPid: process.pid,
+    argv,
+    ...(kind === "observer-ready" ? { publicKey } : {}),
+    ...fields,
+  };
+  const signature = crypto
+    .sign(null, Buffer.from(canonical(event)), keyPair.privateKey)
+    .toString("base64");
+  await send({ ...event, signature });
+}
+
+await emit("observer-ready", { runKind });
 
 let passed = 0;
 let failed = 0;
@@ -82,4 +138,8 @@ const summary = Object.freeze({
   decidingMessage,
 });
 process.exitCode = failed > 0 ? 1 : 0;
-await send(summary);
+await emit(runKind, {
+  observation: summary,
+  observationSha256: sha256(canonical(summary)),
+});
+if (process.connected) process.disconnect();

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -21,6 +21,12 @@ import { stampConverged, validateAuditReport } from '../../scripts/write-audit-c
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.resolve(__dirname, '../../scripts/standards-coverage.mjs');
+const RUNNER_REF = 'scripts/lib/standards-enforcement-node-test-runner.mjs';
+const TRUSTED_RUNNER_SHA256 = '04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2';
+const trustedRunnerContent = fs.readFileSync(path.resolve(__dirname, `../../${RUNNER_REF}`), 'utf8');
+if (crypto.createHash('sha256').update(trustedRunnerContent).digest('hex') !== TRUSTED_RUNNER_SHA256) {
+  throw new Error('trusted structured test runner digest does not match the independently reviewed bytes');
+}
 
 let repo: string;
 let auditCounter: number;
@@ -211,6 +217,7 @@ function writeFixtureEnforcementProof(): void {
         schemaVersion: 2,
         execution: {
           runner: 'node-test-events-v1',
+          runnerSha256: TRUSTED_RUNNER_SHA256,
           argv: ['node', 'scripts/lib/standards-enforcement-node-test-runner.mjs', ref],
           workspaceRefs: [subjectRef, ref].sort(),
         },
@@ -242,6 +249,7 @@ beforeEach(() => {
   write('src/server/routes.ts', "router.get('/x', (req,res)=>{});\n");
   write('src/widget.ts', 'export const widgetGuarded = true;\n');
   write('tests/unit/widget.test.ts', "import assert from 'node:assert/strict';\nimport test from 'node:test';\nimport { widgetGuarded } from '../../src/widget.ts';\ntest('observes the guarded widget rule', () => assert.equal(widgetGuarded, true));\n");
+  write(RUNNER_REF, trustedRunnerContent);
   write('docs/specs/reports/family-review.md', '# Family review\n\nFixture convergence evidence.\n');
   write('docs/STANDARDS-REGISTRY.md', [
     '## Building',
@@ -289,6 +297,7 @@ function snapshotMeasurementBase(): string {
   copy('docs/standards-enforcement-verdicts.json');
   copy('src/widget.ts');
   copy('tests/unit/widget.test.ts');
+  copy(RUNNER_REF);
   return baseRoot;
 }
 

--- a/tests/unit/standards-enforcement-measurement.test.ts
+++ b/tests/unit/standards-enforcement-measurement.test.ts
@@ -23,6 +23,12 @@ const write = (root: string, rel: string, content: string): void => {
   fs.writeFileSync(full, content);
 };
 const digest = (value: string): string => crypto.createHash('sha256').update(value).digest('hex');
+const RUNNER_REF = 'scripts/lib/standards-enforcement-node-test-runner.mjs';
+const TRUSTED_RUNNER_SHA256 = '04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2';
+const trustedRunnerContent = fs.readFileSync(path.resolve(RUNNER_REF), 'utf8');
+if (digest(trustedRunnerContent) !== TRUSTED_RUNNER_SHA256) {
+  throw new Error('trusted structured test runner digest does not match the independently reviewed bytes');
+}
 const article = (id: string, files: string[]) => {
   const rule = `fixture rule ${id}`;
   return {
@@ -35,6 +41,7 @@ const article = (id: string, files: string[]) => {
   };
 };
 const certifiedRecord = (
+  protectedRoot: string,
   protectedArticle: ReturnType<typeof article>,
   ref: string,
   observerContent: string,
@@ -45,6 +52,7 @@ const certifiedRecord = (
   mutationReplacement = 'false',
 ) => {
   const subjectAfter = subjectContent.replace(mutationSearch, mutationReplacement);
+  write(protectedRoot, RUNNER_REF, trustedRunnerContent);
   return ({
   articleId: protectedArticle.id,
   articleSha256: protectedArticle.articleSha256,
@@ -55,6 +63,7 @@ const certifiedRecord = (
     schemaVersion: 2,
     execution: {
       runner: 'node-test-events-v1',
+      runnerSha256: TRUSTED_RUNNER_SHA256,
       argv: ['node', 'scripts/lib/standards-enforcement-node-test-runner.mjs', ref],
       workspaceRefs: [...new Set([ref, subjectRef])].sort(),
     },
@@ -113,7 +122,7 @@ describe('protected standards enforcement measurement', () => {
     write(candidate, subjectRef, subjectContent);
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
-      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+      records: [certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
     expect(fs.readFileSync(path.join(candidate, ref), 'utf8')).toContain('expect(true).toBe(true)');
     const result = await measureAnchoredEnforcement({
@@ -159,7 +168,7 @@ describe('protected standards enforcement measurement', () => {
     }
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
-      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+      records: [certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
 
     const result = await measureAnchoredEnforcement({
@@ -204,7 +213,7 @@ describe('protected standards enforcement measurement', () => {
     }
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
-      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+      records: [certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
 
     const result = await measureAnchoredEnforcement({
@@ -245,7 +254,7 @@ describe('protected standards enforcement measurement', () => {
       '',
     ].join('\n');
     const protectedArticle = article('rule-a', [ref]);
-    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
     record.proof.execution.workspaceRefs = [helperRef, subjectRef, ref].sort();
     for (const root of [base, candidate]) {
       write(root, ref, content);
@@ -286,7 +295,7 @@ describe('protected standards enforcement measurement', () => {
       '',
     ].join('\n');
     const protectedArticle = article('rule-a', [ref]);
-    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
     record.proof.mutation.subjectAfterSha256 = digest('wrong but well-shaped after bytes');
     for (const root of [base, candidate]) {
       write(root, ref, content);
@@ -323,7 +332,7 @@ describe('protected standards enforcement measurement', () => {
       '',
     ].join('\n');
     const protectedArticle = article('rule-a', [ref]);
-    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
     write(base, ref, content);
     write(base, subjectRef, subjectContent);
     const snapshot = resolveProtectedMeasurementSnapshot({ root: base, fixtureRoot: base });
@@ -354,7 +363,7 @@ describe('protected standards enforcement measurement', () => {
       '',
     ].join('\n');
     const protectedArticle = article('rule-a', [ref]);
-    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
     write(base, ref, content);
     write(base, subjectRef, subjectContent);
     const snapshot = resolveProtectedMeasurementSnapshot({ root: base, fixtureRoot: base });
@@ -374,6 +383,67 @@ describe('protected standards enforcement measurement', () => {
     });
     expect(elapsedMs).toBeLessThan(1_000);
     console.log(`W35_C3D descendantHoldsStdio=true timeoutMs=100 elapsedMs=${elapsedMs} property=UNKNOWN deciding="clean observer execution timed out"`);
+  });
+
+  it('C2 refuses an exact-schema summary from a digest-mismatched runner before execution', async () => {
+    const base = makeRoot();
+    const ref = 'tests/unit/untrusted-runner-target.test.mjs';
+    const subjectRef = 'src/untrusted-runner-subject.mjs';
+    const markerRef = 'untrusted-runner-executed';
+    const markerPath = path.join(base, markerRef);
+    const subjectContent = 'export const guarded = true;\n';
+    const content = [
+      "import assert from 'node:assert/strict';",
+      "import test from 'node:test';",
+      "import { guarded } from '../../src/untrusted-runner-subject.mjs';",
+      "test('observes subject', () => assert.equal(guarded, true));",
+      '',
+    ].join('\n');
+    const protectedArticle = article('rule-a', [ref]);
+    const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
+    write(base, ref, content);
+    write(base, subjectRef, subjectContent);
+    const forgedRunner = [
+      "import fs from 'node:fs';",
+      "const marker = process.env.W37_UNTRUSTED_RUNNER_MARKER;",
+      "if (!marker) throw new Error('untrusted runner marker is required');",
+      "fs.writeFileSync(marker, 'executed');",
+      `process.send?.(${JSON.stringify({
+        schema: 'standards-enforcement-node-test-events/v1',
+        source: 'node:test TestsStream',
+        observerRef: ref,
+        testsRun: 999,
+        passed: 999,
+        failed: 0,
+        assertionFailures: 0,
+        decidingMessage: '',
+      })});`,
+      '',
+    ].join('\n');
+    write(base, RUNNER_REF, forgedRunner);
+    const forgedRunnerSha256 = digest(forgedRunner);
+    expect(forgedRunnerSha256).not.toBe(TRUSTED_RUNNER_SHA256);
+
+    const previousMarker = process.env.W37_UNTRUSTED_RUNNER_MARKER;
+    process.env.W37_UNTRUSTED_RUNNER_MARKER = markerPath;
+    let observed;
+    try {
+      observed = await verifyProtectedExecutionProof({
+        record,
+        snapshot: resolveProtectedMeasurementSnapshot({ root: base, fixtureRoot: base }),
+      });
+    } finally {
+      if (previousMarker === undefined) delete process.env.W37_UNTRUSTED_RUNNER_MARKER;
+      else process.env.W37_UNTRUSTED_RUNNER_MARKER = previousMarker;
+    }
+
+    expect(observed).toEqual({
+      status: 'unknown',
+      reason: `protected structured test runner digest mismatch: expected=${TRUSTED_RUNNER_SHA256} actual=${forgedRunnerSha256}`,
+      artifact: null,
+    });
+    expect(fs.existsSync(markerPath)).toBe(false);
+    console.log(`W37_C2 expectedRunnerSha256=${TRUSTED_RUNNER_SHA256} actualRunnerSha256=${forgedRunnerSha256} runnerExecuted=false summarySchema=standards-enforcement-node-test-events/v1 outcome=UNKNOWN artifact=null deciding="protected structured test runner digest mismatch"`);
   });
 
   it('caps candidate strength at the protected article/reference census', async () => {
@@ -419,7 +489,7 @@ describe('protected standards enforcement measurement', () => {
     write(candidate, subjectRef, subjectContent);
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
-      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+      records: [certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
     write(candidate, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
@@ -438,7 +508,8 @@ describe('protected standards enforcement measurement', () => {
       evidenceStatus: 'proven',
       execution: expect.objectContaining({
         observationSource: 'node:test TestsStream',
-        runnerSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        runnerSha256: TRUSTED_RUNNER_SHA256,
+        observationsReceiptBound: true,
         cleanExitCode: 0,
         cleanTestsRun: 1,
         mutatedExitCode: 1,
@@ -451,6 +522,7 @@ describe('protected standards enforcement measurement', () => {
     }));
     expect(result.articles[0].references[0].execution?.decidingOutput).not.toContain('999');
     console.log('W36_C1 source="node:test TestsStream" misleadingRendererCounts=ignored mutationLanded=true cleanExit=0 cleanTests=1 mutatedExit=1 mutatedTests=1 confirmationExit=0 confirmationTests=1 failureKind=assertion artifact=authenticated verdict=ratchet');
+    console.log(`W37_C1 protectedRunnerSha256=${TRUSTED_RUNNER_SHA256} digestCompared=true protectedRunnerMaterialized=true observationsReceiptBound=true verdict=ratchet`);
   });
 
   it('rejects a proof that mutates its observer instead of an independent rule subject', async () => {
@@ -459,7 +531,7 @@ describe('protected standards enforcement measurement', () => {
     const ref = 'tests/unit/certified.test.ts';
     const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
     const protectedArticle = article('rule-a', [ref]);
-    const record = certifiedRecord(protectedArticle, ref, content, ref, content);
+    const record = certifiedRecord(base, protectedArticle, ref, content, ref, content);
     record.proof.execution.workspaceRefs = ['src/unused.ts', ref].sort();
     write(base, ref, content);
     write(candidate, ref, content);
@@ -487,7 +559,7 @@ describe('protected standards enforcement measurement', () => {
     const content = "import { expect, it } from 'vitest'; it('observes', () => expect(subject).toBe(true));\n";
     const subjectContent = 'export const subject = true;\n';
     const protectedArticle = article('rule-a', [ref]);
-    const record = certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent);
+    const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
     (record.proof as typeof record.proof & { control: unknown }).control = {
       exitCode: 0,
       testsRun: 1,
@@ -532,7 +604,7 @@ describe('protected standards enforcement measurement', () => {
     write(candidate, subjectRef, subjectContent);
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
-      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+      records: [certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
     const result = await measureAnchoredEnforcement({
       root: candidate,
@@ -561,7 +633,7 @@ describe('protected standards enforcement measurement', () => {
     write(base, subjectRef, subjectContent);
     write(base, 'docs/standards-enforcement-verdicts.json', `${JSON.stringify({
       schemaVersion: 3,
-      records: [certifiedRecord(protectedArticle, ref, content, subjectRef, subjectContent)],
+      records: [certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent)],
     })}\n`);
     const result = await measureAnchoredEnforcement({
       root: candidate,

--- a/upgrades/next/enforcement-measurement.md
+++ b/upgrades/next/enforcement-measurement.md
@@ -10,6 +10,8 @@ The standards-coverage report now measures enforcement against a closed rule cen
 
 Completed observer counts and assertion direction now come from the structured `TestsStream` returned by `node:test.run()`, not from TAP/spec/glyph summary text. This closes a supported-runtime split where Node 22 passed all controls but Node 25.6.1 produced `null` counts and refused even a genuine observer. Misleading renderer text is ignored.
 
+The structured collector is content-addressed by protected authority, compared before materialization and execution, and its signed exact observation is bound into the authenticated child-exit receipt. An exact-schema digest-mismatched collector is refused before execution with UNKNOWN and no artifact.
+
 References are graded on the existing ratchet, gate, lint, spec-only, and documented-only ladder. A protected verdict may supersede structural grading only when its plan binds the cited rule to an independent subject and the measurement boundary itself runs the same real check in three independently materialized pristine workspaces: clean, mutated, then pristine confirmation. The mutation lands only in the second; that run must fail by assertion and the third must reset to passing. All three bounded exits carry authenticated child-exit receipts. The ledger can no longer declare its own exit codes, test counts, failure kind, deciding output, or output hashes. Every declared workspace input must byte-match the candidate tree before protected proof carries forward; candidate-authored verdict records are ignored. Empty or unreadable populations fail measurement rather than reporting 100%.
 
 ## Evidence

--- a/upgrades/side-effects/w37-authenticated-structured-observation.md
+++ b/upgrades/side-effects/w37-authenticated-structured-observation.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — authenticated structured observation
+
+**Version / slug:** `w37-authenticated-structured-observation`
+**Date:** `2026-08-18`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `/root/w37_side_effects_review`
+**Independent judgement:** pending
+
+## Summary
+
+The protected standards execution plan now authorizes an exact collector SHA-256. The verifier compares and materializes those protected bytes, and H1 binds the collector's signed structured observation into the authenticated child-exit receipt. A digest-mismatched exact-schema forgery fails closed before execution.
+
+## Decision points
+
+- Protected execution schema — adds the exact `runnerSha256` authority field.
+- Execution verifier — reads the runner from the protected snapshot, compares before materialization and immediately before each execution, authenticates sequenced signed observations, and retains receipt linkage.
+- Node test runner — emits signed ready and observation events around the existing `TestsStream` summary.
+- Measurement output — exposes the exact observation digests and explicit receipt binding.
+- Negative control — proves a forged exact-schema runner returns UNKNOWN with no artifact and does not execute.
+
+## Over-block
+
+Any protected plan without the current collector digest becomes UNKNOWN. Collector updates therefore require an independently reviewed protected-plan digest update. Missing, duplicated, malformed, unsigned, out-of-sequence, or receipt-unbound events also fail closed. This is intentional because those cases lack authorship proof.
+
+## Under-block
+
+The protected collector establishes mechanical provenance for counts and assertion classification; it does not establish semantic adequacy of the chosen observer, subject, or mutation. Those still require independent review. Node itself and the outer grading harness remain environmental instruments and must be pinned for a particular hand-verification claim.
+
+## Abstraction fit
+
+The change repairs the narrow authority boundary instead of inventing a second test protocol. It preserves the native `node:test.run()` TestsStream source and the existing clean/mutated/pristine execution design, adding only protected content addressing and receipt linkage.
+
+## Signal vs authority
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Hard invariant over enumerable structure.
+
+The protected snapshot, exact SHA-256 comparison, Ed25519 signatures, monotonically sequenced events, exact observation digest, and H1 receipt linkage are mechanical authority checks. Human stdout remains diagnostic only. Ambiguity cannot promote.
+
+## Judgment-point check
+
+No static heuristic is added at a competing-signals decision point. This is a hard-invariant boundary over an enumerable execution-plan schema, exact file bytes, cryptographic event linkage, and exact child outcomes; it does not interpret conversational meaning or choose among live contextual signals.
+
+## Interactions
+
+- Existing C1/C3 two-way discrimination remains unchanged.
+- Both old TAP-like and new glyph-like forged renderer summaries remain ignored.
+- H1's core file is unchanged; W3.7 consumes its existing authenticated observer-event boundary.
+- Timeout and isolated workspace cleanup remain unchanged.
+- Candidate ledger records remain ignored as authority.
+- The W3.7 worktree shares W3.5 `node_modules`; final hand evidence disables Vitest cache and pins the complete resolved shared input tree before and after execution, excluding only Vitest's disabled runtime-results output.
+
+## External surfaces
+
+Protected schema-v3 execution plans gain a required `runnerSha256`. Protected main currently has no such live plans, so there is no persisted migration. No network, database, user, operator, CI, or deployment surface changes.
+
+## Operator-surface quality
+
+No operator surface — not applicable.
+
+## Multi-machine posture
+
+Collector and observation identities are portable because they are content-addressed. Ephemeral event keys, sessions, process IDs, timestamps, receipts, and artifact hashes are machine-local by design. The hand-evidence harness pins each machine's Node binary and resolved dependency tree separately.
+
+The mechanism emits no user-facing notices, holds no durable runtime state, and generates no URLs. It therefore needs no one-voice notification gate, topic-transfer replication, or cross-machine URL treatment.
+
+## Rollback
+
+A code revert removes the digest and event-receipt binding and restores the accepted J18 evidence-authorship fault. There is no data migration.
+
+## Conclusion
+
+The review found the exact-digest and receipt-linkage checks to be hard invariants at the correct authority layer. The shared-tree review caused Vitest cache to be disabled and the complete remaining transitive input tree to be pinned. Independent b03 grading remains separate.
+
+## Second-pass review
+
+**Reviewer:** `/root/w37_side_effects_review`
+**Independent read of the artifact:** concur
+
+Concur with the review — the protected digest gate, materialized runner, signed observation-to-receipt linkage, fail-closed controls, and disclosed shared-tree pinning place authority correctly and are accurately represented.
+
+## Evidence
+
+- `scratchpad/phaseB/REPORT-W37.md`
+- `tests/unit/standards-enforcement-measurement.test.ts`
+- `tests/unit/standards-coverage-ratchet.test.ts`
+
+Independent b03 judgement remains pending. This record claims only BUILT WITH HAND EVIDENCE.
+
+## Class-Closure Declaration
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence: { enforcementType: gate, citation: tests/unit/standards-enforcement-measurement.test.ts, howCaught: an exact-schema collector forgery with a marker write is rejected by a protected expected-digest mismatch before execution, returns UNKNOWN, and mints no artifact while the genuine receipt-bound C1 path still reaches ratchet }`.

--- a/upgrades/w37-authenticated-structured-observation.eli16.md
+++ b/upgrades/w37-authenticated-structured-observation.eli16.md
@@ -1,0 +1,11 @@
+# Standards measurement: trust the instrument and its result
+
+The standards measurement already ran a real test three ways: clean, with a protected mutation, and clean again. W3.6 fixed its test counting by reading Node's structured events instead of decorated console text. The remaining problem was authorship: the branch-owned event collector created the counts and assertion classification, while the authenticated receipt covered only process-exit facts.
+
+W3.7 makes the collector's exact protected bytes part of the authority. A protected plan names a known SHA-256. The verifier reads the collector from the protected snapshot, compares that expected digest before doing anything, copies the approved bytes into each isolated workspace, and compares again immediately before execution. A mismatched collector returns UNKNOWN without running or creating evidence.
+
+The collector now signs both its ready event and the exact structured observation with an ephemeral key. The independent receipt authority pins that identity, verifies the sequenced observation, and issues the child-exit receipt only when it links to the exact last authenticated event. Promotion therefore depends on one chain: approved collector bytes -> signed structured observation -> receipt-bound event -> live execution artifact.
+
+The negative control replaces the protected collector with an exact-schema forgery claiming 999 passing tests. Digest comparison refuses it before its marker write, returns UNKNOWN, and produces no artifact. The positive control still passes clean, fails after the relevant mutation, and passes pristine confirmation; both fake renderer summaries remain ignored.
+
+Node 22.18.0 and 25.6.1 do not have a built-in `json` test reporter: both interpret `--test-reporter=json` as a missing custom package. A custom reporter would recreate the same authorship boundary, so the protected content-addressed collector remains necessary.


### PR DESCRIPTION
## Summary
- require the protected execution plan to pin the exact structured collector SHA-256 and compare it before materialization and every execution
- authenticate the exact signed TestsStream observation and bind its event identity into the H1 child-exit receipt
- refuse an exact-schema digest-mismatched collector before spawn with UNKNOWN and no artifact
- preserve clean/mutated/pristine discrimination and both renderer-forgery controls

## Route A shared-tree evidence
The W3.7 worktree shares the W3.5 node_modules tree. Final hand evidence disables the Vitest results cache and compares a deterministic digest over all 13,966 remaining shared input files plus 30 symlinks before and after. No install or rebuild was run. Full details and named digests are in REPORT-W37.md.

## Verification
- Node 25.6.1 measurement suite: 16/16 passed with full shared-input-tree pre/post digest match
- Node 22.18.0: full 16-case compatibility run plus corrected decisive C1/C2 rerun passed
- coverage focused set: 4 passed / 34 skipped
- pre-push affected set: 54/54 passed
- tsc --noEmit, node --check, and git diff --check passed

## Reporter finding
Node 22.18.0 and Node 25.6.1 both treat --test-reporter=json as a custom package and exit ERR_MODULE_NOT_FOUND; it cannot remove the collector. A local custom JSON reporter would recreate the same evidence-authorship boundary.

State: BUILT WITH HAND EVIDENCE. Independent b03 judgement remains pending. No merge requested.