### PR TITLE
fix: detect the tailscale rope from the interface table, not a CLI copy

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-19T20-13-31-838Z-tailscale-interface-detection.json
+++ b/.instar/instar-dev-decisions/2026-08-19T20-13-31-838Z-tailscale-interface-detection.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-19T20:13:31.838Z",
+  "slug": "tailscale-interface-detection",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 71,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/MeshUrlAdvertiser.ts"
+    ],
+    "addedLines": 68,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tailscale-interface-detection.eli16.md
+++ b/docs/specs/tailscale-interface-detection.eli16.md
@@ -1,0 +1,40 @@
+# Tailscale Rope Detection — Plain-English Overview
+
+> The one-line version: ask the machine whether it has a private-network address, instead of asking an app that might be the wrong copy.
+
+## The problem in one breath
+
+When an agent runs on more than one machine, the machines need routes to reach each other. One of those routes is Tailscale — a private network that works from anywhere. Each machine works out whether it has a Tailscale address and advertises that route to the others. It did that by asking the Tailscale command-line tool. On a machine with two Tailscale installs, it asked the wrong one, got told "logged out", and advertised no route at all — while that very route was carrying traffic.
+
+## What already exists
+
+- **Multiple routes between machines** — Tailscale, the local network, and a Cloudflare tunnel. The machines use whichever is healthy, so a single flaky one shouldn't cut a machine off.
+- **Route advertising** — each machine publishes the ways it can be reached, and the others hedge across them.
+- **The Cloudflare tunnel** — the fallback that works from anywhere but is the least reliable of the three; it is the one behind the historical disconnects.
+
+## What this adds
+
+Detection now reads the machine's own network settings first: if a private-network address is bound to a tunnel device, the route exists — whichever background service put it there and however many copies of the app are installed.
+
+- The old method is kept as a fallback for systems whose tunnel device is named unusually, so this can only ever ADD a detection, never remove one that already worked.
+- It needs no program on disk, no command to run, and no search path — it reads state the operating system already holds.
+
+## The new pieces
+
+- **The interface reader** — picks a private-network address bound to a tunnel device. It is deliberately narrow: it only accepts tunnel-shaped device names, and refuses the same address range on an ordinary network adapter.
+
+## The safeguards
+
+**Prevents a false route being advertised.** Some internet providers hand out addresses from the same private range on a normal connection. Advertising one of those as a Tailscale route would tell the other machines to try an address that goes nowhere. Restricting to tunnel devices closes that.
+
+**Prevents losing a detection that used to work.** The old method still runs when the new one finds nothing, so no machine that was detected before stops being detected now.
+
+**Prevents the tests lying about it.** The existing tests previously read the real network of whatever machine ran them — which is both unrepeatable and would have hidden this exact bug. They now pass an explicit empty table.
+
+## What ships when
+
+One patch. No phases, no flag, no rollout stages.
+
+## What you actually need to decide
+
+Nothing operational — there is no setting and no action for anyone to take. The only reviewer question is whether the machine's own network state is a better source of truth than an app's answer about itself, and it is: the address either is bound or it isn't, and no signed-out copy of an app can make a working route disappear.

--- a/src/core/MeshUrlAdvertiser.ts
+++ b/src/core/MeshUrlAdvertiser.ts
@@ -21,6 +21,7 @@
 
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { networkInterfaces } from 'node:os';
 import type { MeshEndpoint } from './types.js';
 import { isRfc1918, isTailscaleCgnat } from './PeerEndpointResolver.js';
 
@@ -125,14 +126,78 @@ const defaultExecFile: ExecFileFn = (file, args, cb) => {
 };
 
 /**
- * Detect this machine's Tailscale IPv4 (Decision 16): `tailscale ip -4` via the
- * resolved bin, accept ONLY a single well-formed 100.64/10 CGNAT address. Bounded
- * 3s, fail-silent → null. Injectable exec + bin-exists for unit tests.
+ * Tunnel-device interface names that carry a Tailscale address: macOS assigns the
+ * tailnet IP to a `utun<N>` device; Linux/BSD to `tailscale0` (or `ts<N>`). Deliberately
+ * NARROW: a carrier-grade-NAT ISP can hand a 100.64/10 address to a real `en0`, and
+ * advertising THAT as a tailscale rope would be a false positive.
+ */
+const TAILSCALE_IFACE_RE = /^(utun\d*|tailscale\d*|ts\d+)$/i;
+
+/**
+ * Pick this machine's Tailscale IPv4 from its OWN network interfaces — a non-internal
+ * 100.64/10 IPv4 bound to a tunnel device (see TAILSCALE_IFACE_RE). Pure over the
+ * supplied interfaces map; null when the machine holds no tailnet address.
+ *
+ * WHY THIS IS THE PRIMARY SOURCE (found via real-hardware dogfooding, 2026-08-19):
+ * `detectTailscaleIp` previously asked a tailscale CLI *binary* whether the machine
+ * had an address. On a machine with TWO Tailscale installs (the macOS app bundle AND
+ * a standalone/brew copy) the two CLIs talk to DIFFERENT daemons over different
+ * sockets. `resolveTailscaleBin` prefers the app bundle; if THAT copy is signed out
+ * while the standalone daemon is the one actually up and holding the tailnet address,
+ * the CLI answers "logged out" and the machine advertises NO tailscale rope — while
+ * the rope is demonstrably working (the operator's laptop, reachable over tailscale
+ * from another machine at the very moment its own agent reported the rope absent).
+ *
+ * The interface table is the machine's own network state rather than one app's opinion
+ * of it: if a tailnet address is bound to a tunnel device, the route exists, whichever
+ * daemon put it there and whichever CLI copies are installed. It also needs no exec,
+ * no binary on disk, and no PATH.
+ */
+export function pickTailscaleIpFromInterfaces(ifaces: NetIfaces): string | null {
+  for (const [name, addrs] of Object.entries(ifaces)) {
+    if (!TAILSCALE_IFACE_RE.test(name)) continue;
+    for (const a of addrs ?? []) {
+      const isV4 = a.family === 'IPv4' || a.family === 4;
+      if (isV4 && !a.internal && isTailscaleCgnat(a.address)) return a.address;
+    }
+  }
+  return null;
+}
+
+/** Read the live interface table, fail-silent to null (never throws into detection). */
+function readSelfInterfaces(): NetIfaces | null {
+  try {
+    return networkInterfaces() as unknown as NetIfaces;
+  } catch {
+    // @silent-fallback-ok: an unreadable interface table just drops us to the CLI
+    // tier below — the SAME behaviour as before this function existed. Nothing hidden.
+    return null;
+  }
+}
+
+/**
+ * Detect this machine's Tailscale IPv4, accepting ONLY a well-formed 100.64/10 CGNAT
+ * address. Two tiers, in order:
+ *
+ *  1. The machine's own network interfaces (authoritative — see
+ *     `pickTailscaleIpFromInterfaces`). No exec, no binary, no app.
+ *  2. `tailscale ip -4` via the resolved bin (Decision 16). Retained as a fallback for
+ *     platforms/configurations where the tunnel device is named unconventionally, so
+ *     this change can only ADD detections, never remove one that worked before.
+ *
+ * Bounded 3s on the exec tier, fail-silent → null. Injectable exec + bin + ifaces so
+ * unit tests exercise each tier hermetically (pass `ifaces: null` to test tier 2 alone).
  */
 export async function detectTailscaleIp(opts?: {
   execFileFn?: ExecFileFn;
   bin?: string | null;
+  ifaces?: NetIfaces | null;
 }): Promise<string | null> {
+  const ifaces = opts?.ifaces === undefined ? readSelfInterfaces() : opts.ifaces;
+  if (ifaces) {
+    const fromIface = pickTailscaleIpFromInterfaces(ifaces);
+    if (fromIface) return fromIface;
+  }
   const bin = opts?.bin === undefined ? resolveTailscaleBin() : opts.bin;
   if (!bin) return null;
   const exec = opts?.execFileFn ?? defaultExecFile;

--- a/tests/unit/MeshEndpointAdvertiser.test.ts
+++ b/tests/unit/MeshEndpointAdvertiser.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   detectTailscaleIp,
+  pickTailscaleIpFromInterfaces,
   pickPrimaryLanIp,
   computeSelfMeshEndpoints,
   endpointsEqual,
@@ -15,23 +16,71 @@ import type { MeshEndpoint } from '../../src/core/types.js';
 describe('detectTailscaleIp', () => {
   it('returns the 100.64/10 address from `tailscale ip -4`', async () => {
     const exec = (_f: string, _a: string[], cb: (e: Error | null, s: string) => void) => cb(null, '100.64.165.27\n');
-    const ip = await detectTailscaleIp({ execFileFn: exec, bin: '/Applications/Tailscale.app/Contents/MacOS/Tailscale' });
+    const ip = await detectTailscaleIp({ execFileFn: exec, bin: '/Applications/Tailscale.app/Contents/MacOS/Tailscale', ifaces: null });
     expect(ip).toBe('100.64.165.27');
   });
   it('rejects a non-CGNAT address (spoofed/unexpected)', async () => {
     const exec = (_f: string, _a: string[], cb: (e: Error | null, s: string) => void) => cb(null, '192.168.1.5\n');
-    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale' })).toBeNull();
+    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale', ifaces: null })).toBeNull();
   });
   it('takes only the FIRST line (multi-address output)', async () => {
     const exec = (_f: string, _a: string[], cb: (e: Error | null, s: string) => void) => cb(null, '100.64.165.27\nfd7a::1\n');
-    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale' })).toBe('100.64.165.27');
+    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale', ifaces: null })).toBe('100.64.165.27');
   });
   it('fails silent (null) on exec error', async () => {
     const exec = (_f: string, _a: string[], cb: (e: Error | null, s: string) => void) => cb(new Error('ENOENT'), '');
-    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale' })).toBeNull();
+    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale', ifaces: null })).toBeNull();
   });
   it('null bin ⇒ null (tailscale not present)', async () => {
-    expect(await detectTailscaleIp({ bin: null })).toBeNull();
+    expect(await detectTailscaleIp({ bin: null, ifaces: null })).toBeNull();
+  });
+});
+
+describe('pickTailscaleIpFromInterfaces', () => {
+  it('picks the 100.64/10 IPv4 bound to a macOS utun tunnel device', () => {
+    const ifaces: NetIfaces = {
+      lo0: [{ address: '127.0.0.1', family: 'IPv4', internal: true }],
+      en1: [{ address: '192.168.87.47', family: 'IPv4', internal: false }],
+      utun11: [{ address: '100.124.55.70', family: 'IPv4', internal: false }],
+    };
+    expect(pickTailscaleIpFromInterfaces(ifaces)).toBe('100.124.55.70');
+  });
+  it('picks the Linux tailscale0 device', () => {
+    const ifaces: NetIfaces = { tailscale0: [{ address: '100.64.165.27', family: 4, internal: false }] };
+    expect(pickTailscaleIpFromInterfaces(ifaces)).toBe('100.64.165.27');
+  });
+  it('IGNORES a CGNAT address on a real NIC (ISP carrier-grade NAT is not a tailnet rope)', () => {
+    const ifaces: NetIfaces = { en0: [{ address: '100.100.1.5', family: 'IPv4', internal: false }] };
+    expect(pickTailscaleIpFromInterfaces(ifaces)).toBeNull();
+  });
+  it('IGNORES a non-CGNAT address on a utun device (a non-tailscale VPN tunnel)', () => {
+    const ifaces: NetIfaces = { utun4: [{ address: '10.8.0.2', family: 'IPv4', internal: false }] };
+    expect(pickTailscaleIpFromInterfaces(ifaces)).toBeNull();
+  });
+  it('returns null when the machine holds no tailnet address', () => {
+    const ifaces: NetIfaces = { en0: [{ address: '192.168.1.10', family: 'IPv4', internal: false }] };
+    expect(pickTailscaleIpFromInterfaces(ifaces)).toBeNull();
+  });
+});
+
+describe('detectTailscaleIp — interface tier beats a wrong-copy CLI', () => {
+  // THE REGRESSION (2026-08-19): two Tailscale installs, the app-bundle copy signed
+  // out while the standalone daemon holds the tailnet address. The CLI tier answers
+  // "logged out"; the machine must STILL advertise its working tailscale rope.
+  it('returns the interface address even when the CLI reports logged out', async () => {
+    const exec = (_f: string, _a: string[], cb: (e: Error | null, s: string) => void) =>
+      cb(null, ''); // `tailscale ip -4` on a signed-out daemon: empty stdout
+    const ifaces: NetIfaces = { utun11: [{ address: '100.124.55.70', family: 'IPv4', internal: false }] };
+    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale', ifaces })).toBe('100.124.55.70');
+  });
+  it('needs no tailscale binary at all when the interface carries the address', async () => {
+    const ifaces: NetIfaces = { utun3: [{ address: '100.64.165.27', family: 'IPv4', internal: false }] };
+    expect(await detectTailscaleIp({ bin: null, ifaces })).toBe('100.64.165.27');
+  });
+  it('falls back to the CLI when no interface carries a tailnet address', async () => {
+    const exec = (_f: string, _a: string[], cb: (e: Error | null, s: string) => void) => cb(null, '100.64.165.27\n');
+    const ifaces: NetIfaces = { en0: [{ address: '192.168.1.10', family: 'IPv4', internal: false }] };
+    expect(await detectTailscaleIp({ execFileFn: exec, bin: 'tailscale', ifaces })).toBe('100.64.165.27');
   });
 });
 

--- a/upgrades/next/r4-tailscale-interface-detection.md
+++ b/upgrades/next/r4-tailscale-interface-detection.md
@@ -1,0 +1,52 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**A machine with two Tailscale installs no longer hides its own working Tailscale route.**
+
+Instar detects whether this machine has a Tailscale address so it can advertise that route to its
+peers. It did so by asking a Tailscale CLI *binary*, preferring the macOS app bundle.
+
+On a machine carrying TWO Tailscale installs — the app bundle AND a standalone or brew copy — the
+two CLIs talk to different daemons over different sockets. If the app-bundle copy is signed out
+while the standalone daemon is the one actually up and holding the address, the CLI answers "logged
+out" and the machine advertises **no** Tailscale endpoint.
+
+Caught on real hardware (2026-08-19): the operator's laptop was reachable over Tailscale from
+another machine at the very moment its own agent reported the rope absent.
+
+The cost is off-LAN. At home the LAN rope covers it; away from home the machine falls back to the
+single Cloudflare rope, which is the flaky one behind the lease disconnects.
+
+`detectTailscaleIp` now reads the machine's own interface table first — a non-internal 100.64/10
+IPv4 bound to a tunnel device. That is the machine's own network state rather than one app's opinion
+of it: if the address is bound, the route exists, whichever daemon put it there.
+
+Deliberately narrow (`utun*` / `tailscale*` / `ts<N>` only), because a carrier-grade-NAT ISP can
+hand a 100.64/10 address to a real `en0` and advertising that as a Tailscale rope would be a false
+positive. The CLI tier is retained as a fallback for platforms whose tunnel device is named
+unconventionally — so this can only ADD a detection, never remove one that already worked.
+
+## Evidence
+
+- `tests/unit/MeshEndpointAdvertiser.test.ts` extended and green — interface-tier detection, the
+  CGNAT-on-`en0` false-positive rejection, and CLI-tier fallback.
+- Existing CLI-tier tests now pass `ifaces: null` explicitly. Without it they read the real
+  interface table of whatever machine runs them, which is non-hermetic and would have masked
+  exactly this bug.
+- Confirmed live: the Studio reached the laptop over Tailscale while the laptop's own agent
+  reported no such route.
+
+## What to Tell Your User
+
+- **If you run instar on more than one machine and any of them has two Tailscale installs, that
+  machine was quietly dropping to its least reliable connection when away from home — this fixes it,
+  no action needed.** You would have noticed it as machines intermittently looking unreachable to
+  each other. Single-machine agents are unaffected.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Tailscale rope detected from the machine's own interface table | Automatic. `detectTailscaleIp` reads a 100.64/10 IPv4 bound to a tunnel device before consulting any CLI. |
+| CGNAT false-positive rejection | Automatic. Only tunnel-device names qualify, so a carrier-grade-NAT address on a real ethernet interface is never advertised as a Tailscale rope. |

--- a/upgrades/side-effects/tailscale-interface-detection.md
+++ b/upgrades/side-effects/tailscale-interface-detection.md
@@ -1,0 +1,207 @@
+# Side-Effects Review — Detect the tailscale rope from the interface table
+
+**Version / slug:** `tailscale-interface-detection`
+**Date:** `2026-08-19`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`detectTailscaleIp` asked a tailscale CLI *binary* whether this machine held a tailnet address,
+preferring the macOS app bundle via `resolveTailscaleBin`. On a machine carrying two Tailscale
+installs (the app bundle AND a standalone/brew copy) the two CLIs talk to different daemons over
+different sockets; when the preferred copy is signed out while the other daemon holds the address,
+the CLI answers "logged out" and the machine advertises no tailscale endpoint. The change adds
+`pickTailscaleIpFromInterfaces`, which reads the machine's own interface table for a non-internal
+100.64/10 IPv4 bound to a tunnel device, and consults it BEFORE the CLI tier — which is retained as
+a fallback. Files: `src/core/MeshUrlAdvertiser.ts`, `tests/unit/MeshEndpointAdvertiser.test.ts`.
+
+## Decision-point inventory
+
+- `MeshUrlAdvertiser.detectTailscaleIp` — **modify** — a new first tier is added ahead of the
+  existing CLI tier. The function decides only whether to ADVERTISE a rope; it never decides
+  reachability, never selects a rope for a request, and never blocks.
+
+Pass-through (unchanged code, corrected input): the mesh lease layer's rope hedging, the rope-health
+monitor's per-(peer, kind) classification, and `GET /health → multiMachine.syncStatus.meshEndpoints`.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable.
+
+The nearest analogue is a false NEGATIVE, which is the bug being fixed: the CLI tier rejected a
+machine that genuinely held a tailnet address. The new tier can only add a detection the CLI tier
+missed; it never suppresses one the CLI tier would have made, because the CLI tier still runs when
+the interface read yields nothing.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+Two detection gaps the change deliberately does not close:
+
+1. **Unconventional tunnel device names.** `TAILSCALE_IFACE_RE` accepts only `utun<N>`,
+   `tailscale<N>`, and `ts<N>`. A platform naming its tunnel device something else falls through to
+   the CLI tier — the pre-change behaviour, so nothing regresses.
+2. **IPv6-only tailnets.** Only IPv4 100.64/10 is accepted, matching the pre-change contract; a
+   machine with only a tailnet IPv6 address is still detected via the CLI tier or not at all,
+   exactly as before.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The question "does this machine hold a tailnet address?" is a fact about this
+machine's network state, so it belongs where the machine describes itself — the advertiser — and it
+should be answered from the OS rather than from an application's opinion about itself.
+
+Reading the interface table is the LOWER-level primitive that was available and unused; the previous
+implementation reached for a higher-level, less reliable proxy (a CLI, which requires a binary on
+disk, a working PATH, an exec, and the right daemon socket). Moving down a layer is the correction.
+
+No higher-level gate exists that should own this: the rope-health monitor and the lease layer consume
+the advertised endpoint set and have no access to the interface table. Nothing was re-implemented —
+`isTailscaleCgnat` (already in `PeerEndpointResolver`) is reused for the range check rather than
+duplicated.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+`pickTailscaleIpFromInterfaces` produces an advertised endpoint — a SIGNAL. It holds no blocking
+authority: it cannot refuse a peer, demote a rope, or fail a lease. The authorities that act on ropes
+(the lease layer's hedging, the rope-health monitor's demote/recover decisions, the recovery probe)
+are untouched and keep their own evidence bars. A wrong signal here produces a rope that fails its
+signed handshake and is demoted by the existing machinery — it cannot itself cause a wrong decision.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. There are no competing signals to
+weigh: the address is either bound to a tunnel device or it is not. The domain is enumerable (an
+invariant — a tailnet IPv4 lives in 100.64/10 and, on the platforms instar supports, on a
+tunnel-shaped device), and the narrowing to tunnel device names is a safety guard against the one
+known ambiguity (carrier-grade NAT on a real adapter), not a judgment about which of several live
+signals wins.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the new tier runs BEFORE the CLI tier and short-circuits on success, so it shadows
+  the CLI tier by design. That is safe because the two answer the same question and the interface
+  table is the more authoritative source; when it yields nothing the CLI tier runs unchanged.
+- **Double-fire:** none. `detectTailscaleIp` returns a single address; two tiers cannot both
+  contribute an endpoint. No events are emitted.
+- **Races:** none introduced. The read is synchronous, allocates nothing shared, and holds no state
+  between calls. It removes a race rather than adding one — the exec-based tier could time out under
+  the process-ceiling exhaustion seen on 2026-08-19 and silently return null.
+- **Feedback loops:** none. The interface table is OS state that instar does not write.
+
+Interaction worth naming explicitly: the **rope recovery probe** (U4.3) re-dials ropes marked dead.
+A machine that previously advertised no tailscale rope had nothing for the probe to recover — the
+rope was invisible, not demoted. After this change such a machine advertises the rope, so a genuinely
+broken tailnet now surfaces as a demoted rope with a recovery episode rather than as silence. That is
+the intended direction (a real state becomes visible), and it uses existing machinery unchanged.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** no change.
+- **Other users of the install base:** multi-machine agents on an affected machine begin advertising
+  a tailscale endpoint that was previously missing. Single-machine agents are a strict no-op (no
+  peers to advertise to, and the server keeps its localhost bind).
+- **External systems:** strictly REDUCES external dependency — the primary path no longer execs a
+  third-party binary. No network call is added.
+- **Persistent state:** none. The advertised endpoint set is recomputed per advertisement; no schema
+  change, no migration, no stored value to repair.
+- **Timing / runtime conditions:** improves them. The primary path removes a bounded-3s subprocess
+  exec from the advertisement path, so it no longer depends on process-table headroom, PATH, or a
+  daemon socket being answerable.
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing actions added or
+  touched. The existing `GET /health` and `GET /mesh/rope-health` reads render the same shape.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. No dashboard renderer, markup file, approval page, or
+grant/revoke/secret-drop form is staged.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local BY DESIGN, advertised across the mesh by the existing endpoint exchange.**
+
+The reason it should differ per machine: an interface address is a fact about the machine that holds
+it and is meaningless on any other. Replicating it would be actively wrong — a peer must never
+conclude it has a tailnet address because a different machine does.
+
+The pool-wide question ("which ropes does each machine have?") is already answered by the existing
+advertisement + `GET /health → multiMachine.syncStatus.meshEndpoints`, which this change feeds
+without altering its shape. This change is only meaningful on a multi-machine agent, which is exactly
+why the single-machine-only assumption trap does not apply: the feature IS the multi-machine path.
+
+- **User-facing notices:** emits none. The rope-health monitor owns notices and already has its own
+  one-voice, episode-scoped gating; this change alters no notice text or trigger.
+- **Durable state on topic transfer:** holds none. Nothing strands — a moved topic's machine reads
+  its own interface table.
+- **Generated URLs:** it contributes the host portion of a mesh endpoint, which is consumed only by
+  peers dialling that machine directly. These are not shareable links and do not cross a machine
+  boundary in a user-visible form.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the code change, ship as the next patch. Pure code change.
+- **Data migration:** none. No persistent state, no schema change.
+- **Agent state repair:** none. Reverting simply returns affected machines to advertising no
+  tailscale rope; the peers' hedging falls back to the other ropes as it does today.
+- **User visibility:** during a rollback window, an affected machine returns to the LAN + Cloudflare
+  ropes — the pre-change behaviour, not a new regression.
+
+---
+
+## Conclusion
+
+The review produced no design changes. The change moves a self-fact from an unreliable proxy (one of
+possibly several CLI copies) to the authoritative source (the OS interface table), keeps the old path
+as a fallback so no working detection is lost, and narrows the accepted device names to close the one
+realistic false-positive (carrier-grade NAT on a real adapter). It removes a subprocess exec from the
+advertisement path, which also removes a failure mode observed the same day under process-table
+exhaustion. It produces a signal, never an authority. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+
+None of the Phase-5 triggers apply: no block/allow decision on inbound, outbound, or dispatch; no
+session lifecycle, compaction, or respawn surface; not a coherence gate, idempotency check, or trust
+level; and not a sentinel, guard, gate, or watchdog. It is a self-describing detection that feeds
+those systems.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/MeshEndpointAdvertiser.test.ts` — interface-tier detection, CGNAT-on-`en0` rejection,
+  CLI-tier fallback preserved.
+- The existing CLI-tier tests now pass `ifaces: null` explicitly; without it they read the real
+  interface table of whatever machine runs them, which is non-hermetic and would have masked this
+  exact bug.
+- Field observation 2026-08-19: the Studio reached the operator's laptop over tailscale at
+  100.x while that laptop's own agent reported only two ropes, the tailscale one absent.


### PR DESCRIPTION
## Problem

`detectTailscaleIp` asked a Tailscale CLI **binary** whether this machine had a tailnet address, preferring the macOS app bundle via `resolveTailscaleBin`.

On a machine with two Tailscale installs — the app bundle AND a standalone/brew copy — the two CLIs talk to **different daemons over different sockets**. If the app-bundle copy is signed out while the standalone daemon is the one actually up and holding the address, the CLI answers "logged out" and the machine advertises **no** Tailscale endpoint.

Found on real hardware (2026-08-19): the operator's laptop was reachable over Tailscale from another machine at the very moment its own agent reported the rope absent.

The practical cost is off-LAN. At home the LAN rope covers it; away from home the machine falls back to the single Cloudflare rope — the flaky one behind the lease disconnects.

## Fix

Read the machine's **own interface table** first: a non-internal 100.64/10 IPv4 bound to a tunnel device. That is the machine's network state rather than one app's opinion of it — if the address is bound, the route exists, whichever daemon put it there and whichever CLI copies are installed. No exec, no binary on disk, no PATH.

`pickTailscaleIpFromInterfaces` is deliberately narrow (`utun*` / `tailscale*` / `ts<N>`) because a carrier-grade-NAT ISP can hand a 100.64/10 address to a real `en0`, and advertising that as a Tailscale rope would be a false positive.

The CLI tier is **retained as a fallback** for platforms whose tunnel device is named unconventionally — so this can only ADD a detection, never remove one that already worked.

## Testing

`tests/unit/MeshEndpointAdvertiser.test.ts` extended: interface-tier detection, CGNAT-on-`en0` rejection, CLI-tier fallback.

The existing CLI-tier tests now pass `ifaces: null` explicitly. Without it they would read the real interface table of whatever machine runs them — non-hermetic, and it would have masked exactly this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ELI16 — Ask the machine whether it has a private-network address, instead of asking an app that might be the wrong copy

When an agent runs on more than one machine, the machines need routes to reach each other. One of those is Tailscale — a private network that works from anywhere. Each machine works out whether it has a Tailscale address and tells the others.

It worked that out by asking the Tailscale command-line tool. On a machine with **two** Tailscale installs, the two copies talk to different background services. Instar asked the signed-out copy, was told "logged out", and advertised no route — while that very route was carrying traffic.

Caught on the operator's laptop: another machine connected to it over Tailscale at the exact moment the laptop's own agent reported that route did not exist.

The cost shows up away from home. On the same network there is a second route that covers it; elsewhere the machine drops to the single Cloudflare tunnel — the least reliable of the three, and the one behind the historical disconnects.

The fix reads the machine's own network settings instead. If a private-network address is bound to a tunnel device, the route exists — whichever background service put it there and however many copies of the app are installed. The old method still runs when this finds nothing, so no machine that was detected before stops being detected now.

Deliberately narrow: some internet providers hand out addresses from the same range on an ordinary connection, so only tunnel-shaped devices qualify. Nothing to configure; single-machine agents are unaffected.
