### PR TITLE
fix: classify codex rate-limit windows by declared length, not key order

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-19T20-04-36-070Z-codex-window-classification.json
+++ b/.instar/instar-dev-decisions/2026-08-19T20-04-36-070Z-codex-window-classification.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-19T20:04:36.070Z",
+  "slug": "codex-window-classification",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 71,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/QuotaPoller.ts"
+    ],
+    "addedLines": 69,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/codex-window-classification.eli16.md
+++ b/docs/specs/codex-window-classification.eli16.md
@@ -1,0 +1,43 @@
+# Codex Window Classification — Plain-English Overview
+
+> The one-line version: read what codex says a usage window IS, instead of assuming the first one it sends is always the short one.
+
+## The problem in one breath
+
+Codex tells us how much of a subscription has been used across two windows — a short one that refills every five hours, and a long one that refills weekly. Instar assumed the first window in the message was always the five-hour one. On a live pro account it wasn't: codex sent the WEEKLY window first and omitted the other. Instar filed a fraction of a seven-day allowance as if it were a five-hour figure.
+
+## What already exists
+
+- **The usage poller** — asks each enrolled account how much it has spent and records two numbers, one per window. Already working; the numbers themselves were correct.
+- **The account switcher** — moves work off an account approaching its limit, and moves it back after the window refills. It reads those two numbers as window LENGTHS.
+- **The load-shed brake** — stops starting new work when an account is walled, and decides how long to wait based on which window is exhausted.
+- **Placement** — decides which machine and account a new session lands on.
+
+None of those re-derive the window length. They trust the label. So a mislabel is not a display bug — it is a wrong input to three separate decisions.
+
+## What this adds
+
+Each window is now sorted by the length it declares, not by the order it arrived in. If codex says a window is 10,080 minutes long, it is filed as the weekly one no matter which slot it came in.
+
+- Ties — both windows landing in the same class — resolve deterministically: the shortest represents the short bucket, the longest the long one. A bucket is never filled by an arbitrary pick.
+- A window that declares no usable length keeps its old positional meaning. So the change can only ever correct a mislabel; it cannot introduce one.
+
+## The new pieces
+
+- **`classifyCodexWindows`** — a pure function that takes the two windows and returns which is short and which is long. It does not fetch, cache, or decide anything about usage; it only sorts. It is deliberately not allowed to invent a window that codex did not send.
+
+## The safeguards
+
+**Prevents a silent regression on accounts that were fine.** An account reporting windows in the conventional order classifies exactly as before — the same two numbers land in the same two places.
+
+**Prevents a new failure on incomplete data.** Codex sometimes omits a window or sends one without a declared length. Rather than guessing, those keep the behaviour that shipped before this change.
+
+**Prevents a false correction.** The boundary between "short" and "long" is a full day. Codex's real values are 300 and 10,080 minutes, so there is no realistic value that sits near the line and could flip class from noise.
+
+## What ships when
+
+One patch. There are no phases, no dark flag and no rollout stages — the function is either correct or it isn't, and it is covered by tests both ways.
+
+## What you actually need to decide
+
+Nothing operational: this is a straight correction with no configuration and no user action. The only question for a reviewer is whether sorting by declared length rather than arrival order is the right rule — and it is, because arrival order is a convention of the sender while the declared length is the sender stating a fact.

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -278,6 +278,69 @@ export function mapUsageResponse(
   return snap;
 }
 
+/**
+ * Boundary between codex's short (5-hour) and long (weekly) rate-limit windows,
+ * in minutes. Codex reports 300 and 10080; anything under a day is the short window.
+ */
+export const CODEX_LONG_WINDOW_MIN_MINUTES = 1440;
+
+/**
+ * Route codex's two rate-limit windows into the short (5h) and long (weekly) buckets
+ * by the `windowMinutes` each window REPORTS, rather than by whether it arrived under
+ * the `primary` or `secondary` key.
+ *
+ * WHY (found on real hardware, 2026-08-19): the mapping used to be positional —
+ * `primary → fiveHour`, `secondary → sevenDay` — because codex conventionally puts the
+ * 5-hour window first. A live account on the pro plan reported `primary` with
+ * `window_minutes: 10080` (the WEEKLY window) and `secondary: null`. The pool duly
+ * recorded 20% of a seven-day allowance as a five-hour figure, and the account page
+ * showed a weekly wall resetting "in hours". Every consumer of fiveHour/sevenDay —
+ * proactive swap, placement, the load-shed brake — reads those two fields as window
+ * LENGTHS, so a mislabel there is a wrong decision, not a cosmetic one.
+ *
+ * Positional order is a convention of the producer; `windowMinutes` is the producer
+ * stating what the window actually is. Prefer the statement over the convention.
+ *
+ * Ties are resolved deterministically: when both windows fall in the same class the
+ * more extreme one represents it (shortest for the short bucket, longest for the long),
+ * so a bucket is never filled by an arbitrary pick. A window carrying no usable
+ * `windowMinutes` falls back to its positional meaning, so this can only correct a
+ * mislabel, never introduce one.
+ */
+export function classifyCodexWindows(
+  primary: CodexUsageSnapshot['primary'],
+  secondary: CodexUsageSnapshot['secondary'],
+): { short: CodexUsageSnapshot['primary']; long: CodexUsageSnapshot['secondary'] } {
+  const candidates: Array<{ w: NonNullable<CodexUsageSnapshot['primary']>; positional: 'short' | 'long' }> = [];
+  if (primary) candidates.push({ w: primary, positional: 'short' });
+  if (secondary) candidates.push({ w: secondary, positional: 'long' });
+
+  const classOf = (c: (typeof candidates)[number]): 'short' | 'long' => {
+    const m = c.w.windowMinutes;
+    if (typeof m !== 'number' || !Number.isFinite(m) || m <= 0) return c.positional;
+    return m >= CODEX_LONG_WINDOW_MIN_MINUTES ? 'long' : 'short';
+  };
+  // A window with no usable length keeps its positional meaning; ranking it by a
+  // sentinel would let it beat a window that genuinely stated its length.
+  const lengthOf = (c: (typeof candidates)[number]): number =>
+    typeof c.w.windowMinutes === 'number' && Number.isFinite(c.w.windowMinutes) && c.w.windowMinutes > 0
+      ? c.w.windowMinutes
+      : c.positional === 'short'
+        ? 0
+        : Number.MAX_SAFE_INTEGER;
+
+  let short: CodexUsageSnapshot['primary'] = null;
+  let long: CodexUsageSnapshot['secondary'] = null;
+  for (const c of candidates) {
+    if (classOf(c) === 'short') {
+      if (!short || lengthOf(c) < (short.windowMinutes ?? Number.MAX_SAFE_INTEGER)) short = c.w;
+    } else {
+      if (!long || lengthOf(c) > (long.windowMinutes ?? 0)) long = c.w;
+    }
+  }
+  return { short, long };
+}
+
 export class QuotaPoller {
   private readonly pool: SubscriptionPool;
   private readonly pollIntervalMs: number;
@@ -493,8 +556,12 @@ export class QuotaPoller {
         }
         return { utilizationPct: value.usedPercent, resetsAt: value.resetsAtIso ?? '' };
       };
-      const fiveHour = window(usage.primary);
-      const sevenDay = window(usage.secondary);
+      // Route each window by the length IT reports, not by which key it arrived under
+      // (see classifyCodexWindows) — a weekly window filed as `fiveHour` tells every
+      // downstream swap/placement decision that a multi-day wall clears in hours.
+      const { short: shortWindow, long: longWindow } = classifyCodexWindows(usage.primary, usage.secondary);
+      const fiveHour = window(shortWindow);
+      const sevenDay = window(longWindow);
       const snap: AccountQuotaSnapshot = {
         source: 'codex-rollout',
         measuredAt: usage.capturedAt ?? nowIso,

--- a/tests/unit/codex-window-classification.test.ts
+++ b/tests/unit/codex-window-classification.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { classifyCodexWindows, CODEX_LONG_WINDOW_MIN_MINUTES } from '../../src/core/QuotaPoller.js';
+import type { CodexRateWindow } from '../../src/providers/adapters/openai-codex/observability/codexRateLimitReader.js';
+
+const win = (usedPercent: number, windowMinutes: number): CodexRateWindow => ({
+  usedPercent,
+  remainingPercent: 100 - usedPercent,
+  windowMinutes,
+  resetsAt: 1787196626,
+  resetsAtIso: '2026-08-20T03:30:26.000Z',
+  resetsInSeconds: 36596,
+});
+
+describe('classifyCodexWindows', () => {
+  it('routes the conventional shape (primary=5h, secondary=weekly) unchanged', () => {
+    const { short, long } = classifyCodexWindows(win(13, 300), win(93, 10080));
+    expect(short?.usedPercent).toBe(13);
+    expect(long?.usedPercent).toBe(93);
+  });
+
+  // THE REGRESSION (live capture, 2026-08-19): a pro account reported the WEEKLY
+  // window under `primary` with `secondary: null`. Positional mapping filed 20% of a
+  // seven-day allowance as a five-hour figure.
+  it('routes a WEEKLY window arriving under `primary` to the long bucket', () => {
+    const { short, long } = classifyCodexWindows(win(20, 10080), null);
+    expect(short).toBeNull();
+    expect(long?.usedPercent).toBe(20);
+    expect(long?.windowMinutes).toBe(10080);
+  });
+
+  it('routes a 5h window arriving under `secondary` to the short bucket', () => {
+    const { short, long } = classifyCodexWindows(null, win(42, 300));
+    expect(short?.usedPercent).toBe(42);
+    expect(long).toBeNull();
+  });
+
+  it('classifies exactly at the boundary as the long window', () => {
+    const { short, long } = classifyCodexWindows(win(5, CODEX_LONG_WINDOW_MIN_MINUTES), null);
+    expect(short).toBeNull();
+    expect(long?.usedPercent).toBe(5);
+  });
+
+  it('both short ⇒ the SHORTER window represents the short bucket, deterministically', () => {
+    const { short, long } = classifyCodexWindows(win(10, 600), win(70, 300));
+    expect(short?.usedPercent).toBe(70);
+    expect(short?.windowMinutes).toBe(300);
+    expect(long).toBeNull();
+  });
+
+  it('both long ⇒ the LONGER window represents the long bucket, deterministically', () => {
+    const { short, long } = classifyCodexWindows(win(30, 10080), win(80, 43200));
+    expect(short).toBeNull();
+    expect(long?.windowMinutes).toBe(43200);
+  });
+
+  it('falls back to positional meaning when windowMinutes is unusable', () => {
+    const bad = { ...win(11, 300), windowMinutes: 0 as unknown as number };
+    const { short, long } = classifyCodexWindows(bad, null);
+    expect(short?.usedPercent).toBe(11); // positional: primary ⇒ short
+    expect(long).toBeNull();
+  });
+
+  it('both absent ⇒ both buckets empty', () => {
+    expect(classifyCodexWindows(null, null)).toEqual({ short: null, long: null });
+  });
+});

--- a/tests/unit/quota-poller.test.ts
+++ b/tests/unit/quota-poller.test.ts
@@ -327,6 +327,28 @@ describe('QuotaPoller', () => {
     expect(pool.get('claude-off')!.lastQuota ?? null).toBeNull();
   });
 
+  // REGRESSION (live capture from a pro account, 2026-08-19): codex reported the
+  // WEEKLY window under `primary` with `secondary: null`. The positional mapping filed
+  // 20% of a seven-day allowance as `fiveHour`, so every swap/placement consumer read a
+  // multi-day wall as one that clears in hours.
+  it('files a WEEKLY window arriving under `primary` as sevenDay, not fiveHour', async () => {
+    const p = new QuotaPoller({
+      pool,
+      now: () => Date.parse('2026-08-19T17:17:00Z'),
+      codexUsageReader: async () => ({
+        source: 'codex-rollout', rolloutPath: '/rollout.jsonl', threadId: 't',
+        capturedAt: '2026-08-19T17:17:35.377Z', model: 'gpt-5.4-mini', planType: 'pro', rateLimitReachedType: null,
+        primary: { usedPercent: 20, remainingPercent: 80, windowMinutes: 10080, resetsAt: 1787196626, resetsAtIso: '2026-08-20T03:30:26.000Z', resetsInSeconds: 36596 },
+        secondary: null,
+      }),
+    });
+    pool.addFixture({ ...ACCT, id: 'codex-weekly-first', provider: 'openai', framework: 'codex-cli' });
+    await p.pollAll();
+    const q = pool.get('codex-weekly-first')!.lastQuota!;
+    expect(q.sevenDay?.utilizationPct).toBe(20);
+    expect(q.fiveHour).toBeUndefined();
+  });
+
   it('normalizes a Codex window to fresh 0% after its known reset passes', async () => {
     const now = Date.parse('2026-06-08T00:00:00Z');
     const p = new QuotaPoller({

--- a/upgrades/next/r3-codex-window-classification.md
+++ b/upgrades/next/r3-codex-window-classification.md
@@ -1,0 +1,48 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**Codex usage windows are now labelled by the length the window reports, not by the order codex
+sends them in.** Codex reports two rate-limit windows — a short (5-hour) one and a long (weekly)
+one — and instar used to assume the first one was always the 5-hour window, because that is
+codex's usual ordering.
+
+Observed live on a pro account (2026-08-19): codex reported the WEEKLY window first
+(`window_minutes: 10080`) with the second window absent entirely. Instar duly filed a fraction of a
+seven-day allowance as a five-hour figure.
+
+That is not a display bug. Everything downstream reads those two fields as window LENGTHS —
+proactive account swap, session placement, and the codex load-shed brake. A weekly wall filed as a
+five-hour one tells all of them that a multi-day exhaustion clears in a couple of hours, so an
+account that is actually out for days looks like it is about to come back.
+
+`classifyCodexWindows` now routes each window by the `window_minutes` it declares. Position is a
+convention of the producer; `window_minutes` is the producer stating what the window actually is.
+Ties resolve deterministically (shortest represents the short bucket, longest the long), and a
+window carrying no usable `window_minutes` keeps its old positional meaning — so the change can
+only correct a mislabel, never introduce one.
+
+## Evidence
+
+- New focused classification suite: 8 tests covering weekly-under-primary, absent secondary,
+  conventional ordering, same-class ties, and missing/invalid `window_minutes` fallback.
+- Existing quota-poller suite extended and green: 23 tests.
+- Both suites pass against the live tree (31 tests, 0 failures).
+- Found on real hardware while enrolling a second codex account, which put two codex accounts in
+  one pool for the first time and made the per-account readings comparable enough for the
+  discrepancy to show.
+
+## What to Tell Your User
+
+- **If you run codex accounts, your remaining-usage numbers were capable of being wrong in a way
+  that mattered — this corrects it, no action needed.** A weekly allowance could be reported as if
+  it were the short window that resets in hours. Because the automatic account switching reads
+  those same numbers, it could move work onto an account that was actually exhausted for days.
+  Claude-only agents are unaffected.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Codex rate-limit windows classified by declared length | Automatic. `QuotaPoller` routes each window by its `window_minutes` instead of by `primary`/`secondary` key order. |
+| Safe fallback for windows with no declared length | Automatic. A window with no usable `window_minutes` keeps its positional meaning, so the change can only correct a mislabel. |

--- a/upgrades/side-effects/codex-window-classification.md
+++ b/upgrades/side-effects/codex-window-classification.md
@@ -1,0 +1,195 @@
+# Side-Effects Review — Classify codex rate-limit windows by declared length
+
+**Version / slug:** `codex-window-classification`
+**Date:** `2026-08-19`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`QuotaPoller` mapped codex's two rate-limit windows positionally — `primary → fiveHour`,
+`secondary → sevenDay` — because codex conventionally reports the 5-hour window first. A live pro
+account (2026-08-19) reported `primary` carrying `window_minutes: 10080` (the WEEKLY window) with
+`secondary: null`, so a fraction of a seven-day allowance was recorded as a five-hour figure. The
+change adds `classifyCodexWindows`, a pure function that routes each window into the short/long
+bucket by the `windowMinutes` it declares. Files: `src/core/QuotaPoller.ts`,
+`tests/unit/codex-window-classification.test.ts`, `tests/unit/quota-poller.test.ts`.
+
+## Decision-point inventory
+
+- `QuotaPoller` codex window mapping — **modify** — the two windows are now sorted by declared
+  length rather than by `primary`/`secondary` key position. This is a data-labelling step feeding
+  downstream decisions; it makes no decision itself.
+
+Downstream consumers are **pass-through** (unchanged code, corrected input): the proactive/reactive
+account swap, pool placement, and the codex load-shed brake all read `fiveHour`/`sevenDay` as window
+LENGTHS.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The function classifies; it never rejects a
+window. A window codex sends is always placed somewhere, and a window codex omits stays absent
+exactly as before.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+The nearest analogue is a mislabel this change still cannot correct: if codex sends a window with
+**no** `window_minutes` (or a non-finite/zero value), the function falls back to that window's
+positional meaning. That is deliberate — with no declared length there is nothing better than the
+convention, and inventing a class from a sentinel would let a length-less window outrank one that
+genuinely stated its length. A codex build that dropped `window_minutes` entirely would therefore
+still be classified positionally, i.e. exactly as before this change.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The mislabel originates where the vendor payload is mapped into instar's internal
+shape, so the fix belongs at that mapping — not in each of the three consumers, which would have
+meant three copies of the same length heuristic drifting apart.
+
+It is a low-level, cheap, deterministic transform with no context requirement, which is exactly what
+this layer should hold. No higher-level gate exists that should own it: the swap/placement/brake
+gates consume the labelled numbers and have no access to the raw payload. No lower-level primitive
+was re-implemented — `CodexUsageSnapshot` already carries `windowMinutes`; it was simply not being
+read.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+`classifyCodexWindows` is a pure data-shaping function. It holds no blocking authority: it cannot
+stop a session, refuse a spawn, or shed load. It corrects an INPUT consumed by existing authorities
+(the swap and the load-shed brake), which keep their own decision logic untouched. This is the
+compliant direction — a brittle-but-cheap transform feeding smart consumers, never a brittle
+transform holding the block.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The domain is enumerable and this is
+an invariant, not a judgment: codex defines exactly two window classes with fixed lengths (300 and
+10,080 minutes), and the boundary constant (1440 minutes — one day) sits an order of magnitude away
+from both. There are no competing live signals to weigh; there is one declared fact per window.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. `classifyCodexWindows` runs inside the existing codex mapping path, before
+  any consumer sees the snapshot. It replaces the positional assignment rather than running
+  alongside it, so there is no second mapper it could shadow or be shadowed by.
+- **Double-fire:** not applicable — the function is invoked once per poll per account, on the same
+  schedule as the mapping it replaces. It emits no events.
+- **Races:** none. The function is pure over its two arguments, holds no state, touches no file or
+  shared store, and reads no clock.
+- **Feedback loops:** none introduced. The corrected labels feed the swap/brake, which change which
+  account runs work — but the labels themselves are derived from the vendor payload, not from
+  instar's own behaviour, so there is no path back into the input.
+
+One genuine behavioural interaction worth naming: on an account previously affected by the mislabel,
+the load-shed brake will now correctly treat a weekly wall as multi-day rather than expecting it to
+clear in hours. That is the intended correction, and it means such an account will be avoided for
+longer than it was yesterday — the safe direction (previously it was returned to service while still
+exhausted).
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** no change. The function is internal to quota polling.
+- **Other users of the install base:** codex-enrolled agents get corrected numbers on the next poll.
+  Claude-only agents are a strict no-op (the function is only reached on the codex path).
+- **External systems:** none. No new request is made to codex; the same payload is read more
+  carefully.
+- **Persistent state:** the polled snapshot is overwritten each poll. No schema change, no new
+  field, no migration. A previously-mislabelled stored snapshot self-corrects at the next poll
+  rather than needing repair.
+- **Timing / runtime conditions:** none — the function reads no clock and takes no I/O.
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing actions added or
+  touched. The existing `GET /subscription-pool` and dashboard Subscriptions tab render the same
+  two fields; they now render correct values.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. No dashboard renderer, markup file, approval page, or
+grant/revoke/secret-drop form is staged.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local BY DESIGN, already proxied-on-read at the layer above.**
+
+The reason it should differ per machine: a rate-limit reading is derived from codex's rollout files
+on the local disk, and a per-machine seat is genuinely distinct data — the same account polled on two
+machines is two real observations, not a duplicate. This is why the existing pooled read
+(`GET /subscription-pool?scope=pool`) deliberately keeps the same account individually visible per
+machine rather than coalescing.
+
+That existing merged read is the pool-wide answer and needs no change: it merges whatever each
+machine's poller produced, so correcting the per-machine labelling corrects the pooled view for
+free.
+
+- **User-facing notices:** emits none, so no one-voice gating is required.
+- **Durable state on topic transfer:** holds none — the snapshot is per-machine, overwritten each
+  poll, and a moved topic re-reads the destination machine's own snapshot. Nothing strands.
+- **Generated URLs:** none.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the code change, ship as the next patch. Pure code change.
+- **Data migration:** none. No persistent state, no schema change; the next poll overwrites the
+  snapshot either way.
+- **Agent state repair:** none. No agent needs notifying or resetting.
+- **User visibility:** during a rollback window an affected account returns to the previous
+  mislabel — the pre-change behaviour, not a new regression.
+
+---
+
+## Conclusion
+
+The review produced no design changes. The change is a pure, deterministic relabel at the vendor
+boundary with no block/allow surface, no persistent state, no external calls, and a strictly
+narrowing failure mode: a window that declares its length is now classified correctly, and a window
+that declares nothing keeps exactly the behaviour that shipped before. The one behavioural
+consequence worth flagging to a reviewer is intended and in the safe direction — a genuinely
+exhausted weekly window is now avoided for its real duration rather than being returned to service
+early. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+
+This change touches none of the Phase-5 triggers: it makes no block/allow decision on inbound,
+outbound, or dispatch; it does not touch session lifecycle, compaction, or respawn; it is not a
+coherence gate, idempotency check, or trust level; and it is not a sentinel, guard, gate, or
+watchdog. It is a data-mapping correction consumed by those systems.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/codex-window-classification.test.ts` — 8 tests: weekly-under-primary, absent
+  secondary, conventional ordering, same-class ties, missing/invalid `window_minutes` fallback.
+- `tests/unit/quota-poller.test.ts` — 23 tests, extended for the new mapping.
+- Local run 2026-08-19: 31 tests, 0 failures.
+- Field observation: a live pro account reporting `primary` with `window_minutes: 10080` and
+  `secondary: null`, found while enrolling a second codex account into the pool.


### PR DESCRIPTION
## Problem

`QuotaPoller` mapped codex's two rate-limit windows **positionally** — `primary → fiveHour`, `secondary → sevenDay` — because codex conventionally reports the 5-hour window first.

Observed on a live pro account (2026-08-19): codex reported `primary` carrying `window_minutes: 10080` (the **weekly** window) with `secondary: null`. The pool duly recorded a fraction of a seven-day allowance as a five-hour figure.

This is a wrong decision, not a cosmetic mislabel. Every consumer of `fiveHour`/`sevenDay` reads those fields as window **lengths**: proactive swap, placement, and the codex load-shed brake. A weekly wall filed as a five-hour one tells all of them that a multi-day exhaustion clears in hours.

## Fix

`classifyCodexWindows` routes each window by the `windowMinutes` it declares. Position is a convention of the producer; `window_minutes` is the producer stating what the window actually is — prefer the statement over the convention.

- Ties resolve deterministically (shortest represents the short bucket, longest the long), so a bucket is never filled by an arbitrary pick.
- A window carrying no usable `windowMinutes` keeps its **positional** meaning, so the change can only correct a mislabel, never introduce one.

## Testing

- New `tests/unit/codex-window-classification.test.ts` — 8 tests: weekly-under-primary, absent secondary, conventional ordering, same-class ties, missing/invalid `window_minutes` fallback.
- `tests/unit/quota-poller.test.ts` extended — 23 tests.
- Both green locally (31 tests, 0 failures).

## Provenance

Found on real hardware while enrolling a second codex account — that put two codex accounts in one pool for the first time and made the per-account readings comparable enough for the discrepancy to show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ELI16 — Read what codex SAYS a usage window is, instead of assuming the first one it sends is the short one

Codex tells us how much of a subscription has been used across two windows: a short one that refills every five hours, and a long one that refills weekly. Instar assumed the first window in the message was always the five-hour one.

On a live pro account it was not. Codex sent the **weekly** window first and omitted the other one entirely. So instar filed a fraction of a seven-day allowance as if it were a five-hour figure.

That matters because three separate systems read those two numbers as window *lengths* — the thing that decides how long to wait before using an account again, which account to put work on, and when to stop starting new work. A weekly wall labelled as a five-hour one tells all three that an account which is actually out for days will be back in a couple of hours.

The fix is to sort each window by the length codex declares for it rather than by the order it arrived in. A window that declares no length keeps its old meaning, so this can only ever correct a mislabel — it cannot introduce one.

Nothing to configure, and no user action. Claude-only agents are unaffected.

---

## ELI16 — Read what codex SAYS a usage window is, instead of assuming the first one it sends is the short one

Codex tells us how much of a subscription has been used across two windows: a short one that refills every five hours, and a long one that refills weekly. Instar assumed the first window in the message was always the five-hour one.

On a live pro account it was not. Codex sent the **weekly** window first and omitted the other one entirely. So instar filed a fraction of a seven-day allowance as if it were a five-hour figure.

That matters because three separate systems read those two numbers as window *lengths* — the thing that decides how long to wait before using an account again, which account to put work on, and when to stop starting new work. A weekly wall labelled as a five-hour one tells all three that an account which is actually out for days will be back in a couple of hours.

The fix is to sort each window by the length codex declares for it, rather than by the order it arrived in. A window that declares no length keeps its old meaning, so this can only ever correct a mislabel — it cannot introduce one.

Nothing to configure and no user action. Claude-only agents are unaffected.
