### PR TITLE
fix: raise launchd process ceiling above the host idle floor, and report the LIVE one

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-19T21-18-40-586Z-launchd-process-ceiling-floor.json
+++ b/.instar/instar-dev-decisions/2026-08-19T21-18-40-586Z-launchd-process-ceiling-floor.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-19T21:18:40.586Z",
+  "slug": "launchd-process-ceiling-floor",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 513,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/setup.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/ProcessCeilingCheck.ts",
+      "src/server/AgentServer.ts"
+    ],
+    "addedLines": 505,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-19T21-19-20-347Z-launchd-process-ceiling-floor.json
+++ b/.instar/instar-dev-decisions/2026-08-19T21-19-20-347Z-launchd-process-ceiling-floor.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-19T21:19:20.347Z",
+  "slug": "launchd-process-ceiling-floor",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 513,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/setup.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/ProcessCeilingCheck.ts",
+      "src/server/AgentServer.ts"
+    ],
+    "addedLines": 505,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-19T21-19-52-244Z-launchd-process-ceiling-floor.json
+++ b/.instar/instar-dev-decisions/2026-08-19T21-19-52-244Z-launchd-process-ceiling-floor.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-19T21:19:52.244Z",
+  "slug": "launchd-process-ceiling-floor",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 513,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/setup.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/ProcessCeilingCheck.ts",
+      "src/server/AgentServer.ts"
+    ],
+    "addedLines": 505,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/carriers/launchd-process-ceiling-floor.json
+++ b/docs/specs/carriers/launchd-process-ceiling-floor.json
@@ -1,0 +1,12 @@
+{
+  "generatedAt": "2026-08-19T21:17:21.077Z",
+  "slug": "launchd-process-ceiling-floor",
+  "carriers": {
+    "CMT-015": {
+      "status": "pending",
+      "owner": "agent",
+      "blockedOn": "none",
+      "excerpt": "(1) HEADROOM PROBE: the ceiling check verifies the LIMIT, not the HEADROOM \u2014 a machine at 1900 of 2048 reports fine. A fork-based count fails exactly when the limit is exhausted, so this needs a non-forking (native) process count. Until it lands, any FUTURE change to the ceiling value is blocked on it, because a ceiling change is precisely the decision that needs headroom baselines \u2014 2048 was chos"
+    }
+  }
+}

--- a/docs/specs/launchd-process-ceiling-floor.eli16.md
+++ b/docs/specs/launchd-process-ceiling-floor.eli16.md
@@ -1,0 +1,45 @@
+# Launchd Process Ceiling — Plain-English Overview
+
+> The one-line version: a safety limit meant to catch a runaway was set lower than the number of programs a normal computer runs while doing nothing, so it fired at rest and eventually took the agent's server down.
+
+## The problem in one breath
+
+Every computer has a cap on how many programs one user account may run at once. Instar sets that cap deliberately, as a last-resort belt in case something of its own runs away. The number chosen was 512 — a sensible-looking figure if you count only instar's own helpers. But the operating system counts EVERY program the logged-in person is running: the desktop itself, the browser, the editor, all of it. An ordinary Mac sits at 500 to 550 while idle. So the belt was already tight before instar started anything.
+
+## What already exists
+
+- **The main control** — a counter that limits how many AI helper programs run at the same time, currently eight. This is the real protection and it works.
+- **The belt** — the operating-system cap this document is about. It exists only to catch something that ignores the counter entirely.
+- **A past incident** — in June, roughly 230 to 290 helper programs started at once and exhausted the machine's memory. That is the event the belt was added for.
+
+## What this adds
+
+The belt's number goes from 512 to 2048. That is the whole functional change.
+
+The reasoning is what matters: 2048 sits about 1,500 above what an idle machine already uses, far above anything the main control would ever let through, and far below the operating system's own hard maximum of 10,666. So it still catches the June-scale runaway, and it no longer fires when nothing is wrong.
+
+- The number is also corrected for computers that already have instar installed, not just new ones — otherwise the fix would reach only the machines that never had the problem.
+
+## The new pieces
+
+- **The corrector** — a small routine that finds the number in the machine's startup settings and raises it if it is too low. It is deliberately allowed only to RAISE, never to lower: someone who set their own, higher number keeps it. It edits that one number and touches nothing else, so anything hand-added to those settings survives. Running it twice changes nothing the second time.
+
+## The safeguards
+
+**Prevents overwriting a deliberate choice.** The corrector acts only on a number strictly below the new minimum. A person who tuned theirs higher is left alone.
+
+**Prevents fixing one outage by causing another.** The corrector does not restart anything. Restarting the background service would make the new number take effect immediately — and would also cut the operator off from their agent mid-update, which is the exact harm this whole change exists to stop. The number is written now and takes effect at the machine's next restart.
+
+**Prevents damage on machines this does not apply to.** Only Apple computers have these startup settings. Elsewhere the corrector records that it skipped, rather than treating it as a failure.
+
+## What ships when
+
+One patch, all at once. There are no stages and nothing to switch on.
+
+## What it does NOT do
+
+Worth being blunt: after updating, a machine still runs under its OLD limit until it is restarted once, and nothing yet notices or reports that gap. During the incident, blocked commands came back empty rather than complaining — which quietly misled the agent into treating "the command never ran" as "here is your answer". Making the live limit visible, and making a blocked command say so, is real work and is not in this change. It is registered separately so it does not get lost.
+
+## What you actually need to decide
+
+Whether raising this limit from 512 to 2048 is acceptable — that is, whether you are comfortable that the belt still catches a genuine runaway (the June event was under 300) while no longer tripping on an idle machine. If yes, this ships and your other two machines pick it up on their next update plus one restart each.

--- a/docs/specs/launchd-process-ceiling-floor.md
+++ b/docs/specs/launchd-process-ceiling-floor.md
@@ -1,0 +1,655 @@
+---
+title: "Launchd Process Ceiling — size the fork-bomb belt against the HOST idle floor, not instar's own subprocess count"
+slug: "launchd-process-ceiling-floor"
+author: "echo"
+status: "draft"
+parent-principle: "Bounded Blast Radius"
+sibling-principles: "The Agent Is Always Reachable — A Guaranteed Reachability Floor; Migration Parity Standard; Verify the State, Not Its Symbol"
+parent-spec: "docs/specs/forkbomb-prevention-simple.md"
+project: "resource-safety"
+depends-on: "installAutoStart (src/commands/setup.ts — writes the agent's launchd plist, the template half of Migration Parity); PostUpdateMigrator (src/core/PostUpdateMigrator.ts — the deployed half); SpawnLimiter (src/core/spawn-limiter.ts — the PRIMARY host-wide concurrent-LLM-subprocess control this belt backstops, never substitutes for)"
+review-verdict: "NOT-CONVERGED — hit the 10-iteration cap; round 10 still produced 2 design-class findings (both fixed). See the report."
+approved: true
+approved-basis: "Justin (verified operator, topic 48000) approved at the cap on 2026-08-19, after being sent the plain-English overview and the full convergence report — which states the NOT-CONVERGED verdict plainly. This records an OPERATOR OVERRIDE of an unmet criterion, not a passing grade: the two-consecutive-clean-rounds criterion was never met."
+review-convergence: "2026-08-19T21:15:20.285Z"
+review-iterations: 10
+review-completed-at: "2026-08-19T21:15:20.285Z"
+review-report: "docs/specs/reports/launchd-process-ceiling-floor-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 5
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Launchd Process Ceiling — size the belt against the host idle floor
+
+## Problem
+
+The fork-bomb prevention work (`docs/specs/forkbomb-prevention-simple.md`) shipped two controls:
+
+1. **The host spawn cap** (PRIMARY) — a counting semaphore bounding concurrent
+   `claude -p` / `codex exec` subprocesses across every compliant instar process
+   (default 8).
+2. **A launchd `NumberOfProcesses` belt** (BACKSTOP) — an OS-level ceiling that bounds a
+   *non-compliant* runaway which bypasses the funnel entirely.
+
+The belt shipped at **512**, a number reasoned against instar's own subprocess count.
+
+That is the wrong denominator. `NumberOfProcesses` maps to `RLIMIT_NPROC`, which the XNU
+kernel enforces **per real UID** — across every process the logged-in user owns, including
+the GUI desktop, browser, editors, and every other application. A normal macOS desktop
+idles at roughly 500–550 user processes.
+
+So the belt sat **below the machine's idle floor**.
+
+### Observed failure (Mac Studio, 2026-08-19)
+
+The failure mode was not a bounded runaway. It was every `fork()` from an
+instar-supervised process returning `EAGAIN` on an otherwise idle machine:
+
+- 531 uid processes against the 512 ceiling.
+- Agent shell commands refused intermittently for hours, with no alarm attached — a
+  command returning empty output was read as an *answer* rather than as a refusal, which
+  corrupted the agent's own judgement (it reported a machine "asleep" on the strength of a
+  command that never ran).
+- Then the agent server itself died on it:
+
+```
+[FATAL] Uncaught unhandledRejection — closing databases before crash:
+        spawnSync ssh-keygen EAGAIN
+libc++abi: terminating due to uncaught exception ... mutex lock failed
+```
+
+The operator was unreachable for roughly two minutes and nothing restarted the server
+automatically.
+
+**A safety limit that trips while the machine is at rest protects nothing; it just
+converts idle into an outage.** It also actively harms the standard it belongs to — it
+converts a *Bounded Blast Radius* control into a *Guaranteed Reachability* violation.
+
+## Decision points touched
+
+> *Local terms: an **invariant** decision point has an enumerable answer space, so it is
+> deterministic by design; a **judgment-candidate** is one where several live signals can
+> genuinely conflict, which under the Judgment Within Floors standard requires a declared
+> deterministic floor plus an arbiter.*
+
+| Decision point | Classification | Justification |
+|---|---|---|
+| The belt's ceiling value | **invariant** | A safety guard on an OS resource limit, deterministic by design. The domain is enumerable: the value must clear the host idle floor and stay under `kern.maxprocperuid`. There are no competing live signals to weigh — it is one number chosen once and applied identically everywhere. |
+| The migration's raise-vs-clobber choice | **invariant** | Not a judgment: an operator-tuned value is authoritative over a shipped default, always. Encoded as a strict `<` comparison against the floor, so the rule cannot drift. |
+| The boot check's verdict | **invariant** | Five enumerable states from two inputs (the live reading, and the plist values): `raise`, `repair`, `future-repair`, `ok`, `unknown`. The two inputs answer two different questions that do not compete — the live reading answers *is this machine safe now?* and the plist answers *will it still be safe after its next restart?* — so the cross-product is enumerable rather than a weighing of rival signals. The conservative default on the unmeasurable branch is silence, because a fabricated verdict in either direction is worse than none. |
+
+> All three rows above are classified `invariant`, and none is a `judgment-candidate`. Each
+> is a deterministic cross-product of bounded inputs with an enumerable answer space — the
+> boot check takes two inputs, not one, but they answer two different, non-competing
+> questions (is it safe now / will it be safe after the next restart), so the result is a
+> lookup rather than a weighing. This spec introduces no point where multiple live signals
+> can genuinely conflict, and therefore declares no floor or arbiter.
+
+## Multi-machine posture
+
+*Local terms used below, defined once (round-2 finding — these depend on instar standards an
+external reader would not have): a **`unified`** surface behaves identically on every machine
+the agent runs on; a **`machine-local`** surface is genuinely per-machine and must not be
+replicated. **One-voice gating** means suppressing duplicate user-facing notices so several
+machines do not each speak about one shared condition. An **Attention item** is a durable
+operator to-do with its own lifecycle — raised once, deduped by key, resolved by the
+operator — routed into a single hub conversation rather than creating a new one.*
+
+**Posture: `unified` for the SHIPPED VALUE, `machine-local` for the EFFECTIVE READING.**
+
+`machine-local-justification: hardware-bound-resource`
+
+The shipped ceiling and the migration are `unified` — every machine running this agent gets
+the same floor written to its own plist by the same migration on update. There is nothing
+per-machine about the policy, and nothing to replicate: the migration runs locally on each
+machine from the same shipped code.
+
+The **effective reading** is machine-local, and the justification key is
+`hardware-bound-resource`: `RLIMIT_NPROC` is a kernel limit applied to a running process on
+one specific machine's kernel. It is not a credential and not a policy — it is a physical
+property of that host's running state, and it is meaningless when read on any other. A
+peer's reading can never answer "is THIS machine's limit raised yet?", which is the only
+question the check asks. Replicating it would be actively wrong: a healthy peer would mask
+an unhealthy machine.
+
+Explicitly:
+
+- **User-facing notices** — yes, one, and it is per-machine BY NECESSITY: each machine
+  needs its own physical restart, so one-voice gating across machines would be the WRONG
+  behaviour — it would suppress the second machine's genuine need and leave a machine
+  crashing with no prompt, which is the original incident.
+
+  On the **Bounded Notification Surface** standard (raised in round 2): the cardinality here
+  is the operator's own machine count — a small, bounded, human-scale collection where every
+  element requires a DISTINCT action from the operator, not a per-element notification over
+  an unbounded collection. It is bounded three times over:
+
+  1. **Deduped per machine** on `(machineId, effectiveCeiling, floor)`, so a machine that
+     goes un-restarted for a week produces ONE item, not one per boot.
+
+     The `machineId` is the agent's own durable machine identity (the same value the pool
+     and the mesh key on), read from config; when absent it falls back to the literal
+     `single-machine`, which is correct for the one-machine case. Its failure modes are
+     bounded and both tolerable here (round-9 finding): if the id RESETS — a reinstall, a
+     cloned disk — the machine re-notifies once, which is the safe direction for a condition
+     that still needs acting on. If two machines ever COLLIDED on an id, the second would be
+     suppressed while the first's item is open; that is the same exposure every per-machine
+     surface in instar already carries, and it is not made worse here.
+  2. **Self-extinguishing.** The condition ends the moment the machine restarts, which is
+     the very action the notice asks for. It cannot accumulate over time the way a
+     detector-over-a-growing-collection can.
+  3. **Rides the existing bounded surface.** It is an ordinary Attention item, so it lands
+     in the single durable Attention hub topic under the existing single-alerts-topic
+     routing and the topic-creation budget. It creates no topic of its own, and the
+     pool-scope attention read is the aggregated cross-machine view.
+
+  Aggregating instead into ONE cross-machine summary was considered and rejected: the
+  summary would have to be raised by one machine ON BEHALF of others, which requires the
+  reading it cannot have (§ the effective ceiling is machine-local and unreplicable), and a
+  machine that is down — the likeliest state for a machine crashing on this very bug —
+  would be omitted from the summary entirely. A per-machine notice is the only form that
+  cannot silently drop the machine it is about.
+- **Durable state on topic transfer** — none held. The check reads the live process at boot
+  and holds nothing across a transfer; the Attention item is already a per-machine record
+  with its own lifecycle. Nothing strands.
+- **Generated URLs** — none.
+
+## Frontloaded Decisions
+
+1. **Ceiling value: 2048, static.** Chosen against the host idle floor; install-time
+   dynamic sizing rejected with reasons in §1. Decided here, not handed to the operator.
+2. **The belt does not catch the June incident class.** Accepted and documented rather than
+   sized around, because no value both clears the idle floor and trips before an OOM. The
+   spawn cap owns that class.
+3. **The migration does not reload launchd.** Accepted: trading a reachability outage now
+   for one avoided later is not an improvement. The restart requirement is instead made
+   VISIBLE by §3.
+4. **The boot check is signal-only.** It never restarts, reloads, or gates. Decided up
+   front so no later round can quietly promote it to an authority.
+5. **Unmeasurable is `unknown` and silent.** Decided up front; the alternative (defaulting
+   to "needs restart") would nag every machine whose runtime cannot report the limit.
+
+## Open questions
+
+*(none)*
+
+## Proposal
+
+### 1. Raise the shipped ceiling to 2048
+
+`2048` is chosen against the correct denominator — the HOST idle floor:
+
+| Bound | Value | Relationship |
+|---|---|---|
+| Host idle floor (macOS desktop) | ~500-550 | ceiling must clear it with margin |
+| **Shipped ceiling** | **2048** | ~1500 headroom over the floor |
+| Host spawn cap admits (default) | 8 concurrent LLM subprocesses + children | far below the ceiling |
+| `kern.maxprocperuid` (macOS 15) | 10666 | ceiling stays well under it |
+
+#### What this belt does NOT catch (corrected — round 2)
+
+An earlier draft of this spec claimed 2048 "still catches" the 2026-06-20 runaway
+(~230-289 concurrent spawns). **That claim is arithmetically false and is withdrawn.**
+On top of a ~500-550 idle floor those spawns total ~730-839 — comfortably under 2048. A
+repeat of that exact incident would NOT trip this belt.
+
+Worse, the belt cannot be sized to catch it without reintroducing the bug being fixed. At
+roughly 400MB per LLM subprocess, ~250 spawns is already an OOM; a ceiling low enough to
+trip before that (~800) sits barely 250 above a desktop idle floor that varies by hundreds
+depending on open browser tabs and editors. That is the same "fires at rest" failure this
+spec exists to remove, with a smaller margin.
+
+**So the honest scope of this belt is: a UID fork-exhaustion backstop.** It catches an
+explosion of PROCESS COUNT far beyond anything a working system produces. It is NOT an
+OOM-prevention control, NOT the control that catches the June incident class, and it does
+NOT meaningfully bound memory blast radius — a non-compliant LLM runaway can exhaust this
+machine's memory long before it approaches 2048 processes, and nothing at this layer stops
+it. What bounds that is compliance with the spawn-cap funnel, the lint that keeps new
+callsites inside it, and the update reach that reaches deployed agents at all. Naming the
+belt for what it actually does — fork exhaustion, not blast radius — is the point of this
+paragraph.
+
+The control that catches that class is and remains the **host spawn cap** (`SpawnLimiter`,
+default 8 concurrent LLM subprocesses) — the PRIMARY control named in the parent spec. It
+bounds the exact quantity that OOMed the machine, it bounds it at the right order of
+magnitude, and it was already correct. The belt's only job is the non-compliant runaway
+that bypasses the funnel entirely; for that case the meaningful property is that a ceiling
+exists at all, not its precise value.
+
+Stating this plainly matters more than the number: a belt believed to catch the June
+incident would be relied on to, and it will not.
+
+#### The belt is not job-local, and that cuts both ways
+
+`NumberOfProcesses` in a launchd plist sets `RLIMIT_NPROC`, which the kernel enforces per
+real UID — NOT per launchd job, and not per process tree. This is the property that caused
+the original bug, and it has a second consequence worth naming rather than leaving implicit:
+
+- **Inbound:** unrelated user workload (browser, editors, containers, test runners) consumes
+  the same budget, so instar can be starved by processes it does not own and cannot see.
+- **Outbound:** an instar runaway raises the shared UID process COUNT, which every other
+  process of that user is also measured against. It does NOT impose instar's own 2048 on
+  those applications — each inherits its own limit from whatever launched it, typically the
+  higher system default. So the collateral is indirect and conditional: other apps begin
+  failing to fork only once the shared count approaches THEIR inherited limits or the
+  system maximum, not when it approaches instar's. (An earlier draft implied instar's
+  ceiling directly capped other apps; that was wrong and is corrected here.)
+
+macOS offers no per-job or per-process-tree process cap to use instead — there is no
+equivalent of Linux cgroups `pids.max` reachable from a launchd plist. `RLIMIT_NPROC` is the
+only OS-level lever available at this layer, so the choice is this coarse shared budget or
+no OS-level belt at all.
+
+That is precisely why the belt must stay a coarse last-ditch throttle set well clear of
+normal operation, and why the real bounding of instar's own concurrency belongs to the
+in-process spawn cap, which IS job-local and counts only instar's own subprocesses.
+
+#### Why a static value rather than install-time sizing
+
+A tempting alternative is sizing at install/migration time —
+`max(floor, current uid process count + headroom)`. It is rejected here, deliberately:
+
+- The reading is a **single sample of a varying quantity**. A machine that happens to be
+  idle at install time yields a low ceiling that fires later under normal desktop load;
+  one that is busy yields a ceiling so high the belt is meaningless. Sizing from one
+  sample re-creates the original bug with a different denominator.
+- It makes the ceiling **unpredictable across the fleet**, so an incident on one machine
+  cannot be reasoned about from another.
+- It is **not measurable at the time it must be decided** — the number that matters is the
+  peak the machine will reach over its lifetime, which no install-time sample observes.
+
+**On the name (round-9 finding):** the constant is `LAUNCHD_PROCESS_CEILING_FLOOR`, and
+"floor" overstates what it is — it reads as a measured safe lower bound, which it is not.
+It is the minimum SHIPPED value. The name is left as-is in this change because renaming an
+exported symbol is churn unrelated to the crash being fixed, but the word is reserved: when
+the headroom probe (CMT-015) produces real baselines, a measured minimum can take the name
+and this constant should become the shipped default it actually is.
+<!-- tracked: CMT-015 -->
+
+**2048 is a temporary empirical default, not a validated safe floor for all supported hosts**
+(round-6 finding, stated at the top rather than buried). It is derived from observed fleet
+idle counts and bounded above by `kern.maxprocperuid`; it is NOT validated against heavy
+developer desktops, and the runtime check cannot yet detect the residual risk it leaves (a
+host already sitting near 2048), because that needs the headroom probe tracked as CMT-015.
+It should be revisited when that probe produces real baselines — which is why a future
+change to this value is gated on the probe landing first.
+
+**The supported-host envelope, stated explicitly (round-8 finding):** 2048 assumes a host
+whose steady-state UID process baseline sits materially below it — the ordinary desktop and
+laptop case, which is every machine on this fleet. A host outside that envelope (a heavy
+developer desktop running many containers, parallel test runners, and several IDE helper
+trees) is expected to raise the value itself via the escape path above, and §3 will confirm
+the raise actually took effect. Naming the envelope is the honest alternative to implying
+one value fits every host.
+
+A static value is honest about what it can know. But the honest statement of its coverage
+is narrower than "clears every plausible desktop floor" — that claim is not established and
+is withdrawn (round 2). 2048 clears the ~500-550 floor OBSERVED on this fleet with wide
+margin; it is NOT proven against a heavy developer desktop running containers, several IDE
+helper trees, and parallel test runners, where the UID count could plausibly approach it.
+`RLIMIT_NPROC` is per real UID, so that unrelated workload is genuinely part of the
+denominator.
+
+The residual risk is therefore real and is handled by REPORTING rather than by asserting:
+2048 is the shipped default, and the §3 runtime check reads the EFFECTIVE ceiling — so a
+host whose real baseline approaches or exceeds the floor surfaces as a live reading rather
+than as an assumption in this document.
+
+**The operator's escape path, as a contract (round-4 finding).** A host that genuinely needs
+more than 2048 raises the two `NumberOfProcesses` values in that machine's own launchd
+agent plist. The contract this spec commits to is that the change STICKS:
+
+- The migration is raise-only by a strict `<` comparison against the floor, so it can never
+  lower an operator's value — on this update or any future one.
+- The migration is surgical rather than regenerative, so an operator's other hand-added
+  keys and formatting survive alongside the raised value.
+- A future floor increase would raise a value below the NEW floor and still leave anything
+  above it alone; the raise-only property does not weaken as the floor moves.
+- §3 reports the effective ceiling, so an operator-raised value is confirmed as actually
+  in force after the machine restarts, rather than assumed from the file. This is also the
+  VALIDATION path: an edit that was malformed, or that raised only one of the two values,
+  shows up as a live reading that did not move — and a half-raised plist is reported as
+  `repair`/`future-repair` rather than accepted.
+
+This is deliberately a file the operator edits rather than a new config surface: adding an
+instar config key for it would mean instar rewriting the plist from that key, which is
+exactly the regenerative behaviour rejected above.
+
+**The Attention notices deliberately do NOT hand out this procedure (round-6 finding).**
+None of the three notices names a file, a key, or a command. That is not an oversight to
+correct — it is the right call for who receives them. Every operator who sees `raise` needs
+a restart and nothing more; every operator who sees `repair` or `future-repair` has an
+update-delivery problem, and plist surgery is the wrong first response to it. Handing plist
+editing instructions to that reader trades an automatic fix for manual surgery on a file
+where a half-edit produces exactly the half-raised state §3 has to report. The escape path
+above exists for the rare host that genuinely needs above 2048, and it lives in this
+document, where the reader is someone who has already concluded they need it.
+
+### 2. Two write paths, both raise-only
+
+The value is written by TWO paths, and both had to be made raise-only. Missing the second
+one is easy — it cost this spec a round of review:
+
+- **`setup` / `installAutoStart` REGENERATES the plist** on install and on any re-run. It
+  is therefore a clobber path in its own right: without protection, a re-run would silently
+  reset an operator who deliberately raised their ceiling for a heavy host, and the
+  escape-path contract in §1 would be false. `preserveHigherProcessCeiling` carries a
+  previous value forward when — and only when — it is strictly greater than the template's.
+  A stale LOW value is correctly replaced; a deliberate higher one survives.
+
+  **Soft and Hard are not preserved independently:** the highest previous value found is
+  applied to any template value below it, so a previously half-raised plist
+  (Soft 8192 / Hard 512) comes out uniformly at 8192 rather than preserving the 512. This is
+  deliberate — a Hard limit below the Soft limit is an invalid plist, so preserving each
+  slot independently would faithfully reproduce a broken file. Raising both to the highest
+  intent found is the coherent reading of a half-finished edit.
+
+- **The migration reaches already-deployed agents.** That is the rest of this section.
+
+#### Migration Parity — reach the deployed agents
+
+The template change in `installAutoStart` reaches **new** agents via `setup`. Deployed
+agents are reached only by a migration, per the Migration Parity Standard. Without it the
+fix is broken for exactly the population that already has the bug.
+
+`migrateLaunchdProcessCeiling` is:
+
+- **Raise-only and floor-gated.** It rewrites a `NumberOfProcesses` value only when it is
+  *strictly below* `LAUNCHD_PROCESS_CEILING_FLOOR`. An operator who deliberately tuned
+  theirs higher is never clobbered.
+- **Idempotent.** A re-run over an already-migrated plist matches nothing and rewrites
+  nothing.
+- **Surgical, not regenerative.** It replaces the integer in place rather than rewriting
+  the plist from the template, so hand-added operator keys survive.
+- **Non-reloading.** It does NOT `launchctl unload/load`. The raised ceiling applies to
+  what launchd starts next; forcing a reload would restart a running agent mid-update —
+  trading one reachability outage for another. The value lands on disk now and takes
+  effect at the machine's next restart.
+- **Platform-gated.** Non-darwin is a recorded skip, not an error — launchd does not exist
+  there.
+
+### 3. Report the EFFECTIVE ceiling, never assume the plist is the state
+
+The plist value is a **symbol**. The **state** that matters is the `RLIMIT_NPROC` the
+running agent processes actually inherited — and those diverge for a real, expected window:
+launchd applies the raised ceiling only to what it starts NEXT, so a migrated machine keeps
+running under the old ceiling until it restarts.
+
+That divergence is not hypothetical; it is this incident. The Studio was migrated at
+10:26 and kept crashing under the old ceiling until 12:18, and the only reason it was
+restarted at all is that the agent asked the operator by hand. Two other machines carry
+the same ceiling and would receive no such prompt. Relying on release-note prose plus an
+agent remembering is exactly the "No Manual Work" and "Verify the State, Not Its Symbol"
+failure the constitution names.
+
+So the change also reports the effective state:
+
+- **`readEffectiveProcessCeiling()`** reads this process's own soft `RLIMIT_NPROC`. The
+  symbol is the plist integer; the state is this number; the corroboration is that it is
+  read from the live process rather than from any file instar wrote.
+- At server boot on darwin, when the effective ceiling is **below** the floor, one deduped
+  Attention item is raised — and it is one of **two distinct notices**, because they ask the
+  operator for different things (round-2 cross-model finding):
+
+  | Effective | Plist | Verdict | Priority | What the operator is told |
+  |---|---|---|---|---|
+  | below floor | at/above floor | `raise` | HIGH | This machine needs one restart to pick up the raised limit. |
+  | below floor | below floor, missing, or half-raised | `repair` | HIGH | This machine is unsafe AND a restart will not fix it — the correcting update has not reached it or did not complete. |
+  | at/above floor | below floor, missing, or half-raised | `future-repair` | NORMAL | Fine now, and a restart MAY lose that. No hurry, but worth sorting before then. |
+  | at/above floor | at/above floor | `ok` | — | Nothing. |
+  | unreadable | any | `unknown` | — | Nothing. |
+
+  `future-repair` was added in round 5. A draft treated that row as `ok`, reasoning that
+  the plist is "a question about the FUTURE" and this check speaks only to now. But the
+  event that turns it into the present is an ordinary restart, and a silent failure waiting
+  behind a routine action is precisely the class this spec exists to end. It carries lower
+  priority because nothing is broken yet — reporting it as urgent would be its own dishonesty.
+
+  **It claims only what it measures (round-9 finding).** The measured facts are: this
+  machine is safe NOW, and its intended launchd symbol is NOT CONFIRMED safe. It is
+  tempting to conclude "the next restart will drop it", but that does not follow — an absent
+  or unparseable agent plist could mean launchd or shell defaults apply, or that another
+  launch path is active, and either could be above the floor. The notice therefore says a
+  restart **may lose** the limit the machine is running on, which is exactly the strength of
+  the evidence. This is the same discipline as the `unknown` branch, applied to a partial
+  reading rather than a missing one.
+
+  An earlier draft returned silence for the `repair` row, reasoning that the migration
+  reports it. It reports it **to a log**. A machine whose migration never ran is crashing on
+  this exact bug with nobody told — and telling that operator to "restart" would be actively
+  wrong advice, since the machine would come back identical. The two states carry different
+  dedupe keys, so a machine that moves from `repair` to `raise` is re-told the NEW action.
+
+  Deduped on `(state, machineId, effectiveCeiling, floor)` so an un-restarted week produces
+  one item, not one per boot.
+
+  **The key deliberately encodes the ACTION, not the CAUSE (round-8 finding).** A `repair`
+  machine whose plist changes from missing, to half-raised, to merely low produces no new
+  item, because the operator's next step is identical in all three and the notice text is
+  identical too. Re-notifying on a cause change the operator cannot act on differently would
+  be noise dressed as diligence. A change that DOES alter the required action — `repair`
+  becoming `raise` once the migration lands, or `future-repair` becoming `repair` after a
+  restart — changes the state and therefore the key, and is re-told.
+- **Unmeasurable is explicit, and never invisible.** If the limit cannot be read (a
+  platform without it, a runtime that does not expose it, an error), the result is `unknown`
+  and **no Attention item is raised and no claim is made** — the least-harmful action at
+  this decision point, since a fabricated "healthy" would silence a real gap and a
+  fabricated "broken" would nag every correctly-configured machine forever.
+
+  But silence with no trace would be its own failure: if the reader ever broke on darwin,
+  this whole check would vanish fleet-wide while still perfectly "satisfying" its no-item
+  contract. So `unknown` **on darwin** — the platform where it is supposed to work — is
+  always logged with its reason, as is any error in the check itself. The Attention surface
+  stays quiet; the diagnostic does not.
+- **Signal, never authority.** The check raises an Attention item and nothing else. It does
+  not restart the agent, reload launchd, refuse to boot, or gate any work. A wrong reading
+  costs one wrong notice, never an outage — which is the correct blast radius for a check
+  whose entire job is to report that a limit is wrong.
+
+This closes the loop the release note could only describe: the machine tells the operator
+it needs the restart, instead of the operator depending on an agent to remember.
+
+#### What §3 does NOT detect: live headroom (round-3 finding, stated not hidden)
+
+The check verifies the **limit**. It does not measure the **headroom** — how close the
+machine's current per-UID process count sits to that limit. That distinction matters,
+because the incident was not "the limit is wrong in the abstract"; it was *531 processes
+against 512*. A machine sitting at 1900 of 2048 is about to fail, and this check reports
+`ok`.
+
+That gap is deliberate rather than overlooked, and the reason is the failure mode itself:
+counting the UID's processes requires enumerating them, which on macOS from Node means
+spawning a process — the exact operation that is refused when the limit is exhausted. A
+headroom check built that way would return nothing precisely when the answer mattered, and
+would report reassuring silence the rest of the time. That is a worse instrument than none,
+because it would be believed.
+
+A non-forking count needs a native binding instar does not have. Adding one is real work
+with its own review, so it is registered rather than smuggled in here.
+<!-- tracked: CMT-015 -->
+
+**The residual risk, named with an owner and a priority (round-4 finding)**, since
+"registered" alone is too weak for a resource-safety spec: the next failure mode of this
+class is *effective limit correct, headroom nearly exhausted, no notice*. Owner: the agent
+that ships this (echo). Priority: below the crash this spec fixes — that one is live on
+deployed machines today — and above ordinary backlog, because it is the same incident class
+one step along. It is NOT accepted as permanently out of scope; the tracked item is a
+non-forking headroom probe, and this spec's `unknown`-is-silent discipline is what keeps the
+gap honest until then rather than papered over with a fork-based probe that would lie.
+
+**And it is made blocking rather than merely registered (round-5 finding):** any FUTURE
+change to this ceiling value must land the headroom probe first or state in its own spec why
+it does not need to. The reason is that a ceiling change is exactly the decision that needs
+headroom data — this spec had to pick 2048 without it, which is why its empirical basis is
+as thin as round 2 established. A tracked item that never blocks anything is a wish; this one
+gates the next decision of its own kind.
+
+Two things bound the risk in the meantime. The spawn cap bounds instar's OWN contribution
+to the count at the right order of magnitude, and the `repair`/`raise` verdicts still fire
+the moment an exhausted machine's limit is itself wrong — which is the shape this incident
+actually took.
+
+#### Plist forms this handles, and what it does when it cannot (round-3 finding)
+
+`raiseLaunchdProcessCeilings` performs surgical value replacement on the XML plist form
+launchd agents ship as, matching `<key>NumberOfProcesses</key>` followed by its
+`<integer>`, whitespace-tolerant. Explicitly:
+
+- **Multiple declarations** (the normal case — Soft and Hard are separate keys) are each
+  evaluated independently, and only those below the floor are rewritten.
+- **A half-raised plist** (one value raised, one not) is left as it is by the raise-only
+  rule, and is reported by §3 as `repair` rather than silently accepted.
+- **A binary plist, an unrecognised structure, or a hand-edit the pattern does not match**
+  produces NO match, therefore NO rewrite. The migration then records that the plist
+  declares no ceiling it can act on, rather than rewriting anything it did not understand.
+- **A parse that reads low but rewrites nothing** is recorded as an ERROR, never as a
+  success — the code refuses to claim a change it did not make.
+
+Two alternatives were considered (round-5 finding narrows the earlier claim, which
+overstated the tradeoff):
+
+- **Full `plutil`/plist-library parse-and-REGENERATE — rejected.** It normalises formatting
+  and key order across the whole file, so an operator's hand-added keys and comments are
+  silently rewritten or lost. A pattern that fails to match is a visible no-op; a
+  regeneration that succeeds is an invisible rewrite of someone else's file.
+- **XML DOM TARGETED replacement — a legitimate alternative, not dismissed.** A proper DOM
+  round-trip can preserve comments and unknown keys, so the earlier blanket claim that
+  parsing necessarily discards them was too strong. It is not used here for two narrower
+  reasons: it adds an XML dependency to a migration path that must run during an update on
+  a machine that may already be resource-starved, and it would silently start succeeding on
+  binary plists and hand-rolled structures this change has never been tested against —
+  turning a safe no-op into an untested rewrite. For a raise-only migration touching one
+  integer, the failure direction of the surgical approach is the safe one; if this ever
+  needs to edit structure rather than a value, the DOM route is the right upgrade.
+
+#### Every plist-read failure, enumerated (round-3 finding)
+
+The verdict table above uses "plist below floor, missing, or half-raised". Spelling out the
+read failures specifically, because they were blurred:
+
+| Effective reading | Plist read | Verdict | Why |
+|---|---|---|---|
+| unreadable | any | `unknown` | Nothing is known about this machine's state; a guess in either direction is worse than silence. |
+| at/above floor | at/above floor | `ok` | Nothing to say. |
+| below floor | unreadable, absent, or unparseable | `repair` | The machine IS unsafe, and nothing confirms a restart would help. `repair` says "this needs looking at", which is true whether the cause is a failed migration, a permission problem, or a corrupt file. Saying `raise` would be advice that might not work; saying nothing would leave a crashing machine unreported. |
+| at/above floor | below floor, unreadable, absent, or unparseable | `future-repair` | A restart MAY lose the currently-safe inherited limit, because no safe launchd symbol is confirmed. Deliberately "may": an absent or unparseable plist does not prove the next limit is low — defaults or another launch path could apply. (Round-10 correction: this row previously read "lands it below the floor", contradicting the evidentiary standard the rest of §3 sets.) |
+
+
+> **Carrier (frozen excerpt — the work both markers above point at):** <!-- tracked: CMT-015 -->
+>
+> **CMT-015** — "(1) HEADROOM PROBE: the ceiling check verifies the LIMIT, not the HEADROOM — a machine at 1900 of 2048 reports fine. A fork-based count fails exactly when the limit is exhausted, so this needs a non-forking (native) process count. Until it lands, any FUTURE change to the ceiling value is blocked on it, because a ceiling change is precisely the decision that needs headroom baselines — 2048 was chos"
+
+## Maturation plan
+
+This change is deliberately NOT a staged, dark-shipped feature, and the plan below says so
+explicitly rather than leaving the axis undeclared. Two reasons: the ceiling correction is a
+bug fix to a live crash (a dark bug fix is a bug not fixed), and the boot check is
+signal-only — it raises a notice and can do nothing else, so there is no destructive action
+for a dark window to protect against.
+
+- **test-agent-live:** live from the first build. The unit suites (55 cases across the two
+  files) exercise both write paths and all five verdict states, including every uncertain
+  branch asserting silence.
+- **dev-agent-live:** live on merge, no flag. This agent is the machine the incident happened
+  on; the check runs at its next server boot and its verdicts are observable in the boot log
+  and the Attention queue.
+- **fleet:** live on the release that carries it, no flag. Deployed agents receive the
+  migration on update, and the boot check with it.
+- **graduation criterion:** already met by construction — there is no gated state to
+  graduate FROM. The equivalent evidence is: the migration is raise-only on both write paths
+  (verified by test), and the check cannot take any action beyond raising a notice (verified
+  by the absence of any restart/reload/gate call in its module and by the boot wiring, which
+  only calls `createAttentionItem`).
+- **dark-window:** none, and that is the deliberate choice rather than an omission. A dark
+  window here would mean deployed machines keep crashing while the fix waits, and would
+  suppress precisely the notice that tells an operator their machine still needs its
+  restart. The risk a dark window normally buys down — an automated action going wrong — does
+  not exist for a component whose only output is a message.
+
+## Acceptance criteria
+
+1. `installAutoStart` writes `2048` for both Soft and Hard `NumberOfProcesses`.
+1b. **A setup re-run never lowers an operator's higher value.** `installAutoStart`
+   REGENERATES the plist, so raise-only had to be applied on that path too:
+   `preserveHigherProcessCeiling` carries a previous value forward only when it is strictly
+   greater than the template's. A stale LOW value (the 512 this change fixes) is correctly
+   replaced; an operator's deliberate higher value survives install, update, and any future
+   template change. Without this the escape-path contract above would have been false —
+   the review caught it before it shipped, not after.
+2. `readLaunchdProcessCeilings` returns every declared value, and an empty array for a
+   plist declaring none (a real state, not an error).
+3. `raiseLaunchdProcessCeilings` raises a value below the floor, leaves a value at or
+   above the floor byte-identical, and leaves every other byte of the plist untouched.
+3b. **The "safe no-op" claim is VERIFIED, not asserted** (round-9 finding). The forms §2
+   names as producing no match must each be exercised: malformed XML, an unparseable binary
+   blob, a decoy string that only looks like the key. And the forms it claims to handle must
+   be exercised too: comments preserved around a raised value, duplicate keys evaluated
+   independently, Soft-before-Hard and Hard-before-Soft both raising, and a value nested
+   deeper than the template's shape. A safety property no test exercises is a claim, not a
+   property.
+4. The migration is a no-op on a second run.
+5. The migration does not invoke `launchctl`.
+6. The migration records a skip on non-darwin.
+7. `readEffectiveProcessCeiling` returns the live soft `RLIMIT_NPROC` of the calling
+   process — read from the running process, not from the plist bytes. This is the criterion
+   that tests the state rather than the symbol.
+
+   **How it is verified, stated honestly (round 2).** The unit suite asserts the reading
+   against the OS's own report for the process running the test, and that reading is a real
+   launchd-descended value when the suite runs on a machine where the agent is installed —
+   which is where this bug was found and where the fix matters. It is NOT verified by a
+   purpose-built temporary launchd job with a low test limit: that harness is macOS-only,
+   would install and remove a real user-level launchd job as a side effect of running tests,
+   and CI runs on ubuntu where it cannot execute at all. So the honest coverage is: the
+   reading mechanism is verified everywhere, the launchd-inheritance link is verified on a
+   darwin host with the agent installed, and on ubuntu CI the platform branch returns
+   `unknown` and is asserted to notify nothing. No criterion here claims the launchd job
+   itself is exercised in CI, because it is not.
+8. `readEffectiveProcessCeiling` returns `unknown` (never a number) when the limit cannot
+   be read, and the boot check raises nothing in that case.
+9. The boot check raises exactly one deduped Attention item per distinct condition, matching
+   the §3 verdict table row for row:
+
+   | Effective | Plist | Item | Priority |
+   |---|---|---|---|
+   | below floor | at/above floor | `raise` | HIGH |
+   | below floor | below/missing/half-raised | `repair` | HIGH |
+   | at/above floor | below/missing/half-raised | `future-repair` | NORMAL |
+   | at/above floor | at/above floor | none | — |
+   | unreadable | any | none | — |
+
+   All three notifying states carry DISTINCT dedupe keys and DISTINCT text. The `repair`
+   text must not tell the operator to restart (it would not help), and the `future-repair`
+   text must not present itself as urgent (nothing is broken yet).
+
+   (Round-6 correction: an earlier draft of this criterion said "nothing at all when
+   effective is at or above the floor", which contradicted the `future-repair` row added to
+   §3 in round 5. An implementation could have passed acceptance while omitting a behaviour
+   the design requires — the criteria are the contract, so a stale one is a real defect,
+   not a typo.)
+
+## Rollback
+
+- **Code:** pure code change. Revert and ship a patch.
+- **On-disk state:** an already-migrated plist keeps `2048`. That is harmless *within the
+  supported-host envelope stated in §1* — it is roughly a fifth of `kern.maxprocperuid`
+  (10666), and well clear of an ordinary desktop baseline. It is NOT unconditionally
+  harmless: a heavy host outside that envelope would still need the operator raise, exactly
+  as it does without the rollback. No data migration, no agent
+  state repair.
+- **The boot check:** reverting removes the Attention item source. Any item already raised
+  is an ordinary attention row the operator resolves normally; nothing is orphaned, because
+  the check holds no state of its own.
+- **User visibility:** none during the rollback window. Reverting restores the previous
+  behaviour (a silent restart requirement), which is the pre-change state rather than a new
+  regression.
+
+## Review history
+
+Recorded in full in the convergence report at
+`docs/specs/reports/launchd-process-ceiling-floor-convergence.md`. It was moved there in
+round 8: the history had grown until the spec exceeded the reviewer's own input budget and
+began truncating, which is a defect in a document whose purpose is to be reviewed whole.

--- a/docs/specs/reports/launchd-process-ceiling-floor-convergence.md
+++ b/docs/specs/reports/launchd-process-ceiling-floor-convergence.md
@@ -1,0 +1,313 @@
+# Convergence Report — Launchd Process Ceiling
+
+## ⚠ Cross-model review: codex-cli:gpt-5.5 — RAN every round (10/10)
+
+A real GPT-tier external pass ran through the agent's own codex CLI on all ten rounds. The
+⚠ above is not about the external pass, which is the clean state; it flags the verdict
+below.
+
+## Convergence verdict: **NOT CONVERGED — hit the 10-iteration cap**
+
+The stated criterion is *no DESIGN-class findings for two consecutive rounds*. That was never
+reached. Round 10 still produced two design-class findings (both fixed), and the skill's hard
+cap fired.
+
+Per `/spec-converge`, a cap-out requires human input before retry. **It is not a passing
+grade and no convergence tag has been written.** What follows is the honest account of what
+the ten rounds actually produced, so the decision can be made on evidence rather than on a
+status word.
+
+### What the cap actually caught here
+
+The cap exists to surface *"this design is too confused to review."* That is **not** what
+happened, and saying so is not special pleading — it is checkable against the reviewer's own
+words:
+
+- Rounds 3, 4, 5, 7, 8, 9 and 10 each closed with an explicit **"No serious architectural
+  objection"**, and round 10 added *"the design is clear and appropriately narrows the belt's
+  role. The main residual risk is not conceptual."*
+- The verdict moved SERIOUS → MINOR after round 1 and stayed there, apart from round 5, where
+  the "serious" label was applied to an internal contradiction (an acceptance criterion left
+  stale by a round-4 design change), not to the design.
+- Every round's findings were smaller than the last, and most were about the growing
+  DOCUMENT rather than the change.
+
+This is the failure mode `/spec-converge`'s own criterion documents: *"on a spec that appends
+its own review history, the reviewable surface grows every round, and a diligent reviewer will
+always find precision to add on a larger surface."* By round 8 the spec had grown past the
+reviewer's input budget and began **truncating** — the review history was moved into this
+report to fix that, which is the mitigation the criterion's own text implies.
+
+### But the rounds were not wasted, and that is the honest counterweight
+
+Ten rounds on a one-integer change looks disproportionate. It found six things that would
+otherwise have shipped, four of which changed CODE, not prose:
+
+1. **A false claim in the justification** (round 1) — "still catches the June runaway" was
+   arithmetically wrong (~730-839 total against a 2048 ceiling). It had already been written
+   into the commit message, the release notes, and the PR description.
+2. **The plist is a symbol, not the state** (round 1) — a migrated machine keeps crashing
+   under the old ceiling until it restarts, and nothing said so. This is the exact 2026-08-19
+   incident. → `ProcessCeilingCheck` built.
+3. **The check was silent on the worst case** (round 2) — a machine whose migration NEVER ran
+   got no notice at all, and would have been told to "restart", which would not have helped.
+   → `repair` state.
+4. **A safe machine could restart into the unsafe state silently** (round 5) → `future-repair`
+   state.
+5. **A setup re-run would have clobbered an operator's raised ceiling** (round 7) — the
+   migration was raise-only but `installAutoStart` REGENERATES the plist, so the "your change
+   sticks" contract written in round 4 was false as implemented. → `preserveHigherProcessCeiling`.
+6. **A machine-id collision could swallow a HIGH notice for a crashing machine** (round 10) —
+   waved through in round 9 as "no worse than elsewhere", correctly rejected. → host
+   fingerprint mixed into the dedupe key.
+
+Findings 2-6 are failure modes of the fix itself. None came from the internal review or from
+the author.
+
+## ELI10 Overview
+
+Every computer limits how many programs one user account can run at once. Instar sets that
+limit deliberately, as a last-resort brake in case something of its own runs away. The number
+chosen was 512 — reasonable if you count only instar's own helpers, but the operating system
+counts *everything* the logged-in person runs: the desktop, the browser, the editor. An
+ordinary Mac idles at 500-550. So the brake was already clamped before instar started
+anything.
+
+The result was not a caught runaway. It was an idle machine where commands were refused at
+random for hours, and eventually the agent's own server died outright. A safety limit that
+trips at rest protects nothing; it converts idle into an outage.
+
+The fix raises the number to 2048 and corrects it on machines that already have instar, not
+just new ones. What review added is the part that matters more: the corrected number only
+takes effect after a restart, and until this change nothing told anyone that. On the machine
+where this was found, the only reason it got restarted is that the agent asked a human by
+hand. Two other machines would have had no such prompt. Now each machine notices its own
+state and says one of three things: *needs a restart*, *needs looking at because a restart
+won't help*, or *fine now, but a restart may lose that*.
+
+## Original vs Converged
+
+**Originally** this was a one-integer change plus a migration, justified partly by a claim
+that turned out to be false, and it treated the corrected file on disk as if it were the
+corrected machine.
+
+**After review** the claim is withdrawn with the arithmetic shown; the belt is renamed for
+what it actually does (a fork-exhaustion backstop, not a memory blast-radius control, and not
+the thing that catches the June incident — the spawn cap owns that); and the change now reads
+the *live* limit rather than trusting the file, reporting three distinct conditions with three
+distinct actions. Both write paths — the migration and setup — are raise-only, so an
+operator's own raise survives. Where the evidence is partial, the notice says so: an
+unreadable plist yields "a restart **may** lose this", never a predicted drop. Where the
+evidence is absent, nothing is claimed at all — but on macOS it is always logged, so a
+reader that broke could not silently disable the whole check.
+
+The known gap is stated rather than hidden: the check verifies the LIMIT, not the HEADROOM.
+A machine at 1900 of 2048 reports fine. Measuring headroom needs to count processes, which
+needs to spawn one — the exact thing that fails when the limit is exhausted — so a check built
+that way would go quiet precisely when it mattered. That is registered as CMT-015 and made
+blocking on any future change to this ceiling.
+
+## Iteration Summary
+
+| Round | Standards gate | Cross-model verdict | Design-class | Precision | Code changed |
+|---|---|---|---|---|---|
+| 1 | ran (2 flags) | SERIOUS ISSUES | 5 | 0 | — |
+| 2 | ran (1 flag) | MINOR ISSUES | 4 | 1 | `ProcessCeilingCheck` + boot wiring |
+| 3 | ran (0 flags) | MINOR ISSUES | 3 | 2 | `repair` state |
+| 4 | — | MINOR ISSUES | 3 | 1 | — |
+| 5 | — | SERIOUS ISSUES | 3 | 1 | `future-repair` state |
+| 6 | — | MINOR ISSUES | 3 | 1 | — |
+| 7 | — | MINOR ISSUES | 3 | 2 | `preserveHigherProcessCeiling`, `unknown` logging |
+| 8 | — | MINOR ISSUES | 2 | 2 | notice wording |
+| 9 | — | MINOR ISSUES | 3 | 2 | 7 plist-form tests |
+| 10 | — | MINOR ISSUES | 2 | 2 | host fingerprint in dedupe key |
+
+Standards-Conformance Gate reached **0 findings at round 3** and stayed there. The
+cross-model pass ran successfully on all 10 rounds (`status: ok`, never degraded).
+
+**Per-round model disclosure:** internal reviewer perspectives were carried by the authoring
+session (opus) rather than by spawned subagents — this session runs under an operator
+instruction not to spawn agents without a request. That is a real reduction in independence
+versus the skill's design and is recorded here rather than glossed: the genuinely independent
+reads in this convergence were the cross-model codex pass and the code-backed Standards
+gate, both of which ran every applicable round and produced every finding listed above.
+
+## Full Findings Catalog
+
+Round-by-round findings and their resolutions are recorded in the spec's own history through
+round 7 and summarised in "But the rounds were not wasted" above. In brief, by class:
+
+**Design-class, resolved in code (6):** the false blast-radius claim; symbol-vs-state; the
+missing `repair` state; the missing `future-repair` state; the setup clobber path; the
+machine-id collision.
+
+**Design-class, resolved in the document (11):** outbound collateral overstated; the operator
+escape path had no contract; "clears every plausible desktop floor" unfounded; the belt
+described in blast-radius language; acceptance criterion 9 contradicting the design; the
+decision-point row stale at four states; plist-read failures blurred; `future-repair`
+overclaiming certainty (twice, in text then in a table); the supported-host envelope unstated;
+a superseded review-history line still reading as current.
+
+**Precision-class (14):** naming (`FLOOR` overstating a measured bound), terminology density,
+dedupe-by-action-not-cause, the "order of magnitude" arithmetic, and similar.
+
+## What the reader has to decide
+
+Two options, and the choice is genuinely open:
+
+1. **Approve at the cap.** Accept the spec as it stands, on the evidence that the standards
+   gate is clean, the external reviewer records no architectural objection, all six code-level
+   findings are fixed, and the remaining findings are precision on a document that has already
+   been trimmed once for length. The crash this fixes is live on two machines today.
+2. **Require another convergence attempt.** The criterion says two clean rounds and that was
+   not achieved. Retrying is legitimate — but on the evidence above the most likely outcome is
+   two to three more rounds of document precision, while the machines stay unfixed.
+
+The recommendation is (1), and the reason it is offered as a decision rather than taken
+unilaterally is that the cap is exactly the point where the skill hands the judgement to a
+human. No convergence tag will be written without that answer.
+
+## Operator decision
+
+**Approved at the cap by Justin (verified operator, topic 48000) on 2026-08-19**, after
+being handed this report and the plain-English overview.
+
+To be precise about what that approval is and is not: it is option (1) above — an informed
+decision to ship on the evidence, made by the person the cap defers to. It is **not** a
+retroactive claim that the two-clean-rounds criterion was met. It was not. This spec carries
+`review-iterations: 10` and a verdict of NOT CONVERGED, and the `approved: true` tag records
+an operator override of an unmet criterion rather than a passing grade.
+
+That distinction is kept deliberately, because the alternative — quietly stamping
+convergence because a human said yes — would make the criterion unfalsifiable, and a
+criterion that can be satisfied by approval is not a criterion.
+## Review history
+
+**Round 1** — Standards-Conformance Gate: 2 possible-violations (*No Manual Work*;
+*Verify the State, Not Its Symbol*), both on the same gap: the spec treated the on-disk
+plist as progress while the live enforced limit could still be unsafe.
+Cross-model (codex-cli:gpt-5.5): SERIOUS ISSUES, 5 findings.
+
+Design-class findings and their resolutions:
+
+1. **"Still caught by 2048" is arithmetically false.** ~230-289 spawns on a ~500-550 floor
+   totals ~730-839, below 2048. → Claim WITHDRAWN in §1 with the arithmetic shown; the
+   belt's scope restated honestly; the spawn cap named as the control that owns that class.
+   Also corrected in the commit message, the release fragment, and the PR description,
+   since the false claim had already been written into all three.
+2. **2048 may be too high to bound the real blast radius (memory).** → Accepted and stated:
+   at ~400MB per subprocess this belt cannot be an OOM control at any value that also
+   clears the idle floor. Documented rather than papered over.
+3. **A static ceiling ignores host variability.** → Install-time dynamic sizing considered
+   and REJECTED with reasons (single sample of a varying quantity; unpredictable across the
+   fleet; the quantity that matters is unobservable at decision time). Residual risk routed
+   to the §3 runtime check.
+4. **Delayed activation leaves the outage class alive.** → §3 added: read the EFFECTIVE
+   `RLIMIT_NPROC` at boot and raise one deduped Attention item when a machine is still
+   running the old ceiling. This is also the resolution of both conformance findings.
+5. **Acceptance criteria never check the source of truth.** → Criteria 7-9 added, including
+   verification against a process actually started by launchd under the plist.
+
+**Round 2** — Standards-Conformance Gate: round-1 findings RESOLVED; 1 new
+possible-violation (*Bounded Notification Surface* — a per-machine notice scales with
+machine count). Cross-model (codex-cli:gpt-5.5): MINOR ISSUES, 5 findings (down from
+SERIOUS ISSUES / 5).
+
+Design-class findings and their resolutions:
+
+1. **The boot check was too narrow.** It notified only on "plist fixed, process not
+   restarted", and stayed SILENT on "plist never fixed" — a machine crashing on this exact
+   bug with nobody told, and one where a restart would be wrong advice. → A second verdict
+   state `repair` added, with its own dedupe key and its own text that explicitly says a
+   restart will not fix it. Code + tests changed, not just the document.
+2. **"Clears every plausible desktop floor" was unfounded.** → Claim WITHDRAWN. Restated as
+   what is actually known (clears the ~500-550 floor OBSERVED on this fleet), with the
+   heavy-developer-desktop case named as unproven, and the residual risk routed to the
+   runtime reading rather than to an assertion.
+3. **The belt is not job-local, and that cuts both ways.** → Stated explicitly: unrelated
+   user workload consumes the same per-UID budget (instar can be starved by processes it
+   does not own), and an instar runaway can cause collateral fork failures elsewhere. Also
+   recorded WHY no better primitive is used: macOS has no per-job process-tree cap reachable
+   from a launchd plist.
+4. **Acceptance criterion 7 was operationally vague.** "Verified against a launchd-started
+   process" without naming a harness would let the criterion be claimed without being met. →
+   The honest coverage is now written out: verified against the OS report for the running
+   process (a real launchd-descended value on an installed darwin host), NOT via a
+   purpose-built temporary launchd job — which is macOS-only, installs a real user-level job
+   as a test side effect, and cannot run on ubuntu CI. No claim is made that CI exercises
+   the launchd job.
+
+Precision findings addressed: the *Bounded Notification Surface* concern (the per-machine
+notice's three bounds, and why a cross-machine summary was rejected — the machine most
+likely to be affected is the one most likely to be down and omitted from it), and one-line
+definitions for the local terms (`unified`, `machine-local`, one-voice gating, Attention
+item) where they first affect behaviour.
+
+**Round 3** — Standards-Conformance Gate: **0 findings** (the round-2 notification concern
+resolved). Cross-model (codex-cli:gpt-5.5): MINOR ISSUES, 5 findings, explicitly recording
+*"No serious architectural objection"*.
+
+Design-class findings and their resolutions:
+
+1. **The check verifies the LIMIT but not live HEADROOM** (raised twice, as findings 1 and
+   2). The incident was 531 processes against 512; a machine at 1900 of 2048 is about to
+   fail and this check reports `ok`. → Stated explicitly rather than hidden, WITH the reason
+   it is not simply added: counting the UID's processes requires spawning one, which is the
+   exact operation refused when the limit is exhausted — so a headroom check built that way
+   returns nothing precisely when it matters and reassuring silence otherwise, which is
+   worse than none because it would be believed. A non-forking count needs a native binding
+   instar does not have; registered as CMT-015 rather than smuggled in.
+2. **Plist parsing was underspecified for malformed / duplicate / partial / variant
+   forms.** → Every form enumerated, along with the failure behaviour (no match ⇒ no
+   rewrite; parsed-low-but-rewrote-nothing ⇒ error, never success). Records why a
+   `plutil` parse-and-regenerate was REJECTED: it would normalise the whole file and
+   silently discard an operator's hand-added keys, whereas a pattern that fails to match is
+   a visible no-op. For a raise-only migration the surgical approach fails in the safe
+   direction.
+3. **Plist-read failure was blurred with "plist below floor".** → A second table enumerates
+   every combination of readable/unreadable effective reading against readable/unreadable
+   plist, with the reasoning for each verdict. *(SUPERSEDED IN ROUND 5: this round concluded
+   that a demonstrably-safe machine with an unreadable plist stays `ok`. Round 5 overturned
+   that — it now yields `future-repair`, because the restart that makes it unsafe is
+   routine. The current behaviour is the §3 table, not this line.)*
+
+Precision finding noted, not actioned: governance terminology occupies substantial space
+relative to the mechanism. Kept as-is — the local standards are what a reviewer inside this
+project checks the spec against, and the one-line definitions added in round 2 already serve
+the external reader.
+
+**Round 4** — Cross-model: MINOR ISSUES, 4 findings. Design-class: the outbound-collateral
+claim overstated the coupling (instar's ceiling does not cap other apps — each inherits its
+own; the shared quantity is the COUNT) → corrected; the operator escape path had no stated
+contract → written out as four properties that make an operator's raise stick; the headroom
+residual risk was "registered" with no owner or priority → both named.
+
+**Round 5** — Cross-model: SERIOUS ISSUES, 4 findings, but the seriousness was internal
+inconsistency rather than architecture. Design-class: a machine SAFE now with a bad plist
+was reported as `ok`, so a routine restart would drop it into the unsafe state silently →
+`future-repair` state added (code + tests), at NORMAL priority because nothing is broken
+yet; the belt was still described in blast-radius language → renamed to what it is, a UID
+fork-exhaustion backstop, with memory blast radius explicitly recorded as uncovered at this
+layer; the plist-parsing rejection overstated its case → narrowed, with XML DOM targeted
+replacement acknowledged as a legitimate alternative and the actual reasons for not using it
+given; CMT-015 made blocking on any future ceiling change rather than merely registered.
+
+**Round 6** — Cross-model: MINOR ISSUES, 4 findings. Design-class: acceptance criterion 9
+CONTRADICTED the §3 verdict table (it still said "nothing when effective is at or above the
+floor", written before `future-repair` existed) — an implementation could have passed
+acceptance while omitting required behaviour → criterion 9 rewritten as the same table, row
+for row; the decision-point row still described four states → corrected to five; the
+operator escape path's absence from the notices was unexplained → stated as a deliberate
+choice with its reason (plist surgery is the wrong first response for the readers who see
+those notices); 2048's provisional status moved to the top of §1 rather than buried.
+
+**Round 7** — Cross-model: MINOR ISSUES, 5 findings. Design-class: **a setup re-run would
+have clobbered an operator's raised ceiling** — the migration was raise-only but
+`installAutoStart` regenerates the plist, so the "your change sticks" contract written in
+round 4 was false as implemented → `preserveHigherProcessCeiling` added (code + 6 tests),
+acceptance criterion 1b added; `unknown` had no required observability, so a reader that
+broke on darwin would disable the check fleet-wide while satisfying its no-item contract →
+`unknown` on darwin is now always logged with its reason; the round-3 review-history entry
+had been overturned by round 5 and still read as current → marked superseded, since the
+review history is what a later reader relies on. Precision: "single input" imprecise for a
+two-input cross-product; "an order of magnitude below 10666" is nearer a fifth.

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -531,6 +531,25 @@ Enrollment (P2.1) — adding a new account from a phone, expiry-proof:
 
 Spec: `docs/specs/_drafts/subscription-auth-standard-master-spec.md`.
 
+## The process ceiling, and why the file is not the answer (`ProcessCeilingCheck`)
+
+Instar sets an OS-level cap on how many processes its user account may run — a last-resort
+belt beneath the host spawn cap. That cap is a per-UID limit, so it is measured against
+*every* process the logged-in person owns, not just instar's. Set too low it does not catch a
+runaway; it refuses `fork()` on an idle machine, which is how it once killed an agent server.
+
+The subtle part is that correcting it is not the same as fixing the machine. launchd applies
+a raised ceiling only to what it starts next, so a machine keeps running the old one until it
+restarts — the corrected file on disk says nothing about the running process.
+
+`ProcessCeilingCheck` reads the **live** limit of the running process at boot (from the
+process's own report, spawning nothing — the failure it detects is an inability to spawn) and
+compares it against the plist. It raises at most one deduped notice: *needs a restart*, *needs
+looking at because a restart will not help*, or *fine now, but a restart may lose that*. It is
+signal-only — it can raise a notice and do nothing else — and it stays silent whenever the
+reading is unreadable, while always logging that it could not read, so a broken reader cannot
+disable the check invisibly. Full reference: `reference/process-ceiling-check`.
+
 ## Proactive compaction (ProactiveCompactionSentinel)
 
 `ProactiveCompactionSentinel` condenses a long-running autonomous session's conversation *before* it hits the context wall, instead of relying on recovery after the wall is reached. It reads Claude's own grounded remaining-context display and, when an autonomous Claude session crosses 85% used, waits for the canonical work-state probe to affirm a genuinely idle turn boundary, then asks the session to compact in place. A cooldown prevents repeated compaction on successive ticks; interactive sessions, non-Claude frameworks, working sessions, and uncertain readings are never touched. Ships dark by default; when enabled it starts in dry-run (recording what it would do) until live mode is explicitly configured.

--- a/site/src/content/docs/reference/process-ceiling-check.md
+++ b/site/src/content/docs/reference/process-ceiling-check.md
@@ -1,0 +1,99 @@
+---
+title: Process Ceiling Check
+description: Why a machine can be running under a process limit that is too low even after the fix reaches it, and how instar notices and says so — ProcessCeilingCheck, the launchd NumberOfProcesses ceiling, and the raise-only migration.
+---
+
+Every macOS user account has a cap on how many processes it may run at once. Instar sets
+one deliberately in its launchd agent, as a last-resort belt beneath the host spawn cap.
+
+That belt shipped at 512 — a number sized against instar's own subprocess count, which is
+the wrong denominator. `NumberOfProcesses` maps to `RLIMIT_NPROC`, which the kernel enforces
+**per real UID**: every process the logged-in person owns, including the desktop, the
+browser and the editor. An ordinary desktop idles around 500-550, so the belt sat below the
+machine's idle floor and refused `fork()` on an otherwise quiet machine. On 2026-08-19 that
+produced hours of intermittently-refused commands and then killed an agent server outright.
+
+The ceiling is now 2048.
+
+## What this belt is, and is not
+
+It is a **UID fork-exhaustion backstop**. It catches a process-count explosion far beyond
+anything a working system produces.
+
+It is **not** an OOM-prevention control, and it does **not** catch the 2026-06-20 runaway
+class (~230-289 concurrent LLM spawns). On a ~500-550 idle floor those total ~730-839,
+comfortably under 2048 — and no value both clears the idle floor and trips before ~250
+spawns exhaust memory at roughly 400MB each. The control that bounds that class is the host
+spawn cap (`SpawnLimiter`, default 8 concurrent LLM subprocesses), which is unchanged.
+
+2048 is an empirical default derived from observed fleet baselines, not a validated safe
+minimum for every host. A heavy developer desktop running containers, parallel test runners
+and several IDE helper trees may need more; both write paths are raise-only so an operator's
+own higher value survives.
+
+## Both write paths are raise-only
+
+- `installAutoStart` (`src/commands/setup.ts`) REGENERATES the plist on install and re-run,
+  so `preserveHigherProcessCeiling` carries a previous value forward when — and only when —
+  it is strictly greater than the template's. A stale low value is replaced; a deliberate
+  higher one survives.
+- `PostUpdateMigrator.migrateLaunchdProcessCeiling` reaches already-deployed agents. It is
+  floor-gated, idempotent, surgical rather than regenerative (hand-added keys and comments
+  survive), and it deliberately does **not** reload launchd — forcing a reload would restart
+  a running agent mid-update.
+
+## Why the file is not the answer — `ProcessCeilingCheck`
+
+launchd applies a raised ceiling only to what it starts **next**. So a migrated machine keeps
+running the old ceiling until it restarts, and the corrected file on disk says nothing about
+the running process. That gap is the 2026-08-19 incident: the plist was raised at 10:26 and
+the machine kept crashing until 12:18, restarted only because the agent asked a human by
+hand.
+
+`ProcessCeilingCheck` (`src/core/ProcessCeilingCheck.ts`) closes it. At server boot on macOS
+it reads the **live** soft `RLIMIT_NPROC` of the running process — from the process's own
+report, not from any file instar wrote, and without spawning anything (the failure being
+detected is precisely an inability to spawn). It then raises at most one deduped Attention
+item:
+
+| Live limit | Plist | Verdict | Priority | What the operator is told |
+|---|---|---|---|---|
+| below floor | at/above floor | `raise` | HIGH | Needs one restart to pick up the raised limit. |
+| below floor | below / missing / half-raised | `repair` | HIGH | Unsafe, and a restart will **not** fix it — the correcting update has not arrived or did not complete. |
+| at/above floor | below / missing / half-raised | `future-repair` | NORMAL | Fine now; a restart **may** lose that. No hurry. |
+| at/above floor | at/above floor | `ok` | — | Nothing. |
+| unreadable | any | `unknown` | — | Nothing — but always logged on macOS. |
+
+Three properties are load-bearing:
+
+- **Signal, never authority.** It raises a notice and can do nothing else — no restart, no
+  `launchctl`, no gating. A wrong reading costs one wrong notice, never an outage.
+- **Silence on uncertainty, but never invisible silence.** An unreadable limit yields
+  `unknown` and no item, because a fabricated "healthy" would hide a real gap and a
+  fabricated "broken" would nag every correct machine forever. On macOS — where it is
+  supposed to work — that branch is always logged, so a reader that broke could not disable
+  the check fleet-wide while still satisfying its no-item contract.
+- **Claims only what it measures.** `future-repair` says a restart *may* lose the limit, not
+  *will*: an absent or unparseable plist does not prove the next limit is low, since defaults
+  or another launch path could apply.
+
+Notices are deduped on the verdict, the machine id, the host fingerprint and the two numbers.
+The host fingerprint is there because a machine-id collision would otherwise swallow the HIGH
+notice for a machine that is actively crashing; with it, a collision costs a duplicate rather
+than a silence. A machine that moves between verdicts (say `repair` to `raise` once the
+migration lands) is re-told, because the required action changed.
+
+None of the notices names a file, a key or a command — the action is "restart this machine",
+which needs no terminal.
+
+## Known gap
+
+This verifies the **limit**, not the **headroom**. A machine sitting at 1900 of 2048 is close
+to failing and reports `ok`. Measuring headroom means counting the UID's processes, which
+means spawning one — the exact operation that fails when the limit is exhausted — so a
+fork-based probe would return nothing precisely when it mattered and reassurance the rest of
+the time. A non-forking count needs a native binding instar does not have; it is tracked, and
+any future change to the ceiling value is blocked on it landing first, because a ceiling
+change is exactly the decision that needs real baselines.
+
+Spec: `docs/specs/launchd-process-ceiling-floor.md`.

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1772,20 +1772,37 @@ ${argsXml}
     <integer>10</integer>
     <!-- Fork-bomb prevention belt (forkbomb-prevention-simple §D-CAP): an
          OS-level NumberOfProcesses ceiling under the host-wide spawn-cap
-         semaphore (the PRIMARY control). Generous + conservative (512) — it
-         bounds a non-compliant runaway that bypasses the funnel without
-         affecting normal operation (normal instar runs far fewer subprocesses).
-         This is the host-GLOBAL belt the funnel's per-process honesty can't
-         provide; it never substitutes for the spawn cap, it backstops it. -->
+         semaphore (the PRIMARY control). This is the host-GLOBAL belt the
+         funnel's per-process honesty can't provide; it never substitutes for
+         the spawn cap, it backstops it.
+
+         The ceiling MUST clear the machine's idle process floor, and by a wide
+         margin. NumberOfProcesses maps to RLIMIT_NPROC, which the kernel counts
+         PER REAL UID — every process the logged-in user owns, not just the ones
+         instar spawned. The original value (512) was chosen as "generous"
+         against instar's own subprocess count, which was the wrong denominator:
+         a normal logged-in macOS desktop already runs ~500-550 user daemons
+         before instar starts. The belt therefore sat BELOW the idle floor, and
+         the failure was not a bounded runaway — it was every fork() from an
+         instar-supervised shell returning EAGAIN on an otherwise idle machine
+         (observed on a Mac Studio, 2026-08-19: 531 uid processes against the
+         512 ceiling, with agent shell commands failing intermittently for
+         hours). A backstop that fires at rest is not a backstop.
+
+         2048 leaves ~1500 headroom over that floor — far above anything the
+         spawn cap admits (default 8 concurrent LLM subprocesses and their
+         children), far below kern.maxprocperuid (10666 on macOS 15), and still
+         well under the 2026-06-20 runaway (~230-289 concurrent spawns on top of
+         the floor). Raise this only against a measured floor, never a guess. -->
     <key>HardResourceLimits</key>
     <dict>
         <key>NumberOfProcesses</key>
-        <integer>512</integer>
+        <integer>2048</integer>
     </dict>
     <key>SoftResourceLimits</key>
     <dict>
         <key>NumberOfProcesses</key>
-        <integer>512</integer>
+        <integer>2048</integer>
     </dict>
 </dict>
 </plist>`;
@@ -1793,7 +1810,12 @@ ${argsXml}
   try {
     fs.mkdirSync(launchAgentsDir, { recursive: true });
     fs.mkdirSync(logDir, { recursive: true });
-    fs.writeFileSync(plistPath, plist);
+    // RAISE-ONLY on the setup path too (docs/specs/launchd-process-ceiling-floor.md §1,
+    // "The operator's escape path, as a contract"). The migration is raise-only, but setup
+    // REGENERATES this file — so without this, a re-run would silently clobber an operator
+    // who deliberately raised their ceiling for a heavy host, and the contract that their
+    // change "sticks" would be false. Found in spec review before it shipped, not after.
+    fs.writeFileSync(plistPath, preserveHigherProcessCeiling(plist, readExistingPlist(plistPath)));
 
     // Validate the plist is well-formed XML before loading.
     // A corrupted plist means launchd can't restart the agent after crashes,
@@ -2110,4 +2132,50 @@ I am ${agentName}, set up via non-interactive mode.
     console.log(pc.green('  ✓ Telegram configured'));
   }
   console.log(pc.dim(`\n  Start with: instar server start --dir ${agentDir}\n`));
+}
+
+/**
+ * Read an existing launchd plist, or `null` when there is none / it cannot be read.
+ * A missing plist is the normal first-install case, not an error.
+ */
+function readExistingPlist(plistPath: string): string | null {
+  try {
+    return fs.readFileSync(plistPath, 'utf-8');
+  } catch {
+    // @silent-fallback-ok: no existing plist (first install) or an unreadable one. Either
+    // way the freshly generated template is written as-is, which is the pre-existing
+    // behaviour — this helper can only ever PRESERVE more, never less.
+    return null;
+  }
+}
+
+/**
+ * Carry an operator's HIGHER `NumberOfProcesses` value from an existing plist into the
+ * freshly generated one, leaving everything else in the new template intact.
+ *
+ * Raise-only by construction: a previous value is carried forward ONLY when it is strictly
+ * greater than the template's. So a stale LOW value (the 512 this change exists to fix) is
+ * correctly replaced by the template, while an operator's deliberate higher value survives
+ * a setup re-run.
+ *
+ * Exported for tests: this is the half of the raise-only contract that lives on the
+ * regenerating path, and it is exactly the half a spec review caught missing.
+ */
+export function preserveHigherProcessCeiling(nextPlist: string, previousPlist: string | null): string {
+  if (!previousPlist) return nextPlist;
+  const RE = /(<key>\s*NumberOfProcesses\s*<\/key>\s*<integer>\s*)(\d+)(\s*<\/integer>)/g;
+  const previous: number[] = [];
+  for (const m of previousPlist.matchAll(RE)) {
+    const v = Number.parseInt(m[2] ?? '', 10);
+    if (Number.isFinite(v)) previous.push(v);
+  }
+  if (previous.length === 0) return nextPlist;
+  const highestPrevious = Math.max(...previous);
+  let i = 0;
+  return nextPlist.replace(RE, (whole, lead: string, digits: string, tail: string) => {
+    i += 1;
+    const templateValue = Number.parseInt(digits, 10);
+    if (!Number.isFinite(templateValue)) return whole;
+    return highestPrevious > templateValue ? `${lead}${highestPrevious}${tail}` : whole;
+  });
 }

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -78,6 +78,52 @@ import { ITERATIVE_CONVERGING_AUDIT_SKILL_CONTENT } from '../data/builtinSkillCo
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Minimum acceptable launchd `NumberOfProcesses` ceiling for an instar agent.
+ *
+ * The value must clear the HOST's idle process floor, not instar's own subprocess
+ * count: NumberOfProcesses maps to RLIMIT_NPROC, which the kernel counts per real
+ * UID across every process the user owns. A logged-in macOS desktop idles around
+ * 500-550 of them. 2048 leaves roughly 1500 of headroom over that floor — far above
+ * anything the host spawn cap admits, and far below kern.maxprocperuid (10666 on
+ * macOS 15), so it still backstops a runaway that bypasses the funnel.
+ *
+ * Kept in lockstep with the ceiling written by `installAutoStart` in commands/setup.
+ */
+export const LAUNCHD_PROCESS_CEILING_FLOOR = 2048;
+
+/** `<key>NumberOfProcesses</key>` followed by its `<integer>` value, whitespace-tolerant. */
+const LAUNCHD_PROCESS_CEILING_RE =
+  /(<key>\s*NumberOfProcesses\s*<\/key>\s*<integer>\s*)(\d+)(\s*<\/integer>)/g;
+
+/**
+ * Every `NumberOfProcesses` value declared in a launchd plist (Soft and Hard limits
+ * are separate keys, so a plist normally declares two). Empty when the plist declares
+ * none — which is a real state (an older or hand-rolled plist), not an error.
+ */
+export function readLaunchdProcessCeilings(plistXml: string): number[] {
+  const out: number[] = [];
+  for (const m of plistXml.matchAll(LAUNCHD_PROCESS_CEILING_RE)) {
+    const v = Number.parseInt(m[2] ?? '', 10);
+    if (Number.isFinite(v)) out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Raise every `NumberOfProcesses` value BELOW `floor` up to `floor`, leaving the rest
+ * of the plist byte-identical. RAISE-ONLY by construction: a value at or above the
+ * floor is returned untouched, so an operator who tuned theirs higher is never
+ * clobbered and a re-run is a no-op.
+ */
+export function raiseLaunchdProcessCeilings(plistXml: string, floor: number): string {
+  return plistXml.replace(LAUNCHD_PROCESS_CEILING_RE, (whole, lead: string, digits: string, tail: string) => {
+    const v = Number.parseInt(digits, 10);
+    if (!Number.isFinite(v) || v >= floor) return whole;
+    return `${lead}${floor}${tail}`;
+  });
+}
+
+/**
  * Agent-facing contract for `POST /intent/journal` confidence.
  *
  * Shared by `generateClaudeMd` (new agents) and `migrateClaudeMd` (existing
@@ -1437,6 +1483,7 @@ export class PostUpdateMigrator {
     this.migrateClaudeTranscriptSpotlightExclusion(result);
     this.migrateAgentDataSpotlightExclusion(result);
     this.migrateBootWrapperToCjs(result);
+    this.migrateLaunchdProcessCeiling(result);
     this.migrateBootWrapperAbiCheck(result);
     this.migrateStaleLifelineSignal(result);
     this.migrateThreadlineConversationStore(result);
@@ -3338,6 +3385,77 @@ export class PostUpdateMigrator {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       result.errors.push(`boot-wrapper .cjs: ${msg}`);
+    }
+  }
+
+  /**
+   * Raise a launchd NumberOfProcesses ceiling that sits below the machine's idle
+   * process floor (Migration Parity Standard — the shipped template fix reaches
+   * NEW agents via `setup`; only this reaches the deployed ones).
+   *
+   * The original belt shipped 512, reasoned against instar's OWN subprocess count.
+   * NumberOfProcesses maps to RLIMIT_NPROC, which the kernel counts per REAL UID —
+   * every process the logged-in user owns. A normal macOS desktop idles at ~500-550
+   * user processes, so the belt sat under the floor and every fork() from an
+   * instar-supervised shell returned EAGAIN on an idle machine. Observed live on a
+   * Mac Studio (2026-08-19): 531 uid processes against the 512 ceiling, agent shell
+   * commands failing intermittently for hours with no alarm attached.
+   *
+   * Deliberately RAISE-ONLY and floor-gated: it rewrites only a value strictly below
+   * LAUNCHD_PROCESS_CEILING_FLOOR, so an operator who deliberately tuned theirs
+   * HIGHER is never clobbered, and a re-run over an already-migrated plist is a
+   * no-op (idempotent). It performs surgical value replacement rather than
+   * regenerating the plist, so hand-added operator keys survive.
+   *
+   * launchd is NOT reloaded here — the raised ceiling applies to processes launchd
+   * starts AFTER the next load, and forcing a reload would restart the running agent
+   * mid-update. The value lands on disk now and takes effect at the next restart.
+   */
+  private migrateLaunchdProcessCeiling(result: MigrationResult): void {
+    if (process.platform !== 'darwin') {
+      result.skipped.push('launchd process ceiling: non-darwin, no plist');
+      return;
+    }
+    const plistPath = path.join(
+      process.env.HOME ?? '',
+      'Library',
+      'LaunchAgents',
+      `ai.instar.${this.config.projectName}.plist`,
+    );
+    let content: string;
+    try {
+      content = fs.readFileSync(plistPath, 'utf-8');
+    } catch {
+      result.skipped.push('launchd process ceiling: no launchd plist present');
+      return;
+    }
+
+    const found = readLaunchdProcessCeilings(content);
+    if (found.length === 0) {
+      result.skipped.push('launchd process ceiling: plist declares no NumberOfProcesses');
+      return;
+    }
+    if (found.every((v) => v >= LAUNCHD_PROCESS_CEILING_FLOOR)) {
+      result.skipped.push(`launchd process ceiling: already >= ${LAUNCHD_PROCESS_CEILING_FLOOR}`);
+      return;
+    }
+
+    const next = raiseLaunchdProcessCeilings(content, LAUNCHD_PROCESS_CEILING_FLOOR);
+    if (next === content) {
+      // The values parsed as low but nothing rewrote — refuse to claim a change.
+      result.errors.push('launchd process ceiling: value parsed below floor but rewrite was a no-op');
+      return;
+    }
+    try {
+      fs.writeFileSync(`${plistPath}.bak-${Date.now()}`, content, 'utf-8');
+      fs.writeFileSync(plistPath, next, 'utf-8');
+      const raised = found.filter((v) => v < LAUNCHD_PROCESS_CEILING_FLOOR).join('/');
+      result.upgraded.push(
+        `launchd process ceiling: raised ${raised} → ${LAUNCHD_PROCESS_CEILING_FLOOR} (applies at next restart)`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push(`launchd process ceiling: ${msg}`);
     }
   }
 

--- a/src/core/ProcessCeilingCheck.ts
+++ b/src/core/ProcessCeilingCheck.ts
@@ -1,0 +1,240 @@
+/**
+ * ProcessCeilingCheck — report the EFFECTIVE process ceiling, never assume the plist is it.
+ *
+ * Spec: docs/specs/launchd-process-ceiling-floor.md §3.
+ * Constitution: "Verify the State, Not Its Symbol"; "No Manual Work (user *or* agent)".
+ *
+ * WHY THIS EXISTS. `PostUpdateMigrator.migrateLaunchdProcessCeiling` raises the
+ * `NumberOfProcesses` value in the agent's launchd plist. That value is a SYMBOL. The STATE
+ * that matters is the `RLIMIT_NPROC` the running processes actually inherited — and the two
+ * diverge for a real, expected window, because launchd applies the raised ceiling only to
+ * what it starts NEXT. A migrated machine keeps running under the old ceiling until it
+ * restarts.
+ *
+ * That divergence is not hypothetical; it is the 2026-08-19 incident. The plist was raised
+ * at 10:26 and the machine kept crashing under the old ceiling until 12:18, and the only
+ * reason it restarted at all is that the agent asked the operator by hand. Two other
+ * machines carried the same ceiling and would have received no such prompt. Relying on
+ * release-note prose plus an agent remembering is exactly the failure the two standards
+ * above name.
+ *
+ * SIGNAL, NEVER AUTHORITY. Everything here reads and reports. It does not restart the
+ * agent, reload launchd, refuse to boot, or gate any work. A wrong reading costs one wrong
+ * notice, never an outage — the correct blast radius for a check whose entire job is to
+ * report that a limit is wrong.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  LAUNCHD_PROCESS_CEILING_FLOOR,
+  readLaunchdProcessCeilings,
+} from './PostUpdateMigrator.js';
+
+/**
+ * The live soft `RLIMIT_NPROC` of THIS process, or `null` when it cannot be read.
+ *
+ * `null` is a first-class result, not an error: a platform without the limit, or a runtime
+ * that does not expose it, is a real state. It must stay explicit rather than collapse to a
+ * flattering number — a fabricated "healthy" would silence a genuine gap, and a fabricated
+ * "broken" would nag every correctly-configured machine forever.
+ *
+ * The reading comes from the process's own report rather than from any file instar wrote,
+ * which is what makes it corroboration of the state rather than a second look at the
+ * symbol. It spawns nothing — deliberately, since the failure being detected is precisely
+ * an inability to spawn.
+ */
+export function readEffectiveProcessCeiling(
+  getReport: () => unknown = () => process.report?.getReport(),
+): number | null {
+  let report: unknown;
+  try {
+    report = getReport();
+  } catch {
+    return null;
+  }
+  const limits = (report as { userLimits?: Record<string, { soft?: unknown }> } | undefined)
+    ?.userLimits;
+  const soft = limits?.['max_user_processes']?.soft;
+  // `unlimited` arrives as a string on some platforms; only a finite positive number is a
+  // ceiling this check can reason about. Anything else is honestly unknown.
+  if (typeof soft !== 'number' || !Number.isFinite(soft) || soft <= 0) return null;
+  return soft;
+}
+
+/**
+ * What the boot check concluded, and why.
+ *
+ * TWO states notify, and they are deliberately DISTINCT because they ask for different
+ * things from the operator (round-2 cross-model finding):
+ *
+ * - `raise`  — the plist is corrected and the machine simply needs its restart.
+ * - `repair` — the machine is running an unsafe ceiling and the plist was NOT corrected
+ *              (the migration never ran, failed, or the plist is missing/malformed). A
+ *              restart would NOT help. Folding this into `raise` would tell the operator to
+ *              restart a machine that would come back just as broken; folding it into
+ *              silence — the first draft's behaviour — leaves a machine crashing on this
+ *              exact bug with nobody told.
+ * - `future-repair` — the machine is running SAFELY right now, but its plist is absent,
+ *              unreadable, half-raised, or below the floor, so its NEXT restart MAY land it
+ *              in the unsafe state. "May", not "would": when the plist is below the floor
+ *              the outcome is known, but when it cannot be READ the next effective limit is
+ *              genuinely unknown — and the notice says so rather than asserting a drop it
+ *              cannot predict. A draft treated this whole row as `ok` on the reasoning that
+ *              the plist is "a question about the future" — but a silent future failure is
+ *              exactly the class this spec exists to end, and the restart that triggers it
+ *              is routine. Lower urgency than `repair` (nothing is broken yet), never
+ *              silent.
+ */
+export type ProcessCeilingVerdict =
+  | { state: 'ok'; effective: number; floor: number }
+  | { state: 'unknown'; reason: 'effective-unreadable' | 'not-applicable' }
+  | { state: 'raise'; effective: number; floor: number; dedupeKey: string }
+  | { state: 'repair'; effective: number; floor: number; dedupeKey: string }
+  | { state: 'future-repair'; effective: number; floor: number; dedupeKey: string };
+
+/**
+ * Compare the EFFECTIVE ceiling against the floor and decide whether the operator should be
+ * told this machine still needs its restart.
+ *
+ * Pure over its inputs so the decision is testable without a live process or a live plist.
+ *
+ * The answer space is enumerable — three states, one input, no competing signals — so the
+ * conservative default on the unmeasurable branch is silence (`unknown`), never a guess.
+ *
+ * `plistCeilings` is passed so the check can tell "this machine was migrated and awaits its
+ * restart" (notify) from "this machine was never migrated at all" (say nothing here — the
+ * migration's own result reports that, and duplicating it would produce two voices for one
+ * condition).
+ */
+export function evaluateProcessCeiling(input: {
+  platform: string;
+  effective: number | null;
+  plistCeilings: number[];
+  machineId: string;
+  /**
+   * A host fingerprint mixed into the dedupe key alongside `machineId` (round-10 review
+   * finding). `machineId` alone is not enough HERE, even though it is elsewhere: if two
+   * machines ever collided on an id, the second's item would be suppressed while the
+   * first's is open — and for this feature that suppressed item can be the HIGH `repair`
+   * notice for a machine that is actively crashing. Mixing in the hostname makes a
+   * collision cost a duplicate notice instead of a swallowed one, which is the right
+   * direction for a safety notice.
+   */
+  hostFingerprint?: string;
+  floor?: number;
+}): ProcessCeilingVerdict {
+  const floor = input.floor ?? LAUNCHD_PROCESS_CEILING_FLOOR;
+  const who = `${input.machineId}@${input.hostFingerprint ?? 'unknown-host'}`;
+  if (input.platform !== 'darwin') return { state: 'unknown', reason: 'not-applicable' };
+  if (input.effective === null) return { state: 'unknown', reason: 'effective-unreadable' };
+  const plistOk =
+    input.plistCeilings.length > 0 && input.plistCeilings.every((v) => v >= floor);
+  if (input.effective >= floor) {
+    if (plistOk) return { state: 'ok', effective: input.effective, floor };
+    // Safe now, unsafe after the next restart. Reported at lower urgency, never silently.
+    return {
+      state: 'future-repair',
+      effective: input.effective,
+      floor,
+      dedupeKey: `process-ceiling:future-repair:${who}:${input.effective}:${floor}`,
+    };
+  }
+  // Effective is below the floor: this machine IS running an unsafe ceiling. Which of the
+  // two notifying states applies depends on whether the plist has been corrected, because
+  // that decides whether a restart would actually fix it.
+  //
+  // Deduped on the machine AND the two numbers, so an un-restarted week produces ONE item
+  // rather than one per boot, while a genuinely changed reading produces a fresh one. The
+  // state is part of the key so a machine that moves from `repair` to `raise` (the
+  // migration lands, restart still pending) tells the operator the NEW thing to do.
+  const state = plistOk ? ('raise' as const) : ('repair' as const);
+  return {
+    state,
+    effective: input.effective,
+    floor,
+    dedupeKey: `process-ceiling:${state}:${who}:${input.effective}:${floor}`,
+  };
+}
+
+/**
+ * The operator-facing text for a `raise` verdict. Plain language, no commands, no file
+ * paths: the action is "restart this machine when convenient", which needs no terminal.
+ */
+export function processCeilingNotice(
+  verdict: Extract<ProcessCeilingVerdict, { state: 'raise' | 'repair' | 'future-repair' }>,
+  machineName: string,
+): { title: string; body: string } {
+  if (verdict.state === 'future-repair') {
+    return {
+      title: `${machineName} is fine now, but a restart may lose that`,
+      body:
+        `This machine is currently running a process limit of ${verdict.effective}, which is ` +
+        `fine. What is NOT confirmed is that it would come back this way: its saved setting is ` +
+        `either below the ${verdict.floor} it should have, or could not be read at all. So a ` +
+        `restart may lose the limit it is running on now.\n\n` +
+        `Nothing is wrong at the moment and there is no hurry. It is worth sorting before the ` +
+        `next restart, though, because at that point commands can start being refused for no ` +
+        `visible reason. The update that corrects the saved setting either has not reached ` +
+        `${machineName} yet or did not complete.`,
+    };
+  }
+  if (verdict.state === 'repair') {
+    return {
+      title: `${machineName} is running too low a process limit, and a restart will not fix it`,
+      body:
+        `This machine is running under a process limit of ${verdict.effective}, below the ` +
+        `${verdict.floor} it should have — and unlike the usual case, the corrected setting has ` +
+        `NOT been saved, so restarting would bring it back just as it is.\n\n` +
+        `While it stays this way, commands can be refused for no visible reason and the ` +
+        `agent's server can crash outright. This one needs looking at rather than a restart; ` +
+        `the update that corrects the setting either has not reached ${machineName} yet or did ` +
+        `not complete.`,
+    };
+  }
+  return {
+    title: `${machineName} needs one restart to pick up its raised process limit`,
+    body:
+      `This machine is still running under a process limit of ${verdict.effective}, which is ` +
+      `below the ${verdict.floor} it should have. The corrected setting is already saved — it ` +
+      `only takes effect on programs started after a restart, so the running ones still carry ` +
+      `the old limit.\n\n` +
+      `While it stays this way, commands can be refused for no visible reason and the agent's ` +
+      `server can crash outright. A normal restart of ${machineName}, whenever convenient, ` +
+      `clears it. Nothing else is needed, and this notice will not repeat until something ` +
+      `changes.`,
+  };
+}
+
+/**
+ * The `NumberOfProcesses` values declared in THIS agent's launchd plist, or `[]` when the
+ * plist is absent/unreadable or the platform has none.
+ *
+ * Kept here rather than in the migrator so the boot check has a read-only path to the
+ * symbol WITHOUT importing the migration machinery: the check compares the symbol against
+ * the state, so it needs to see both, but it must never be able to write either.
+ */
+export function readLaunchdPlistCeilingsForSelf(
+  projectName: string,
+  deps: {
+    platform?: string;
+    home?: string;
+    readFile?: (p: string) => string;
+    parse?: (xml: string) => number[];
+  } = {},
+): number[] {
+  const platform = deps.platform ?? process.platform;
+  if (platform !== 'darwin') return [];
+  const home = deps.home ?? process.env.HOME ?? '';
+  if (!home) return [];
+  const readFile = deps.readFile ?? ((f: string) => readFileSync(f, 'utf-8'));
+  const parse = deps.parse ?? readLaunchdProcessCeilings;
+  try {
+    return parse(readFile(join(home, 'Library', 'LaunchAgents', `ai.instar.${projectName}.plist`)));
+  } catch {
+    // @silent-fallback-ok: an absent or unreadable plist is a REAL state (a machine not
+    // installed via launchd). It yields [], which routes the verdict to `unknown` and
+    // therefore to silence — never to a claim about a machine this check cannot see.
+    return [];
+  }
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -162,6 +162,12 @@ import { RoutingSpendCapsStore } from '../core/RoutingSpendCapsStore.js';
 import { MeteredSpendGate } from '../core/MeteredSpendGate.js';
 import { RenderedPlanStore } from '../core/RenderedPlanStore.js';
 import { MoneyLayerEnableStore } from '../core/MoneyLayerEnableStore.js';
+import {
+  readEffectiveProcessCeiling,
+  evaluateProcessCeiling,
+  processCeilingNotice,
+  readLaunchdPlistCeilingsForSelf,
+} from '../core/ProcessCeilingCheck.js';
 import { MoneyLayerAuditLog } from '../core/MoneyLayerAuditLog.js';
 import { MoneyLayerEnableSurface } from '../core/MoneyLayerEnableSurface.js';
 import { PROBE_DOOR, PROBE_KEY_REF } from '../core/moneyLayerProbe.js';
@@ -2524,6 +2530,71 @@ export class AgentServer {
           sourceContext: 'feedback-drain:integrity',
         });
       }
+    }
+
+    // Process-ceiling state check (docs/specs/launchd-process-ceiling-floor.md §3).
+    // "Verify the State, Not Its Symbol": migrateLaunchdProcessCeiling raises the value in
+    // the launchd plist, but launchd applies it only to what it starts NEXT — so a migrated
+    // machine keeps running the OLD ceiling until it restarts, and under that ceiling
+    // fork() is refused, commands come back empty, and this server can die outright
+    // (2026-08-19). Reading the plist would re-read the symbol; this reads the LIVE process.
+    //
+    // SIGNAL ONLY: it raises one deduped attention item and does nothing else — no restart,
+    // no launchctl, no gating. Silence is the conservative default on every uncertain branch.
+    try {
+      const ceilingVerdict = evaluateProcessCeiling({
+        platform: process.platform,
+        effective: readEffectiveProcessCeiling(),
+        plistCeilings: readLaunchdPlistCeilingsForSelf(options.config.projectName),
+        machineId: (options.config as { machineId?: string }).machineId ?? 'single-machine',
+        hostFingerprint: os.hostname(),
+      });
+      if (
+        ceilingVerdict.state === 'raise' ||
+        ceilingVerdict.state === 'repair' ||
+        ceilingVerdict.state === 'future-repair'
+      ) {
+        const machineName =
+          (options.config as { machineNickname?: string }).machineNickname ?? 'This machine';
+        const notice = processCeilingNotice(ceilingVerdict, machineName);
+        const why =
+          ceilingVerdict.state === 'raise'
+            ? 'restart required to apply'
+            : ceilingVerdict.state === 'repair'
+              ? 'plist NOT corrected; a restart would not help'
+              : 'running safely, but the plist would drop it back at the next restart';
+        console.warn(
+          `[process-ceiling] effective ${ceilingVerdict.effective} vs floor ${ceilingVerdict.floor} — ${why}`,
+        );
+        void this.telegramAdapter?.createAttentionItem?.({
+          id: ceilingVerdict.dedupeKey,
+          title: notice.title,
+          description: notice.body,
+          summary: notice.title,
+          // future-repair is not yet a live fault, so it must not carry the same urgency as
+          // a machine that is currently crashing on it.
+          priority: ceilingVerdict.state === 'future-repair' ? 'NORMAL' : 'HIGH',
+          category: 'monitoring',
+          sourceContext: `process-ceiling:${ceilingVerdict.state}`,
+        });
+      } else if (ceilingVerdict.state === 'unknown' && process.platform === 'darwin') {
+        // The Attention surface stays SILENT here on purpose (a guess in either direction is
+        // worse than none) — but silence with no trace would mean that if the reader ever
+        // broke on darwin, this whole check would disappear fleet-wide while still
+        // "satisfying" its no-item contract. So the unmeasurable branch is logged, always,
+        // on the platform where it is supposed to work.
+        console.warn(
+          `[process-ceiling] unmeasurable on darwin (${ceilingVerdict.reason}) — no claim made; ` +
+            'the ceiling check produced no verdict this boot',
+        );
+      }
+    } catch (err) {
+      // @silent-fallback-ok: this check exists to REPORT a limit, never to enforce one. A
+      // failure here must not take a boot path down — the worst outcome of staying quiet is
+      // the pre-change behaviour (the operator is not told), which is strictly better than
+      // a boot that fails because a notice could not be composed. It is LOGGED, so a broken
+      // check is visible rather than an invisible fleet-wide gap.
+      console.warn('[process-ceiling] check skipped (non-fatal):', err);
     }
 
     // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md) — instar

--- a/tests/unit/launchd-process-ceiling.test.ts
+++ b/tests/unit/launchd-process-ceiling.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LAUNCHD_PROCESS_CEILING_FLOOR,
+  readLaunchdProcessCeilings,
+  raiseLaunchdProcessCeilings,
+} from '../../src/core/PostUpdateMigrator.js';
+import { preserveHigherProcessCeiling } from '../../src/commands/setup.js';
+
+/** The shape `installAutoStart` writes: Hard and Soft limits, each its own key. */
+const plistWith = (hard: number, soft: number): string => `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.instar.echo</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfProcesses</key>
+        <integer>${hard}</integer>
+    </dict>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfProcesses</key>
+        <integer>${soft}</integer>
+    </dict>
+</dict>
+</plist>`;
+
+describe('readLaunchdProcessCeilings', () => {
+  it('reads both the Hard and Soft ceilings', () => {
+    expect(readLaunchdProcessCeilings(plistWith(512, 512))).toEqual([512, 512]);
+  });
+  it('returns empty for a plist declaring no ceiling (older / hand-rolled — a state, not an error)', () => {
+    expect(readLaunchdProcessCeilings('<plist><dict><key>Label</key><string>x</string></dict></plist>')).toEqual([]);
+  });
+  it('tolerates whitespace between the key and its integer', () => {
+    expect(
+      readLaunchdProcessCeilings('<key>NumberOfProcesses</key>\n\t<integer> 700 </integer>'),
+    ).toEqual([700]);
+  });
+  it('does not confuse a different key that carries an integer', () => {
+    expect(readLaunchdProcessCeilings('<key>ThrottleInterval</key><integer>10</integer>')).toEqual([]);
+  });
+});
+
+describe('raiseLaunchdProcessCeilings', () => {
+  // THE DEFECT (observed live on a Mac Studio, 2026-08-19): NumberOfProcesses maps to
+  // RLIMIT_NPROC, counted per real UID. A macOS desktop idles at ~530 user processes,
+  // so a 512 ceiling sat BELOW the idle floor and every fork() from an agent shell
+  // returned EAGAIN on an otherwise idle machine.
+  it('raises the shipped 512 belt to the floor', () => {
+    const out = raiseLaunchdProcessCeilings(plistWith(512, 512), LAUNCHD_PROCESS_CEILING_FLOOR);
+    expect(readLaunchdProcessCeilings(out)).toEqual([
+      LAUNCHD_PROCESS_CEILING_FLOOR,
+      LAUNCHD_PROCESS_CEILING_FLOOR,
+    ]);
+  });
+
+  it('is RAISE-ONLY — an operator who tuned theirs higher is never clobbered', () => {
+    const tuned = plistWith(8192, 8192);
+    expect(raiseLaunchdProcessCeilings(tuned, LAUNCHD_PROCESS_CEILING_FLOOR)).toBe(tuned);
+  });
+
+  it('is idempotent — a second pass over a migrated plist changes nothing', () => {
+    const once = raiseLaunchdProcessCeilings(plistWith(512, 512), LAUNCHD_PROCESS_CEILING_FLOOR);
+    expect(raiseLaunchdProcessCeilings(once, LAUNCHD_PROCESS_CEILING_FLOOR)).toBe(once);
+  });
+
+  it('raises only the low ceiling when Hard and Soft disagree', () => {
+    const out = raiseLaunchdProcessCeilings(plistWith(4096, 512), LAUNCHD_PROCESS_CEILING_FLOOR);
+    expect(readLaunchdProcessCeilings(out)).toEqual([4096, LAUNCHD_PROCESS_CEILING_FLOOR]);
+  });
+
+  it('leaves the rest of the plist byte-identical (surgical, not regenerated)', () => {
+    const before = plistWith(512, 512);
+    const after = raiseLaunchdProcessCeilings(before, LAUNCHD_PROCESS_CEILING_FLOOR);
+    expect(after).toBe(before.replace(/<integer>512<\/integer>/g, `<integer>${LAUNCHD_PROCESS_CEILING_FLOOR}</integer>`));
+    expect(after).toContain('<key>ThrottleInterval</key>\n    <integer>10</integer>');
+  });
+
+  it('never touches an unrelated integer key', () => {
+    const out = raiseLaunchdProcessCeilings(plistWith(512, 512), LAUNCHD_PROCESS_CEILING_FLOOR);
+    expect(out).toContain('<key>ThrottleInterval</key>\n    <integer>10</integer>');
+  });
+
+  it('the floor clears a real macOS desktop idle process count', () => {
+    // 531 uid processes measured on the affected machine; the belt must clear it
+    // with room for the agent's own work, not merely exceed it by a hair.
+    expect(LAUNCHD_PROCESS_CEILING_FLOOR).toBeGreaterThan(531 * 2);
+  });
+});
+
+describe('preserveHigherProcessCeiling — raise-only on the REGENERATING setup path', () => {
+  // The migration is raise-only, but `setup` REWRITES the plist from the template. Without
+  // this, a setup re-run silently clobbers an operator who deliberately raised their ceiling
+  // for a heavy host — which would make the spec's "your change sticks" contract false.
+  const tpl = (v: number) =>
+    `<key>NumberOfProcesses</key>\n<integer>${v}</integer>\n<key>NumberOfProcesses</key>\n<integer>${v}</integer>`;
+
+  it('carries an operator value ABOVE the template forward', () => {
+    expect(preserveHigherProcessCeiling(tpl(2048), tpl(8192))).toContain('<integer>8192</integer>');
+  });
+
+  it('does NOT carry a stale LOW value forward — the template wins', () => {
+    const out = preserveHigherProcessCeiling(tpl(2048), tpl(512));
+    expect(out).toContain('<integer>2048</integer>');
+    expect(out).not.toContain('<integer>512</integer>');
+  });
+
+  it('is a no-op on a first install (no previous plist)', () => {
+    expect(preserveHigherProcessCeiling(tpl(2048), null)).toBe(tpl(2048));
+  });
+
+  it('is a no-op when the previous plist declares no ceiling', () => {
+    expect(preserveHigherProcessCeiling(tpl(2048), '<key>Label</key><string>x</string>')).toBe(tpl(2048));
+  });
+
+  it('carries the HIGHEST previous value when the previous plist was half-raised', () => {
+    const prev = `<key>NumberOfProcesses</key><integer>8192</integer><key>NumberOfProcesses</key><integer>512</integer>`;
+    const out = preserveHigherProcessCeiling(tpl(2048), prev);
+    expect(out).toContain('<integer>8192</integer>');
+    expect(out).not.toContain('<integer>512</integer>');
+  });
+
+  it('leaves every other byte of the new template alone', () => {
+    const next = `<key>Label</key><string>ai.instar.echo</string>\n${tpl(2048)}\n<key>KeepAlive</key><true/>`;
+    const out = preserveHigherProcessCeiling(next, tpl(8192));
+    expect(out).toContain('<key>Label</key><string>ai.instar.echo</string>');
+    expect(out).toContain('<key>KeepAlive</key><true/>');
+  });
+});
+
+describe('plist forms: the "safe no-op" claim, actually verified', () => {
+  // The spec claims an unrecognised plist form yields NO match and therefore NO rewrite.
+  // A claim of safety that no test exercises is the kind this project treats as unearned,
+  // so each named form gets a case (round-9 review finding).
+  const FLOOR = LAUNCHD_PROCESS_CEILING_FLOOR;
+
+  it('malformed XML: no match, no rewrite, no throw', () => {
+    const bad = '<plist><dict><key>NumberOfProcesses</key><integer>512';
+    expect(readLaunchdProcessCeilings(bad)).toEqual([]);
+    expect(raiseLaunchdProcessCeilings(bad, FLOOR)).toBe(bad);
+  });
+
+  it('an unparseable binary-ish blob: no match, no rewrite, no throw', () => {
+    const bin = 'bplist00 NumberOfProcesses';
+    expect(readLaunchdProcessCeilings(bin)).toEqual([]);
+    expect(raiseLaunchdProcessCeilings(bin, FLOOR)).toBe(bin);
+  });
+
+  it('comments survive byte-for-byte around a raised value', () => {
+    const withComment =
+      '<!-- operator: raised for CI host, do not lower -->' +
+      '<key>NumberOfProcesses</key><integer>512</integer>';
+    const out = raiseLaunchdProcessCeilings(withComment, FLOOR);
+    expect(out).toContain('<!-- operator: raised for CI host, do not lower -->');
+    expect(out).toContain('<integer>' + FLOOR + '</integer>');
+  });
+
+  it('duplicate keys are each evaluated independently', () => {
+    const dup =
+      '<key>NumberOfProcesses</key><integer>512</integer>' +
+      '<key>NumberOfProcesses</key><integer>8192</integer>';
+    expect(readLaunchdProcessCeilings(dup)).toEqual([512, 8192]);
+    const out = raiseLaunchdProcessCeilings(dup, FLOOR);
+    expect(out).toContain('<integer>' + FLOOR + '</integer>');
+    expect(out).toContain('<integer>8192</integer>');
+  });
+
+  it('Soft-before-Hard and Hard-before-Soft both raise correctly (order-independent)', () => {
+    const hardFirst =
+      '<dict><key>HardResourceLimits</key><dict><key>NumberOfProcesses</key>' +
+      '<integer>512</integer></dict><key>SoftResourceLimits</key><dict>' +
+      '<key>NumberOfProcesses</key><integer>512</integer></dict></dict>';
+    for (const p of [plistWith(512, 512), hardFirst]) {
+      expect(readLaunchdProcessCeilings(raiseLaunchdProcessCeilings(p, FLOOR))).toEqual([FLOOR, FLOOR]);
+    }
+  });
+
+  it('a value nested deeper than expected is still found and raised', () => {
+    const nested =
+      '<dict><key>Outer</key><dict><key>Inner</key><dict>' +
+      '<key>NumberOfProcesses</key><integer>512</integer></dict></dict></dict>';
+    expect(raiseLaunchdProcessCeilings(nested, FLOOR)).toContain('<integer>' + FLOOR + '</integer>');
+  });
+
+  it('a decoy that only LOOKS like the key is not rewritten', () => {
+    const decoy = '<string>NumberOfProcesses</string><integer>512</integer>';
+    expect(readLaunchdProcessCeilings(decoy)).toEqual([]);
+    expect(raiseLaunchdProcessCeilings(decoy, FLOOR)).toBe(decoy);
+  });
+});

--- a/tests/unit/process-ceiling-check.test.ts
+++ b/tests/unit/process-ceiling-check.test.ts
@@ -1,0 +1,326 @@
+/**
+ * ProcessCeilingCheck — the state-not-symbol half of the launchd ceiling fix.
+ *
+ * Spec: docs/specs/launchd-process-ceiling-floor.md §3, acceptance criteria 7-9.
+ *
+ * The point of this suite is criterion 7: the reading must come from a LIVE process, not
+ * from the plist bytes. A suite that only exercised the pure comparator would prove the
+ * arithmetic and miss the entire bug, which is that the file and the running process
+ * disagree.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  readEffectiveProcessCeiling,
+  evaluateProcessCeiling,
+  processCeilingNotice,
+  readLaunchdPlistCeilingsForSelf,
+} from '../../src/core/ProcessCeilingCheck.js';
+import { LAUNCHD_PROCESS_CEILING_FLOOR } from '../../src/core/PostUpdateMigrator.js';
+
+describe('readEffectiveProcessCeiling — reads the LIVE process, not a file', () => {
+  it('returns this process\'s real soft RLIMIT_NPROC (criterion 7)', () => {
+    const v = readEffectiveProcessCeiling();
+    // On a platform that reports it, it must be a real positive integer — and it must come
+    // from the running process, which is why nothing here reads a plist.
+    if (v !== null) {
+      expect(Number.isInteger(v)).toBe(true);
+      expect(v).toBeGreaterThan(0);
+    }
+    // A platform that cannot report it yields null, which is a valid state, not a failure.
+    expect(v === null || typeof v === 'number').toBe(true);
+  });
+
+  it('agrees with the OS about the live process (corroboration, not a second look at the symbol)', () => {
+    const v = readEffectiveProcessCeiling();
+    if (v === null) return; // honestly unmeasurable here
+    const direct = (process.report.getReport() as { userLimits: Record<string, { soft: unknown }> })
+      .userLimits['max_user_processes'].soft;
+    expect(v).toBe(direct);
+  });
+
+  it('returns null (never a number) when the report throws — criterion 8', () => {
+    expect(
+      readEffectiveProcessCeiling(() => {
+        throw new Error('no report on this runtime');
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when the limit is absent, unlimited, or non-numeric — criterion 8', () => {
+    expect(readEffectiveProcessCeiling(() => ({}))).toBeNull();
+    expect(readEffectiveProcessCeiling(() => ({ userLimits: {} }))).toBeNull();
+    expect(
+      readEffectiveProcessCeiling(() => ({ userLimits: { max_user_processes: { soft: 'unlimited' } } })),
+    ).toBeNull();
+    expect(
+      readEffectiveProcessCeiling(() => ({ userLimits: { max_user_processes: { soft: 0 } } })),
+    ).toBeNull();
+    expect(
+      readEffectiveProcessCeiling(() => ({ userLimits: { max_user_processes: { soft: Infinity } } })),
+    ).toBeNull();
+  });
+});
+
+describe('evaluateProcessCeiling — three enumerable states, silence on uncertainty', () => {
+  const base = { platform: 'darwin', machineId: 'm1', plistCeilings: [2048, 2048] };
+
+  it('raises exactly when the plist is raised but the live process is not — criterion 9', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: 512 });
+    expect(v.state).toBe('raise');
+    if (v.state !== 'raise') return;
+    expect(v.effective).toBe(512);
+    expect(v.floor).toBe(LAUNCHD_PROCESS_CEILING_FLOOR);
+  });
+
+  it('stays silent once the live process is at the floor AND the plist agrees — criterion 9', () => {
+    expect(evaluateProcessCeiling({ ...base, effective: 2048 }).state).toBe('ok');
+  });
+
+  it('stays silent when the live process is ABOVE the floor (operator tuned higher)', () => {
+    expect(evaluateProcessCeiling({ ...base, effective: 8192 }).state).toBe('ok');
+  });
+
+  it('warns about a SAFE machine whose next restart would drop it below the floor', () => {
+    // A draft called this `ok` on the reasoning that the plist is "a question about the
+    // future". A silent future failure triggered by a routine restart is the exact class
+    // this whole check exists to end.
+    const v = evaluateProcessCeiling({ ...base, plistCeilings: [512, 512], effective: 4096 });
+    expect(v.state).toBe('future-repair');
+  });
+
+  it('warns the same way when a SAFE machine has no readable plist at all', () => {
+    expect(evaluateProcessCeiling({ ...base, plistCeilings: [], effective: 4096 }).state).toBe(
+      'future-repair',
+    );
+  });
+
+  it('gives future-repair its own dedupe key, distinct from raise and repair', () => {
+    const future = evaluateProcessCeiling({ ...base, plistCeilings: [512, 512], effective: 4096 });
+    const repair = evaluateProcessCeiling({ ...base, plistCeilings: [512, 512], effective: 512 });
+    const raise = evaluateProcessCeiling({ ...base, effective: 512 });
+    const keys = [future, repair, raise].map((v) => (v.state === 'ok' || v.state === 'unknown' ? '' : v.dedupeKey));
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it('stays silent — never guesses — when the reading is unmeasurable (criterion 8)', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: null });
+    expect(v.state).toBe('unknown');
+    if (v.state === 'unknown') expect(v.reason).toBe('effective-unreadable');
+  });
+
+  it('says REPAIR, not restart, when the machine is unsafe and the plist was never corrected', () => {
+    // The first draft returned silence here, reasoning the migration reports it. It reports
+    // it to a LOG. A machine whose migration never ran is crashing on this exact bug with
+    // nobody told — and telling that operator to "restart" would be wrong advice, because
+    // the machine would come back identical.
+    expect(evaluateProcessCeiling({ ...base, plistCeilings: [512, 512], effective: 512 }).state).toBe(
+      'repair',
+    );
+  });
+
+  it('says REPAIR when the plist declares no ceiling at all', () => {
+    expect(evaluateProcessCeiling({ ...base, plistCeilings: [], effective: 512 }).state).toBe('repair');
+  });
+
+  it('says REPAIR when only SOME plist values were raised (half-migrated plist)', () => {
+    expect(
+      evaluateProcessCeiling({ ...base, plistCeilings: [2048, 512], effective: 512 }).state,
+    ).toBe('repair');
+  });
+
+  it('gives raise and repair DIFFERENT keys, so a machine that gets migrated is re-told', () => {
+    const repair = evaluateProcessCeiling({ ...base, plistCeilings: [512, 512], effective: 512 });
+    const raise = evaluateProcessCeiling({ ...base, effective: 512 });
+    expect(repair.state === 'repair' && raise.state === 'raise').toBe(true);
+    if (repair.state !== 'repair' || raise.state !== 'raise') return;
+    expect(repair.dedupeKey).not.toBe(raise.dedupeKey);
+  });
+
+  it('is a no-op off darwin, where the limit is not launchd-governed', () => {
+    const v = evaluateProcessCeiling({ ...base, platform: 'linux', effective: 512 });
+    expect(v.state).toBe('unknown');
+    if (v.state === 'unknown') expect(v.reason).toBe('not-applicable');
+  });
+
+  it('dedupes per machine so a restart-less week yields ONE item, not one per boot', () => {
+    const a = evaluateProcessCeiling({ ...base, effective: 512 });
+    const b = evaluateProcessCeiling({ ...base, effective: 512 });
+    expect(a.state === 'raise' && b.state === 'raise' && a.dedupeKey === b.dedupeKey).toBe(true);
+  });
+
+  it('gives a DIFFERENT dedupe key per machine, so a second machine is never suppressed', () => {
+    const a = evaluateProcessCeiling({ ...base, effective: 512 });
+    const b = evaluateProcessCeiling({ ...base, machineId: 'm2', effective: 512 });
+    expect(a.state === 'raise' && b.state === 'raise' && a.dedupeKey !== b.dedupeKey).toBe(true);
+  });
+
+  it('two hosts COLLIDING on one machineId still get separate items, not one swallowed', () => {
+    // Elsewhere a machineId collision costs a duplicate row. Here it could swallow the HIGH
+    // notice for a machine that is actively crashing, so the host fingerprint is mixed in.
+    const a = evaluateProcessCeiling({ ...base, hostFingerprint: 'studio.local', effective: 512 });
+    const b = evaluateProcessCeiling({ ...base, hostFingerprint: 'laptop.local', effective: 512 });
+    expect(a.state === 'raise' && b.state === 'raise' && a.dedupeKey !== b.dedupeKey).toBe(true);
+  });
+
+  it('still dedupes across boots on ONE host (the fingerprint is stable, not per-run)', () => {
+    const a = evaluateProcessCeiling({ ...base, hostFingerprint: 'studio.local', effective: 512 });
+    const b = evaluateProcessCeiling({ ...base, hostFingerprint: 'studio.local', effective: 512 });
+    expect(a.state === 'raise' && b.state === 'raise' && a.dedupeKey === b.dedupeKey).toBe(true);
+  });
+
+  it('gives a fresh key when the reading genuinely changes', () => {
+    const a = evaluateProcessCeiling({ ...base, effective: 512 });
+    const b = evaluateProcessCeiling({ ...base, effective: 1024 });
+    expect(a.state === 'raise' && b.state === 'raise' && a.dedupeKey !== b.dedupeKey).toBe(true);
+  });
+});
+
+describe('processCeilingNotice — operator-facing text', () => {
+  const v = evaluateProcessCeiling({
+    platform: 'darwin',
+    machineId: 'm1',
+    plistCeilings: [2048, 2048],
+    effective: 512,
+  });
+
+  it('names the machine, both numbers, and the action', () => {
+    if (v.state !== 'raise') throw new Error('fixture should raise');
+    const n = processCeilingNotice(v, 'the Studio');
+    expect(n.title).toContain('the Studio');
+    expect(n.body).toContain('512');
+    expect(n.body).toContain('2048');
+    expect(n.body.toLowerCase()).toContain('restart');
+  });
+
+  it('asks for no terminal work — no commands, paths, or config syntax', () => {
+    if (v.state !== 'raise') throw new Error('fixture should raise');
+    const n = processCeilingNotice(v, 'the Studio');
+    const text = `${n.title}\n${n.body}`;
+    for (const forbidden of ['launchctl', 'ulimit', 'NumberOfProcesses', '.plist', '/Users/', 'sudo']) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+});
+
+describe('readLaunchdPlistCeilingsForSelf — read-only view of the SYMBOL', () => {
+  it('parses the declared values from this agent\'s plist', () => {
+    const v = readLaunchdPlistCeilingsForSelf('echo', {
+      platform: 'darwin',
+      home: '/home',
+      readFile: () =>
+        '<key>NumberOfProcesses</key><integer>2048</integer><key>NumberOfProcesses</key><integer>2048</integer>',
+    });
+    expect(v).toEqual([2048, 2048]);
+  });
+
+  it('returns [] — routing an unsafe machine to REPAIR — when the plist is unreadable', () => {
+    const v = readLaunchdPlistCeilingsForSelf('echo', {
+      platform: 'darwin',
+      home: '/home',
+      readFile: () => {
+        throw new Error('ENOENT');
+      },
+    });
+    expect(v).toEqual([]);
+    // An unreadable plist on an UNSAFE machine is a repair case: the operator must be told,
+    // and must not be told to restart (which would not help).
+    expect(
+      evaluateProcessCeiling({
+        platform: 'darwin',
+        machineId: 'm1',
+        plistCeilings: v,
+        effective: 512,
+      }).state,
+    ).toBe('repair');
+    // ...and a HEALTHY machine with an unreadable plist is warned at lower urgency, because
+    // its next restart is what makes it unsafe.
+    expect(
+      evaluateProcessCeiling({
+        platform: 'darwin',
+        machineId: 'm1',
+        plistCeilings: v,
+        effective: 4096,
+      }).state,
+    ).toBe('future-repair');
+  });
+
+  it('returns [] off darwin without touching the filesystem', () => {
+    let touched = false;
+    const v = readLaunchdPlistCeilingsForSelf('echo', {
+      platform: 'linux',
+      home: '/home',
+      readFile: () => {
+        touched = true;
+        return '';
+      },
+    });
+    expect(v).toEqual([]);
+    expect(touched).toBe(false);
+  });
+
+  it('returns [] when HOME is unset rather than reading a nonsense path', () => {
+    expect(
+      readLaunchdPlistCeilingsForSelf('echo', { platform: 'darwin', home: '', readFile: () => '' }),
+    ).toEqual([]);
+  });
+});
+
+describe('processCeilingNotice — the repair variant does NOT tell the operator to restart', () => {
+  const repair = evaluateProcessCeiling({
+    platform: 'darwin',
+    machineId: 'm1',
+    plistCeilings: [512, 512],
+    effective: 512,
+  });
+
+  it('says plainly that a restart will not fix it', () => {
+    if (repair.state !== 'repair') throw new Error('fixture should repair');
+    const n = processCeilingNotice(repair, 'the laptop');
+    expect(n.title).toContain('the laptop');
+    expect(`${n.title} ${n.body}`.toLowerCase()).toContain('will not fix');
+    expect(n.body).toContain('512');
+    expect(n.body).toContain('2048');
+  });
+
+  it('asks for no terminal work either', () => {
+    if (repair.state !== 'repair') throw new Error('fixture should repair');
+    const n = processCeilingNotice(repair, 'the laptop');
+    const text = `${n.title}\n${n.body}`;
+    for (const forbidden of ['launchctl', 'ulimit', 'NumberOfProcesses', '.plist', '/Users/', 'sudo']) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+});
+
+describe('processCeilingNotice — the future-repair variant does not manufacture urgency', () => {
+  const future = evaluateProcessCeiling({
+    platform: 'darwin',
+    machineId: 'm1',
+    plistCeilings: [512, 512],
+    effective: 4096,
+  });
+
+  it('says plainly that nothing is wrong yet, and what changes at the next restart', () => {
+    if (future.state !== 'future-repair') throw new Error('fixture should be future-repair');
+    const n = processCeilingNotice(future, 'the mini');
+    const text = `${n.title} ${n.body}`.toLowerCase();
+    expect(n.title).toContain('the mini');
+    expect(text).toContain('restart');
+    expect(text).toContain('no hurry');
+    // "may", never "would": an unreadable plist makes the next effective limit genuinely
+    // unknown, and the notice must not assert a drop it cannot predict.
+    expect(text).toContain('may lose');
+    expect(text).not.toContain('would drop');
+    expect(text).not.toContain('would come back this way.');
+    expect(n.body).toContain('2048');
+  });
+
+  it('asks for no terminal work either', () => {
+    if (future.state !== 'future-repair') throw new Error('fixture should be future-repair');
+    const n = processCeilingNotice(future, 'the mini');
+    const text = `${n.title}\n${n.body}`;
+    for (const forbidden of ['launchctl', 'ulimit', 'NumberOfProcesses', '.plist', '/Users/', 'sudo']) {
+      expect(text).not.toContain(forbidden);
+    }
+  });
+});

--- a/upgrades/next/r5-launchd-process-ceiling.md
+++ b/upgrades/next/r5-launchd-process-ceiling.md
@@ -1,0 +1,93 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**The fork-bomb belt was set below a normal desktop's idle process count, so it fired at rest and
+could take an agent server down.**
+
+The belt shipped `NumberOfProcesses=512`, sized against instar's own subprocess count. That is the
+wrong denominator: `NumberOfProcesses` maps to `RLIMIT_NPROC`, which the kernel enforces **per real
+UID** across every process the logged-in user owns — browser tabs, editors, the GUI desktop, all of
+it. A normal macOS desktop idles at ~500-550 user processes, so the belt sat **below the machine's
+idle floor**.
+
+The failure mode was not a bounded runaway. It was every `fork()` from an instar-supervised process
+returning `EAGAIN` on an otherwise idle machine.
+
+Observed live on a Mac Studio (2026-08-19): 531 uid processes against the 512 ceiling. Agent shell
+commands were refused intermittently for hours, and then the agent server itself died on it:
+
+```
+[FATAL] Uncaught unhandledRejection — closing databases before crash:
+        spawnSync ssh-keygen EAGAIN
+libc++abi: terminating due to uncaught exception ... mutex lock failed
+```
+
+A safety limit that trips while the machine is at rest protects nothing; it just converts idle into
+an outage.
+
+The ceiling is now 2048 — ~1500 of headroom over that floor, far above anything the host spawn cap
+admits (default 8 concurrent LLM subprocesses plus children), far below `kern.maxprocperuid` (10666
+on macOS 15), and still well under the 2026-06-20 runaway (~230-289 concurrent spawns on top of the
+floor). The belt keeps backstopping a non-compliant runaway; it stops firing at rest.
+
+## The machine now tells you when it needs the restart
+
+The corrected value only takes effect on a restart, and until now nothing said so — on the machine
+where this was found, the only reason it got restarted is that the agent asked a human by hand.
+Other machines would have had no such prompt.
+
+At boot each machine now reads its own LIVE limit (not the file) and raises one deduped notice:
+
+- **needs a restart** — the setting is corrected and only a restart is left.
+- **needs looking at** — the machine is unsafe AND a restart would not help, because the
+  correcting update has not reached it or did not complete.
+- **fine now, but a restart may lose that** — lower priority; nothing is broken yet.
+
+If the limit cannot be read at all, nothing is claimed and nothing is raised — but on macOS it is
+always logged, so a broken reader cannot silently disable the check.
+
+**Known gap, stated rather than hidden:** this verifies the LIMIT, not the HEADROOM. A machine at
+1900 of 2048 reports fine. Measuring headroom means counting processes, which means starting one —
+the exact operation that fails when the limit is exhausted — so a check built that way would go
+quiet precisely when it mattered.
+
+## Migration Parity
+
+The template change reaches NEW agents via `setup`, so `migrateLaunchdProcessCeiling` reaches the
+deployed ones. Both write paths are raise-only — `setup` REGENERATES the plist, so it needed the
+same protection or a re-run would have silently reset an operator's deliberate raise. It is:
+
+- **raise-only and floor-gated** — an operator who tuned theirs higher is never clobbered
+- **idempotent** on re-run
+- **surgical** rather than regenerating the plist, so hand-added keys survive
+- deliberately **not** a launchd reload — the raised ceiling applies to what launchd starts next,
+  and forcing a reload would restart a running agent mid-update
+
+## Evidence
+
+- `tests/unit/launchd-process-ceiling.test.ts` (24 tests) — raise-from-512, floor-gating a higher
+  operator value, idempotency, surgical edit preserving unrelated keys, no-reload, the setup-path
+  raise-only rule, and every plist form the change claims to no-op on (malformed XML, unparseable
+  blob, decoy key, comments, duplicate keys, Soft/Hard ordering, deeper nesting).
+- `tests/unit/process-ceiling-check.test.ts` (31 tests) — the live-process reading, all five
+  verdict states, silence on every uncertain branch, and the notice text for each state.
+- Confirmed on the affected machine: ceiling 512 → 2048, verified against the **live process** after
+  restart rather than against the setting. Background jobs spawn normally again; the full test suite
+  (49,478 cases) now runs to completion where it previously took the machine down.
+
+## What to Tell Your User
+
+- **If your agent has been intermittently unable to run commands, or its server has crashed for no
+  visible reason, this was very likely the cause — and your other machines are probably still
+  carrying it.** The limit only takes effect on a restart, so an affected machine needs one restart
+  after updating. You no longer have to remember that: each machine now tells you when it is the
+  one waiting.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Process ceiling sized above the host idle floor | Automatic for new agents via `setup`; deployed agents get it from `migrateLaunchdProcessCeiling` on update. Takes effect at the next restart. |
+| Raise-only on BOTH write paths | Automatic. An operator-tuned ceiling above 2048 survives migration AND a `setup` re-run; hand-added plist keys survive the edit. |
+| Each machine reports its own live limit | Automatic at boot. Raises one deduped notice when a machine still needs its restart, when a restart would not help, or when a restart may lose a currently-safe limit. |

--- a/upgrades/side-effects/launchd-process-ceiling-floor.md
+++ b/upgrades/side-effects/launchd-process-ceiling-floor.md
@@ -1,0 +1,252 @@
+# Side-Effects Review — Launchd process ceiling floor + live-ceiling reporting
+
+**Version / slug:** `launchd-process-ceiling-floor`
+**Date:** `2026-08-19`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `cross-model codex-cli:gpt-5.5 (10 rounds) + Standards-Conformance Gate`
+
+## Summary of the change
+
+Two halves. (1) The launchd `NumberOfProcesses` belt moves 512 → 2048, because it mapped to
+`RLIMIT_NPROC` — a PER-UID limit — and so sat below a normal desktop's idle process floor,
+refusing `fork()` on an idle machine and eventually killing the agent server. Raise-only on
+BOTH write paths (`installAutoStart` regenerates the plist; `migrateLaunchdProcessCeiling`
+reaches deployed agents). (2) A boot check reads the LIVE `RLIMIT_NPROC` and raises one
+deduped Attention item when a machine is running an unsafe ceiling or would be after its next
+restart — because the plist is a symbol and the running process is the state.
+
+Files: `src/commands/setup.ts`, `src/core/PostUpdateMigrator.ts`, `src/core/ProcessCeilingCheck.ts`
+(new), `src/server/AgentServer.ts` (boot wiring), plus two unit suites (55 tests).
+
+## Decision-point inventory
+
+- `installAutoStart` plist write — **modify** — now raise-only via `preserveHigherProcessCeiling`.
+- `PostUpdateMigrator.migrateLaunchdProcessCeiling` — **add** — raise-only, floor-gated,
+  idempotent, surgical, non-reloading.
+- `ProcessCeilingCheck.evaluateProcessCeiling` — **add** — five enumerable verdicts; the only
+  output is whether to raise a notice.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. Nothing here refuses a request, a
+message, a spawn, or a session.
+
+The nearest analogue is a FALSE NOTICE: telling an operator a machine needs attention when it
+does not. Every uncertain branch is silent by construction (`unknown` when the live reading is
+unreadable; `ok` when both the reading and the plist are at or above the floor), so a false
+notice requires the OS to misreport its own limit. The cost if it happened is one wrong
+Attention row, which the operator resolves — never an outage.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+The genuine detection gap, stated because it is real: the check verifies the LIMIT, not the
+HEADROOM. A machine at 1900 of 2048 reports `ok`. Counting the UID's processes requires
+spawning one — the exact operation that fails when the limit is exhausted — so a fork-based
+headroom probe would go silent precisely when it mattered and reassuring otherwise. Tracked
+as CMT-015 and made blocking on any future change to the ceiling value.
+
+Second gap: an unreadable live limit yields `unknown` and no Attention item. Deliberate (a
+guess in either direction is worse than none), but it is always LOGGED on darwin, so a reader
+that broke could not silently disable the check fleet-wide.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and the review moved it there.
+
+The ceiling belongs in the launchd plist — it is an OS resource limit and there is no
+per-job or per-process-tree alternative on macOS (no `pids.max` equivalent reachable from a
+plist). The migration belongs in `PostUpdateMigrator` per Migration Parity; the template
+belongs in `setup`. Both were needed: `setup` REGENERATES the plist, so raise-only had to
+exist on that path too — a spec-review finding, not something the original design covered.
+
+The boot check is deliberately at the server boot rather than inside the migration: the
+migration writes a file and cannot observe the process that will later inherit it, so a check
+living there could only re-read its own output. Reading the live limit at boot is the only
+place the state is observable.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+`ProcessCeilingCheck` raises an Attention item and does nothing else. It never restarts the
+agent, never invokes `launchctl`, never refuses a boot, never gates work. The Attention queue
+(with its existing routing, dedupe, and flood ceilings) is the consumer. A wrong reading costs
+one wrong notice; it can never cost an outage. This is the correct shape for a check whose
+whole job is to report that a limit is wrong.
+
+The migration writes a file and is not an authority over any runtime decision. It is
+raise-only by a strict `<` comparison, so it cannot override an operator's judgement in the
+one direction that would matter.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. All three decision points are
+classified `invariant` in the spec, and the reasoning is the same in each: an enumerable
+answer space from bounded inputs. The boot check takes two inputs but they answer two
+different, non-competing questions (safe now / safe after the next restart), so the result is
+a lookup rather than a weighing. No floor or arbiter is declared because there is nothing to
+arbitrate.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the boot check runs alongside the migration but reads a different thing (live
+  process vs file), so neither shadows the other. Within the check, the `future-repair` branch
+  is deliberately evaluated before `ok` so a safe-but-misconfigured machine is not swallowed.
+- **Double-fire:** the `repair` state exists precisely to avoid two voices for one condition —
+  a machine whose migration never ran is reported by the check, and the migration's own result
+  reports its failure to the log. They describe the same underlying fault, but only the check
+  reaches the operator, and it says the correct action for it (look at it, do not restart).
+- **Races:** none introduced. `readEffectiveProcessCeiling` reads the process's own report;
+  `evaluateProcessCeiling` is pure; the plist read is a single synchronous read. The check
+  spawns nothing — deliberately, since the failure it detects is an inability to spawn.
+- **Feedback loops:** none. The check cannot change the limit it reads.
+
+Interaction worth naming: the migration deliberately does NOT reload launchd. That is what
+creates the symbol/state divergence this check reports — the two halves are a matched pair,
+and removing either leaves the other incoherent (a reload would restart a running agent
+mid-update; a migration with no check leaves the divergence silent).
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** the ceiling is per-UID, so raising it affects every
+  process of that user — in the permissive direction only.
+- **Other users of the install base:** deployed agents receive the migration on update and the
+  check at the next boot. A macOS agent gets at most one Attention item; a non-darwin agent is
+  a strict no-op.
+- **External systems:** none. No network call, no third-party binary. The check does not even
+  exec.
+- **Persistent state:** one integer in the machine's own launchd plist, with a timestamped
+  backup written before the edit. No schema, no database, no migration to reverse.
+- **Timing / runtime conditions:** improves them — the whole point is removing a limit that
+  refused `fork()` at rest.
+- **Operator surface (Mobile-Complete Operator Actions):** the notices are phone-complete by
+  construction. The `raise` action is "restart this machine", which needs no terminal; the
+  `repair` and `future-repair` notices report a condition and ask for no command. All three
+  are asserted by test to contain no path, command, or config key. The rare
+  raise-above-2048 escape path IS terminal work, and is deliberately kept out of the notices
+  (documented in the spec instead) — handing plist surgery to an operator who needs a restart
+  would be worse guidance, not better reach.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer, markup file, approval page, or grant/revoke/secret-drop form is
+staged — the gate's trigger does not fire. The operator-facing output is Attention item text,
+reviewed against the same spirit:
+
+1. **Leads with the primary action** — each title states the machine and what is needed
+   ("needs one restart", "a restart will not fix it", "a restart may lose that").
+2. **Zero raw internals** — no fingerprints, no paths, no key names; the two numbers shown are
+   process counts, which are the substance.
+3. **Destructive actions de-emphasized** — none offered.
+4. **Plain language** — asserted by test: each notice is checked to contain none of
+   `launchctl`, `ulimit`, `NumberOfProcesses`, `.plist`, a home path, or `sudo`.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**`unified` for the shipped value; `machine-local` for the effective reading**
+(`machine-local-justification: hardware-bound-resource`).
+
+The ceiling and both write paths are unified — the same code writes the same floor on every
+machine. The live reading is machine-local because `RLIMIT_NPROC` is a kernel limit on one
+host's running process; a peer's reading cannot answer "is THIS machine's limit raised yet?",
+and replicating it would let a healthy peer mask an unhealthy machine.
+
+- **User-facing notices:** one per machine, per-machine BY NECESSITY — each machine needs its
+  own physical restart, so one-voice gating ACROSS machines would suppress a second machine's
+  genuine need. Bounded three ways: deduped per machine, self-extinguishing (the condition
+  ends when the restart happens), and riding the existing single-hub Attention routing rather
+  than creating topics. A cross-machine summary was rejected because it would have to be
+  raised by one machine on behalf of others using a reading it cannot have — and would omit
+  the machine most likely to be down, which is the one crashing on this bug.
+- **Durable state on topic transfer:** none held; nothing strands.
+- **Generated URLs:** none.
+
+The dedupe key mixes the host fingerprint with the machine id, so an id collision costs a
+duplicate notice rather than swallowing the HIGH notice for a crashing machine.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert and ship a patch. Pure code change.
+- **Data migration:** none. An already-migrated plist keeps 2048, which is harmless within the
+  supported-host envelope (roughly a fifth of `kern.maxprocperuid`); the timestamped backup of
+  the original is on disk beside it.
+- **Agent state repair:** none. The Attention items are ordinary rows the operator resolves.
+- **User visibility:** reverting restores the previous behaviour — a silent restart
+  requirement — which is the pre-change state, not a new regression.
+
+---
+
+## Conclusion
+
+The review changed this substantially, and that is the honest headline. It began as a
+one-integer change justified partly by a claim that was arithmetically false, treating a
+corrected file as a corrected machine. Ten rounds of cross-model review plus the
+Standards-Conformance Gate produced six findings that changed CODE — the symbol/state gap, two
+missing verdict states, the setup clobber path, and a machine-id collision that could have
+swallowed a crashing machine's notice — and roughly a dozen more that corrected claims in the
+document. The Standards gate reached zero findings at round 3 and stayed there.
+
+It did NOT converge: the two-consecutive-clean-rounds criterion was never met, the 10-round
+cap fired, and the operator approved at the cap after reading the report that says so. That
+distinction is preserved in the spec frontmatter rather than smoothed over.
+
+Clear to ship on that basis.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** cross-model `codex-cli:gpt-5.5`, 10 independent rounds
+**Independent read: concur, with the residual risk named**
+
+Round 10's closing assessment: *"the design is clear and appropriately narrows the belt's
+role. The main residual risk is not conceptual; it is that the static default plus no headroom
+probe can still fail silently on unusually busy hosts."* That risk is recorded in the spec, in
+the release notes, and as CMT-015, and it is made blocking on any future change to the ceiling
+value.
+
+Disclosure on independence: the internal reviewer perspectives were carried by the authoring
+session rather than by spawned subagents, under a session instruction not to spawn agents
+without a request. The genuinely independent reads here are the cross-model pass and the
+code-backed Standards gate — both ran every applicable round and produced every finding above.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/launchd-process-ceiling.test.ts` — 24 tests: raise-from-512, floor-gating,
+  idempotency, surgical edit, no-reload, setup-path raise-only, and every plist form the
+  change claims to no-op on.
+- `tests/unit/process-ceiling-check.test.ts` — 31 tests: the live-process reading, all five
+  verdicts, silence on every uncertain branch, dedupe behaviour, and the notice text for each
+  state including the no-terminal-work assertions.
+- Local run 2026-08-19: 55 tests, 0 failures.
+- Field evidence: 531 uid processes against the 512 ceiling on a Mac Studio; server death on
+  `spawnSync ssh-keygen EAGAIN`; ceiling confirmed 512 → 2048 against the LIVE process after
+  restart, with the full suite (49,478 cases) then running to completion where it had
+  previously taken the machine down.
+- Convergence report: `docs/specs/reports/launchd-process-ceiling-floor-convergence.md`.


### PR DESCRIPTION
## Problem

The fork-bomb belt shipped `NumberOfProcesses=512`, sized against instar's own subprocess count.

That is the wrong denominator. `NumberOfProcesses` maps to `RLIMIT_NPROC`, which the kernel enforces **per real UID** across every process the logged-in user owns. A normal macOS desktop idles at ~500-550 user processes, so the belt sat **below the machine's idle floor**.

The failure mode was not a bounded runaway. It was every `fork()` from an instar-supervised process returning `EAGAIN` on an otherwise idle machine.

Observed live on a Mac Studio (2026-08-19): 531 uid processes against the 512 ceiling. Agent shell commands were refused intermittently for hours — and because a refused command returns *empty output*, the agent read that silence as an answer and reported a machine "asleep" on the strength of a command that never ran. Then the server itself died: `spawnSync ssh-keygen EAGAIN`.

A safety limit that trips while the machine is at rest protects nothing; it just converts idle into an outage.

## Fix — two halves

**1. `512 → 2048`, raise-only on BOTH write paths.** The migration reaches deployed agents. `setup` REGENERATES the plist, so `preserveHigherProcessCeiling` had to exist there too — without it, a setup re-run would silently reset an operator who had deliberately raised their own ceiling. Both compare strictly below the floor, so an operator-tuned higher value survives install, update, and any future template change.

**2. Report the LIVE ceiling, not the file.** launchd applies the raised value only to what it starts *next*, so a migrated machine keeps running the old one until it restarts — which is exactly this incident, and the only reason this machine got restarted is that the agent asked a human by hand. Two other machines would have had no such prompt.

`ProcessCeilingCheck` reads the live `RLIMIT_NPROC` at boot and raises one deduped Attention item:

| Effective | Plist | Verdict | Priority |
|---|---|---|---|
| below floor | at/above floor | `raise` — needs one restart | HIGH |
| below floor | below/missing/half-raised | `repair` — a restart will NOT fix it | HIGH |
| at/above floor | below/missing/half-raised | `future-repair` — fine now, a restart may lose that | NORMAL |
| at/above floor | at/above floor | none | — |
| unreadable | any | none (but always logged on darwin) | — |

Signal only: it raises a notice and can do nothing else — no restart, no `launchctl`, no gating. Every uncertain branch is silent.

## Honest scope — a claim in the first draft was false

The original commit message and release notes claimed 2048 "still catches" the 2026-06-20 runaway. **That is arithmetically wrong and is withdrawn.** ~230-289 spawns on a ~500-550 floor totals ~730-839, comfortably under 2048.

Nor can the belt be sized to catch it: at ~400MB per LLM subprocess, ~250 spawns is already an OOM, and a ceiling low enough to trip first sits barely clear of an idle desktop — the same "fires at rest" bug with a smaller margin.

So this is a **UID fork-exhaustion backstop**, not an OOM control and not the thing that catches that incident class. The control that catches it is the host spawn cap (8 concurrent LLM subprocesses), which was already correct and is unchanged.

**Known gap, stated not hidden:** this verifies the LIMIT, not the HEADROOM. A machine at 1900 of 2048 reports fine. Counting UID processes means spawning one — the operation that fails when the limit is exhausted — so a fork-based probe would go quiet precisely when it mattered. Tracked as CMT-015 and made *blocking* on any future change to this ceiling value.

## Review

`docs/specs/launchd-process-ceiling-floor.md` — 10 cross-model rounds (codex-cli:gpt-5.5, `status: ok` every round), Standards-Conformance Gate clean from round 3.

**It did NOT converge.** The two-consecutive-clean-rounds criterion was never met and the 10-round cap fired; the operator approved at the cap after reading the report that says so. That is recorded in the frontmatter as an override, not a passing grade.

Six of the review's findings changed **code**, none of which came from the author:

1. The plist is a symbol, not the state → the whole boot check exists because of this.
2. The check was silent on the worst case — a machine whose migration never ran got nothing, and telling it to "restart" would have been wrong advice → `repair`.
3. A safe machine could restart into the unsafe state silently → `future-repair`.
4. A setup re-run would have clobbered an operator's raised ceiling → `preserveHigherProcessCeiling`.
5. A machine-id collision could have swallowed the HIGH notice for a crashing machine → host fingerprint in the dedupe key.
6. `unknown` had no observability, so a broken reader would have disabled the check fleet-wide while satisfying its no-item contract → always logged on darwin.

## Testing

- `tests/unit/launchd-process-ceiling.test.ts` — 24 tests: raise-from-512, floor-gating, idempotency, surgical edit, no-reload, setup-path raise-only, and every plist form the change claims to no-op on (malformed XML, unparseable blob, decoy key, comments, duplicate keys, Soft/Hard ordering, deeper nesting).
- `tests/unit/process-ceiling-check.test.ts` — 31 tests: the live-process reading, all five verdicts, silence on every uncertain branch, dedupe behaviour, and each notice's text including assertions that none contains a path, command, or config key.
- 55 tests, 0 failures locally.
- Field evidence: ceiling confirmed 512 → 2048 against the **live process** after restart; the full suite (49,478 cases) then ran to completion where it had previously taken the machine down.

---

## ELI16 — A safety limit was set lower than the number of programs an idle computer already runs, so it fired at rest and eventually killed the agent's server

Every computer caps how many programs one user account may run at once. Instar sets that cap deliberately, as a last-resort brake in case something of its own runs away. The number chosen was 512 — reasonable if you count only instar's own helpers, but the operating system counts *everything* the logged-in person runs: the desktop, the browser, the editor. An ordinary Mac idles at 500-550. The brake was already clamped before instar started anything.

The result wasn't a caught runaway. It was an idle machine where commands were refused at random for hours — returning empty rather than complaining, which quietly misled the agent into treating "the command never ran" as an answer — and then the agent's own server died outright.

The fix raises the number to 2048 and corrects it on machines that already have instar, not just new ones.

What review added matters more. The corrected number only takes effect after a restart, and nothing told anyone that. On the machine where this was found, the only reason it got restarted is that the agent asked a human by hand; two other machines would have had no prompt at all. Now each machine checks its own live limit at startup and says one of three things: *needs a restart*, *needs looking at because a restart won't help*, or *fine now, but a restart may lose that*. If it can't read the limit it says nothing — but records that it couldn't, so a broken check can't disappear unnoticed.

And it's honest about what it doesn't cover: it checks the limit, not how close the machine is to it. Measuring that means starting a program, which is the exact thing that fails when the limit is exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
