### PR TITLE
fix(standards): close live artifact integrity

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-18T21-31-53-969Z-w38-live-artifact-closure.json
+++ b/.instar/instar-dev-decisions/2026-08-18T21-31-53-969Z-w38-live-artifact-closure.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-08-18T21:31:53.969Z",
+  "slug": "w38-live-artifact-closure",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 172,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lib/standards-enforcement-execution-verifier.mjs",
+      "scripts/lib/standards-enforcement-measurement.mjs",
+      "scripts/standards-coverage.mjs"
+    ],
+    "addedLines": 158,
+    "deletedLines": 14
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "gate",
+      "citation": "tests/unit/standards-enforcement-measurement.test.ts",
+      "howCaught": "W38_C4 requires the genuine live artifact and all nested copies to remain frozen; W38_C5 re-addresses every copied observation-field tamper and requires both internal consistency and the exported live predicate to reject it; W38_C6 refuses operational status for fixtures or incomplete canonical admissions."
+    },
+    "component": "standards-enforcement-measurement"
+  },
+  "verdict": "pass"
+}

--- a/scratchpad/phaseB/REPORT-W38.md
+++ b/scratchpad/phaseB/REPORT-W38.md
@@ -1,0 +1,145 @@
+# W3.8 — live-artifact integrity and prospective-authority closure
+
+## Status
+
+**BUILT WITH HAND EVIDENCE; independent judgment assigned to a different lane.** This report does not grade the repair. No merge was performed.
+
+```text
+branch: phaseb/w38-live-artifact-closure
+base:   60642c7ea9986eda24027d31071487a6e93eca8d (phaseb/w37-authenticated-structured-observation)
+implementation commit: pending first commit
+pull request: pending
+```
+
+## What changed
+
+### Limit 1 — reusable artifact integrity
+
+The authenticated execution artifact schema advances from v3 to v4. Construction now recursively freezes the artifact and every reachable nested object/array before registering it as live. Clean and pristine-confirmation copies now carry the same assertion-classification fields as the mutated run.
+
+`isLiveAuthenticatedExecutionArtifact()` now requires all of the following in addition to live WeakSet/event/receipt identity:
+
+1. every reachable artifact object is frozen;
+2. `artifactSha256` is recomputed from the canonical payload and matches exactly;
+3. each clean, mutated, and confirmation signed observation remains schema-valid and digest-valid;
+4. all five copied observation fields—`testsRun`, `passed`, `failed`, `assertionFailures`, and `decidingOutput`—exactly match the corresponding signed observation;
+5. copied exit code and existing event/receipt kind, session, sequence, signature-hash, guard, PID, child PID, and argv links still match.
+
+The W3.7 sentence that reusable validation “rechecks every link” is now true for the outer content address, copied observation values, signed event, and authenticated receipt chain.
+
+### Limit 2 — prospective, not operating canonical authority
+
+No runner or verdict ledger was added to main. Instead, every measurement record now carries `measurement.basis.executionAuthority`, with explicit `operational`, `prospective`, `test-stand-in`, or `unavailable` mode; the non-quiet CLI prints it.
+
+“Operational” requires all of these facts at once:
+
+- snapshot source is the content-addressed merge base derived from server-advertised canonical main;
+- that snapshot contains `scripts/lib/standards-enforcement-node-test-runner.mjs`;
+- that snapshot contains `docs/standards-enforcement-verdicts.json` in exact schema-v3 form;
+- at least one structurally valid proof record binds the exact SHA-256 of the admitted runner bytes.
+
+Explicit fixtures are labeled stand-ins even when they contain both files. Missing, empty, malformed, or digest-mismatched canonical state remains prospective and names the admissions still required.
+
+## Observed controls
+
+### Pre-fix red control
+
+Before the repair, the newly added W38_C4 ran against W3.7 and failed for the intended reason:
+
+```text
+W38_C4 mutationBlocked=false originalTestsRun=1 currentTestsRun=999 predicate=true
+AssertionError: expected false to be true
+```
+
+That run proved the exact scope limit: a caller could mutate a nested copied result and the exported live predicate still returned true.
+
+### Post-fix two-way controls
+
+The final targeted run observed both acceptance and refusal directions:
+
+```text
+W38_C4 mutationBlocked=true originalTestsRun=1 currentTestsRun=1 predicate=true
+W38_C5 copiedObservationTampers=15 readdressed=true allRejected=true wrongContentAddressRejected=true
+W38_C6 fixtureMode=test-stand-in canonicalNeither=prospective runnerOnly=prospective ledgerOnly=prospective emptyLedger=prospective mismatchedDigest=prospective canonicalBoundRecord=operational
+Test Files  1 passed (1)
+Tests       3 passed | 16 skipped (19)
+```
+
+- **Must accept:** the genuine recursively frozen artifact retains its original value and remains live.
+- **Must fail:** all fifteen copied-field tampers (five fields across three runs) are rejected even after the clone is deep-frozen and its outer address recomputed; an independently wrong outer address is also rejected.
+- **Must not overclaim:** fixtures, either missing canonical admission, an empty ledger, and a valid-shaped but mismatched digest all remain non-operational; only a canonical snapshot with runner bytes plus a fully valid digest-binding record reaches operational.
+
+## Live canonical-main observation
+
+At 2026-08-18 14:19 PDT, the production resolver read the server-advertised canonical main and returned:
+
+```text
+protected main: 248ed7177f5bf416aa7bdad9763741478195e1fc
+merge base:     248ed7177f5bf416aa7bdad9763741478195e1fc
+source:         canonical-server-content-addressed-merge-base
+mode:           prospective
+operationalOnCanonicalMain: false
+runnerPresentInSnapshot: false
+verdictLedgerPresentInSnapshot: false
+runnerDigestBoundByVerdictLedger: false
+```
+
+The emitted statement was:
+
+> Protected execution authority is NOT operational on canonical main; admit scripts/lib/standards-enforcement-node-test-runner.mjs and docs/standards-enforcement-verdicts.json with a schema-v3 record binding the admitted runner's exact SHA-256 before claiming protected digest authority.
+
+This is a read and a record only. W3.8 does not make or imply the merge decision that would admit those files.
+
+## Full verification
+
+```text
+Node 25.6.1 measurement: 19/19 passed
+Node 22.18.0 measurement: 19/19 passed
+affected standards-coverage ratchet: 38/38 passed
+node --check (three changed .mjs files): exit 0
+tsc --noEmit: exit 0
+git diff --check: exit 0
+```
+
+The full measurement runs retained W35 C3a/C3b/C3c/C3d, W37 C2, W36 C1, and W37 C1. The affected coverage suite exercised its real subprocess fixtures for 520.78 seconds and printed `test-stand-in` or `unavailable`, never operational, for noncanonical/missing state.
+
+The sandboxed first targeted Vitest invocation failed before assertion because Vite could not create its transient bundled-config file inside the agent-home worktree. The identical permitted invocation then ran; this is recorded as setup failure, not test evidence. The native `better-sqlite3` notice is unrelated and non-blocking for these files; no SQLite-backed assertion ran. No dependency install or rebuild was performed.
+
+## Instrument identity
+
+| Instrument | Identity | SHA-256 |
+|---|---|---|
+| Primary Node + `node:test` | `/opt/homebrew/Cellar/node/25.6.1/bin/node` | `f739e02b8e68d8accc60f15308c0d1dbe9cde2dfdb15463ba7389103b1b450e1` |
+| Compatibility Node + `node:test` | `/Users/justin/.asdf/installs/nodejs/22.18.0/bin/node` | `9187ad22c98cea5b635a79db52fa32ab3f6aa9d41e3abf5da71437cfef1ca9de` |
+| protected structured runner (unchanged) | `scripts/lib/standards-enforcement-node-test-runner.mjs` | `04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2` |
+| H1 receipt core (unchanged) | `scratchpad/phaseB/authenticated-execution-receipt.mjs` | `6534ed0983b733311d343c23b60bc70d13648ca9d911a136875504d20d6e4817` |
+| Vitest entry | shared `node_modules/vitest/vitest.mjs` | `39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6` |
+| Vitest CLI | shared `node_modules/vitest/dist/cli.js` | `88e96cc0817e9248dadf452c0db5f543dc25ec9ce1c801c2310ca3ac8ffdf48d` |
+| Vite CJS / Node entries | shared `node_modules/vite/index.cjs`; `vite/dist/node/index.js` | `9f3d9f0d380bb14380fe3cd9c64be336ae0b892613229b07d837ab44784cbb96`; `2b295e9da790eb9d1b02b167a4678bd9106253d97e07a75f774cd2f3b1930476` |
+| TypeScript verifier | shared `node_modules/typescript/lib/typescript.js` | `3ae902c92cc44dace175c0e69e13a4b0899f6983c6121d76b9ab8dd5795e7675` |
+| YAML dependency | shared `node_modules/js-yaml/index.js` | `7d1ebc0d9929b9124997b439d1a1fd9aff8feb6bb0a1b59e977ea638944f34ba` |
+
+## Four-field dependency record
+
+1. **Execution runtime:** Node 25.6.1 primary and Node 22.18.0 compatibility binaries, with exact paths and hashes above. The promoted observation itself uses only the selected Node binary, Node core `node:test`, and the protected copied runner.
+2. **Outer harness inputs:** Vitest, Vite, TypeScript, and js-yaml exact entrypoint hashes above. They drive the test harness and source analysis; they do not author the signed `node:test` observation.
+3. **Resolved dependency root:** the W3.8 `node_modules` symlink resolves to `/Users/justin/.instar/agents/instar-codey/.worktrees/phaseb-w35-observed-enforcement-proof/node_modules`. A sorted manifest of entry type + relative path + file SHA-256/symlink target was identical before and after all deciding tests: `5fc63b51706d69dc9f2f56385a16b83d15af894fbeee5cc268a7f9387bfb8098`, 13,966 regular files, 30 symlinks, 572,000,653 regular-file bytes.
+4. **Mutable output/cache boundary:** exactly `.vite/vitest/results.json` was excluded because it is a result cache, not an input, and every deciding Vitest run used `--no-cache`. Its pre/post record was identical: 222 bytes, mtime `1787085693226.3052`, SHA-256 `0b2e4b43415baf763b75722e6d2fb3a0ada7c2a57bca333ce7fc48ce3223dd68`. No other dependency-tree byte was excluded.
+
+The dependency tree was linked from the already-audited W3.5 tree. No install, rebuild, purge, restore, or manual dependency rewrite occurred. Husky generated only worktree-local ignored hook shims from that pinned tree so the real repository gates could execute.
+
+## Changed-file identities
+
+| File | Before SHA-256 | After SHA-256 |
+|---|---|---|
+| `scripts/lib/standards-enforcement-execution-verifier.mjs` | `0cf6fbb303a49c664bd1587bdf852e58fde02b85408167b984bb07e9c7fadde4` | `c605798570fcaa24e7778d01f67a7ddd5f3f12d36b5519d575f5e6e037f44950` |
+| `scripts/lib/standards-enforcement-measurement.mjs` | `0c34eeb22e49602c7fba2315a1de75a160cf3bb82628d7654f4bd2a8b97332f0` | `215f72ab9f92baf13a0f2f993c11f9b5d8e55da74cad3fc2cb0f9bcbbe88d3d3` |
+| `scripts/standards-coverage.mjs` | `e69ec89ff423d76db2070c05840dda698c4c6639f92d508c8af7a17abc856c6f` | `2afd719c2997ba3fe9d8ea7c4d06d9953e88a3c4412bf0b90f9f69c4491eccd6` |
+| `tests/unit/standards-enforcement-measurement.test.ts` | `7345c2c879c991d34101238b17c5e6c3833efa75809d64e41824d8fb31d14bb2` | `330dec664351c65353dacd56245c99f23b85cbdc156328416759751e1f8ac4be` |
+| `upgrades/next/enforcement-measurement.md` | `3ed4f1181f1f52bd31779138e020e6167d7c65fb8969a8d78667d713302d2172` | `8e43633ed6fa3ec28f0fe52a374cb286493c0d881e99f45c863aa03851a1a635` |
+
+The W3.8 report, ELI16 overview, and side-effects review are new files and therefore have no pre-change identity.
+
+## Scope and handoff
+
+No approver key, runner, verdict ledger, CI file, canonical-main content, or runtime service was changed. No force-push or merge was performed. The builder records the hand evidence and leaves admissibility and disposition to the independently assigned judging lane.

--- a/scratchpad/phaseB/REPORT-W38.md
+++ b/scratchpad/phaseB/REPORT-W38.md
@@ -7,8 +7,8 @@
 ```text
 branch: phaseb/w38-live-artifact-closure
 base:   60642c7ea9986eda24027d31071487a6e93eca8d (phaseb/w37-authenticated-structured-observation)
-implementation commit: pending first commit
-pull request: pending
+implementation commit: 4af2e56e944fe0c0b918590d0c0540fedf2913ae
+pull request: https://github.com/JKHeadley/instar/pull/1939
 ```
 
 ## What changed
@@ -96,12 +96,13 @@ This is a read and a record only. W3.8 does not make or imply the merge decision
 Node 25.6.1 measurement: 19/19 passed
 Node 22.18.0 measurement: 19/19 passed
 affected standards-coverage ratchet: 38/38 passed
+required pre-push affected set: 57/57 passed (2 files, 608.95s)
 node --check (three changed .mjs files): exit 0
 tsc --noEmit: exit 0
 git diff --check: exit 0
 ```
 
-The full measurement runs retained W35 C3a/C3b/C3c/C3d, W37 C2, W36 C1, and W37 C1. The affected coverage suite exercised its real subprocess fixtures for 520.78 seconds and printed `test-stand-in` or `unavailable`, never operational, for noncanonical/missing state.
+The full measurement runs retained W35 C3a/C3b/C3c/C3d, W37 C2, W36 C1, and W37 C1. The affected coverage suite exercised its real subprocess fixtures for 520.78 seconds and printed `test-stand-in` or `unavailable`, never operational, for noncanonical/missing state. The non-force push gate independently reran both affected files as 57 tests and pushed only after all 57 passed.
 
 The sandboxed first targeted Vitest invocation failed before assertion because Vite could not create its transient bundled-config file inside the agent-home worktree. The identical permitted invocation then ran; this is recorded as setup failure, not test evidence. The native `better-sqlite3` notice is unrelated and non-blocking for these files; no SQLite-backed assertion ran. No dependency install or rebuild was performed.
 

--- a/scripts/lib/standards-enforcement-execution-verifier.mjs
+++ b/scripts/lib/standards-enforcement-execution-verifier.mjs
@@ -10,7 +10,7 @@ import {
 } from "../../scratchpad/phaseB/authenticated-execution-receipt.mjs";
 import { SafeFsExecutor } from "../../dist/core/SafeFsExecutor.js";
 
-const ARTIFACT_SCHEMA = "standards-enforcement-observed-execution/v3";
+const ARTIFACT_SCHEMA = "standards-enforcement-observed-execution/v4";
 const RUNNER = "node-test-events-v1";
 const RUNNER_REF = "scripts/lib/standards-enforcement-node-test-runner.mjs";
 const OBSERVATION_SCHEMA = "standards-enforcement-node-test-events/v1";
@@ -30,6 +30,20 @@ function canonical(value) {
       .join(",")}}`;
   }
   return JSON.stringify(value);
+}
+
+function deepFreeze(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== "object" || seen.has(value)) return value;
+  seen.add(value);
+  for (const key of Reflect.ownKeys(value)) deepFreeze(value[key], seen);
+  return Object.freeze(value);
+}
+
+function isDeepFrozen(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== "object" || seen.has(value)) return true;
+  if (!Object.isFrozen(value)) return false;
+  seen.add(value);
+  return Reflect.ownKeys(value).every((key) => isDeepFrozen(value[key], seen));
 }
 
 function safeRepoPath(rel) {
@@ -403,6 +417,8 @@ function artifactFor(
       testsRun: cleanAuthentication.observation.testsRun,
       passed: cleanAuthentication.observation.passed,
       failed: cleanAuthentication.observation.failed,
+      assertionFailures: cleanAuthentication.observation.assertionFailures,
+      decidingOutput: cleanAuthentication.observation.decidingMessage,
       outputSha256: clean.outputSha256,
     },
     mutated: {
@@ -425,10 +441,12 @@ function artifactFor(
       testsRun: confirmationAuthentication.observation.testsRun,
       passed: confirmationAuthentication.observation.passed,
       failed: confirmationAuthentication.observation.failed,
+      assertionFailures: confirmationAuthentication.observation.assertionFailures,
+      decidingOutput: confirmationAuthentication.observation.decidingMessage,
       outputSha256: confirmation.outputSha256,
     },
   };
-  const artifact = Object.freeze({
+  const artifact = deepFreeze({
     ...payload,
     artifactSha256: sha256(canonical(payload)),
   });
@@ -716,34 +734,76 @@ export async function verifyProtectedExecutionProof({
   }
 }
 
-export function isLiveAuthenticatedExecutionArtifact(artifact) {
-  const liveRun = (run) => {
+function artifactContentIsInternallyConsistent(artifact) {
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) return false;
+  if (!isDeepFrozen(artifact) || artifact.schema !== ARTIFACT_SCHEMA) return false;
+  if (!SHA256_RE.test(artifact.artifactSha256 ?? "")) return false;
+  const { artifactSha256, ...payload } = artifact;
+  if (artifactSha256 !== sha256(canonical(payload))) return false;
+  if (
+    artifact.observer?.runner !== RUNNER ||
+    !SHA256_RE.test(artifact.observer?.runnerSha256 ?? "") ||
+    artifact.observer?.structuredSource !== "node:test TestsStream" ||
+    !Array.isArray(artifact.observer?.argv) ||
+    artifact.subject?.mutationLanded !== true
+  )
+    return false;
+
+  const consistentRun = (run, expectedKind) => {
     const event = run?.observationEvent;
     const receipt = run?.receipt;
+    const observation = event?.observation;
     return Boolean(
       event &&
       receipt &&
-      isLiveAuthenticatedObserverEvent(event) &&
-      isLiveAuthenticatedReceipt(receipt) &&
-      validObservation(event.observation, artifact.observer?.ref) &&
-      run.observationSha256 === sha256(canonical(event.observation)) &&
+      validObservation(observation, artifact.observer?.ref) &&
+      run.observationSha256 === sha256(canonical(observation)) &&
       event.observationSha256 === run.observationSha256 &&
+      run.testsRun === observation.testsRun &&
+      run.passed === observation.passed &&
+      run.failed === observation.failed &&
+      run.assertionFailures === observation.assertionFailures &&
+      run.decidingOutput === observation.decidingMessage &&
+      run.exitCode === receipt.childExitCode &&
+      event.kind === expectedKind &&
       receipt.observerSession === event.observerSession &&
       receipt.observerEventSequence === event.sequence &&
       receipt.observerEventSignatureHash === sha256(event.signature) &&
-      receipt.kind === event.kind
+      receipt.kind === event.kind &&
+      receipt.guardId === event.guardId &&
+      receipt.observerPid === event.observerPid &&
+      receipt.childPid === event.observerPid &&
+      canonical(receipt.argv?.slice(1)) === canonical(event.argv)
     );
   };
+
   return Boolean(
-    artifact &&
-    typeof artifact === "object" &&
-    liveArtifacts.has(artifact) &&
-    liveRun(artifact.clean) &&
-    liveRun(artifact.mutated) &&
-    liveRun(artifact.confirmation),
+    canonical(artifact.observer.argv) === canonical(artifact.clean?.receipt?.argv) &&
+    consistentRun(artifact.clean, "clean-observer-exit") &&
+    consistentRun(artifact.mutated, "mutated-observer-exit") &&
+    consistentRun(artifact.confirmation, "confirmation-clean-observer-exit")
   );
 }
 
+export function isLiveAuthenticatedExecutionArtifact(artifact) {
+  const liveRun = (run) => Boolean(
+    isLiveAuthenticatedObserverEvent(run?.observationEvent) &&
+    isLiveAuthenticatedReceipt(run?.receipt)
+  );
+  return Boolean(
+    liveArtifacts.has(artifact) &&
+    artifactContentIsInternallyConsistent(artifact) &&
+    liveRun(artifact.clean) &&
+    liveRun(artifact.mutated) &&
+    liveRun(artifact.confirmation)
+  );
+}
+
+export const __testing = Object.freeze({
+  artifactContentIsInternallyConsistent,
+});
+
 export const STANDARDS_EXECUTION_ARTIFACT_SCHEMA = ARTIFACT_SCHEMA;
 export const STANDARDS_EXECUTION_RUNNER = RUNNER;
+export const STANDARDS_EXECUTION_RUNNER_REF = RUNNER_REF;
 export const STANDARDS_EXECUTION_DEFAULT_TIMEOUT_MS = DEFAULT_OBSERVER_TIMEOUT_MS;

--- a/scripts/lib/standards-enforcement-measurement.mjs
+++ b/scripts/lib/standards-enforcement-measurement.mjs
@@ -7,6 +7,7 @@ import ts from 'typescript';
 import {
   isLiveAuthenticatedExecutionArtifact,
   STANDARDS_EXECUTION_RUNNER,
+  STANDARDS_EXECUTION_RUNNER_REF,
   verifyProtectedExecutionProof,
 } from './standards-enforcement-execution-verifier.mjs';
 
@@ -162,6 +163,59 @@ export function resolveProtectedMeasurementSnapshot({ root, fixtureRoot = null }
       return git(root, ['grep', '-q', '-w', '--fixed-strings', marker, baseRevision, '--', 'src']) !== null;
     },
   };
+}
+
+export function describeProtectedExecutionAuthority(snapshot) {
+  const canonicalSnapshot = snapshot?.source === 'canonical-server-content-addressed-merge-base';
+  let runnerContent = null;
+  let verdictLedgerContent = null;
+  let runnerPresentInSnapshot = false;
+  let verdictLedgerPresentInSnapshot = false;
+  let runnerDigestBoundByVerdictLedger = false;
+  try {
+    runnerContent = snapshot?.readFile?.(STANDARDS_EXECUTION_RUNNER_REF) ?? null;
+    verdictLedgerContent = snapshot?.readFile?.(PROTECTED_VERDICTS_PATH) ?? null;
+    runnerPresentInSnapshot = typeof runnerContent === 'string';
+    verdictLedgerPresentInSnapshot = typeof verdictLedgerContent === 'string';
+    if (runnerPresentInSnapshot && verdictLedgerPresentInSnapshot) {
+      const ledger = JSON.parse(verdictLedgerContent);
+      const runnerSha256 = sha256(runnerContent);
+      runnerDigestBoundByVerdictLedger = Boolean(
+        exactKeys(ledger, ['schemaVersion', 'records']) &&
+        ledger.schemaVersion === PROTECTED_VERDICT_SCHEMA_VERSION &&
+        Array.isArray(ledger.records) &&
+        ledger.records.some((record, index) =>
+          validProofRecord(record, index) === null &&
+          record.proof.execution.runnerSha256 === runnerSha256)
+      );
+    }
+  } catch {
+    runnerDigestBoundByVerdictLedger = false;
+  }
+  const operationalOnCanonicalMain = canonicalSnapshot && runnerPresentInSnapshot && runnerDigestBoundByVerdictLedger;
+  const mode = operationalOnCanonicalMain ? 'operational' : canonicalSnapshot ? 'prospective' : 'test-stand-in';
+  const requiredCanonicalAdmissions = operationalOnCanonicalMain
+    ? []
+    : canonicalSnapshot
+      ? [
+          ...(!runnerPresentInSnapshot ? [STANDARDS_EXECUTION_RUNNER_REF] : []),
+          ...(!runnerDigestBoundByVerdictLedger ? [`${PROTECTED_VERDICTS_PATH} with a schema-v3 record binding the admitted runner's exact SHA-256`] : []),
+        ]
+      : [STANDARDS_EXECUTION_RUNNER_REF, `${PROTECTED_VERDICTS_PATH} with a schema-v3 record binding the admitted runner's exact SHA-256`];
+  const statement = operationalOnCanonicalMain
+    ? 'Protected execution authority is operational: canonical main supplies both the runner bytes and schema-v3 verdict ledger.'
+    : mode === 'prospective'
+      ? `Protected execution authority is NOT operational on canonical main; admit ${requiredCanonicalAdmissions.join(' and ')} before claiming protected digest authority.`
+      : `This explicit test fixture is a stand-in only; protection is NOT operational authority on canonical main until ${STANDARDS_EXECUTION_RUNNER_REF} and ${PROTECTED_VERDICTS_PATH} are admitted there.`;
+  return Object.freeze({
+    mode,
+    operationalOnCanonicalMain,
+    runnerPresentInSnapshot,
+    verdictLedgerPresentInSnapshot,
+    runnerDigestBoundByVerdictLedger,
+    requiredCanonicalAdmissions: Object.freeze(requiredCanonicalAdmissions),
+    statement,
+  });
 }
 
 export function routeTableFromSnapshot(snapshot) {
@@ -580,6 +634,7 @@ export async function measureAnchoredEnforcement({
       protectedMainSha: snapshot.protectedMainSha,
       baseRevision: snapshot.baseRevision,
       candidateTreeMayRaiseStrength: false,
+      executionAuthority: describeProtectedExecutionAuthority(snapshot),
     },
     population: {
       protectedBase: protectedById.size,

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -74,6 +74,18 @@ const args = new Set(process.argv.slice(2));
 const CHECK = args.has('--check');
 const JSON_ONLY = args.has('--json');
 const QUIET = args.has('--quiet');
+const unavailableExecutionAuthority = (reason) => ({
+  mode: 'unavailable',
+  operationalOnCanonicalMain: false,
+  runnerPresentInSnapshot: false,
+  verdictLedgerPresentInSnapshot: false,
+  runnerDigestBoundByVerdictLedger: false,
+  requiredCanonicalAdmissions: [
+    'scripts/lib/standards-enforcement-node-test-runner.mjs',
+    "docs/standards-enforcement-verdicts.json with a schema-v3 record binding the admitted runner's exact SHA-256",
+  ],
+  statement: `Protected execution authority is NOT established: ${reason}. Canonical main must admit the protected runner and a valid schema-v3 verdict record binding its exact SHA-256 before protected digest authority is operational.`,
+});
 /**
  * `--rebaseline-floor="<reason>"` — the ONLY way a family's enforcement floor may go
  * DOWN, and it exists because of a specific operator ruling (Justin, 2026-08-08).
@@ -1274,7 +1286,13 @@ async function compute() {
       measurement: {
         status: 'not-proven',
         errors: ['candidate rule population is empty or unreadable'],
-        basis: { source: null, protectedMainSha: null, baseRevision: null, candidateTreeMayRaiseStrength: false },
+        basis: {
+          source: null,
+          protectedMainSha: null,
+          baseRevision: null,
+          candidateTreeMayRaiseStrength: false,
+          executionAuthority: unavailableExecutionAuthority('the candidate rule population is empty or unreadable'),
+        },
         population: { protectedBase: 0, candidate: 0, continuity: 0, additions: [], removals: [], byFamily: {} },
         protectedFloor: { enforced: 0, total: 0, ratio: null, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 }, byFamily: {} },
         unverifiedReferences: [],
@@ -1408,7 +1426,13 @@ async function compute() {
     measurement = {
       status: 'not-proven',
       errors: [error instanceof Error ? error.message : String(error)],
-      basis: { source: null, protectedMainSha: null, baseRevision: null, candidateTreeMayRaiseStrength: false },
+      basis: {
+        source: null,
+        protectedMainSha: null,
+        baseRevision: null,
+        candidateTreeMayRaiseStrength: false,
+        executionAuthority: unavailableExecutionAuthority('the protected measurement snapshot could not be resolved'),
+      },
       population: { protectedBase: 0, candidate: articles.length, continuity: 0, additions: [], removals: [], byFamily: {} },
       protectedFloor: { enforced: 0, total: 0, ratio: null, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 }, byFamily: {} },
       unverifiedReferences: [],
@@ -1804,6 +1828,11 @@ async function main() {
       `protected-population=${report.measurement.population.protectedBase} ` +
       `candidate-population=${report.measurement.population.candidate} ` +
       `unverified-references=${report.measurement.unverifiedReferences.length}`);
+    const executionAuthority = report.measurement.basis.executionAuthority ??
+      unavailableExecutionAuthority('the report did not contain an execution-authority record');
+    console.error(`[standards-coverage] protected-execution-authority=${executionAuthority.mode} ` +
+      `operational-on-canonical-main=${executionAuthority.operationalOnCanonicalMain} ` +
+      `statement=${JSON.stringify(executionAuthority.statement)}`);
     console.error(`[standards-coverage] protected-strength-floor=${report.measurement.protectedFloor.enforced}/${report.measurement.protectedFloor.total} ` +
       `ratio=${report.measurement.protectedFloor.ratio} candidate-may-raise=false`);
     for (const error of report.measurement.errors) {

--- a/tests/unit/standards-enforcement-measurement.test.ts
+++ b/tests/unit/standards-enforcement-measurement.test.ts
@@ -5,11 +5,16 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  describeProtectedExecutionAuthority,
   gradeFileReference,
   measureAnchoredEnforcement,
   resolveProtectedMeasurementSnapshot,
 } from '../../scripts/lib/standards-enforcement-measurement.mjs';
-import { verifyProtectedExecutionProof } from '../../scripts/lib/standards-enforcement-execution-verifier.mjs';
+import {
+  __testing as executionVerifierTesting,
+  isLiveAuthenticatedExecutionArtifact,
+  verifyProtectedExecutionProof,
+} from '../../scripts/lib/standards-enforcement-execution-verifier.mjs';
 
 const roots: string[] = [];
 const makeRoot = (): string => {
@@ -23,6 +28,32 @@ const write = (root: string, rel: string, content: string): void => {
   fs.writeFileSync(full, content);
 };
 const digest = (value: string): string => crypto.createHash('sha256').update(value).digest('hex');
+const canonical = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+};
+const deepFreeze = <T>(value: T, seen = new WeakSet<object>()): T => {
+  if (value === null || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const key of Reflect.ownKeys(value)) deepFreeze((value as Record<PropertyKey, unknown>)[key], seen);
+  return Object.freeze(value);
+};
+const isDeepFrozen = (value: unknown, seen = new WeakSet<object>()): boolean => {
+  if (value === null || typeof value !== 'object' || seen.has(value)) return true;
+  if (!Object.isFrozen(value)) return false;
+  seen.add(value);
+  return Reflect.ownKeys(value).every((key) =>
+    isDeepFrozen((value as Record<PropertyKey, unknown>)[key], seen));
+};
+const readdressAndFreeze = <T extends { artifactSha256: string }>(artifact: T): T => {
+  const { artifactSha256: _oldAddress, ...payload } = artifact;
+  artifact.artifactSha256 = digest(canonical(payload));
+  return deepFreeze(artifact);
+};
 const RUNNER_REF = 'scripts/lib/standards-enforcement-node-test-runner.mjs';
 const TRUSTED_RUNNER_SHA256 = '04795f8857d8bb08ccf7c0a18103b7233ef644b395ac9bd576d9726e98da57f2';
 const trustedRunnerContent = fs.readFileSync(path.resolve(RUNNER_REF), 'utf8');
@@ -85,6 +116,32 @@ const certifiedRecord = (
   },
   });
 };
+
+async function genuineObservedArtifact() {
+  const base = makeRoot();
+  const ref = 'tests/unit/w38-artifact.test.mjs';
+  const subjectRef = 'src/w38-artifact-subject.mjs';
+  const subjectContent = 'export const guarded = true;\n';
+  const content = [
+    "import assert from 'node:assert/strict';",
+    "import test from 'node:test';",
+    "import { guarded } from '../../src/w38-artifact-subject.mjs';",
+    "test('observes subject', () => assert.equal(guarded, true));",
+    '',
+  ].join('\n');
+  const protectedArticle = article('rule-w38', [ref]);
+  const record = certifiedRecord(base, protectedArticle, ref, content, subjectRef, subjectContent);
+  write(base, ref, content);
+  write(base, subjectRef, subjectContent);
+
+  const observed = await verifyProtectedExecutionProof({
+    record,
+    snapshot: resolveProtectedMeasurementSnapshot({ root: base, fixtureRoot: base }),
+  });
+  expect(observed.status).toBe('proven');
+  expect(observed.artifact).not.toBeNull();
+  return observed.artifact!;
+}
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
@@ -444,6 +501,144 @@ describe('protected standards enforcement measurement', () => {
     });
     expect(fs.existsSync(markerPath)).toBe(false);
     console.log(`W37_C2 expectedRunnerSha256=${TRUSTED_RUNNER_SHA256} actualRunnerSha256=${forgedRunnerSha256} runnerExecuted=false summarySchema=standards-enforcement-node-test-events/v1 outcome=UNKNOWN artifact=null deciding="protected structured test runner digest mismatch"`);
+  });
+
+  it('W38_C4 blocks mutation of copied observation fields before reusable validation', async () => {
+    const artifact = await genuineObservedArtifact();
+    const originalTestsRun = artifact.clean.testsRun;
+    let mutationBlocked = false;
+    try {
+      artifact.clean.testsRun = 999;
+    } catch (error) {
+      mutationBlocked = error instanceof TypeError;
+    }
+    const liveAfterMutationAttempt = isLiveAuthenticatedExecutionArtifact(artifact);
+
+    console.log(`W38_C4 mutationBlocked=${mutationBlocked} originalTestsRun=${originalTestsRun} currentTestsRun=${artifact.clean.testsRun} predicate=${liveAfterMutationAttempt}`);
+    expect(mutationBlocked).toBe(true);
+    expect(artifact.clean.testsRun).toBe(originalTestsRun);
+    expect(isDeepFrozen(artifact)).toBe(true);
+    expect(liveAfterMutationAttempt).toBe(true);
+  });
+
+  it('W38_C5 rejects every re-addressed copied-observation tamper', async () => {
+    const artifact = await genuineObservedArtifact();
+    expect(executionVerifierTesting.artifactContentIsInternallyConsistent(artifact)).toBe(true);
+
+    const tamperCases: Array<[string, (copy: any) => void]> = [];
+    for (const runName of ['clean', 'mutated', 'confirmation'] as const) {
+      tamperCases.push(
+        [`${runName}.testsRun`, (copy) => { copy[runName].testsRun += 1; }],
+        [`${runName}.passed`, (copy) => { copy[runName].passed += 1; }],
+        [`${runName}.failed`, (copy) => { copy[runName].failed += 1; }],
+        [`${runName}.assertionFailures`, (copy) => { copy[runName].assertionFailures += 1; }],
+        [`${runName}.decidingOutput`, (copy) => { copy[runName].decidingOutput = 'forged classification'; }],
+      );
+    }
+
+    for (const [label, tamper] of tamperCases) {
+      const copy = structuredClone(artifact);
+      tamper(copy);
+      readdressAndFreeze(copy);
+      expect(
+        executionVerifierTesting.artifactContentIsInternallyConsistent(copy),
+        `${label} must remain linked to the signed observation even after re-addressing`,
+      ).toBe(false);
+      expect(isLiveAuthenticatedExecutionArtifact(copy)).toBe(false);
+    }
+
+    const wrongAddress = structuredClone(artifact);
+    wrongAddress.artifactSha256 = '0'.repeat(64);
+    deepFreeze(wrongAddress);
+    expect(executionVerifierTesting.artifactContentIsInternallyConsistent(wrongAddress)).toBe(false);
+    expect(isLiveAuthenticatedExecutionArtifact(wrongAddress)).toBe(false);
+    console.log(`W38_C5 copiedObservationTampers=${tamperCases.length} readdressed=true allRejected=true wrongContentAddressRejected=true`);
+  });
+
+  it('W38_C6 labels fixtures as stand-ins and requires both canonical admissions', () => {
+    const snapshot = (source: string, files: Record<string, string>) => ({
+      source,
+      readFile: (ref: string) => files[ref] ?? null,
+    });
+    const runnerRef = 'scripts/lib/standards-enforcement-node-test-runner.mjs';
+    const ledgerRef = 'docs/standards-enforcement-verdicts.json';
+    const runnerContent = 'protected runner bytes';
+    const boundRecord = {
+      articleId: 'rule-w38-authority',
+      articleSha256: digest('fixture article'),
+      ref: 'tests/unit/w38-authority.test.mjs',
+      sha256: digest('fixture observer'),
+      verdict: 'EFFECTIVE',
+      proof: {
+        schemaVersion: 2,
+        execution: {
+          runner: 'node-test-events-v1',
+          runnerSha256: digest(runnerContent),
+          argv: ['node', runnerRef, 'tests/unit/w38-authority.test.mjs'],
+          workspaceRefs: ['src/w38-authority-subject.mjs', 'tests/unit/w38-authority.test.mjs'],
+        },
+        relevance: {
+          articleId: 'rule-w38-authority',
+          ruleSha256: digest('fixture rule'),
+          observerRef: 'tests/unit/w38-authority.test.mjs',
+          observerSha256: digest('fixture observer'),
+          subjectRef: 'src/w38-authority-subject.mjs',
+          subjectBeforeSha256: digest('before'),
+        },
+        mutation: {
+          mutationId: 'violate-w38-authority',
+          subjectRef: 'src/w38-authority-subject.mjs',
+          search: 'true',
+          replacement: 'false',
+          subjectAfterSha256: digest('after'),
+        },
+      },
+    };
+    const boundLedger = JSON.stringify({
+      schemaVersion: 3,
+      records: [boundRecord],
+    });
+    const mismatchedLedger = JSON.stringify({
+      schemaVersion: 3,
+      records: [{
+        ...boundRecord,
+        proof: {
+          ...boundRecord.proof,
+          execution: { ...boundRecord.proof.execution, runnerSha256: digest('other runner') },
+        },
+      }],
+    });
+
+    const standIn = describeProtectedExecutionAuthority(snapshot('explicit-test-fixture', { [runnerRef]: runnerContent, [ledgerRef]: boundLedger }));
+    const neither = describeProtectedExecutionAuthority(snapshot('canonical-server-content-addressed-merge-base', {}));
+    const runnerOnly = describeProtectedExecutionAuthority(snapshot('canonical-server-content-addressed-merge-base', { [runnerRef]: runnerContent }));
+    const ledgerOnly = describeProtectedExecutionAuthority(snapshot('canonical-server-content-addressed-merge-base', { [ledgerRef]: boundLedger }));
+    const emptyLedger = describeProtectedExecutionAuthority(snapshot('canonical-server-content-addressed-merge-base', {
+      [runnerRef]: runnerContent,
+      [ledgerRef]: JSON.stringify({ schemaVersion: 3, records: [] }),
+    }));
+    const mismatched = describeProtectedExecutionAuthority(snapshot('canonical-server-content-addressed-merge-base', {
+      [runnerRef]: runnerContent,
+      [ledgerRef]: mismatchedLedger,
+    }));
+    const both = describeProtectedExecutionAuthority(snapshot('canonical-server-content-addressed-merge-base', { [runnerRef]: runnerContent, [ledgerRef]: boundLedger }));
+
+    expect(standIn).toEqual(expect.objectContaining({ mode: 'test-stand-in', operationalOnCanonicalMain: false }));
+    expect(standIn.statement).toContain('stand-in only');
+    expect(neither).toEqual(expect.objectContaining({ mode: 'prospective', operationalOnCanonicalMain: false }));
+    expect(neither.requiredCanonicalAdmissions[0]).toBe(runnerRef);
+    expect(neither.requiredCanonicalAdmissions[1]).toContain(ledgerRef);
+    expect(runnerOnly.requiredCanonicalAdmissions).toHaveLength(1);
+    expect(runnerOnly.requiredCanonicalAdmissions[0]).toContain(ledgerRef);
+    expect(ledgerOnly.requiredCanonicalAdmissions[0]).toBe(runnerRef);
+    expect(ledgerOnly.requiredCanonicalAdmissions[1]).toContain(ledgerRef);
+    expect(emptyLedger).toEqual(expect.objectContaining({ mode: 'prospective', runnerDigestBoundByVerdictLedger: false }));
+    expect(emptyLedger.requiredCanonicalAdmissions[0]).toContain('schema-v3 record');
+    expect(mismatched).toEqual(expect.objectContaining({ mode: 'prospective', runnerDigestBoundByVerdictLedger: false }));
+    expect(both).toEqual(expect.objectContaining({ mode: 'operational', operationalOnCanonicalMain: true }));
+    expect(both.runnerDigestBoundByVerdictLedger).toBe(true);
+    expect(both.requiredCanonicalAdmissions).toEqual([]);
+    console.log(`W38_C6 fixtureMode=${standIn.mode} canonicalNeither=${neither.mode} runnerOnly=${runnerOnly.mode} ledgerOnly=${ledgerOnly.mode} emptyLedger=${emptyLedger.mode} mismatchedDigest=${mismatched.mode} canonicalBoundRecord=${both.mode}`);
   });
 
   it('caps candidate strength at the protected article/reference census', async () => {

--- a/upgrades/next/enforcement-measurement.md
+++ b/upgrades/next/enforcement-measurement.md
@@ -21,3 +21,5 @@ The live protected baseline measures 0 of 88 rules at proven ratchet, gate, or l
 ## Known Limits
 
 This change measures protected, behaviorally observed enforcement evidence and uses structural inspection only to explain why an uncertified reference is hollow or unverified. The first pinned runner supports direct Node tests only. It does not itself certify a live guard or alter CI wiring. Independent J7 re-certification of the shared H1 receipt core and independent judge evaluation of this measurement remain pending.
+
+The protected-digest path is **prospective, not operational authority on canonical main** as of W3.8. Canonical main does not yet carry either `scripts/lib/standards-enforcement-node-test-runner.mjs` or `docs/standards-enforcement-verdicts.json`. Operational authority begins only after a merge decision admits both the runner bytes and a structurally valid schema-v3 ledger record whose execution plan binds the exact admitted runner SHA-256. The machine-readable report repeats that state under `measurement.basis.executionAuthority`; test fixtures are labeled stand-ins and cannot satisfy the canonical-main condition.

--- a/upgrades/side-effects/w38-live-artifact-closure.md
+++ b/upgrades/side-effects/w38-live-artifact-closure.md
@@ -1,0 +1,84 @@
+# Side-Effects Review — W3.8 live-artifact closure
+
+**Version / slug:** `w38-live-artifact-closure`
+**Date:** `2026-08-18`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** different judging lane, pending after PR by operator assignment
+
+## Summary of the change
+
+The standards execution verifier now recursively freezes authenticated artifacts and revalidates their content address plus every copied observation count/classification against the signed observation. Standards measurement now records whether protected execution authority is operational, prospective, a test stand-in, or unavailable; the CLI prints that record. Canonical status becomes operational only when the canonical snapshot contains both the protected runner and a valid schema-v3 verdict record binding its exact SHA-256.
+
+## Decision-point inventory
+
+- `isLiveAuthenticatedExecutionArtifact` — **modify** — adds exact mechanical integrity checks before an artifact can contribute to promotion.
+- `describeProtectedExecutionAuthority` — **add** — classifies an enumerable canonical-state condition and records the specific missing admissions.
+- standards-coverage fallback and CLI output — **modify** — makes absence/non-operation visible instead of silently omitting authority state.
+
+## 1. Over-block
+
+Artifacts created under the W3.7 schema are rejected by the W3.8 live predicate because the schema advances from v3 to v4 and the clean/confirmation copies now include assertion classification fields. There is no persisted artifact migration: artifacts are ephemeral, minted and consumed inside one measurement. A canonical ledger that merely contains a digest-shaped nested value is also rejected; it must contain a structurally valid schema-v3 proof record. That stricter condition is intentional because malformed records are not authority.
+
+## 2. Under-block
+
+This repair establishes internal mechanical consistency, not semantic adequacy. A separately admitted observer, subject, or mutation can still be poorly chosen; independent judgment remains responsible for that meaning. The live WeakSet continues to ensure cloned objects are not promoted even when internally consistent. The prospective authority record does not merge the missing runner or ledger and cannot make canonical protection operational by itself.
+
+## 3. Level-of-abstraction fit
+
+The artifact validator is the correct layer because it owns the exported reusable predicate and has all signed event, receipt, copied-field, and address inputs. The canonical-authority description belongs beside protected snapshot measurement because only that layer knows the snapshot source and reads both canonical files. The CLI only renders the structured record; it does not independently infer authority.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Hard-invariant validation over an enumerable domain.
+
+The modified block path checks exact schema, SHA-256 equality, recursive frozen state, exact signed-field equality, and exact presence of two canonical artifacts. It interprets no conversational meaning and weighs no competing signals. Deterministic refusal is appropriate for this cryptographic/structural authority boundary.
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals judgment point. The states are mechanically enumerable: protected runner bytes absent/present, valid ledger absent/present, exact digest binding mismatched/matched, and canonical/test source.
+
+## 5. Interactions
+
+- **Shadowing:** the new checks extend the existing live-artifact predicate; they do not bypass event or receipt authentication.
+- **Double-fire:** there is one predicate and one authority record. The CLI renders the record produced by measurement and adds an explicit unavailable fallback only when measurement cannot produce one.
+- **Races:** artifacts are deep-frozen before entering the live WeakSet. Measurement still consumes the artifact immediately, but correctness no longer depends on that timing.
+- **Feedback loops:** none. The record is report output and does not mutate canonical state.
+
+## 6. External surfaces
+
+The JSON standards report gains `measurement.basis.executionAuthority`, and non-quiet CLI output gains one human-readable authority line. No network API, database, user message, operator action, or durable ledger write is added. The production resolver already reads canonical GitHub main; this change only describes the resolved state. No operator-facing action is introduced.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design for ephemeral artifacts; portable for canonical status.** Each execution artifact contains machine-local process IDs, sessions, receipts, and timestamps and is consumed in-process. Its structural validation is identical on every machine. The authority record derives from content-addressed canonical repository bytes and therefore converges across machines that resolve the same main SHA. The change emits no user-facing notice, holds no new durable state, and generates no URL.
+
+## 8. Rollback cost
+
+Pure code and documentation revert. No data migration, agent-state repair, or persisted-artifact cleanup is required. Rolling back would reopen the reusable-artifact integrity gap and remove the explicit prospective-state warning.
+
+## Conclusion
+
+The review found the repair at the existing hard-invariant boundaries. The implementation was tightened during review so an operational ledger binding requires a fully valid proof record, and fallback reports also carry an explicit non-operational state. Independent judgment remains assigned to another lane and is not claimed here.
+
+## Second-pass review
+
+**Reviewer:** different judging lane after PR
+**Independent read of the artifact:** pending
+
+The builder does not self-judge. The operator explicitly assigned independent judgment to a different lane.
+
+## Evidence pointers
+
+- `scratchpad/phaseB/REPORT-W38.md`
+- `tests/unit/standards-enforcement-measurement.test.ts`
+- `tests/unit/standards-coverage-ratchet.test.ts`
+
+## Class-Closure Declaration
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence: { enforcementType: gate, citation: tests/unit/standards-enforcement-measurement.test.ts, howCaught: W38_C4 requires the genuine live artifact and every nested copy to remain frozen, while W38_C5 re-addresses each of the fifteen copied observation-field tampers and requires internal consistency and the exported live predicate to reject them; W38_C6 refuses to label fixtures or incomplete canonical snapshots operational }`.

--- a/upgrades/w38-live-artifact-closure.eli16.md
+++ b/upgrades/w38-live-artifact-closure.eli16.md
@@ -1,0 +1,35 @@
+# W3.8 live-artifact closure — plain-English overview
+
+> The one-line version: a reusable execution artifact now proves that its visible result fields still match the signed observation that created it, while the report says plainly that canonical-main authority is not live until both required files are merged there.
+
+## The problem in one breath
+
+W3.7 correctly authenticated the structured test observation used by the immediate standards-measurement path, but its reusable artifact carried convenient copies of the test totals and failure classification. Those copies were mutable, and the exported validator did not recompute the artifact address or compare every copy back to the signed observation. Separately, test fixtures demonstrated the future protected-digest mechanism even though canonical main did not yet contain the protected runner or verdict ledger, leaving room for a reader to mistake a prospective mechanism for an operating one.
+
+## What already exists
+
+- **Protected execution runner** — a content-addressed Node test collector whose signed structured observation is linked to an authenticated child-exit receipt.
+- **Three-run discrimination** — clean, deliberately violated, and pristine-confirmation executions distinguish a meaningful check from a hollow or stateful one.
+- **Canonical snapshot resolver** — production measurement reads a content-addressed merge base derived from the server-advertised canonical main, never candidate-authored tracking state.
+
+## What this adds
+
+The returned artifact is recursively frozen, including its nested copied records. Reusable validation recomputes the artifact SHA-256 and rechecks all five copied observation fields—tests run, passed, failed, assertion failures, and deciding output—for each of the clean, mutated, and confirmation runs. It also retains the existing event, receipt, session, sequence, signature, process, and argv links.
+
+The measurement record now carries an explicit execution-authority state. Test fixtures say they are stand-ins. A canonical snapshot says “operational” only when the admitted runner bytes are present and a structurally valid schema-v3 verdict record binds their exact SHA-256. Missing, malformed, empty, or mismatched inputs remain prospective, and the command-line report prints that state in plain language.
+
+## The safeguards
+
+**Prevents post-construction drift.** Recursive freezing stops a caller from changing nested copied totals or classifications after the artifact is minted.
+
+**Prevents a new address from laundering a forged copy.** Even if an attacker clones the artifact, changes one copied field, recomputes the outer address, and freezes the result, validation compares the copy to the signed observation and rejects it.
+
+**Prevents prospective evidence from reading as live authority.** The production record names both missing canonical admissions and refuses to call the protection operational until the runner and a valid digest-binding ledger record are actually present on canonical main.
+
+## What ships when
+
+This PR ships the validator closure and the explicit prospective-state record. It does not add the runner or verdict ledger to canonical main and does not make that merge decision. Operational authority begins only when a later admitted canonical state contains both required artifacts in the validated form.
+
+## What you actually need to decide
+
+Does this PR accurately close the reusable-artifact integrity gap and make the current prospective authority boundary impossible to misread, without claiming that canonical main has already admitted the protected inputs?


### PR DESCRIPTION
# W3.8 live-artifact closure — plain-English overview

> The one-line version: a reusable execution artifact now proves that its visible result fields still match the signed observation that created it, while the report says plainly that canonical-main authority is not live until both required files are merged there.

## The problem in one breath

W3.7 correctly authenticated the structured test observation used by the immediate standards-measurement path, but its reusable artifact carried convenient copies of the test totals and failure classification. Those copies were mutable, and the exported validator did not recompute the artifact address or compare every copy back to the signed observation. Separately, test fixtures demonstrated the future protected-digest mechanism even though canonical main did not yet contain the protected runner or verdict ledger, leaving room for a reader to mistake a prospective mechanism for an operating one.

## What already exists

- **Protected execution runner** — a content-addressed Node test collector whose signed structured observation is linked to an authenticated child-exit receipt.
- **Three-run discrimination** — clean, deliberately violated, and pristine-confirmation executions distinguish a meaningful check from a hollow or stateful one.
- **Canonical snapshot resolver** — production measurement reads a content-addressed merge base derived from the server-advertised canonical main, never candidate-authored tracking state.

## What this adds

The returned artifact is recursively frozen, including its nested copied records. Reusable validation recomputes the artifact SHA-256 and rechecks all five copied observation fields—tests run, passed, failed, assertion failures, and deciding output—for each of the clean, mutated, and confirmation runs. It also retains the existing event, receipt, session, sequence, signature, process, and argv links.

The measurement record now carries an explicit execution-authority state. Test fixtures say they are stand-ins. A canonical snapshot says “operational” only when the admitted runner bytes are present and a structurally valid schema-v3 verdict record binds their exact SHA-256. Missing, malformed, empty, or mismatched inputs remain prospective, and the command-line report prints that state in plain language.

## The safeguards

**Prevents post-construction drift.** Recursive freezing stops a caller from changing nested copied totals or classifications after the artifact is minted.

**Prevents a new address from laundering a forged copy.** Even if an attacker clones the artifact, changes one copied field, recomputes the outer address, and freezes the result, validation compares the copy to the signed observation and rejects it.

**Prevents prospective evidence from reading as live authority.** The production record names both missing canonical admissions and refuses to call the protection operational until the runner and a valid digest-binding ledger record are actually present on canonical main.

## What ships when

This PR ships the validator closure and the explicit prospective-state record. It does not add the runner or verdict ledger to canonical main and does not make that merge decision. Operational authority begins only when a later admitted canonical state contains both required artifacts in the validated form.

## What you actually need to decide

Does this PR accurately close the reusable-artifact integrity gap and make the current prospective authority boundary impossible to misread, without claiming that canonical main has already admitted the protected inputs?
