### PR TITLE
fix(tests): classify parked rechecks from structured output

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-18T22-04-36-909Z-r3-structured-parked-test-outcomes.json
+++ b/.instar/instar-dev-decisions/2026-08-18T22-04-36-909Z-r3-structured-parked-test-outcomes.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-18T22:04:36.909Z",
+  "slug": "r3-structured-parked-test-outcomes",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 13,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/recheck-parked-tests.mjs"
+    ],
+    "addedLines": 12,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scripts/recheck-parked-tests.mjs
+++ b/scripts/recheck-parked-tests.mjs
@@ -50,12 +50,14 @@
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CONFIG = path.join(ROOT, 'vitest.push.config.ts');
+const VITEST = path.join(ROOT, 'node_modules', '.bin', 'vitest');
 
 function parseArgs(argv) {
   const out = { slice: 6, runs: 2, json: false, missingOnly: false };
@@ -107,16 +109,94 @@ function rotatingSlice(items, size, dayKey) {
   return Array.from({ length: Math.min(size, items.length) }, (_, i) => items[(start + i) % items.length]);
 }
 
+function runResult(outcome, reason, status, structured = null) {
+  return {
+    outcome,
+    reason,
+    exitCode: Number.isInteger(status) ? status : null,
+    ...(structured ? { structured } : {}),
+  };
+}
+
+function classifyStructuredResult(raw, status) {
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch {
+    return runResult('errored', 'structured-report-unparseable', status);
+  }
+
+  const countFields = [
+    'numTotalTestSuites',
+    'numFailedTestSuites',
+    'numTotalTests',
+    'numPassedTests',
+    'numFailedTests',
+    'numPendingTests',
+    'numTodoTests',
+  ];
+  const schemaValid = report && typeof report === 'object' && !Array.isArray(report)
+    && typeof report.success === 'boolean'
+    && Array.isArray(report.testResults)
+    && countFields.every((field) => Number.isInteger(report[field]) && report[field] >= 0);
+  if (!schemaValid) return runResult('errored', 'structured-report-invalid', status);
+
+  const structured = {
+    success: report.success,
+    testSuites: report.numTotalTestSuites,
+    total: report.numTotalTests,
+    passed: report.numPassedTests,
+    failed: report.numFailedTests,
+    pending: report.numPendingTests,
+    todo: report.numTodoTests,
+  };
+  if (report.numTotalTestSuites === 0 || report.numTotalTests === 0) {
+    return runResult('errored', 'no-tests-executed', status, structured);
+  }
+
+  const assertions = report.testResults.flatMap((result) =>
+    Array.isArray(result?.assertionResults) ? result.assertionResults : []);
+  const failedAssertionObserved = assertions.some((assertion) => assertion?.status === 'failed');
+  const passedAssertionObserved = assertions.some((assertion) => assertion?.status === 'passed');
+
+  if (status !== 0 && report.success === false && report.numFailedTests > 0 && failedAssertionObserved) {
+    return runResult('fail', 'tests-failed', status, structured);
+  }
+  if (status === 0 && report.success === true && report.numFailedTests === 0
+      && report.numPassedTests > 0 && passedAssertionObserved) {
+    return runResult('pass', 'tests-passed', status, structured);
+  }
+  return runResult('errored', 'structured-report-inconsistent', status, structured);
+}
+
 function runOnce(file) {
-  const res = spawnSync(
-    process.execPath,
-    ['./node_modules/.bin/vitest', 'run', file, '--reporter=basic'],
-    { cwd: ROOT, encoding: 'utf-8', timeout: 300_000, env: { ...process.env } },
-  );
-  const out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
-  if (res.status === 0) return 'pass';
-  if (res.error || res.status === null) return 'errored';
-  return /Tests\s+\d+\s+failed/.test(out) ? 'fail' : 'errored';
+  if (!fs.existsSync(VITEST)) return runResult('errored', 'runner-not-started', null);
+
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-parked-test-'));
+  const reportFile = path.join(reportDir, 'vitest.json');
+  try {
+    const res = spawnSync(
+      process.execPath,
+      [VITEST, 'run', file, '--reporter=basic', '--reporter=json', `--outputFile.json=${reportFile}`],
+      { cwd: ROOT, encoding: 'utf-8', timeout: 300_000, env: { ...process.env } },
+    );
+    if (res.error || res.status === null) {
+      const reason = res.error?.code === 'ENOENT' || res.error?.code === 'EACCES'
+        ? 'runner-not-started'
+        : 'runner-did-not-complete';
+      return runResult('errored', reason, res.status);
+    }
+
+    let raw;
+    try {
+      raw = fs.readFileSync(reportFile, 'utf-8');
+    } catch {
+      return runResult('errored', 'structured-report-missing', res.status);
+    }
+    return classifyStructuredResult(raw, res.status);
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
 }
 
 const opts = parseArgs(process.argv);
@@ -134,7 +214,8 @@ const results = [];
 if (!opts.missingOnly) {
   const dayKey = new Date().toISOString().slice(0, 10);
   for (const file of rotatingSlice(present, opts.slice, dayKey)) {
-    const runs = Array.from({ length: opts.runs }, () => runOnce(file));
+    const runDetails = Array.from({ length: opts.runs }, () => runOnce(file));
+    const runs = runDetails.map((run) => run.outcome);
     const verdict = runs.every((r) => r === 'pass')
       ? 'deterministic-pass'
       : runs.every((r) => r === 'fail')
@@ -142,7 +223,7 @@ if (!opts.missingOnly) {
         : runs.includes('errored')
           ? 'could-not-run'
           : 'genuinely-flaky';
-    results.push({ file, runs, verdict });
+    results.push({ file, runs, runDetails, verdict });
   }
 }
 
@@ -171,7 +252,12 @@ if (opts.json) {
   }
   if (results.length) {
     console.log(`  RE-CHECKED THIS RUN (rotating slice of ${results.length}, ${opts.runs} runs each):`);
-    for (const r of results) console.log(`    ${r.verdict.padEnd(20)} ${r.file}`);
+    for (const r of results) {
+      console.log(`    ${r.verdict.padEnd(20)} ${r.file}`);
+      if (r.verdict === 'could-not-run') {
+        console.log(`      reasons: ${r.runDetails.map((run) => run.reason).join(', ')}`);
+      }
+    }
     const back = results.filter((r) => r.verdict === 'deterministic-pass');
     if (back.length) {
       console.log(`\n  ${back.length} entr${back.length === 1 ? 'y' : 'ies'} now pass deterministically HERE.`);

--- a/scripts/recheck-parked-tests.mjs
+++ b/scripts/recheck-parked-tests.mjs
@@ -54,6 +54,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { SafeFsExecutor } from '../dist/core/SafeFsExecutor.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CONFIG = path.join(ROOT, 'vitest.push.config.ts');
@@ -118,6 +119,12 @@ function runResult(outcome, reason, status, structured = null) {
   };
 }
 
+/**
+ * Classify only completed machine-readable evidence. Human reporter text is operator context,
+ * never verdict input; an absent, malformed, or internally inconsistent report stays unknown.
+ * This distinction improves the signal only — the script's unconditional exit-zero contract
+ * remains the authority boundary.
+ */
 function classifyStructuredResult(raw, status) {
   let report;
   try {
@@ -195,7 +202,11 @@ function runOnce(file) {
     }
     return classifyStructuredResult(raw, res.status);
   } finally {
-    fs.rmSync(reportDir, { recursive: true, force: true });
+    SafeFsExecutor.safeRmSync(reportDir, {
+      recursive: true,
+      force: true,
+      operation: 'scripts/recheck-parked-tests.mjs:structured-report-cleanup',
+    });
   }
 }
 

--- a/tests/unit/recheck-parked-tests.test.ts
+++ b/tests/unit/recheck-parked-tests.test.ts
@@ -35,6 +35,87 @@ function runAgainstRealRepo(): { parkedTotal: number; missingFiles: string[]; gl
   return JSON.parse(res.stdout);
 }
 
+type SyntheticMode = 'real' | 'corrupt-report' | 'missing-runner';
+type SyntheticRun = {
+  runs: Array<'pass' | 'fail' | 'errored'>;
+  runDetails: Array<{
+    outcome: 'pass' | 'fail' | 'errored';
+    reason: string;
+    exitCode: number | null;
+    structured?: { total: number; passed: number; failed: number };
+  }>;
+  verdict: string;
+};
+
+function writeSyntheticRepo(mode: SyntheticMode, testBody: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'recheck-outcome-'));
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'tests'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(dir, 'scripts/recheck-parked-tests.mjs'));
+  fs.writeFileSync(path.join(dir, 'vitest.push.config.ts'), [
+    'const FLAKY_TESTS = [',
+    "  'tests/outcome.test.ts',",
+    '];',
+  ].join('\n'));
+  fs.writeFileSync(path.join(dir, 'vitest.config.mjs'),
+    'export default { test: { globals: true } };\n');
+  fs.writeFileSync(path.join(dir, 'tests/outcome.test.ts'), testBody);
+
+  if (mode !== 'missing-runner') {
+    const bin = path.join(dir, 'node_modules', '.bin');
+    fs.mkdirSync(bin, { recursive: true });
+    const realVitest = path.join(ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+    const wrapper = [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs');",
+      "const { spawnSync } = require('node:child_process');",
+      `const realVitest = ${JSON.stringify(realVitest)};`,
+      "const args = [...process.argv.slice(2), '--cache=false'];",
+      "const result = spawnSync(process.execPath, [realVitest, ...args], { cwd: process.cwd(), encoding: 'utf8', env: process.env });",
+      "const stdout = (result.stdout || '').replaceAll('Tests', 'Checks');",
+      "const stderr = (result.stderr || '').replaceAll('Tests', 'Checks');",
+      "if (process.env.R3_RENDER_CAPTURE) fs.writeFileSync(process.env.R3_RENDER_CAPTURE, stdout + stderr);",
+      ...(mode === 'corrupt-report' ? [
+        "const outputArg = args.find((arg) => arg.startsWith('--outputFile.json='));",
+        "if (outputArg) fs.writeFileSync(outputArg.slice('--outputFile.json='.length), '{not-json');",
+      ] : []),
+      'process.stdout.write(stdout);',
+      'process.stderr.write(stderr);',
+      'process.exit(result.status ?? 1);',
+      '',
+    ].join('\n');
+    const wrapperPath = path.join(bin, 'vitest');
+    fs.writeFileSync(wrapperPath, wrapper, { mode: 0o755 });
+  }
+  return dir;
+}
+
+function runSyntheticRepo(dir: string): { result: SyntheticRun; rendered: string } {
+  const renderCapture = path.join(dir, 'rendered.txt');
+  const res = spawnSync(process.execPath,
+    ['scripts/recheck-parked-tests.mjs', '--slice', '1', '--runs', '1', '--json'], {
+      cwd: dir,
+      encoding: 'utf-8',
+      timeout: 120_000,
+      env: { ...process.env, R3_RENDER_CAPTURE: renderCapture },
+    });
+  expect(res.status, res.stderr).toBe(0);
+  const report = JSON.parse(res.stdout);
+  expect(report.checked).toHaveLength(1);
+  return {
+    result: report.checked[0],
+    rendered: fs.existsSync(renderCapture) ? fs.readFileSync(renderCapture, 'utf-8') : '',
+  };
+}
+
+function removeSyntheticRepo(dir: string): void {
+  SafeFsExecutor.safeRmSync(dir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/recheck-parked-tests.test.ts:outcome-cleanup',
+  });
+}
+
 describe('parked-test re-check', () => {
   it('always exits 0 — it reports, it does not gate', () => {
     // Gating here would recreate the original problem from the other side: a red build for a test
@@ -109,6 +190,72 @@ describe('parked-test re-check', () => {
         recursive: true, force: true,
         operation: 'tests/unit/recheck-parked-tests.test.ts:cleanup',
       });
+    }
+  });
+
+  it('MUST-FIRE: a genuine failure comes from JSON even when rendered wording changes', () => {
+    const dir = writeSyntheticRepo('real', [
+      "it('genuinely fails', () => {",
+      '  expect(1).toBe(2);',
+      '});',
+    ].join('\n'));
+    try {
+      const { result, rendered } = runSyntheticRepo(dir);
+      expect(rendered).toMatch(/Checks\s+1\s+failed/);
+      expect(rendered).not.toMatch(/Tests\s+1\s+failed/);
+      expect(result.runs).toEqual(['fail']);
+      expect(result.verdict).toBe('deterministic-fail');
+      expect(result.runDetails[0]).toMatchObject({
+        outcome: 'fail',
+        reason: 'tests-failed',
+        exitCode: 1,
+        structured: { total: 1, passed: 0, failed: 1 },
+      });
+    } finally {
+      removeSyntheticRepo(dir);
+    }
+  });
+
+  it('MUST-NOT-FIRE: a passing run remains a structured pass', () => {
+    const dir = writeSyntheticRepo('real', [
+      "it('genuinely passes', () => {",
+      '  expect(1).toBe(1);',
+      '});',
+    ].join('\n'));
+    try {
+      const { result } = runSyntheticRepo(dir);
+      expect(result.runs).toEqual(['pass']);
+      expect(result.verdict).toBe('deterministic-pass');
+      expect(result.runDetails[0]).toMatchObject({
+        outcome: 'pass',
+        reason: 'tests-passed',
+        exitCode: 0,
+        structured: { total: 1, passed: 1, failed: 0 },
+      });
+    } finally {
+      removeSyntheticRepo(dir);
+    }
+  });
+
+  it('MUST-NOT-FIRE: never-started and unparseable runs stay distinct errors', () => {
+    const neverStarted = writeSyntheticRepo('missing-runner', "it('would pass', () => expect(1).toBe(1));\n");
+    const unparseable = writeSyntheticRepo('corrupt-report', "it('runs then fails', () => expect(1).toBe(2));\n");
+    try {
+      const missingResult = runSyntheticRepo(neverStarted).result;
+      const unparseableResult = runSyntheticRepo(unparseable).result;
+      expect(missingResult.runs).toEqual(['errored']);
+      expect(missingResult.verdict).toBe('could-not-run');
+      expect(missingResult.runDetails[0]).toMatchObject({
+        outcome: 'errored', reason: 'runner-not-started', exitCode: null,
+      });
+      expect(unparseableResult.runs).toEqual(['errored']);
+      expect(unparseableResult.verdict).toBe('could-not-run');
+      expect(unparseableResult.runDetails[0]).toMatchObject({
+        outcome: 'errored', reason: 'structured-report-unparseable', exitCode: 1,
+      });
+    } finally {
+      removeSyntheticRepo(neverStarted);
+      removeSyntheticRepo(unparseable);
     }
   });
 });

--- a/tests/unit/recheck-parked-tests.test.ts
+++ b/tests/unit/recheck-parked-tests.test.ts
@@ -47,11 +47,24 @@ type SyntheticRun = {
   verdict: string;
 };
 
+function copyProductionScript(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(dir, 'scripts/recheck-parked-tests.mjs'));
+
+  // The production script uses the repository's destructive-filesystem funnel for temporary
+  // report cleanup. Synthetic repositories copy the exact compiled runtime dependencies rather
+  // than substituting a weaker cleanup implementation.
+  const distCore = path.join(dir, 'dist', 'core');
+  fs.mkdirSync(distCore, { recursive: true });
+  for (const file of ['SafeFsExecutor.js', 'SafeGitExecutor.js', 'SourceTreeGuard.js']) {
+    fs.copyFileSync(path.join(ROOT, 'dist', 'core', file), path.join(distCore, file));
+  }
+}
+
 function writeSyntheticRepo(mode: SyntheticMode, testBody: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'recheck-outcome-'));
-  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
   fs.mkdirSync(path.join(dir, 'tests'), { recursive: true });
-  fs.copyFileSync(SCRIPT, path.join(dir, 'scripts/recheck-parked-tests.mjs'));
+  copyProductionScript(dir);
   fs.writeFileSync(path.join(dir, 'vitest.push.config.ts'), [
     'const FLAKY_TESTS = [',
     "  'tests/outcome.test.ts',",
@@ -176,8 +189,7 @@ describe('parked-test re-check', () => {
         "  'tests/unit/beta.test.ts',",
         '];',
       ].join('\n'));
-      fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
-      fs.copyFileSync(SCRIPT, path.join(dir, 'scripts/recheck-parked-tests.mjs'));
+      copyProductionScript(dir);
 
       const res = spawnSync(process.execPath, ['scripts/recheck-parked-tests.mjs', '--missing-only', '--json'], {
         cwd: dir, encoding: 'utf-8', timeout: 60_000,

--- a/tests/unit/recheck-parked-tests.test.ts
+++ b/tests/unit/recheck-parked-tests.test.ts
@@ -22,6 +22,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { stripVTControlCharacters } from 'node:util';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -35,7 +36,7 @@ function runAgainstRealRepo(): { parkedTotal: number; missingFiles: string[]; gl
   return JSON.parse(res.stdout);
 }
 
-type SyntheticMode = 'real' | 'corrupt-report' | 'missing-runner';
+type SyntheticMode = 'real' | 'ansi-rendered' | 'wrong-wording' | 'corrupt-report' | 'missing-runner';
 type SyntheticRun = {
   runs: Array<'pass' | 'fail' | 'errored'>;
   runDetails: Array<{
@@ -85,15 +86,27 @@ function writeSyntheticRepo(mode: SyntheticMode, testBody: string): string {
       `const realVitest = ${JSON.stringify(realVitest)};`,
       "const args = [...process.argv.slice(2), '--cache=false'];",
       "const result = spawnSync(process.execPath, [realVitest, ...args], { cwd: process.cwd(), encoding: 'utf8', env: process.env });",
-      "const stdout = (result.stdout || '').replaceAll('Tests', 'Checks');",
-      "const stderr = (result.stderr || '').replaceAll('Tests', 'Checks');",
-      "if (process.env.R3_RENDER_CAPTURE) fs.writeFileSync(process.env.R3_RENDER_CAPTURE, stdout + stderr);",
+      ...(mode === 'wrong-wording' ? [
+        "const stdout = result.stdout || '';",
+        "const stderr = result.stderr || '';",
+      ] : [
+        "const stdout = (result.stdout || '').replaceAll('Tests', 'Checks');",
+        "const stderr = (result.stderr || '').replaceAll('Tests', 'Checks');",
+      ]),
+      ...(mode === 'ansi-rendered' ? [
+        "const renderedStdout = stdout.replace(/(Checks)(\\s+)(1)(\\s+failed)/, '$1$2\\u001b[31m$3$4\\u001b[39m');",
+        "const renderedStderr = stderr.replace(/(Checks)(\\s+)(1)(\\s+failed)/, '$1$2\\u001b[31m$3$4\\u001b[39m');",
+      ] : [
+        'const renderedStdout = stdout;',
+        'const renderedStderr = stderr;',
+      ]),
+      "if (process.env.R3_RENDER_CAPTURE) fs.writeFileSync(process.env.R3_RENDER_CAPTURE, renderedStdout + renderedStderr);",
       ...(mode === 'corrupt-report' ? [
         "const outputArg = args.find((arg) => arg.startsWith('--outputFile.json='));",
         "if (outputArg) fs.writeFileSync(outputArg.slice('--outputFile.json='.length), '{not-json');",
       ] : []),
-      'process.stdout.write(stdout);',
-      'process.stderr.write(stderr);',
+      'process.stdout.write(renderedStdout);',
+      'process.stderr.write(renderedStderr);',
       'process.exit(result.status ?? 1);',
       '',
     ].join('\n');
@@ -127,6 +140,12 @@ function removeSyntheticRepo(dir: string): void {
     force: true,
     operation: 'tests/unit/recheck-parked-tests.test.ts:outcome-cleanup',
   });
+}
+
+function expectRenderedWrapperSummary(rendered: string): void {
+  const text = stripVTControlCharacters(rendered);
+  expect(text).toMatch(/Checks\s+1\s+failed/);
+  expect(text).not.toMatch(/Tests\s+1\s+failed/);
 }
 
 describe('parked-test re-check', () => {
@@ -206,15 +225,14 @@ describe('parked-test re-check', () => {
   });
 
   it('MUST-FIRE: a genuine failure comes from JSON even when rendered wording changes', () => {
-    const dir = writeSyntheticRepo('real', [
+    const dir = writeSyntheticRepo('ansi-rendered', [
       "it('genuinely fails', () => {",
       '  expect(1).toBe(2);',
       '});',
     ].join('\n'));
     try {
       const { result, rendered } = runSyntheticRepo(dir);
-      expect(rendered).toMatch(/Checks\s+1\s+failed/);
-      expect(rendered).not.toMatch(/Tests\s+1\s+failed/);
+      expectRenderedWrapperSummary(rendered);
       expect(result.runs).toEqual(['fail']);
       expect(result.verdict).toBe('deterministic-fail');
       expect(result.runDetails[0]).toMatchObject({
@@ -223,6 +241,21 @@ describe('parked-test re-check', () => {
         exitCode: 1,
         structured: { total: 1, passed: 0, failed: 1 },
       });
+    } finally {
+      removeSyntheticRepo(dir);
+    }
+  });
+
+  it('MUST-FIRE CONTROL: the rendered-summary contract rejects wrong Tests wording', () => {
+    const dir = writeSyntheticRepo('wrong-wording', [
+      "it('genuinely fails', () => {",
+      '  expect(1).toBe(2);',
+      '});',
+    ].join('\n'));
+    try {
+      const { rendered } = runSyntheticRepo(dir);
+      expect(stripVTControlCharacters(rendered)).toMatch(/Tests\s+1\s+failed/);
+      expect(() => expectRenderedWrapperSummary(rendered)).toThrowError(/Checks/);
     } finally {
       removeSyntheticRepo(dir);
     }

--- a/upgrades/next/r3-structured-parked-test-outcomes.md
+++ b/upgrades/next/r3-structured-parked-test-outcomes.md
@@ -16,3 +16,12 @@ always exits zero, and never edits the quarantine or gates a push or merge.
   absent runner, and unparseable structured report.
 - TypeScript, destructive-operation containment, production missing-only smoke, syntax, patch
   hygiene, and the instar-dev Tier-1 gate passed.
+
+## CI5 test-harness correction
+
+The rendered-summary contract now ignores ANSI terminal decoration before applying its unchanged
+requirements: it must contain `Checks 1 failed` and must not contain `Tests 1 failed`. A deterministic
+ANSI fixture covers the CI failure shape, and a separate wrong-wording control proves the assertion
+still fires when the wrapper violates that contract. The structured production classifier is
+unchanged. Final focused proof against the restored bytes passed all 9 tests on Node 22; both negative
+controls were separately observed red before restoration.

--- a/upgrades/next/r3-structured-parked-test-outcomes.md
+++ b/upgrades/next/r3-structured-parked-test-outcomes.md
@@ -1,0 +1,18 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+Parked-test rechecks now classify completed runs from Vitest's structured JSON report rather than
+matching human summary wording. Genuine pass, genuine failure, and runner/report errors remain
+distinct, with reason-bearing details for unknown outcomes. The command remains signal-only,
+always exits zero, and never edits the quarantine or gates a push or merge.
+
+## Evidence
+
+- A pre-fix control showed a real failing test becoming `could-not-run` when only `Tests` changed
+  to `Checks` in the rendered summary.
+- Final focused proof passed all 8 controls, including altered-wording failure, genuine pass,
+  absent runner, and unparseable structured report.
+- TypeScript, destructive-operation containment, production missing-only smoke, syntax, patch
+  hygiene, and the instar-dev Tier-1 gate passed.

--- a/upgrades/r3-structured-parked-test-outcomes.eli16.md
+++ b/upgrades/r3-structured-parked-test-outcomes.eli16.md
@@ -50,3 +50,14 @@ The negative control used a real failing Vitest test while changing only the dis
 the unchanged JSON evidence. Separate real-run controls preserved `pass`, classified a missing runner
 as `errored`, and classified a deliberately corrupted JSON report as `errored` rather than inventing a
 test result.
+
+## CI5 follow-up: colour is presentation too
+
+The original proof also checked that the wrapper visibly printed “Checks 1 failed.” In GitHub Actions,
+Vitest inserted terminal-colour instructions between those words and numbers. People still saw the
+same sentence, but the test's plain-text expression could not jump over invisible control bytes.
+
+The check now removes only those terminal instructions before making the same two demands: the summary
+must say “Checks 1 failed,” and it must not say “Tests 1 failed.” A deliberately wrong-worded wrapper
+is still rejected. This does not change how parked-test outcomes are decided; JSON remains the decision
+source, while rendered output is checked only for the wrapper's separate display contract.

--- a/upgrades/r3-structured-parked-test-outcomes.eli16.md
+++ b/upgrades/r3-structured-parked-test-outcomes.eli16.md
@@ -1,0 +1,52 @@
+# Parked-test rechecks use facts, not display wording — Plain-English Overview
+
+> The one-line version: when Instar samples tests that have been quarantined, it now uses Vitest's
+> machine-readable result to tell a real test failure from a runner that could not finish.
+
+## The problem
+
+Instar keeps a quarantine list for tests that are known to be unreliable in a particular environment.
+A small reporting script periodically samples that list. Its job is informational: show which tests
+still fail, which now pass consistently, and which could not be checked. It never edits the list and
+never blocks a push or merge.
+
+The script previously decided whether a nonzero Vitest run represented a failed test by searching the
+human summary for wording like “Tests 1 failed.” That summary is designed for people, not programs.
+If Vitest changed a label, added decoration, or a wrapper translated “Tests” to “Checks,” the test
+could execute and genuinely fail while the script reported only “could not run.”
+
+## Why that matters
+
+This is not a false green build. The script always exits successfully by design, CI remains the merge
+authority, and no required test shard is directly bypassed by this command. The damage is slower and
+second-order: a real failure mislabeled as an execution problem is not learned as a real failure. The
+test simply stays parked. As the quarantine becomes less accurate, it can continue narrowing the CI
+shards while nobody gets a trustworthy signal about which exclusions are still justified.
+
+## What changes
+
+Each sampled run now asks the pinned Vitest version for both its normal human output and a JSON report
+written to a fresh temporary file. The script classifies a failure only when the process finished,
+Vitest says the run was unsuccessful, the structured counts include a failed test, and a failed
+assertion is present. A pass likewise requires a successful process, consistent counts, and an observed
+passing assertion.
+
+Everything else remains unknown rather than being guessed. The report says whether the runner never
+started, failed to complete, produced no report, produced unreadable or invalid JSON, ran zero tests,
+or disagreed with its own exit status. Those cases still appear as `could-not-run`, with a reason that
+makes the missing evidence visible.
+
+## What does not change
+
+The command remains a signal. It always exits zero, never re-arms a quarantined test, never edits CI,
+and never claims that a local pass proves the test is safe everywhere. Re-arming remains a human
+judgement informed by this more accurate observation. The repair gives the signal better facts without
+turning it into a gate.
+
+## Evidence
+
+The negative control used a real failing Vitest test while changing only the displayed word “Tests” to
+“Checks.” The old script mislabeled it `could-not-run`; the repaired script classified it `fail` from
+the unchanged JSON evidence. Separate real-run controls preserved `pass`, classified a missing runner
+as `errored`, and classified a deliberately corrupted JSON report as `errored` rather than inventing a
+test result.

--- a/upgrades/side-effects/r3-structured-parked-test-outcomes.md
+++ b/upgrades/side-effects/r3-structured-parked-test-outcomes.md
@@ -1,0 +1,155 @@
+# Side-Effects Review — Structured parked-test recheck outcomes
+
+**Version / slug:** `r3-structured-parked-test-outcomes`
+**Date:** `2026-08-18`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** not required
+
+## Summary of the change
+
+`scripts/recheck-parked-tests.mjs` now classifies a sampled Vitest run from the pinned JSON reporter
+and process completion state rather than matching the human `basic` reporter summary. It preserves the
+three public outcomes `pass`, `fail`, and `errored`, adds reason-bearing `runDetails`, and keeps the
+script's deliberate unconditional exit-zero contract. Focused end-to-end coverage in
+`tests/unit/recheck-parked-tests.test.ts` proves altered human wording cannot hide a real failure and
+that passing, absent-runner, and unparseable-report cases remain distinct.
+
+This is Tier 1. It is a small, low-risk correction to a non-gating contributor signal; no application
+runtime, CI definition, protected action, persistent schema, or external authority changes. The PR is
+the independent review surface.
+
+## Build grounding and plan record
+
+- Fresh isolated worktree created with `instar worktree create` from protected `upstream/main` at
+  `248ed7177f5bf416aa7bdad9763741478195e1fc`.
+- Remotes: `upstream=https://github.com/JKHeadley/instar.git` and
+  `origin=https://github.com/JKHeadley/instar-codey.git`.
+- Package version before build: `1.3.1180`.
+- Problem: a real executed failure became `could-not-run` when human summary wording changed.
+- Fix: validate the pinned structured report and keep completed failures separate from unknown runs.
+- Acceptance: the pre-fix negative control misclassifies altered wording; the repaired path returns
+  `fail`; genuine pass returns `pass`; infrastructure and parse failures return reasoned `errored`;
+  the script remains non-gating and exit zero.
+- Rollback: revert this pure script/test change; no stored state needs repair.
+
+## Decision-point inventory
+
+- `classifyStructuredResult` — **modify** — classifies a completed sampled run as pass, fail, or
+  errored from validated machine-readable evidence.
+- Per-file verdict aggregation — **pass-through** — continues to derive deterministic pass/fail,
+  could-not-run, or genuinely-flaky from the individual run outcomes.
+- Process exit — **unchanged** — remains unconditional zero; this command reports and never gates.
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable. A future Vitest schema change can cause a
+sample to report `could-not-run` until reviewed, but it cannot block a user action or merge. Strictly
+rejecting unknown structured shapes is preferable to assigning them a known test outcome.
+
+## 2. Under-block
+
+No blocking authority is intended. The signal can still be incomplete: it samples a rotating subset,
+glob exclusions are reported rather than executed as a single file, and a test may behave differently
+in CI. Those limitations are visible and pre-existing. This repair specifically closes the class where
+a completed failing run was absorbed into execution error by presentation wording.
+
+An adversarial or internally wrong Vitest JSON report is trusted only after consistency checks; this
+change does not independently reimplement Vitest's assertion engine. The dependency is pinned and its
+executed package bytes are recorded in the proof record.
+
+## 3. Level-of-abstraction fit
+
+Vitest owns test execution and emits the structured facts. The recheck script owns the bounded mapping
+of those facts into its informational outcomes. That is the correct boundary: the wrapper no longer
+parses presentation text, and it does not duplicate CI's authority or make the quarantine decision.
+Fresh temporary report paths prevent two sampled runs from sharing an output artifact.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The command is explicitly a brittle, cheap detector and remains one. It always exits zero, never edits
+the quarantine, and never re-arms a test. Structured validation improves the detector's accuracy; it
+does not promote the detector into an authority.
+
+## 4b. Judgment-point check
+
+No new static heuristic is added at a competing-signals judgement point. Process completion, JSON
+shape, numeric counts, and assertion statuses are enumerable evidence invariants. Whether a passing
+sample justifies removing a quarantine remains outside this script and is not statically decided.
+
+## 5. Interactions
+
+- **Shadowing:** the structured report replaces only the old human-summary regex. The normal reporter
+  is retained for operators and cannot affect the verdict.
+- **Double-fire:** there is one spawned Vitest process per sample. Multiple reporters observe that same
+  process; they do not execute the test twice.
+- **Races:** each run owns a unique `mkdtemp` directory and removes it in `finally`. No shared report
+  filename is introduced. Cleanup routes through `SafeFsExecutor`; each real invocation therefore
+  appends the ordinary allowed-operation entry to the local destructive-operations audit log.
+- **Feedback loops:** outcomes are printed and discarded. They do not automatically edit
+  `FLAKY_TESTS`, schedule another run, or feed a retry controller.
+- **Adjacent CI:** the quarantine continues to narrow configured shards exactly as before. This signal
+  only makes stale entries easier to identify; it changes no CI selection logic itself.
+
+## 6. External surfaces
+
+Contributors and agents reading this script's JSON gain `runDetails` and human output gains reasons for
+`could-not-run`. The existing `runs` values and top-level verdict names remain compatible. Temporary
+report cleanup now emits the repository-standard local `.instar/audit/destructive-ops.jsonl` entry;
+that gitignored machine audit is the only new persistent record. There are no application-user,
+Telegram, Slack, GitHub API, dashboard, database, cross-machine ledger, or approval changes. Test
+execution time and environment remain machine-dependent, as they already were.
+
+No operator-facing action or URL is added. The local safety-audit entry above is the only persistent
+state generated.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** This command observes test execution in the current checkout, dependency
+tree, operating system, and machine environment. Those are intentionally per-machine facts and should
+not be replicated as durable truth. A local pass is explicitly not treated as proof about CI or another
+machine. The standard destructive-operation audit entry for temporary cleanup is likewise a
+machine-local safety record.
+
+The change emits no user-facing notice requiring one-voice gating, holds no durable state that could
+strand on topic transfer, and generates no URL.
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the script and focused test changes and ship the next patch.
+- **Data migration:** none.
+- **Agent state repair:** none; reports are temporary and deleted after each run.
+- **User visibility:** contributors would temporarily regain the older, less accurate informational
+  classification. CI and merge authority would remain unchanged.
+
+## Conclusion
+
+No side effect requires a design change. The strict JSON contract can make a future dependency schema
+change visibly unknown, which is the honest failure mode for a non-gating signal. The implementation
+keeps every authority boundary intact, preserves compatibility at the existing outcome fields, and is
+clear to submit for independent judgement.
+
+## Second-pass review
+
+Not required. The change does not touch outbound/inbound messaging, dispatch, session lifecycle,
+coherence, trust, idempotency, a gate, guard, sentinel, watchdog, or self-triggered controller. It
+modifies only a manually invoked, signal-only test observation.
+
+## Evidence pointers
+
+- `tests/unit/recheck-parked-tests.test.ts`
+- `scratchpad/phaseB/REPORT-R3.md` in the coordinating checkout
+- Focused proof: one file and eight tests passed; pre-fix and post-fix real-process controls are
+  recorded in the lane report.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable. This is an
+ordinary result-parser defect in a manually invoked contributor script.

--- a/upgrades/side-effects/r3-structured-parked-test-outcomes.md
+++ b/upgrades/side-effects/r3-structured-parked-test-outcomes.md
@@ -153,3 +153,25 @@ modifies only a manually invoked, signal-only test observation.
 
 No agent-authored-artifact defect and no self-triggered controller — not applicable. This is an
 ordinary result-parser defect in a manually invoked contributor script.
+
+## CI5 addendum — rendered-summary assertion hardening
+
+PR #1938's Node 20 and Node 22 shard-4 jobs exposed a defect in the test's secondary, rendered-output
+assertion. The production classifier remained structured and the wrapper's combined capture already
+contained both stdout and stderr. The captured value also contained the required `Checks` wording.
+The assertion failed because Vitest's ANSI style bytes occurred between `Checks`, `1`, and `failed`,
+so the raw `/Checks\s+1\s+failed/` expression could not span the presentation markup.
+
+The focused test now removes only VT control characters from that same combined rendered capture
+before applying the original two wording requirements. It still requires `Checks 1 failed` and still
+forbids `Tests 1 failed`; neither requirement is deleted or weakened. The synthetic wrapper also has
+an explicit wrong-wording mode, and a must-fire control proves the assertion rejects that mode. A
+separate ANSI-decorated mode makes the CI failure deterministic even on a non-colour local terminal.
+
+This addendum changes test robustness only. `scripts/recheck-parked-tests.mjs`, its two simultaneous
+reporters, its structured classification, its signal-only exit-zero contract, and every authority
+boundary described above are unchanged.
+
+Final focused proof against the restored CI5 bytes passed one file and all nine tests on Node 22. The
+repair-reverted ANSI control and the deliberately wrong-worded control were also run as actual red
+tests before their final expected-control forms were restored.


### PR DESCRIPTION
## Summary

- classify parked-test rechecks from Vitest JSON instead of human summary wording
- preserve distinct pass, fail, and errored outcomes, including never-started versus unparseable structured output
- keep the script signal-only and non-gating; this is a low-severity accuracy repair, not a merge guard

## ELI16 — use test facts, not display wording

The quarantine recheck is an informational tool that samples tests parked for known instability. It used to decide whether a test really failed by searching the text printed for a person. If that wording changed, an executed failing test could be mislabeled as could not run and remain parked without the quarantine learning the truth. The repair reads the pinned Vitest JSON result instead. A completed failing test is reported as fail, a completed passing test as pass, and a runner or report problem stays errored with a specific reason. The command still always exits zero, never edits the quarantine, and never blocks a push or merge; CI remains the authority.

## Proof

- pre-fix negative control: a real failing test with altered summary wording was misclassified as could-not-run
- post-fix controls: altered-wording failure => fail; passing run => pass; missing runner => errored; corrupt JSON => errored
- focused Vitest: 1 file / 8 tests passed
- TypeScript no-emit, syntax, missing-only smoke, and diff hygiene passed

Independent judging is required before certification. No merge requested.