### PR TITLE
fix: make pre-push affected-test selection honest

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-18T19-52-07-951Z-r1-structured-vitest-list.json
+++ b/.instar/instar-dev-decisions/2026-08-18T19-52-07-951Z-r1-structured-vitest-list.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-18T19:52:07.951Z",
+  "slug": "r1-structured-vitest-list",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 147,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lib/pre-push-scope.mjs",
+      "scripts/pre-push-smoke.mjs"
+    ],
+    "addedLines": 125,
+    "deletedLines": 22
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scripts/lib/pre-push-scope.mjs
+++ b/scripts/lib/pre-push-scope.mjs
@@ -1,5 +1,6 @@
 // safe-git-allow: pre-push bootstrap helpers — read-only git only.
 import { execFileSync } from 'node:child_process';
+import path from 'node:path';
 
 export const DEFAULT_SMOKE_LIMITS = Object.freeze({
   maxChangedFiles: 200,
@@ -122,13 +123,66 @@ export function evaluateSmokeBreadth({ changedFileCount, testFileCount, testCase
   return { skip: false, reason: 'within local smoke caps' };
 }
 
-export function summarizeVitestList(stdout) {
-  const tests = String(stdout)
-    .split('\n')
-    .map(s => s.trim())
-    .filter(Boolean);
-  const files = new Set(tests.map(line => line.split(' > ')[0]).filter(Boolean));
-  return { testCaseCount: tests.length, testFileCount: files.size };
+export function summarizeVitestListJson(jsonText) {
+  const text = String(jsonText);
+  if (text.trim().length === 0) {
+    throw new Error('Vitest list JSON is empty');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`Vitest list JSON is malformed: ${err instanceof Error ? err.message : err}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('Vitest list JSON must be an array');
+  }
+
+  const files = new Set();
+  for (const [index, entry] of parsed.entries()) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`Vitest list entry ${index} must be an object`);
+    }
+
+    const keys = Object.keys(entry).sort();
+    if (keys.length !== 2 || keys[0] !== 'file' || keys[1] !== 'name') {
+      throw new Error(`Vitest list entry ${index} must contain exactly "file" and "name"`);
+    }
+    if (typeof entry.name !== 'string' || entry.name.trim().length === 0) {
+      throw new Error(`Vitest list entry ${index} has an invalid name`);
+    }
+    if (typeof entry.file !== 'string' || entry.file.trim().length === 0 || !path.isAbsolute(entry.file)) {
+      throw new Error(`Vitest list entry ${index} has an invalid absolute file path`);
+    }
+
+    files.add(path.normalize(entry.file));
+  }
+
+  return { testCaseCount: parsed.length, testFileCount: files.size };
+}
+
+export function evaluateAffectedSmokeSelection(
+  { changedFileCount, testFileCount, testCaseCount },
+  limits = DEFAULT_SMOKE_LIMITS,
+) {
+  const breadth = evaluateSmokeBreadth({ changedFileCount, testFileCount, testCaseCount }, limits);
+  if (breadth.skip) return { action: 'skip', reason: breadth.reason };
+  if (testCaseCount === 0) return { action: 'no-tests', reason: 'structured affected set is empty' };
+  return { action: 'run', reason: 'structured affected set is within local smoke caps' };
+}
+
+export function classifyVitestListRun({ status, signal }) {
+  if (status === 0) return { action: 'parse' };
+  if (signal === 'SIGTERM') {
+    return {
+      action: 'skip-indeterminate',
+      reason: 'affected-test listing timed out',
+      testsRun: 0,
+    };
+  }
+  return { action: 'fail', exitCode: status ?? 1 };
 }
 
 function normalizeTestFileName(name, cwd) {

--- a/scripts/pre-push-smoke.mjs
+++ b/scripts/pre-push-smoke.mjs
@@ -6,11 +6,13 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import {
   changedFilesSince,
+  classifyVitestListRun,
+  evaluateAffectedSmokeSelection,
   evaluateSmokeBreadth,
   failedTestFilesFromVitestJson,
   readSmokeLimits,
   resolvePrePushBase,
-  summarizeVitestList,
+  summarizeVitestListJson,
 } from './lib/pre-push-scope.mjs';
 
 function run(command, args, opts = {}) {
@@ -28,12 +30,47 @@ function printSkip(reason) {
   console.log('   The PR test matrix still runs the full suite before merge.');
 }
 
+function printIndeterminateSkip(reason) {
+  console.warn(`⏭️  LOCAL SMOKE SKIPPED — affected set indeterminate; tests run: 0. ${reason}.`);
+  console.warn('   PRE_PUSH_SMOKE_RESULT=SKIPPED reason=affected-set-indeterminate tests_run=0');
+  console.warn('   The local tier did not pass; CI remains the authority and runs the full suite before merge.');
+}
+
 function readFailedFiles(reportFile) {
   try {
     return failedTestFilesFromVitestJson(fs.readFileSync(reportFile, 'utf-8'), { cwd: process.cwd() });
   } catch (err) {
     console.warn(`pre-push smoke: could not read failed test files from Vitest JSON (${err instanceof Error ? err.message : err}).`);
     return [];
+  }
+}
+
+function listAffectedTests(baseRef) {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pre-push-list-'));
+  const reportFile = path.join(reportDir, 'vitest-list.json');
+  try {
+    const result = run('npx', [
+      'vitest',
+      'list',
+      '--config',
+      'vitest.push.config.ts',
+      '--changed',
+      baseRef,
+      `--json=${reportFile}`,
+    ], {
+      timeout: Number.parseInt(process.env.INSTAR_PRE_PUSH_SMOKE_LIST_TIMEOUT_MS ?? '', 10) || 120_000,
+    });
+
+    if (result.status !== 0) return { result };
+
+    try {
+      const selected = summarizeVitestListJson(fs.readFileSync(reportFile, 'utf-8'));
+      return { result, selected };
+    } catch (err) {
+      return { result, selectionError: err };
+    }
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
   }
 }
 
@@ -101,33 +138,45 @@ if (breadth.skip) {
   process.exit(0);
 }
 
-const list = run('npx', ['vitest', 'list', '--config', 'vitest.push.config.ts', '--changed', base.ref], {
-  timeout: Number.parseInt(process.env.INSTAR_PRE_PUSH_SMOKE_LIST_TIMEOUT_MS ?? '', 10) || 120_000,
-});
+const listed = listAffectedTests(base.ref);
+const list = listed.result;
+const listDisposition = classifyVitestListRun(list);
 
-if (list.status !== 0) {
+if (listDisposition.action === 'skip-indeterminate') {
   process.stdout.write(list.stdout ?? '');
   process.stderr.write(list.stderr ?? '');
-  if (list.signal === 'SIGTERM') {
-    console.warn('pre-push smoke: affected-test listing timed out — skipping local smoke; CI is the authority.');
-    process.exit(0);
-  }
-  process.exit(list.status ?? 1);
-}
-
-const selected = summarizeVitestList(list.stdout);
-console.log(`🧪 Smoke affected set: ${selected.testFileCount} test files / ${selected.testCaseCount} test cases.`);
-
-breadth = evaluateSmokeBreadth(
-  { changedFileCount: changed.length, testFileCount: selected.testFileCount, testCaseCount: selected.testCaseCount },
-  limits,
-);
-if (breadth.skip) {
-  printSkip(breadth.reason);
+  printIndeterminateSkip(listDisposition.reason);
   process.exit(0);
 }
 
-if (selected.testCaseCount === 0) {
+if (listDisposition.action === 'fail') {
+  process.stdout.write(list.stdout ?? '');
+  process.stderr.write(list.stderr ?? '');
+  process.exit(listDisposition.exitCode);
+}
+
+if (listed.selectionError || !listed.selected) {
+  process.stdout.write(list.stdout ?? '');
+  process.stderr.write(list.stderr ?? '');
+  console.error(
+    `pre-push smoke: could not determine the affected test set from Vitest JSON (${listed.selectionError instanceof Error ? listed.selectionError.message : listed.selectionError ?? 'missing structured result'}) — refusing a reassuring local pass.`,
+  );
+  process.exit(1);
+}
+
+const selected = listed.selected;
+console.log(`🧪 Smoke affected set: ${selected.testFileCount} test files / ${selected.testCaseCount} test cases.`);
+
+const selection = evaluateAffectedSmokeSelection(
+  { changedFileCount: changed.length, testFileCount: selected.testFileCount, testCaseCount: selected.testCaseCount },
+  limits,
+);
+if (selection.action === 'skip') {
+  printSkip(selection.reason);
+  process.exit(0);
+}
+
+if (selection.action === 'no-tests') {
   console.log('✅ No affected tests selected by Vitest.');
   process.exit(0);
 }

--- a/tests/unit/scripts/pre-push-scope.test.ts
+++ b/tests/unit/scripts/pre-push-scope.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  classifyVitestListRun,
+  evaluateAffectedSmokeSelection,
   evaluateSmokeBreadth,
   failedTestFilesFromVitestJson,
   resolvePrePushBase,
-  summarizeVitestList,
+  summarizeVitestListJson,
 } from '../../../scripts/lib/pre-push-scope.mjs';
 
 function fakeGit(outputs: Record<string, string | Error>) {
@@ -77,15 +79,75 @@ describe('pre-push smoke scope helpers', () => {
     expect(result.reason).toContain('affected test file count 81');
   });
 
-  it('summarizes Vitest list output by test cases and unique files', () => {
-    const summary = summarizeVitestList([
-      'tests/unit/a.test.ts > suite > case 1',
-      'tests/unit/a.test.ts > suite > case 2',
-      'tests/integration/b.test.ts > suite > case 1',
-      '',
-    ].join('\n'));
+  it('summarizes schema-pinned Vitest JSON by entries and unique files', () => {
+    const summary = summarizeVitestListJson(JSON.stringify([
+      { name: 'suite > case 1', file: '/repo/tests/unit/a.test.ts' },
+      { name: 'suite > case 2', file: '/repo/tests/unit/a.test.ts' },
+      { name: 'suite > case 1', file: '/repo/tests/integration/b.test.ts' },
+    ]));
 
     expect(summary).toEqual({ testCaseCount: 3, testFileCount: 2 });
+  });
+
+  it.each([
+    ['empty output', ''],
+    ['malformed JSON', '{'],
+    ['old rendered output', 'tests/unit/a.test.ts > suite > case 1'],
+  ])('refuses %s instead of converting it to zero affected tests', (_label, output) => {
+    expect(() => summarizeVitestListJson(output)).toThrow(/Vitest list JSON/);
+  });
+
+  it.each([
+    ['non-array top level', JSON.stringify({ name: 'case', file: '/repo/tests/a.test.ts' })],
+    ['missing file', JSON.stringify([{ name: 'case' }])],
+    ['relative file', JSON.stringify([{ name: 'case', file: 'tests/a.test.ts' }])],
+    ['unexpected field', JSON.stringify([{ name: 'case', file: '/repo/tests/a.test.ts', status: 'passed' }])],
+  ])('fails loudly when the pinned list schema changes: %s', (_label, output) => {
+    expect(() => summarizeVitestListJson(output)).toThrow(/Vitest list/);
+  });
+
+  it('keeps a genuine structured zero distinct and quiet', () => {
+    const summary = summarizeVitestListJson('[]');
+    const decision = evaluateAffectedSmokeSelection({ changedFileCount: 1, ...summary });
+
+    expect(summary).toEqual({ testCaseCount: 0, testFileCount: 0 });
+    expect(decision).toEqual({ action: 'no-tests', reason: 'structured affected set is empty' });
+  });
+
+  it('runs a genuine structured affected set within the caps', () => {
+    const summary = summarizeVitestListJson(JSON.stringify([
+      { name: 'suite > case 1', file: '/repo/tests/unit/a.test.ts' },
+    ]));
+
+    expect(evaluateAffectedSmokeSelection({ changedFileCount: 1, ...summary })).toEqual({
+      action: 'run',
+      reason: 'structured affected set is within local smoke caps',
+    });
+  });
+
+  it('keeps the legitimate breadth skip for a large structured affected set', () => {
+    const entries = Array.from({ length: 1001 }, (_, index) => ({
+      name: `suite > case ${index}`,
+      file: '/repo/tests/unit/a.test.ts',
+    }));
+    const summary = summarizeVitestListJson(JSON.stringify(entries));
+    const decision = evaluateAffectedSmokeSelection({ changedFileCount: 1, ...summary });
+
+    expect(decision.action).toBe('skip');
+    expect(decision.reason).toContain('affected test case count 1001');
+  });
+
+  it('classifies a list timeout as an explicit non-blocking indeterminate skip with zero tests run', () => {
+    expect(classifyVitestListRun({ status: null, signal: 'SIGTERM' })).toEqual({
+      action: 'skip-indeterminate',
+      reason: 'affected-test listing timed out',
+      testsRun: 0,
+    });
+  });
+
+  it('parses only a successful list process and fails other process errors', () => {
+    expect(classifyVitestListRun({ status: 0, signal: null })).toEqual({ action: 'parse' });
+    expect(classifyVitestListRun({ status: 2, signal: null })).toEqual({ action: 'fail', exitCode: 2 });
   });
 
   it('extracts unique failed files from Vitest JSON output', () => {

--- a/upgrades/next/r1-structured-vitest-list.md
+++ b/upgrades/next/r1-structured-vitest-list.md
@@ -1,0 +1,20 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+Hardened the contributor-side pre-push smoke tier so only a valid structured empty Vitest list is
+reported as having no affected tests. Empty, malformed, old rendered, or schema-changed list data
+now fails loudly instead of becoming a reassuring local pass, while valid affected sets still run
+and valid oversized sets retain the existing CI-backed breadth skip.
+
+A list timeout remains non-blocking because protected CI is the exhaustive merge authority and
+local disk contention must not veto a push. The timeout outcome now says `SKIPPED`, records that
+zero tests ran, and explicitly states that the local tier did not pass.
+
+## Evidence
+
+- Focused parser and decision controls: 20 tests passed, including empty, malformed, old rendered,
+  schema mismatch, genuine zero, genuine affected, breadth skip, and timeout cases.
+- Committed pre-push smoke entrypoint: selected 3 files / 73 cases and passed all 73 tests.
+- Full repository lint and the instar-dev Tier-1 side-effects gate passed.

--- a/upgrades/r1-structured-vitest-list.eli16.md
+++ b/upgrades/r1-structured-vitest-list.eli16.md
@@ -1,0 +1,42 @@
+# Honest pre-push affected-test selection — Plain-English Overview
+
+> The one-line version: the local pre-push smoke check now says “no tests” only when Vitest returns a valid, structured empty set; when selection cannot be determined, it says so instead of implying that tests passed.
+
+## The problem in one breath
+
+Before a branch is pushed, Instar runs a quick local test tier over tests affected by the branch. The script counted human-formatted lines printed by another program. If those lines disappeared or changed shape, the script could conclude there was nothing to test, or could decide the set was too large and skip it, even though it had not actually established either fact. A slow, disk-contended machine could also time out while listing tests and exit successfully without running them.
+
+## What already exists
+
+- **The local smoke tier** — gives contributors fast feedback without attempting to replace the complete remote test matrix.
+- **Breadth limits** — deliberately skip local smoke when a genuinely large affected set would make a push impractically slow.
+- **Authoritative CI** — runs the full protected test suite before merge, including when local smoke is skipped.
+
+## What this adds
+
+The test runner now writes its affected-test list as JSON to an explicit temporary file. The script validates the exact structure produced by the pinned Vitest version and counts structured entries and unique absolute file paths. It no longer interprets decorative lines or separators intended for human display.
+
+A valid empty array still means “no affected tests.” Empty output, invalid JSON, old rendered output, a missing field, or a changed schema means “the affected set is indeterminate” and fails loudly. A valid non-empty array runs the existing smoke tier, while a valid set beyond the existing caps still takes the deliberate breadth skip.
+
+## The new pieces
+
+- **Strict list parser** — accepts the pinned `{name, file}` entry shape and rejects every unproved shape. This is boundary validation, not a guess about the meaning of arbitrary text.
+- **Explicit selection outcomes** — keeps “no tests,” “run,” “too broad,” and “could not determine” separate rather than encoding several of them as a zero count.
+- **Honest timeout result** — remains non-blocking because CI is the merge authority and local disk contention must not veto real work, but emits `SKIPPED`, `tests_run=0`, and a direct statement that the local tier did not pass.
+- **Proof cache isolation** — allows verification to place Vitest scheduling cache outside the shared dependency tree, with no change to default operation.
+
+## The safeguards
+
+**Prevents a cosmetic output change from becoming a false pass.** The parser accepts only a version-pinned machine format. Missing or changed evidence cannot reach the reassuring no-tests path.
+
+**Preserves useful local performance limits.** This does not make every push run the full suite. Genuine structured zero stays quiet, valid affected tests run, and valid oversized sets retain the existing CI-backed skip.
+
+**Does not overstate local authority.** The timeout route is deliberately visible rather than blocking. CI remains the exhaustive merge authority, so the local tier is useful early evidence, not the final certification.
+
+## What ships when
+
+This is one contained contributor-tooling change: parser, pre-push orchestration, focused tests, and the proof-only cache seam ship together. It does not change CI or application runtime behavior.
+
+## What you actually need to decide
+
+Should the local smoke tier distinguish a proved empty affected set from every case where it could not determine the set, while keeping timeouts and genuinely broad sets non-blocking under authoritative CI?

--- a/upgrades/side-effects/r1-structured-vitest-list.md
+++ b/upgrades/side-effects/r1-structured-vitest-list.md
@@ -1,0 +1,224 @@
+# Side-Effects Review — Honest pre-push affected-test selection
+
+**Version / slug:** `r1-structured-vitest-list`
+**Date:** `2026-08-18`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** Codex independent reviewer (`r1_side_effects_review`)
+
+## Summary of the change
+
+This change replaces rendered-line counting in `scripts/lib/pre-push-scope.mjs` and
+`scripts/pre-push-smoke.mjs` with a strict parser for the pinned Vitest JSON list schema. It
+separates valid zero, valid affected, valid over-cap, parse/schema failure, process failure, and
+timeout outcomes. Timeout remains a CI-backed non-blocking skip but becomes unambiguously visible
+as `SKIPPED` with zero tests run. Focused coverage lives in
+`tests/unit/scripts/pre-push-scope.test.ts`; `vitest.push.config.ts` gains an opt-in cache-directory
+seam used to keep proof state outside a shared dependency tree.
+
+This is declared Tier 1 despite the size signal's Tier-2 suggestion. The risk floor is Tier 1, the
+production application runtime and CI are untouched, the change is confined to contributor-side
+local smoke selection, and the additional lines are primarily strict boundary controls and tests.
+The PR remains the review surface.
+
+## Build grounding and plan record
+
+- Fresh worktree: created by `instar worktree create` at
+  `/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-r1-structured-vitest-list`.
+- Base: protected `upstream/main` at `248ed7177f5bf416aa7bdad9763741478195e1fc`, locally and
+  remotely verified.
+- Remotes: `upstream=https://github.com/JKHeadley/instar.git` and
+  `origin=https://github.com/JKHeadley/instar-codey.git`.
+- Package version before build: `1.3.1180`.
+- Problem: human-formatted list output could collapse or inflate into exit-zero-without-tests;
+  timeout was another naturally observed exit-zero-without-tests path.
+- Fix: consume and pin structured output; keep proved zero distinct from indeterminate; make
+  timeout visibly skipped without turning local machine slowness into a push veto.
+- Acceptance: malformed/empty/old/schema-changed inputs refuse; valid zero stays quiet; valid
+  affected data runs; valid over-cap data skips; timeout says skipped and zero tests; pinned live
+  Vitest JSON parses; focused tests and lint pass.
+- Rollback: revert this pure code/config change; no persisted application state requires repair.
+
+## Decision-point inventory
+
+- `scripts/pre-push-smoke.mjs` list-process disposition — **modify** — maps process success to
+  parsing, timeout to a visible non-blocking skip, and other process failures to failure.
+- `scripts/pre-push-smoke.mjs` affected-set disposition — **modify** — valid zero exits cleanly,
+  valid over-cap data deliberately skips, valid in-cap data runs, and unproved data fails.
+- `scripts/lib/pre-push-scope.mjs` JSON boundary — **add** — validates the enumerable pinned
+  machine schema before any count can influence a decision.
+
+These are contributor-tooling decisions. CI remains the protected merge authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The strict schema intentionally rejects a future Vitest release that adds an otherwise harmless
+field, changes the top-level shape, emits relative paths, or changes the entry names. Because the
+repository pins Vitest, that is a version-update integration failure rather than an arbitrary live
+input. It is preferable to a false local pass and is repaired by reviewing and updating the pinned
+contract with the dependency upgrade.
+
+Malformed, empty, or old rendered data now blocks the local push instead of silently claiming no
+tests. This is appropriate when the subprocess completed normally: the machine is responsive, but
+the evidence contract failed. Timeout is handled separately and remains non-blocking, preventing
+disk contention from becoming an over-block.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A valid structured affected set can omit a genuinely affected test because Vitest's dependency
+  graph is incomplete. That is an existing limitation of `--changed`; authoritative full-suite CI
+  remains the backstop.
+- A valid affected set over the existing breadth caps still skips locally. This is deliberate and
+  now based on proved structured counts, but it still runs zero local tests.
+- A listing timeout still exits zero and runs no local tests. The remaining under-block is explicit
+  (`SKIPPED`, `tests_run=0`) and backed by CI rather than disguised as a local pass.
+- A process killed by `SIGTERM` for a reason other than the configured `spawnSync` timeout would be
+  described as timed out. In this synchronous private callsite, the configured timeout is the
+  source of `SIGTERM`; there is no interactive cancellation path.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. Vitest owns selection; the local wrapper owns validating the machine contract, deciding
+whether local work is bounded, and explaining the local result. Counting structured entries in the
+shared scope helper lets tests exercise the same primitive used by the script. CI remains at the
+higher authority layer and was not duplicated or weakened.
+
+Failing on an invalid successful response is boundary validation over an enumerable schema, not a
+semantic judgment. Keeping timeout non-blocking belongs in the wrapper, which knows this is a
+best-effort contributor tier and can name CI as the authority.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+None of the checkbox descriptions precisely describes this constrained mechanical boundary. The
+script does block a local push when a subprocess returns success but violates the pinned JSON
+schema. That is permitted **hard-invariant validation** under the cited principle: valid inputs are
+fully enumerable and no conversational or semantic judgment is being made. The policy choice for
+environmental unavailability is not hidden inside the validator: timeout produces an explicit
+non-blocking signal, while protected CI remains the final authority.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic exists at a competing-signals decision point. JSON structure and absolute
+path validity are enumerable boundary invariants. Existing numeric caps are preserved, not added.
+The timeout policy has one environmental fact and one declared authority relationship: local smoke
+is best-effort; CI is exhaustive and merge-blocking.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** Git policy checks still run before local smoke. Within smoke, a list-contract
+  failure stops before breadth or run decisions because neither is meaningful without a set.
+- **Double-fire:** local smoke and CI intentionally both test branches. A local skip leaves only CI;
+  no second local actor consumes the marker.
+- **Races:** the list JSON uses a unique temporary directory and is removed in `finally`. The test
+  result report already uses the same isolated-directory pattern. No shared output filename races.
+- **Feedback loops:** no result is fed back into future decisions. The optional Vitest cache is
+  scheduling state only; proof uses a dedicated external directory.
+- **Adjacent retry:** failed test execution retains its existing focused retry. Listing failure or
+  timeout occurs before execution and is not misreported as a test failure eligible for retry.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- Contributors and build agents see stricter failures for invalid list evidence and a clearer
+  timeout skip message.
+- Application users, Telegram/Slack users, external APIs, and CI behavior are unchanged.
+- No durable application state is written. List and result artifacts use temporary directories.
+- Timing remains machine-dependent; the timeout is intentionally non-blocking because a natural
+  timeout occurred during this work window on the disk-contended machine.
+- No operator-facing action is added. There is no dashboard, approval, or phone workflow surface.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design.** A pre-push hook measures the current checkout, current machine's
+dependency graph, and current machine's ability to run tests. Those facts should differ per machine
+and are not durable agent state to replicate or proxy. Each machine's branch still enters the same
+protected CI authority after push.
+
+This change emits no user-facing notices requiring one-voice gating, holds no durable state that
+could strand on topic transfer, and generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Hot-fix release:** revert the four implementation/test/config files and ship the next patch.
+- **Data migration:** none; no schema or persisted application state.
+- **Agent state repair:** none. Temporary proof/list files are removed or live outside the repo.
+- **User visibility:** only contributors would temporarily regain ambiguous local smoke output;
+  protected CI would remain unchanged throughout rollback.
+
+---
+
+## Conclusion
+
+The design is clear to ship for independent review. The strict successful-response path could
+over-block on a future Vitest schema addition, but that is the intended loud dependency-upgrade
+failure. Timeout remains the honest non-blocking exception, and the new marker prevents it from
+being mistaken for tests having run. CI retains final authority; no application runtime or
+external-system behavior changes.
+
+---
+
+## Second-pass review (required)
+
+**Reviewer:** Codex independent reviewer (`r1_side_effects_review`)
+**Independent read of the artifact:** concur
+
+Concur with the review — strict schema blocking is an enumerable pinned boundary, timeout remains
+non-blocking and unmistakably reports `SKIPPED` with zero tests, and no missed interaction changes
+CI's authority.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/scripts/pre-push-scope.test.ts`
+- `scratchpad/phaseB/REPORT-R1.md` (uncommitted lane record in the coordinating checkout)
+- Focused proof: 1 file / 20 tests passed; pinned Vitest live JSON parsed as 1 file / 20 cases.
+- Full repository lint executed by the first commit attempt; ordinary checks passed and the
+  process gate correctly stopped only for this then-missing side-effects trace.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The defect is an ordinary product parser in a
+contributor-side script. The config change is only an opt-in cache-location seam and is not the
+source of the defect.

--- a/vitest.push.config.ts
+++ b/vitest.push.config.ts
@@ -227,7 +227,10 @@ const FLAKY_TESTS = [
 
 ];
 
+const ISOLATED_CACHE_DIR = process.env.INSTAR_VITEST_CACHE_DIR?.trim();
+
 export default defineConfig(withTestRunnerBound('push', {
+  ...(ISOLATED_CACHE_DIR ? { cacheDir: ISOLATED_CACHE_DIR } : {}),
   test: {
     include: ['tests/unit/**/*.test.ts', 'tests/integration/**/*.test.ts', 'tests/e2e/**/*.test.ts'],
     exclude: FLAKY_TESTS,


### PR DESCRIPTION
## Summary

Hardens the CI-backed local pre-push smoke tier so only a valid structured empty Vitest list is reported as having no affected tests.

This fixes three exit-zero-without-tests routes without overstating severity:

- empty/reshaped rendered output collapsing to a reassuring zero;
- rendered noise inflating counts into the deliberate breadth skip;
- list timeout, observed naturally on the disk-contended build machine during this work window.

CI remains the exhaustive merge authority, so this was a local tier that could silently self-disable, not an unbackstopped merge hole.

## Behavior

- consumes pinned Vitest 2.1.9 JSON via an explicit temporary output path;
- validates the exact live `{name, file}` schema and absolute paths;
- fails loudly for empty, malformed, old rendered, or schema-changed evidence;
- preserves quiet exit zero for a genuine structured empty set;
- preserves the existing skip for a genuine structured oversized set;
- keeps timeout non-blocking, but emits `SKIPPED`, `tests_run=0`, and states that the local tier did not pass;
- supports an external Vitest cache directory for proof isolation.

## Evidence

- pre-fix empty input reproduced `NO_TESTS_EXIT_0`;
- pre-fix structured inflation reproduced `SKIP_EXIT_0`;
- post-fix empty, malformed, old rendered, and schema mismatches are refused;
- focused proof: 1 file / 20 tests passed;
- live pinned JSON: 1 file / 20 cases parsed by production code;
- committed smoke entrypoint: 3 files / 73 tests passed;
- actual mirror pre-push: 3 files / 73 tests passed after waiting for the enforced suite slot;
- full repository lint and instar-dev Tier-1 gate passed;
- independent side-effects review concurred.

No install ran. CI files are untouched. Proof and push caches were isolated outside the shared dependency tree; lockfile, Vitest entry/package, package aggregate, and Node digests were unchanged at the recorded boundaries.

Judge-gated: do not merge from builder evidence alone.


## ELI16 — Prove which affected tests were selected

Before a push, the local smoke check asks Vitest which tests are affected. It used to count display lines, so missing or reshaped output could look like a genuine empty set or an intentionally oversized set. The repaired path accepts only Vitest’s pinned structured list. A valid empty list still means there is nothing local to run; malformed, missing, or changed evidence fails loudly. A real oversized set and a timeout remain non-blocking because full CI is the merge authority, but they are reported as skips rather than passes.
