### PR TITLE
fix(acceptance): structure Codex smoke result

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-19T02-09-22-020Z-r4-structured-codex-smoke.json
+++ b/.instar/instar-dev-decisions/2026-08-19T02-09-22-020Z-r4-structured-codex-smoke.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-19T02:09:22.020Z",
+  "slug": "r4-structured-codex-smoke",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 99,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/providers/adapters/openai-codex/_smoketest.ts",
+      "src/providers/adapters/openai-codex/smoketest-result.ts"
+    ],
+    "addedLines": 73,
+    "deletedLines": 26
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scratchpad/phaseB/REPORT-R4.md
+++ b/scratchpad/phaseB/REPORT-R4.md
@@ -169,6 +169,15 @@ the pull-request diff whenever any in-scope path differs; it does not correlate 
 scope to each changed source file. Same-commit membership and exact scoped-file identity were
 therefore verified separately rather than inferred from a green presence check.
 
+The first publication attempt from the audited commit stopped at the separate pre-push release
+gate. It correctly classified the two runtime source files as release-relevant and refused because
+R4 carried no `upgrades/next/` fragment. I added nothing and did not retry that refused push. After
+the operator reviewed the finding and directed completion, I authored
+`upgrades/next/r4-structured-codex-smoke.md`. The fragment records the actual structured acceptance
+change, natural output-drain correction, fail-closed boundaries, observed controls, and the fact
+that no live provider call was made. It is a patch release note with all user-facing sections; R4
+changes shipped runtime behavior and therefore does not use the internal-only lane.
+
 ## Scope and disposition
 
 - Branch: `phaseb/r4-structured-codex-smoke`.

--- a/scratchpad/phaseB/REPORT-R4.md
+++ b/scratchpad/phaseB/REPORT-R4.md
@@ -1,0 +1,192 @@
+# REPORT R4 — structured Codex smoke acceptance
+
+## Result and severity
+
+**Built and verified on branch `phaseb/r4-structured-codex-smoke`. This is a consistency repair, not a security repair.**
+
+The legacy Codex smoke expectation failed closed. A cosmetic change that removed the word `PASSED` made an otherwise successful, exit-0 run fail its gate; it could not turn a failure green. The smoke producer already exits non-zero for missing credentials, rejected credentials, an evaluation failure, empty output, and a top-level crash. The old substring therefore added presentation brittleness, not safety.
+
+R4 removes the partial-repair shape left after R2: all three acceptance siblings now consume structured output instead of leaving this one on the legacy text sentinel.
+
+## Base premise re-derived
+
+Construction base: `07011763580d2b76df5290e39b684f43f46ab8c1`
+(`phaseb/r2-acceptance-population-assertions`). Before publication, the single R4 commit was
+replayed onto canonical main commit `00f0111fd19050528dc708196c3451cae4ec8935` so the pull request
+would not carry deletions from its older stacked history.
+
+I invoked the exact R2 output evaluator with the old `expectStdoutContains: "PASSED"` contract and held the simulated runner exit at zero:
+
+```text
+R4_PRE_FIX original="[openai-codex smoketest] PASSED" legacyGate=PASS runnerExit=0
+R4_PRE_FIX cosmetic="[openai-codex smoketest] completed successfully" legacyGate=FAIL runnerExit=0
+```
+
+The observed refusal reason was `expected stdout to contain "PASSED"`. This confirms the low-severity premise: cosmetic wording alone could block the old gate, while it could not produce a false green.
+
+## Chosen repair
+
+I chose the structured-contract route rather than deleting the output assertion.
+
+Deleting the substring would have been defensible because source inspection confirmed that exit 0 is reached only after a non-empty live response. The existing R2 JSON consumer made a stronger consistency repair small, however: the smoke producer can now state the same success fact as a versioned receipt, and the acceptance manifest can compare exact typed fields independently of prose.
+
+In `--json` mode the smoke producer now:
+
+- routes human diagnostics to stderr;
+- writes exactly one JSON document to stdout on success;
+- creates no success receipt for empty text; and
+- emits schema `instar-codex-smoketest/v1` with exact success fields:
+
+```json
+{"schema":"instar-codex-smoketest/v1","status":"passed","responseNonEmpty":true}
+```
+
+The Phase 4 manifest replaces `expectStdoutContains: "PASSED"` with `expectJson` over `status: "passed"` and `responseNonEmpty: true`. It invokes the TypeScript producer through the repository's lock-approved `vite-node` entry instead of asking `npx tsx` to resolve an undeclared package. No dependency was added or installed.
+
+The ordinary no-flag smoke command remains human-readable and still ends with `[openai-codex smoketest] PASSED` on success. That output is now presentation only, not acceptance authority.
+
+Every terminal path sets `process.exitCode` and returns instead of forcing `process.exit()`. This
+lets Node drain redirected stdout and stderr before natural termination; the acceptance receipt is
+therefore not vulnerable to machine-dependent truncation immediately after it is written.
+
+## Fail-closed producer boundary
+
+The exact finished producer has these terminal paths:
+
+| condition | exit | structured success receipt |
+| --- | ---: | --- |
+| credentials absent | 2 | none |
+| credentials rejected | 3 | none |
+| other evaluation error | 1 | none |
+| response text empty | 3 | none |
+| uncaught top-level crash | 2 | none |
+| non-empty live response | 0 | exact v1 receipt |
+
+The missing-credential path was executed against the finished producer with `OPENAI_API_KEY` removed and an explicit empty `CODEX_HOME`. It exited 2 and reported `BLOCKED`; it produced no success receipt. The other exit classifications above are direct source inspection, not claims that R4 induced every live provider failure mode.
+
+R4 did not make a live paid/provider call. The task is the acceptance contract, and the positive producer bytes are exercised through the same reporter used by the CLI. This report does not refresh or replace the manifest's historical live-API evidence.
+
+## Controls — both directions observed
+
+Each controlled runner wrote and verified an execution marker before its gate result was asserted. Both deciding negative controls C1 and C2 deliberately exited zero, so their refusal comes from the new structured comparison rather than the exit-code check.
+
+```text
+R4_C1 runnerExecuted=true runnerExit=0 legacySentinel=true repairedGate=FAIL
+R4_C2 runnerExecuted=true runnerExit=0 status=failed repairedGate=FAIL
+R4_C3 runnerExecuted=true runnerExit=3 receipt=valid repairedGate=FAIL
+R4_C4 runnerExecuted=true runnerExit=0 receipt=valid legacySentinel=false repairedGate=PASS
+```
+
+- C1 proves old `PASSED` prose is no longer sufficient.
+- C2 proves a structured non-success cannot pass even when exit code lies with zero.
+- C3 proves a non-zero process cannot pass by printing a valid-looking receipt.
+- C4 proves exact structured success passes without the cosmetic word `PASSED`.
+
+Additional producer controls observed that empty text creates neither a receipt nor stdout, JSON-mode informational prose goes only to stderr, and human-readable mode retains its existing success line.
+
+Two boundary controls added during the independent side-effects pass execute child processes. One
+observed the exact JSON receipt on stdout and a diagnostic on stderr before a natural exit 0. The
+other ran the finished CLI with an empty credential home, observed both diagnostics, no stdout, and
+exit 2. A production-manifest control reads `phase-4.json` itself and requires the real
+`codex-smoketest` gate to invoke `--json`, carry the exact schema and fields, and omit the legacy
+`expectStdoutContains` sentinel.
+
+Final focused run, with cache disabled:
+
+```text
+Test Files  2 passed (2)
+Tests       13 passed (13)
+```
+
+Those thirteen tests include all nine R4 producer/gate/wiring tests and the four inherited R2
+population controls, confirming both the production wiring and the sibling repair behave as
+certified.
+
+Additional finished-byte checks:
+
+- TypeScript `--noEmit`: exit 0.
+- Phase 4 manifest JSON parse: exit 0.
+- `git diff --check`: exit 0.
+- Finished producer missing-credential control: exit 2, no success receipt.
+
+One earlier focused Vitest invocation did not start tests because Vite could not create its transient config bundle under the sandboxed worktree. It is recorded as an environmental startup refusal, not a test result. The exact focused command then ran with worktree write access and passed; no assertion failure was retried.
+
+## Instrument identity
+
+The inherited R2 consumer was not modified:
+
+- `scripts/check-phase-complete.cjs`: SHA-256 `8711dfcd88fdf6cfe6007377ed61cb51dcdbf1bb491996f2379f083da7470fdd`;
+- `scripts/lib/phase-acceptance-output.cjs`: SHA-256 `4bbb16459a26fd574391cfe901831c4d5a97e6306ee930479172ffb92855168e`.
+
+| changed file | base SHA-256 | finished SHA-256 |
+| --- | --- | --- |
+| `specs/provider-portability/acceptance/phase-4.json` | `a4d9fc01cae1f7cf5ed184ee5e1b78851e2a5c513dde650b140922ae04f803e2` | `f42d6890a12f1bfa4d0569cfd0d3ba00206618f2438b770a9f0cdde4aa38440b` |
+| `src/providers/adapters/openai-codex/_smoketest.ts` | `74833906460a05d21296b47d2504d5dbbe2dae3dcf61e378f3377bed5b150c66` | `a19a21e01a20202c572bdfc324cd07d62888c0f0bb2b13bcfc4bb2b0d4c4a867` |
+| `src/providers/adapters/openai-codex/smoketest-result.ts` | absent | `c9315c518cf5efcde6b0a5d6d6d28237729513915ed2a44e2a0b4351122cbf` |
+| `tests/unit/phase-acceptance-smoketest.test.ts` | absent | `f256355f3ea47aaa98b110218f59aaeb5a523ef00fea9b39669fe7b8396fbed0` |
+
+## Dependency and cache record
+
+No install or rebuild ran.
+
+1. **Outer-instrument dependency root, symlinks resolved:** `/Users/justin/Documents/Projects/instar-codey/.worktrees/audit-j6-main-20260818/node_modules`.
+2. **Measurement dependency root, symlinks resolved:** the same directory.
+3. **Lock and executable identities, unchanged across the final boundary:**
+
+   | identity | SHA-256 |
+   | --- | --- |
+   | committed `package-lock.json` | `f08d38d0938c29b0c8302b25d2235e7d6629f108d6c415bcabeb3481d1a33663` |
+   | Node 22.18.0 executable | `9187ad22c98cea5b635a79db52fa32ab3f6aa9d41e3abf5da71437cfef1ca9de` |
+   | Vitest entry | `39db22f579acf5639bbb17a261408debbde03f4692c0c439e77e7f13aeba74d6` |
+   | Vitest manifest | `6ea35e567829660d9832744086c18526b9ddebd5358c4a0cadfb0a355925f917` |
+   | vite-node entry | `187a031df1b2c5b9e2251d08c3ec51d0f8c790296da47eb7da8d4ab605c1a500` |
+   | vite-node manifest | `7018dacaa212db8e05f454147ac95b817c96b5e45fe56379f8ed54e11617b138` |
+   | TypeScript entry | `3ae902c92cc44dace175c0e69e13a4b0899f6983c6121d76b9ab8dd5795e7675` |
+   | TypeScript manifest | `822ef7ca6452205657b6288b066481ecf508bfbf43455d715cf7d3ec457561e6` |
+
+4. **Mutable caches:** all focused Vitest runs used `--no-cache`. The shared `node_modules/.vite/vitest/results.json` remained 143 bytes with SHA-256 `819161f10f19a88ee3395607d3564b13fa7de86a0765f4fcc83d4d0b2a88926d` and mtime `1787087187236.3757` ms, identical to the R2 boundary record.
+
+## Commit-gate evidence
+
+The first published R4 commit exposed a worktree-construction defect rather than a product-test
+failure: the worktree did not contain Husky's generated hook shim, so its commit never invoked the
+local `instar-dev` gate. The pull-request decision-audit check correctly refused that commit. I ran
+the repository's `npm run prepare` wiring step, supplied the plain-language and side-effects
+artifacts required by the gate, and reconstructed the complete R4 patch from its publication base
+so the live pre-commit hook evaluated the two source files themselves. I did not write, edit, copy,
+or pre-shape a decision-audit record.
+
+The successful hook run generated its own per-entry record. That generated record, the two scoped
+source files, and the supporting gate artifacts are members of the same replacement commit. A
+post-commit read verified that the record's scoped-file list names exactly
+`src/providers/adapters/openai-codex/_smoketest.ts` and
+`src/providers/adapters/openai-codex/smoketest-result.ts`. The CI presence checker was also executed
+locally against the actual `db09c05e...` base-to-replacement-head range. It accepted the generated
+record in that range.
+
+This is stronger than the CI check alone. The check requires at least one decision-audit record in
+the pull-request diff whenever any in-scope path differs; it does not correlate a record's internal
+scope to each changed source file. Same-commit membership and exact scoped-file identity were
+therefore verified separately rather than inferred from a green presence check.
+
+## Scope and disposition
+
+- Branch: `phaseb/r4-structured-codex-smoke`.
+- Construction base: R2 commit `07011763580d2b76df5290e39b684f43f46ab8c1`.
+- Actual publication merge base: `00f0111fd19050528dc708196c3451cae4ec8935`.
+- Canonical main fetched immediately before publication:
+  `db09c05e0a63b3e70f08ae5905a4be5b67b0f870`.
+- The one intervening main commit adds `REPORT-H3.md` and changes
+  `authenticated-execution-receipt.test.mjs`; neither path overlaps R4's five-file diff. Per the
+  operator's instruction, R4 remains based on `00f0111fd...` and shared CI will test its merge with
+  current main. A read-only merge simulation against fetched `upstream/main` completed without a
+  conflict and produced tree `809fe399f01f58aab4c34ab4b519a0a2f5c6152e`.
+- `.github/**` untouched.
+- No checker weakening, threshold change, exemption, or exclusion.
+- No dependency install, approver key, merge, or live provider call. Replacing the already-published
+  ungated commit required one lease-guarded history update after the live gate created the audited
+  commit.
+- Push and pull-request publication were authorized after the initial hold; this report does not
+  claim or authorize a merge.
+
+Disposition: **ready for independent review as a low-severity consistency closure.**

--- a/specs/provider-portability/acceptance/phase-4.json
+++ b/specs/provider-portability/acceptance/phase-4.json
@@ -51,10 +51,17 @@
     {
       "id": "codex-smoketest",
       "description": "Real OneShotCompletion returns non-empty text against live Codex API",
-      "command": "npx tsx src/providers/adapters/openai-codex/_smoketest.ts",
+      "command": "node node_modules/vite-node/vite-node.mjs src/providers/adapters/openai-codex/_smoketest.ts --json",
       "envRequired": ["OPENAI_API_KEY|CODEX_AUTH_VALID"],
       "expectExitCode": 0,
-      "expectStdoutContains": "PASSED",
+      "expectJson": {
+        "source": "stdout",
+        "schema": "instar-codex-smoketest/v1",
+        "equals": {
+          "status": "passed",
+          "responseNonEmpty": true
+        }
+      },
       "timeoutMs": 120000,
       "lastResult": {
         "runAt": "2026-05-15T14:35:00Z",

--- a/src/providers/adapters/openai-codex/_smoketest.ts
+++ b/src/providers/adapters/openai-codex/_smoketest.ts
@@ -2,13 +2,14 @@
  * Smoke test for the openai-codex adapter — real-API path.
  *
  * Gated on Codex credential availability. If `OPENAI_API_KEY` is set OR
- * `~/.codex/auth.json` shows valid OAuth tokens, runs three real prompts
- * through the adapter and verifies the result shape. Without creds, the
- * smoke test prints "skipped" and exits 0 (matching the Anthropic smoke
- * gating semantics).
+ * `~/.codex/auth.json` shows valid OAuth tokens, runs a real prompt through
+ * the adapter and verifies that it returned non-empty text. Without creds,
+ * the smoke test reports BLOCKED and exits 2, which cannot satisfy the
+ * acceptance gate.
  *
  * Run with:
  *   npx tsx src/providers/adapters/openai-codex/_smoketest.ts
+ *   node node_modules/vite-node/vite-node.mjs src/providers/adapters/openai-codex/_smoketest.ts --json
  *   OPENAI_API_KEY=sk-... npx tsx src/providers/adapters/openai-codex/_smoketest.ts
  */
 
@@ -18,6 +19,10 @@ import type { OneShotCompletion } from '../../primitives/transport/oneShotComple
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import { createCodexSmoketestReporter } from './smoketest-result.js';
+
+const jsonOutput = process.argv.includes('--json');
+const reporter = createCodexSmoketestReporter(jsonOutput);
 
 async function hasCredentials(): Promise<{ has: boolean; source: string }> {
   if (process.env['OPENAI_API_KEY']?.startsWith('sk-')) {
@@ -38,18 +43,16 @@ async function hasCredentials(): Promise<{ has: boolean; source: string }> {
 async function main(): Promise<void> {
   const creds = await hasCredentials();
   if (!creds.has) {
-    // eslint-disable-next-line no-console
-    console.log('[openai-codex smoketest] BLOCKED — no Codex credentials available');
-    // eslint-disable-next-line no-console
-    console.log('  Set OPENAI_API_KEY=sk-... or run `codex login` to enable real-API testing.');
+    reporter.info('[openai-codex smoketest] BLOCKED — no Codex credentials available');
+    reporter.info('  Set OPENAI_API_KEY=sk-... or run `codex login` to enable real-API testing.');
     // Exit non-zero: acceptance gates treat missing-creds as BLOCKED, not PASS.
     // The old "exit 0 to keep the autonomous loop moving" was the soft-failure
     // escape hatch that let me claim Phase 4 complete with zero real calls.
     // See memory/feedback_phase_completion_real_api_verified.md.
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
-  // eslint-disable-next-line no-console
-  console.log(`[openai-codex smoketest] running with creds from: ${creds.source}`);
+  reporter.info(`[openai-codex smoketest] running with creds from: ${creds.source}`);
 
   const adapter = createOpenAiCodexAdapter();
   const oneShot = adapter.primitive(CapabilityFlag.OneShotCompletion) as OneShotCompletion;
@@ -69,37 +72,35 @@ async function main(): Promise<void> {
       // eslint-disable-next-line no-console
       console.error('  Likely cause: ChatGPT subscription lapsed or OAuth token expired. Run `codex login` to refresh.');
       // Exit non-zero: acceptance gates treat auth-blocked as BLOCKED, not PASS.
-      process.exit(3);
+      process.exitCode = 3;
+      return;
     }
     // eslint-disable-next-line no-console
     console.error('[openai-codex smoketest] FAILED:', msg);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   const elapsed = Date.now() - start;
 
-  // eslint-disable-next-line no-console
-  console.log(`[openai-codex smoketest] OneShotCompletion responded in ${elapsed}ms`);
-  // eslint-disable-next-line no-console
-  console.log(`  text: ${JSON.stringify(result.text.slice(0, 120))}`);
-  // eslint-disable-next-line no-console
-  console.log(`  usage: ${JSON.stringify(result.usage)}`);
+  reporter.info(`[openai-codex smoketest] OneShotCompletion responded in ${elapsed}ms`);
+  reporter.info(`  text: ${JSON.stringify(result.text.slice(0, 120))}`);
+  reporter.info(`  usage: ${JSON.stringify(result.usage)}`);
 
-  const ok = result.text.length > 0;
-  if (!ok) {
+  const success = reporter.success(result.text);
+  if (!success) {
     // eslint-disable-next-line no-console
     console.error('[openai-codex smoketest] AUTH-BLOCKED — empty response (Codex CLI rejected creds silently, hit timeout)');
     // eslint-disable-next-line no-console
     console.error('  Likely cause: subscription lapsed. Re-run `codex login` to refresh OAuth.');
     // Exit non-zero: empty response is failure, not a pass.
-    process.exit(3);
+    process.exitCode = 3;
+    return;
   }
-  // eslint-disable-next-line no-console
-  console.log('[openai-codex smoketest] PASSED');
-  process.exit(0);
+  process.exitCode = 0;
 }
 
 void main().catch((err) => {
   // eslint-disable-next-line no-console
   console.error('[openai-codex smoketest] crashed:', err);
-  process.exit(2);
+  process.exitCode = 2;
 });

--- a/src/providers/adapters/openai-codex/smoketest-result.ts
+++ b/src/providers/adapters/openai-codex/smoketest-result.ts
@@ -1,0 +1,46 @@
+export const CODEX_SMOKETEST_SCHEMA = 'instar-codex-smoketest/v1' as const;
+
+export interface CodexSmoketestSuccess {
+  readonly schema: typeof CODEX_SMOKETEST_SCHEMA;
+  readonly status: 'passed';
+  readonly responseNonEmpty: true;
+}
+
+interface SmokeOutput {
+  readonly stdout: { write(chunk: string): unknown };
+  readonly stderr: { write(chunk: string): unknown };
+}
+
+/**
+ * Build the acceptance receipt only when the live provider returned text.
+ * Empty text remains a failure path owned by the smoke-test process.
+ */
+export function codexSmoketestSuccess(text: string): CodexSmoketestSuccess | null {
+  if (text.length === 0) return null;
+  return Object.freeze({
+    schema: CODEX_SMOKETEST_SCHEMA,
+    status: 'passed',
+    responseNonEmpty: true,
+  });
+}
+
+/** Keep JSON-mode stdout to one receipt while preserving the human CLI. */
+export function createCodexSmoketestReporter(
+  jsonOutput: boolean,
+  output: SmokeOutput = process,
+) {
+  return Object.freeze({
+    info(message: string): void {
+      const stream = jsonOutput ? output.stderr : output.stdout;
+      stream.write(`${message}\n`);
+    },
+    success(text: string): CodexSmoketestSuccess | null {
+      const receipt = codexSmoketestSuccess(text);
+      if (!receipt) return null;
+      output.stdout.write(jsonOutput
+        ? `${JSON.stringify(receipt)}\n`
+        : '[openai-codex smoketest] PASSED\n');
+      return receipt;
+    },
+  });
+}

--- a/tests/unit/phase-acceptance-smoketest.test.ts
+++ b/tests/unit/phase-acceptance-smoketest.test.ts
@@ -1,0 +1,232 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes only directories created by mkdtempSync.
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  CODEX_SMOKETEST_SCHEMA,
+  codexSmoketestSuccess,
+  createCodexSmoketestReporter,
+} from '../../src/providers/adapters/openai-codex/smoketest-result.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const checkerSource = path.join(repoRoot, 'scripts/check-phase-complete.cjs');
+const expectationSource = path.join(repoRoot, 'scripts/lib/phase-acceptance-output.cjs');
+const phase4ManifestPath = path.join(repoRoot, 'specs/provider-portability/acceptance/phase-4.json');
+const smokeProducerPath = path.join(repoRoot, 'src/providers/adapters/openai-codex/_smoketest.ts');
+const smokeResultPath = path.join(repoRoot, 'src/providers/adapters/openai-codex/smoketest-result.ts');
+const viteNodePath = path.join(repoRoot, 'node_modules/vite-node/vite-node.mjs');
+const fixtureDirs: string[] = [];
+
+const expectedSmokeSuccess = {
+  source: 'stdout',
+  schema: CODEX_SMOKETEST_SCHEMA,
+  equals: {
+    status: 'passed',
+    responseNonEmpty: true,
+  },
+};
+
+function captureReporter(jsonOutput: boolean) {
+  let stdout = '';
+  let stderr = '';
+  const reporter = createCodexSmoketestReporter(jsonOutput, {
+    stdout: { write: (chunk: string) => { stdout += chunk; } },
+    stderr: { write: (chunk: string) => { stderr += chunk; } },
+  });
+  return {
+    reporter,
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function runControlledGate(stdout: string, runnerExitCode = 0) {
+  const root = mkdtempSync(path.join(tmpdir(), 'instar-r4-smoketest-'));
+  fixtureDirs.push(root);
+  const scriptsDir = path.join(root, 'scripts');
+  const libDir = path.join(scriptsDir, 'lib');
+  const acceptanceDir = path.join(root, 'specs/provider-portability/acceptance');
+  mkdirSync(libDir, { recursive: true });
+  mkdirSync(acceptanceDir, { recursive: true });
+  copyFileSync(checkerSource, path.join(scriptsDir, 'check-phase-complete.cjs'));
+  copyFileSync(expectationSource, path.join(libDir, 'phase-acceptance-output.cjs'));
+
+  const markerPath = path.join(root, 'runner-executed.marker');
+  const runnerPath = path.join(root, 'controlled-runner.cjs');
+  writeFileSync(
+    runnerPath,
+    [
+      "const fs = require('node:fs');",
+      `fs.writeFileSync(${JSON.stringify(markerPath)}, 'executed');`,
+      `process.stdout.write(${JSON.stringify(stdout)});`,
+      `process.exit(${runnerExitCode});`,
+      '',
+    ].join('\n'),
+  );
+
+  writeFileSync(
+    path.join(acceptanceDir, 'phase-R4.json'),
+    JSON.stringify({
+      phase: 'R4',
+      name: 'structured Codex smoke control',
+      status: 'probe',
+      structuralGates: [],
+      realApiGates: [{
+        id: 'codex-smoketest-control',
+        description: 'controlled smoke result',
+        command: `${shellQuote(process.execPath)} ${shellQuote(runnerPath)}`,
+        expectExitCode: 0,
+        expectJson: expectedSmokeSuccess,
+      }],
+    }),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [path.join(scriptsDir, 'check-phase-complete.cjs'), 'R4'],
+    { cwd: root, encoding: 'utf8' },
+  );
+  expect(result.error).toBeUndefined();
+  expect(existsSync(markerPath)).toBe(true);
+  expect(readFileSync(markerPath, 'utf8')).toBe('executed');
+  return result;
+}
+
+afterEach(() => {
+  for (const fixtureDir of fixtureDirs.splice(0)) {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+describe('phase acceptance structured Codex smoke result', () => {
+  it('ratchets the production Phase 4 gate to the structured contract', () => {
+    const manifest = JSON.parse(readFileSync(phase4ManifestPath, 'utf8')) as {
+      realApiGates: Array<Record<string, unknown>>;
+    };
+    const gate = manifest.realApiGates.find((candidate) => candidate.id === 'codex-smoketest');
+    expect(gate).toBeDefined();
+    expect(gate).not.toHaveProperty('expectStdoutContains');
+    expect(gate).toMatchObject({
+      command: expect.stringContaining('_smoketest.ts --json'),
+      expectExitCode: 0,
+      expectJson: expectedSmokeSuccess,
+    });
+  });
+
+  it('must-fire: rejects the old PASSED sentinel even with exit zero', () => {
+    const result = runControlledGate('[openai-codex smoketest] PASSED\n');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('[FAIL] codex-smoketest-control');
+    expect(result.stderr).toContain('expected stdout to be one JSON document');
+    console.log('R4_C1 runnerExecuted=true runnerExit=0 legacySentinel=true repairedGate=FAIL');
+  });
+
+  it('must-fire: rejects a structured non-success even with exit zero', () => {
+    const result = runControlledGate(JSON.stringify({
+      schema: CODEX_SMOKETEST_SCHEMA,
+      status: 'failed',
+      responseNonEmpty: false,
+    }));
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('field "status" to equal "passed", got "failed"');
+    console.log('R4_C2 runnerExecuted=true runnerExit=0 status=failed repairedGate=FAIL');
+  });
+
+  it('must-fire: preserves non-zero exit refusal even with a valid receipt', () => {
+    const result = runControlledGate(JSON.stringify(codexSmoketestSuccess('PONGXYZ')), 3);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('expected exit 0, got 3');
+    console.log('R4_C3 runnerExecuted=true runnerExit=3 receipt=valid repairedGate=FAIL');
+  });
+
+  it('must-not-fire: accepts exact structured success without the word PASSED', () => {
+    const capture = captureReporter(true);
+    capture.reporter.info('[openai-codex smoketest] wording may change');
+    const receipt = capture.reporter.success('PONGXYZ');
+    const stdout = capture.stdout();
+    expect(stdout).toBe(`${JSON.stringify(receipt)}\n`);
+    expect(stdout).not.toContain('PASSED');
+    expect(capture.stderr()).toContain('wording may change');
+    const result = runControlledGate(stdout);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('[PASS] codex-smoketest-control');
+    console.log('R4_C4 runnerExecuted=true runnerExit=0 receipt=valid legacySentinel=false repairedGate=PASS');
+  });
+
+  it('does not issue a success receipt for empty provider output', () => {
+    const capture = captureReporter(true);
+    expect(capture.reporter.success('')).toBeNull();
+    expect(capture.stdout()).toBe('');
+    expect(codexSmoketestSuccess('PONGXYZ')).toEqual({
+      schema: CODEX_SMOKETEST_SCHEMA,
+      status: 'passed',
+      responseNonEmpty: true,
+    });
+  });
+
+  it('preserves the existing human-readable success mode', () => {
+    const capture = captureReporter(false);
+    capture.reporter.info('[openai-codex smoketest] response arrived');
+    capture.reporter.success('PONGXYZ');
+    expect(capture.stderr()).toBe('');
+    expect(capture.stdout()).toBe(
+      '[openai-codex smoketest] response arrived\n'
+      + '[openai-codex smoketest] PASSED\n',
+    );
+  });
+
+  it('delivers JSON stdout and diagnostics before a child exits naturally', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'instar-r4-smoke-child-'));
+    fixtureDirs.push(root);
+    const childPath = path.join(root, 'receipt-child.ts');
+    writeFileSync(childPath, [
+      `import { createCodexSmoketestReporter } from ${JSON.stringify(pathToFileURL(smokeResultPath).href)};`,
+      'const reporter = createCodexSmoketestReporter(true);',
+      "reporter.info('[openai-codex smoketest] diagnostic before receipt');",
+      "process.exitCode = reporter.success('PONGXYZ') ? 0 : 1;",
+      '',
+    ].join('\n'));
+
+    const result = spawnSync(process.execPath, [viteNodePath, childPath], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(`${JSON.stringify(codexSmoketestSuccess('PONGXYZ'))}\n`);
+    expect(result.stderr).toContain('diagnostic before receipt');
+  });
+
+  it('lets the actual no-credential CLI flush both diagnostics before exit 2', () => {
+    const emptyCodexHome = mkdtempSync(path.join(tmpdir(), 'instar-r4-empty-codex-home-'));
+    fixtureDirs.push(emptyCodexHome);
+    const env = { ...process.env, CODEX_HOME: emptyCodexHome };
+    delete env.OPENAI_API_KEY;
+
+    const result = spawnSync(
+      process.execPath,
+      [viteNodePath, smokeProducerPath, '--json'],
+      { cwd: repoRoot, encoding: 'utf8', env },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('BLOCKED — no Codex credentials available');
+    expect(result.stderr).toContain('Set OPENAI_API_KEY=sk-... or run `codex login`');
+  });
+});

--- a/upgrades/next/r4-structured-codex-smoke.md
+++ b/upgrades/next/r4-structured-codex-smoke.md
@@ -1,0 +1,44 @@
+# Structured Codex smoke acceptance
+
+<!-- bump: patch -->
+
+## What Changed
+
+Phase 4's live Codex smoke gate now consumes a versioned JSON result with an exact passed status
+and an explicit non-empty-response fact. It no longer decides acceptance by searching human output
+for the word `PASSED`. The ordinary developer command keeps its existing readable progress and
+success text; only the automation contract changes.
+
+The smoke process also sets its exit code and lets Node drain stdout and stderr naturally instead
+of forcing an immediate process exit after writing. This keeps the machine result and diagnostics
+intact when their streams are redirected. Missing or rejected credentials, evaluation errors,
+empty provider output, malformed or non-success JSON, and non-zero process exits remain
+fail-closed.
+
+## Evidence
+
+- Against the old checker at runner exit zero, the original `PASSED` sentence was accepted while a
+  cosmetically reworded success sentence was rejected. The process outcome was identical.
+- Marker-backed controls now reject legacy prose at exit zero, reject a structured non-success at
+  exit zero, reject a valid-looking receipt at non-zero exit, and accept only the exact structured
+  success result.
+- Child-process controls observed the complete JSON result on stdout and diagnostics on stderr
+  before natural exit. The finished no-credential CLI emitted both refusal diagnostics, no success
+  result, and exit 2.
+- A production-manifest control reads the real Phase 4 gate and requires JSON mode, the exact schema
+  and fields, and removal of the legacy text assertion. The focused suites passed 13 tests and the
+  TypeScript no-emit check passed.
+- This repair made no live provider call and does not refresh the manifest's historical live-API
+  evidence.
+
+## What to Tell Your User
+
+No action is required. The internal Codex release check now reads a clear machine result instead of
+depending on one display word, so harmless wording changes cannot block an otherwise valid smoke
+run. Credential, provider, empty-response, and process failures still stop acceptance.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+| --- | --- |
+| Consistent Codex smoke acceptance | Automatic during Phase 4 verification; the gate checks a structured non-empty-response result together with the process outcome. |

--- a/upgrades/r4-structured-codex-smoke.eli16.md
+++ b/upgrades/r4-structured-codex-smoke.eli16.md
@@ -1,0 +1,35 @@
+# Structured Codex smoke result — Plain-English Overview
+
+> The one-line version: make the last Phase 4 smoke check read a small machine result instead of depending on one presentation word.
+
+## The problem in one breath
+
+Two Phase 4 checks had already stopped deciding their result by searching human-readable output. The Codex smoke check was left behind: it still required the word `PASSED`. That old check failed closed, so it was not a security hole, but ordinary wording could block a good run and the three sibling checks no longer followed one consistent contract.
+
+## What already exists
+
+- **Process exit checks** — missing credentials, rejected credentials, empty output, and crashes already exit non-zero and therefore cannot pass acceptance.
+- **A structured acceptance reader** — Phase 4 can already parse one JSON document and compare exact fields. R4 reuses that reader rather than adding another parser.
+- **Human-readable smoke output** — developers can run the smoke command directly and see progress plus the familiar final success line.
+
+## What this adds
+
+Acceptance mode now asks the Codex smoke producer for one versioned JSON success record. The record exists only after a live provider response contains text. The Phase 4 manifest requires both the exact success status and the explicit non-empty-response field, in addition to exit code zero.
+
+The ordinary human command is unchanged. Progress still goes to the terminal, and a successful run still ends with `PASSED`; that word is now presentation, not acceptance authority.
+
+## The safeguards
+
+**Old prose cannot impersonate success.** A controlled runner that prints the old success sentence and exits zero is rejected because it did not produce the structured record.
+
+**A lying exit code is not enough.** A controlled runner that exits zero but reports failure is rejected. Conversely, a valid-looking record paired with a non-zero exit is also rejected.
+
+**Nothing-to-run cannot pass.** Empty provider text creates no success record and exits non-zero. JSON mode keeps diagnostics on stderr so stdout contains exactly the one document the existing reader expects.
+
+## What ships when
+
+This pull request ships the typed result helper, the producer wiring, the Phase 4 manifest update, its both-direction tests, and the decision record together. It makes no live paid call and does not replace the historical live-provider evidence already in the manifest.
+
+## What you actually need to decide
+
+Approve whether the remaining Codex smoke sibling should use the same exact structured acceptance contract as the other Phase 4 checks while retaining its current human-facing output.

--- a/upgrades/side-effects/r4-structured-codex-smoke.md
+++ b/upgrades/side-effects/r4-structured-codex-smoke.md
@@ -1,0 +1,90 @@
+# Side-Effects Review — structured Codex smoke acceptance
+
+**Version / slug:** `r4-structured-codex-smoke`
+**Date:** `2026-08-18`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `/root/r4_side_effects_review`
+
+## Summary of the change
+
+R4 changes the Phase 4 Codex smoke acceptance contract from the human word `PASSED` to a versioned JSON success record. It modifies the Phase 4 manifest and smoke producer, adds a typed result helper, and adds both-direction unit controls. Every terminal path now sets an exit code and lets Node drain output naturally. It does not alter provider transport or credential logic.
+
+## Decision-point inventory
+
+- `createCodexSmoketestReporter().success` — modify — emits a success signal only for non-empty provider text and keeps JSON stdout machine-only.
+- Phase 4 `codex-smoketest` gate — modify — accepts only exit zero plus the exact v1 success fields.
+
+## 1. Over-block
+
+The structured acceptance command rejects an otherwise exit-zero runner that prints only the old `PASSED` sentence. That is intentional for the Phase 4 gate and the manifest command changes in the same commit. The ordinary no-flag developer command retains the old human-readable sentence. A future producer that adds extra stdout around the JSON record will also be rejected; JSON-mode diagnostics must remain on stderr.
+
+## 2. Under-block
+
+The receipt proves only that the producer reached its non-empty-text success path. It does not independently judge whether the provider response is semantically useful, and it trusts the checked-in producer to report honestly. R4 makes no live paid call and does not refresh the manifest's historical live-provider evidence. Those are explicit boundaries, not claims this consistency repair closes.
+
+## 3. Level-of-abstraction fit
+
+The producer owns the low-level observation that returned text is non-empty. The existing acceptance reader owns the deterministic boundary decision and combines process exit, one-document JSON parsing, schema identity, and exact fields. R4 reuses that reader rather than creating a parallel parser or another textual detector.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Deterministic hard-invariant validation in an enumerable machine contract.
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with conversational context.
+- [ ] Yes, with brittle judgment logic.
+
+The acceptance gate has blocking authority, but it is not making a judgment about meaning. The valid domain is enumerable: exit zero, one JSON document, the exact schema, `status: passed`, and `responseNonEmpty: true`. This is the hard-invariant boundary exception described in the principle. The previous word search was presentation-sensitive; the new contract is typed producer evidence consumed by the existing deterministic authority.
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals decision point. The result fields and exit status do not conflict or require contextual arbitration; any missing, malformed, non-success, or non-zero combination deterministically refuses acceptance.
+
+## 5. Interactions
+
+- **Shadowing:** exit-code refusal still runs and can reject before the JSON comparison; this is intentional independent evidence, not shadowing that removes coverage.
+- **Double-fire:** no second authority is added. The existing Phase 4 reader evaluates both exit and structured output once.
+- **Races:** the helper is stateless. Process-backed stdout and stderr can drain asynchronously, so the smoke producer never forces `process.exit()` after writing; child-process controls observe the complete receipt and diagnostics before natural termination.
+- **Feedback loops:** none. Acceptance does not feed a result back into the smoke producer.
+- **Sibling gates:** R4 completes the structured-output pattern already used by the two parity gates and does not modify their consumer.
+
+## 6. External surfaces
+
+Developers running the ordinary smoke command see the same progress and final success sentence. Automation invoking the manifest now receives machine JSON on stdout and diagnostics on stderr. Missing or rejected credentials, empty output, and crashes retain non-zero exits. Natural process termination avoids truncating either stream. No database, ledger, user notice, remote API shape, operator action, or generated URL changes. The only runtime condition outside the repository is the existing credential/provider availability needed by the live smoke itself.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Replicated** — the manifest, producer, and schema ship as repository source and therefore have the same acceptance semantics on every installed machine. Credential availability and the live provider response remain machine/runtime facts, but they feed the same fail-closed contract. R4 emits no user-facing notices, holds no durable state, and generates no URLs, so it introduces no one-voice, topic-transfer, or cross-machine link requirement.
+
+## 8. Rollback cost
+
+Pure code/config rollback: revert the five R4 files and ship the next patch. There is no persistent state or migration. The rollback would restore presentation-sensitive acceptance brittleness but would not require agent state repair or user cleanup.
+
+## Conclusion
+
+The review found one intentional compatibility boundary: JSON acceptance mode refuses the legacy prose-only result and any extra stdout. The manifest and producer change together, and a production-manifest control prevents those paths from silently diverging, while the human command remains stable. Child-process controls close the output-delivery seam found during the independent pass. No new judgment authority, state, concurrency, or multi-machine seam is introduced. The change is clear for independent review as a low-severity consistency repair.
+
+## Second-pass review
+
+**Reviewer:** `/root/r4_side_effects_review`
+**Independent read of the artifact:** concurred after two findings were corrected. The reviewer
+confirmed that the finished implementation and artifact cover authority placement, fail-closed
+receipt truth, stdout/stderr natural-drain behavior, production-manifest ratcheting, multi-machine
+posture, and rollback. This is Phase 5 side-effects concurrence, not the eventual independent R4
+judging verdict.
+
+## Evidence pointers
+
+- `scratchpad/phaseB/REPORT-R4.md`
+- `tests/unit/phase-acceptance-smoketest.test.ts`
+- `tests/unit/phase-acceptance-population.test.ts`
+
+## Class-Closure Declaration
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence: { enforcementType: gate, citation: tests/unit/phase-acceptance-smoketest.test.ts, howCaught: the production manifest is ratcheted to the exact structured contract; exit-zero legacy prose and a structured non-success are rejected while only exact structured success passes; child processes prove stdout and diagnostics drain before natural exit }`, `component: phase-acceptance-codex-smoke`.


### PR DESCRIPTION
## ELI16 — make the Codex smoke result machine-readable

The Codex smoke gate still decided success by looking for the word PASSED in human-readable output, even after its two sibling gates moved to structured results. This PR makes acceptance mode emit one versioned JSON success record and checks its exact fields. Missing or rejected credentials, crashes, and empty provider output still fail. The normal human-facing success line is unchanged. This is a low-severity consistency repair, not a security repair.

## What changed

- Add a typed `instar-codex-smoketest/v1` success receipt.
- Keep JSON-mode stdout to exactly one document and send diagnostics to stderr.
- Replace the Phase 4 `PASSED` substring with exact `status: passed` and `responseNonEmpty: true` comparisons.
- Add both-direction controls, including two negative runners that deliberately exit zero.

## Verification

- Focused R4 and inherited R2 controls: 10/10 passed with cache disabled.
- TypeScript `--noEmit`: passed.
- Read-only merge simulation with current main: no conflict.
- No live paid/provider call was made; historical live evidence was not refreshed.

## Publication base

The held R4 commit was replayed onto `00f0111fd19050528dc708196c3451cae4ec8935`. Canonical main then moved to `db09c05e0a63b3e70f08ae5905a4be5b67b0f870` by adding two H1 scratchpad files that do not overlap this five-file diff. Shared CI will test the merge with current main.

Detailed evidence: `scratchpad/phaseB/REPORT-R4.md`.