### PR TITLE
fix: carry the agent identity when a machine joins the mesh, and refuse to invent one

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-20T03-38-17-522Z-agent-identity-continuity-on-expansion.json
+++ b/.instar/instar-dev-decisions/2026-08-20T03-38-17-522Z-agent-identity-continuity-on-expansion.json
@@ -1,0 +1,31 @@
+{
+  "ts": "2026-08-20T03:38:17.522Z",
+  "slug": "agent-identity-continuity-on-expansion",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 807,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/AgentIdentityDivergenceDetector.ts",
+      "src/core/AgentIdentityHandover.ts",
+      "src/core/AgentIdentityReconciler.ts",
+      "src/core/ProcessCeilingCheck.ts",
+      "src/monitoring/guardManifest.ts",
+      "src/server/AgentServer.ts",
+      "src/threadline/client/IdentityManager.ts",
+      "src/threadline/client/JoinedMeshDetector.ts"
+    ],
+    "addedLines": 803,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/agent-identity-continuity-on-expansion.eli16.md
+++ b/docs/specs/agent-identity-continuity-on-expansion.eli16.md
@@ -1,0 +1,67 @@
+# Agent Identity Continuity on Expansion — Plain-English Overview
+
+> The one-line version: when an agent spreads onto a new machine, it should still be the same agent — right now it quietly becomes a second one.
+
+## The problem in one breath
+
+Agents are found by an address, the way a phone number reaches a person. One agent should have one address, whichever of its machines is answering. When an agent expands onto a new machine, the new machine doesn't receive that address — so it makes up its own. Nothing says anything. The agent is now two agents wearing one name.
+
+## The clearest proof it isn't cosmetic
+
+The operator asked whether the feature that stamps Telegram messages as coming from the agent
+rather than from him was affected by this. It is, and testing it settled the question.
+
+A plain message was signed on the new machine and shown to all three:
+
+- The machine that signed it said yes, that's genuinely from the agent.
+- The laptop said no, bad signature.
+- The mini said no, bad signature.
+
+Same message. The two older machines look up the agent and get one identity; the new machine
+signs with another, so to them the signature is a forgery.
+
+In practice that feature is switched off on the new machine — nothing signed there can be
+confirmed as the agent by the others. It fails in the safe direction (it says "this didn't
+check out", not "this was the operator"), but the guarantee it exists to give is simply absent.
+
+## What already exists
+
+- **Expanding onto a new machine** — copies the shared project, gives the new machine its own local settings and its own machine keys, and registers it with the machine it joined. All of that works.
+- **A pairing code** — a short code you carry from one machine to the other to prove the two belong together. It already works and you already use it.
+- **A fix from July** — when this last caused trouble, the message-sending side was taught to prefer the live address over a dead one. That reduced the damage. It didn't stop the cause.
+
+## What this adds
+
+The identity travels with the expansion, over the pairing exchange that already happens. No new step for you.
+
+- If it can't be carried, the new machine **refuses to invent one** and says so, rather than quietly becoming a twin.
+- Machines that are already split get repaired.
+- And something notices when a split exists, which nothing does today.
+
+## The new pieces
+
+- **The sealed handover** — the identity is locked so only the joining machine can open it, and stamped with details of that exact exchange, so it can't be lifted and reused elsewhere.
+- **The refusal** — a machine that has joined a mesh is no longer permitted to invent an identity at all. That's what makes the fix stick rather than depending on the handover always succeeding.
+- **The check** — every machine compares its address with the others and reports what it finds, including when it couldn't reach one, so silence never gets mistaken for agreement.
+
+## The safeguards
+
+**A wrong repair can't take your agent off the network.** Every uncertain case stops and asks rather than guessing. Repairing to the wrong address would be worse than the split.
+
+**Someone impersonating your machine can't hand over a fake identity.** The pairing code you carry is what proves the other end is really yours, and the joining machine checks the identity it receives against a value shown to you.
+
+**A dropped connection doesn't cost you a whole new setup.** The same machine can retry until the code expires; anyone else presenting it is refused.
+
+**A half-written key can't happen.** The identity is written completely or not at all, readable only by its owner, and the old one is kept as a backup first.
+
+## What it does NOT do, and one real cost
+
+The split you already have **cannot be repaired automatically.** The mechanism that decides which address is correct only works for identities created after this ships. Yours predate it, so fixing your machines needs one decision from you — you'll be shown the options in plain terms and pick one, not compare two strings of gibberish.
+
+The stale copies of your agent already registered on the network are **not cleaned up by this.** That needs work on a different component, and I'd rather say so than let you think it's tidier than it is.
+
+And the honest cost: every machine ends up holding the same key, so any one of them can sign as the agent. If a machine is stolen or retired, its copy still works until the identity is replaced everywhere. That's a real weakness, accepted here because the alternative means changing what an agent's address means for everyone who has ever saved one. It's marked as a bridge, not a destination.
+
+## What you actually need to decide
+
+Whether to fix this at the source — so expanding onto a machine carries the identity and refuses to invent one — accepting that your existing split still needs one explicit choice from you afterwards, and that stale registrations stay until separate work clears them.

--- a/docs/specs/agent-identity-continuity-on-expansion.md
+++ b/docs/specs/agent-identity-continuity-on-expansion.md
@@ -1,0 +1,591 @@
+---
+title: "Agent Identity Continuity on Expansion — one agent keeps one identity when it gains a machine"
+slug: "agent-identity-continuity-on-expansion"
+author: "echo"
+status: "draft"
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
+sibling-principles: "Verify the State, Not Its Symbol; No Silent Degradation; Know Your Principal — An Unverified Identity Is a Guess"
+parent-spec: "docs/specs/threadline-duplicate-identity-resolution.md"
+project: "multi-machine-coherence"
+depends-on: "joinMesh (src/commands/machine.ts) — the expansion path; POST /api/pair (src/server/machineRoutes.ts) — the authenticated pairing exchange that already carries the joiner's encryption key; IdentityManager (src/threadline/client/IdentityManager.ts) — getOrCreate() is the minting site; CanonicalIdentityManager (src/identity/IdentityManager.ts) — holds the encrypted-at-rest identity and the unused recovery-phrase facility; ThreadlineBootstrap (src/threadline/ThreadlineBootstrap.ts) — already uses .get() not .getOrCreate(), deliberately"
+review-convergence: "2026-08-20T01:41:25.960Z"
+review-iterations: 7
+review-completed-at: "2026-08-20T01:41:25.960Z"
+review-report: "docs/specs/reports/agent-identity-continuity-on-expansion-convergence.md"
+approved: true
+approved-basis: "Justin (verified operator, topic 48000) replied 'approved' on 2026-08-19 after being sent the plain-English overview and the convergence report, including the post-tag amendment note and the three things deliberately left unfixed (the existing split needs an operator decision; stale relay rows are not cleaned up; every machine holds the same key)."
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 6
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Agent Identity Continuity on Expansion
+
+## Problem
+
+An agent that expands onto a new machine silently becomes **two agents with one name**.
+
+Observed live (2026-08-19). The operator authorised echo's Mac Mini to extend echo onto a
+Mac Studio, and ran the command the Mini produced. The expansion succeeded in every visible
+respect — the Studio is a registered mesh member, holds the serving lease, and answers. But
+it publishes routing fingerprint `ae6feac6…`, while the Mini and Laptop both publish
+`63b1dbb2…`. The canonical value appears 57 times across echo's durable state, including the
+provenance rule that stamps messages sent through the operator's account as agent-authored;
+`ae6feac6…` appears only in files the Studio wrote about itself.
+
+Nothing reported this. It surfaced four days later, while investigating an unrelated request.
+
+### Why it happens (root cause, confirmed in code)
+
+`joinMesh` (`src/commands/machine.ts:363`) provisions:
+
+1. a clone of the mesh repo,
+2. a machine-local `config.json` — deliberately scaffolded fresh, because it holds
+   per-machine secrets (auth token, dashboard PIN),
+3. a **machine** identity via `MachineIdentityManager.generateIdentity()` — machine id,
+   signing key, encryption key,
+4. a `POST /api/pair` exchange that registers the joiner and returns the awake machine's
+   machine identity.
+
+None of those is the **agent** identity. It is not in the cloned repo (gitignored — it holds
+a private key), not in the scaffolded config, not in the pairing response, and not in the
+cross-machine secret-sync key set.
+
+So on first server boot the agent looks for an identity, finds none, and
+`IdentityManager.getOrCreate()` (`src/threadline/client/IdentityManager.ts:49`) mints a fresh
+keypair.
+
+**The design error in one sentence: the agent's identity is treated as a per-machine secret,
+when it is a shared-agent secret.** Machine keys are correctly per-machine — the agent is not.
+
+### Why it is worse than a cosmetic mismatch
+
+- **Messages disappear.** A stale registration survives on the relay keyed by public key, and
+  the sender-side resolver cannot always tell the live row from the dead one. This is the
+  exact July failure recorded in `threadline-duplicate-identity-resolution.md`: *"his replies
+  aren't reaching me… there are two 'echo' identities on the relay, one of which silently
+  drops."* That spec fixed the resolver and one orphan (`64cab8bc…`). It did not close the
+  source. `ae6feac6…` is the next one.
+- **Provenance breaks.** Anything signed on the diverged machine carries a fingerprint that
+  does not match the agent's pinned signing identity, so it does not verify as that agent.
+- **The agent-signature feature is inoperative from the diverged machine — measured, not
+  inferred.** The operator asked whether the feature that stamps Telegram messages as
+  agent-authored rather than operator-typed was affected. It reads the same identity, so a
+  controlled test was run: a PLAIN-TEXT message signed on the Studio, verified on all three
+  machines.
+
+  | Verifier | Verdict |
+  |---|---|
+  | Studio (the signer) | `agent-verified` |
+  | Laptop | `rejected` — `bad-signature` |
+  | Mini | `rejected` — `bad-signature` |
+
+  Plain text was used deliberately, because a known separate limitation rejects signed
+  *markdown* (the Telegram send path rewrites the bytes the signature covers) and would have
+  confounded the result. It did not apply here, and the message was still rejected on both
+  peers. The verifiers resolve `echo` to `63b1dbb2…` while the Studio signs as `ae6feac6…`.
+
+  The failure direction is safe — a Studio-signed message is `rejected`, not silently accepted
+  as operator-typed — but the guarantee the feature exists to provide is simply absent from
+  that machine. This is the sharpest available demonstration that the split is not cosmetic.
+
+- **It is silent.** No guard compares the identity a machine publishes against its peers'.
+  Every additional machine compounds it.
+
+### The half-built mechanism
+
+`CanonicalIdentityManager.create()` can emit a 24-word recovery phrase and stores a recovery
+commitment. Nothing consumes it: there is no restore path and no CLI surface. The facility
+that would let one identity be reconstituted elsewhere exists, is never used, and therefore
+protects nothing today.
+
+## Decision points touched
+
+> *Local terms: an **invariant** decision point has an enumerable answer space and is
+> deterministic by design; a **judgment-candidate** is one where several live signals can
+> genuinely conflict, which requires a declared floor plus an arbiter.*
+
+| Decision point | Classification | Justification |
+|---|---|---|
+| Whether a machine may MINT an agent identity | **invariant** | Two enumerable states with an objective discriminator: a machine that has joined an existing mesh must never mint; a genuinely standalone first machine must. The discriminator is the presence of mesh-join state on disk, not a heuristic. |
+| Whether to accept an agent identity received during pairing | **invariant** | Accept only when it arrives sealed to this machine's own encryption key, in the response to a single-use pairing code this machine just presented. Anything else is refused. No weighing. |
+| Whether a machine's published identity diverges from its peers' | **invariant** | A string comparison against peers reporting the same agent name. Enumerable: agree / disagree / cannot-tell (peer unreachable). `cannot-tell` never PAGES but is always REPORTED — absence of evidence must never render as agreement. |
+
+> None of these is a judgment-candidate. Each is a deterministic function of bounded inputs,
+> and no floor or arbiter is declared because there is nothing to arbitrate.
+
+## Multi-machine posture
+
+> *Local terms: a **unified** surface behaves identically on every machine; a
+> **machine-local** surface is genuinely per-machine and must not be replicated.*
+
+**Posture: `unified` — and that is the entire point of this spec.** The agent identity is the
+canonical example of state that must be identical on every machine of one agent; the current
+behaviour (per-machine) is the defect.
+
+The **machine** identity stays `machine-local`.
+`machine-local-justification: hardware-bound-resource` — the machine id, signing key and
+encryption key identify one physical host to the mesh, are used to verify that host's own
+signatures, and are meaningless on another. Replicating them would make two hosts
+indistinguishable to the lease layer.
+
+- **User-facing notices:** the divergence guard emits one. It is per-agent, not per-machine —
+  a split is one condition about one agent, so exactly one machine raises it (the lease
+  holder), deduped per (agent, observed-fingerprint-set) episode. This is the opposite of the
+  process-ceiling case, where each machine needed its own action.
+- **Durable state on topic transfer:** none introduced. The identity is written once at join
+  and read thereafter.
+- **Generated URLs:** none.
+
+## Frontloaded Decisions
+
+1. **The agent identity travels on the existing pairing exchange.** `POST /api/pair` already
+   receives `ephemeralPublicKey` (the joiner's X25519 encryption public key) and today
+   validates it and uses it for nothing. The identity is sealed to that key and returned in
+   the same response. No new endpoint and no new operator step — the single-use pairing code
+   the operator carried between machines is already the out-of-band human verification.
+
+   **But "no new trust relationship" would be false, and that matters** (round-6 finding). This
+   changes what pairing IS: today a pairing code registers a machine, and a leaked one gets an
+   attacker a registry row. After this change the same code provisions the agent's private
+   identity, so a leaked code is a path to the agent's signing key. The consequence of
+   compromise goes up by an order of magnitude even though the mechanism looks unchanged.
+
+   So pairing is reclassified as **identity provisioning**, and carries the ceremony that
+   warrants: a short expiry measured in minutes rather than hours, a hard cap on failed
+   redemption attempts per session after which it is void, one-at-a-time sessions per agent,
+   and an audit record for every mint, redemption, failure and expiry. The operator is told at
+   mint time what the code now grants, in those words — the value of a secret must be legible
+   to the person carrying it.
+
+   **The envelope is bound to this exchange, not merely encrypted to a key** (round-1
+   finding — encryption to the joiner prevents passive disclosure but does not by itself
+   resist substitution or replay). The sealed payload carries a transcript: the pairing
+   session id, the joiner's machine id, the joiner's encryption public key, the agent name,
+   and an expiry. The whole envelope is signed with the awake machine's machine **signing**
+   key — the key the joiner receives in the same response and pins as the awake machine's
+   identity. The joiner verifies the signature, then checks every transcript field against
+   what it actually sent and who it believes it is talking to, and refuses on any mismatch.
+
+   **What authenticates the responder is the pairing code, not the signature** (round-2
+   finding — worth stating because the signing key arrives in the same response, so on its own
+   the signature proves the response is internally consistent, not that it came from the right
+   machine). The operator carried a single-use code from the awake machine to the joiner
+   out-of-band; possession of a code that machine minted is what identifies it. The signature
+   then binds the envelope to that same responder and to this exchange's transcript, so the
+   payload cannot be lifted from one exchange into another. Where the joiner already knows the
+   awake machine's identity from the pairing challenge, it pins and checks against that too,
+   rather than accepting whatever the response asserts.
+
+   **What each layer actually closes** (round-3 correction — an earlier draft claimed
+   substitution by a hostile responder "fails because the signature fails", which is false: an
+   attacker who controls the response supplies its own signing key alongside it, and the
+   signature verifies perfectly against the key it shipped with):
+
+   - **Wrong-joiner envelope** — closed by the transcript: the machine id and encryption
+     public key inside the envelope must equal what THIS joiner sent, and it cannot decrypt an
+     envelope sealed to anyone else's key.
+   - **Replayed earlier envelope** — closed by the session id and expiry.
+   - **Hostile responder substituting itself** — closed ONLY by the pairing code binding, not
+     by the signature. The code was minted by the intended awake machine and carried
+     out-of-band by the operator; the response must be bound to that server-side session, and
+     the joiner verifies the returned identity against the session it presented the code to.
+     A responder that cannot produce a response bound to that session is rejected regardless
+     of what it signs.
+
+2. **Fail closed, loudly.** A machine that has joined a mesh and cannot obtain the agent
+   identity does NOT mint one and does NOT register on the relay under the agent's name. It
+   reports the failure and stops. A silent twin is worse than a machine that plainly says it
+   could not join properly.
+3. **Never mint on a joined machine — enforced at the minting site**, not at the call sites.
+   `getOrCreate()` is the single chokepoint; guarding the callers would leave the next caller
+   free to reintroduce it.
+4. **Already-diverged machines are reconciled, not left.** A migration detects the split and
+   repairs it through the same sealed path. It does not delete anything: the superseded
+   identity is retained on disk so the change is reversible.
+5. **The orphan relay registration is a NAMED DEPENDENCY, not something this spec can
+   quietly claim.** Repairing the local file leaves the stale row registered on the relay.
+   Round 2 asked how such a row is retired and by what authority, and the honest answer is
+   that this spec cannot specify it: retirement is a relay-side operation with its own
+   authorization model (who may retire a registration, and how the relay knows the requester
+   owns it), and that design does not exist yet.
+
+   What IS true today, and is why local repair is still worth shipping alone: the July fix
+   made the sender-side resolver prefer the LIVE registration, so an orphan row is far less
+   able to absorb messages than it was during the original incident. That mitigates; it does
+   not remove. Until relay-side retirement exists, a repaired agent still has a dead row
+   bearing its name on the relay, and this spec says so rather than implying the split is
+   fully cleaned up.
+   <!-- tracked: CMT-026 -->
+6. **The recovery phrase stays unused by this change.** It is a real facility and a plausible
+   second route, but building a restore path is a separate design with its own threat model
+   (a phrase is a bearer credential for the whole identity). This spec uses the channel that
+   already exists and is already authenticated.
+   <!-- tracked: CMT-026 -->
+
+## Non-goals — and one architectural boundary
+
+This change preserves the current meaning of a routing fingerprint. It is NOT a licence to
+build further on shared-key assumptions (round-5 finding — a spec that normalises a pattern
+invites the next feature to depend on it).
+
+**The boundary: new capabilities must prefer an account identity plus per-device keys, not the
+shared agent private key this change propagates.** Every additional dependency on "any machine
+of this agent can sign as the agent" widens the blast radius of a single compromised host and
+raises the cost of the migration that eventually fixes it. This spec exists solely to stop an
+agent silently becoming several agents; it is a bridge, and it should not be cited as a
+precedent.
+
+Also out of scope, deliberately and named rather than implied: relay-side retirement of stale
+registrations (Frontloaded Decision 5), and any restore-from-recovery-phrase path
+(Frontloaded Decision 6).
+
+## Open questions
+
+*(none)*
+
+## Proposal
+
+### 1. Carry the identity on join
+
+The joiner already sends its encryption public key. The awake machine seals the agent
+identity to it and returns it alongside the machine identity it already returns. The joiner
+decrypts and writes it to the canonical path **before the server first boots**, so the boot
+finds an identity and never reaches the minting branch.
+
+Refusals are explicit and typed: an invalid or burnt pairing code, a malformed or absent
+encryption key, or an awake machine too old to carry the payload each produce a named failure
+rather than a partial join.
+
+#### The pairing session contract (round-4 finding — "bound to the session" needs to be an invariant, not a phrase)
+
+`instar pair` mints a session and stores, server-side: a session id, the pairing code, the
+minting (awake) machine's id, an expiry, a consumed flag, and — once first redeemed — the
+redeeming joiner's machine id and encryption public key.
+
+`POST /api/pair` accepts a request only when the code resolves to a session that is unexpired
+and either unredeemed, or already redeemed BY THIS SAME joiner (matching machine id AND
+encryption public key). It then returns the identity envelope sealed to that joiner's key,
+with the transcript naming the session id, the joiner's machine id and key, the agent name,
+and the expiry. Any other combination is refused with a named reason and provisions nothing.
+
+The joiner accepts an envelope only when it verifies against the session it presented the code
+to and every transcript field matches what it sent.
+
+**What the joiner knows BEFORE it posts, and why a hostile listener cannot exploit it**
+(round-5 finding — the joiner has a URL and a code, and nothing so far authenticated the URL).
+A machine that posts a valid code to the wrong listener learns nothing about the agent, because
+that listener does not hold the identity. The real risk is the reverse: the listener returns a
+FABRICATED identity and the joiner adopts it.
+
+So the pairing artefact the operator carries includes the agent's **fingerprint** alongside the
+code. A fingerprint is public by construction — it is what the agent already advertises — so
+carrying it costs nothing and discloses nothing. The joiner pins it before posting and refuses
+any envelope whose identity does not hash to it. A hostile listener cannot produce a keypair
+matching a fingerprint it does not hold the private key for, so the worst it achieves is
+learning a code that is useless without the identity, and a join that fails loudly.
+
+This also gives the operator a visible cross-check: the value shown on the awake machine is the
+one the agent publishes, and it is the same value the divergence detector compares.
+
+#### Version skew, both directions (round-4 finding)
+
+- **New joiner, old awake machine** — the response carries no identity envelope. The joiner
+  refuses to mint, reports "this machine's mesh cannot yet provide an agent identity — update
+  it and re-pair", and provisions nothing. Loud, and it names the machine to update.
+- **Old joiner, new awake machine** — the awake machine still returns the envelope; the old
+  joiner ignores the unknown field and mints as it always did. That is today's defect, not a
+  new one, and the new awake machine's divergence detector will flag the split it produces.
+  A new awake machine therefore records that it served an envelope to a joiner that did not
+  acknowledge it, so the case is visible rather than inferred later.
+
+#### Installing the key: atomic, restrictive, crash-safe (round-6 finding)
+
+A half-written identity is worse than none — it is an agent that starts with a corrupt or
+partial key.
+
+The identity is written to a temporary file in the destination directory with owner-only
+permissions, synced, then atomically renamed into place; the directory is synced after. A
+repair writes the superseded identity to a timestamped backup beside it BEFORE the rename, so
+no window exists in which neither the old nor the new file is recoverable.
+
+Provisioning is ordered so that a crash at any point leaves a state that is either complete or
+plainly incomplete, never silently wrong: identity written and verified readable → mesh
+registration → server start. A crash after the identity lands but before registration leaves a
+machine that has the right identity and is not yet registered — which the next join or boot
+completes, and which the divergence detector reads as agreement rather than a split.
+
+Permissions are checked on read as well as write: an identity file that is group- or
+world-readable is refused with a named error rather than loaded, because a private key that
+the rest of the machine can read has already failed its one job.
+
+### 2. Refuse to mint on a joined machine
+
+`getOrCreate()` gains one precondition: if this home has mesh-join state, minting is refused
+and the caller receives an explicit "identity not provisioned" failure.
+
+A genuinely standalone first machine is unaffected — it has no join state, so it mints as it
+does today. This is what makes the guard safe to enforce rather than dark-ship: the two cases
+are distinguished by an on-disk fact, not by a guess.
+
+### 3. Reconcile the machines already split
+
+A migration compares this machine's published identity against the peers reporting the same
+agent name. On a confirmed divergence it repairs through the sealed path and retains the superseded
+identity file. It does NOT retire the stale relay registration — see Frontloaded Decision 5;
+that is relay-side work this spec deliberately does not claim.
+
+**Which identity is canonical is decided by declared PROVENANCE, not by weighing evidence and
+not by "who did I join".**
+
+The first draft said "the machine this one joined". Round 2 broke that: in a chain — A joins
+B, C joins a diverged B, B later repairs from A — C's parent held the wrong identity at the
+time C asked, so following the immediate parent preserves the error.
+
+So each identity records how it came to exist, and the record travels with it:
+
+- `minted-standalone` — created on a machine with no mesh-join state. This is the ROOT, and
+  it is the only legitimate way an agent identity is ever created.
+- `received-on-join` — obtained through a pairing exchange, carrying the fingerprint of the
+  root it descends from.
+
+Canonical is then decidable **for identities carrying post-guard provenance**: the identity
+whose lineage terminates in a `minted-standalone` root wins. Where any candidate lacks such a
+record the rule does not apply at all and operator selection is required — see below; the
+qualification is repeated there because an over-strong reading of "decidable" is precisely how
+a repair path talks itself into guessing. A diverged machine's identity terminates in a mint that happened
+ON a joined machine — the state §2 makes impossible going forward, and the exact signature of
+this defect. It is identifiable as wrong without consulting any peer, and a chain repairs
+correctly regardless of the order the repairs happen in, because every machine is comparing
+against the same root rather than against its neighbour.
+
+The record is **self-signed by the identity it describes at mint time** and travels inside the
+sealed payload, so it cannot be attached to a different keypair in transit or rewritten by an
+intermediary.
+
+It is a small fixed shape stored beside the identity and backed up with it: a schema version,
+the origin (`minted-standalone` | `received-on-join`), the root fingerprint, the minting or
+receiving machine id, the creation timestamp, the instar version that produced it, and the
+self-signature over those fields. The version field is what lets a mixed fleet be classified
+rather than guessed at: an identity file with no record present is `unknown-origin`, and a
+record whose schema version is newer than the reader understands is also treated as
+`unknown-origin` rather than partially parsed — both route to operator selection.
+
+**What that does and does not establish, stated plainly** (round-3 finding). A signature binds
+the claim to the keypair; it does not make the claim true — a machine that mints while joined
+could self-sign `minted-standalone` just as easily. What makes the claim trustworthy going
+FORWARD is §2: minting on a machine with join state becomes impossible, so a
+`minted-standalone` record can only be produced where it is accurate.
+
+**And only for honest, current code** (round-6 finding). A compromised host or an older binary
+can self-sign false provenance, and this spec itself keeps old joiners minting during skew. So
+lineage is **operational evidence, not cryptographic authority** — good enough to order a set
+of cooperating machines running current code, not a defence against a machine that lies. Any
+candidate set containing an unsupported or unattested version falls back to operator selection,
+exactly as an `unknown-origin` set does. Treating lineage as proof would be the same
+over-trust this spec was written to correct.
+
+**So the split that already exists cannot be resolved by lineage at all**, and this spec does
+not pretend otherwise. Identities predating the record are `unknown-origin`; an
+`unknown-origin` set — which is exactly today's situation on this agent — REFUSES and requires
+an explicit operator decision naming the canonical fingerprint. That is one confirmation from
+the person who authorised the expansion, on evidence that is already overwhelming, and it is
+the honest alternative to inferring lineage that was never recorded.
+
+**The operator-selection path is a defined protocol, not a conversation** (round-4 finding —
+choosing wrong takes the agent off the network, so it cannot rest on prose).
+
+**The operator chooses between DESCRIPTIONS, not between hex strings.** An earlier draft made
+the operator return a full fingerprint, copied character for character; the conformance gate
+rejected that against the Operator-Surface Quality standard, and it was right. A 32-character
+hex string is not a decision object a person can weigh — asking someone to eyeball two of them
+is how the wrong one gets picked, which is the exact harm the ceremony was meant to prevent.
+
+So the agent renders each candidate in human terms: which machines publish it, since when, and
+what it has been used for — "the identity your Mini and Laptop have both used since May" versus
+"the one this Studio created for itself on Monday". The fingerprint appears as supporting
+detail beneath each option, never as the thing being read. The operator picks an option.
+
+The commitment step still cannot be a bare yes: before anything changes, the agent restates in
+plain words which machine will be altered and what happens to the machine that is not chosen,
+and the operator confirms THAT. The audit record keeps the full candidate set, the fingerprints,
+the chosen value, the operator identity and the timestamp — the precision belongs in the record,
+where it is checkable, not in the question. The decision is
+written to an audit record with the candidate set, the chosen value, the operator identity and
+the timestamp, and repair proceeds only for that value. Cancellation, a mismatched fingerprint,
+or no answer leaves every machine exactly as it is — the split persists, which is the current
+state and is recoverable, whereas a wrong repair may not be.
+
+Deliberately NOT the authority, though each is suggestive: durable prevalence (this agent's
+57-vs-5 file counts are evidence the split happened, not a rule — a long-running wrong
+identity would accumulate the same weight), peer majority (two machines cloned from the same
+mistake would outvote the correct one), and the lease holder (whoever happens to hold it may
+be the diverged machine, which is the case here).
+
+Repair REFUSES, reports, and changes nothing when: no reachable machine presents a
+`minted-standalone` lineage, more than one distinct root is presented, every candidate is
+`unknown-origin`, or the sealed exchange fails. Choosing wrong takes the agent off the network, so every uncertain
+branch stops rather than guessing.
+
+**Alternatives considered** (round-1 finding). *Cross-machine secret sync* — the sync set is
+enrolled per machine and a machine cannot receive its enrolment before it has an identity, so
+it is chicken-and-egg for exactly the case that matters; it remains a sensible carrier for
+KEEPING identities aligned once established. *Recovery-phrase restore* — a real second route,
+but a phrase is a bearer credential for the whole identity and needs its own threat model and
+an operator ceremony; it is also unbuilt. *A signed identity record agreed across machines* —
+solves a harder problem (consensus) than the one here, where one machine authoritatively has
+the identity and one demonstrably lacks it. Pairing wins because the channel, the
+authentication, and the operator's out-of-band step already exist and are already trusted for
+provisioning this machine.
+
+**This is device enrolment, and it is worth naming the pattern** (round-2 finding). The shape
+is standard: an account identity is transferred to a new device over a channel authenticated
+by a short human-carried code, with the payload bound to a handshake transcript. The two
+industry alternatives were weighed. *Per-device certificates* — each device keeps its own key
+and the account is a separate signed record they all present — is the better long-term shape,
+and instar already has its machine layer sitting exactly there; adopting it for the AGENT
+identity would mean changing what a routing fingerprint MEANS across every peer that has one
+pinned, which is a migration of the whole network rather than of this agent. *A durable signed
+identity record agreed across machines* solves consensus, which is not the problem here: one
+machine authoritatively has the identity and one demonstrably lacks it. The transcript binding
+in §1 is the Noise-style protection those patterns supply, applied to the channel that already
+exists.
+
+**This is explicitly a compatibility bridge, and it carries a real cost** (round-4 finding). A
+shared agent private key means every machine of the agent can sign as the agent, so
+compromising ONE host compromises the agent's identity everywhere, and there is no per-machine
+revocation short of rotating the identity for the whole fleet. The per-device-certificate model
+does not have that property. It is accepted here because the alternative is to change what a
+routing fingerprint means for every peer holding one, and because the status quo — silently
+minting a second identity per machine — is worse on every axis including this one. The
+migration toward an account identity plus per-device keys is tracked, not implied.
+
+**One operational consequence must be surfaced, not left to be discovered** (round-7 finding):
+removing a machine from the mesh does NOT revoke its copy of the agent identity. That host can
+still sign as the agent until the identity is rotated for the whole fleet. So machine removal
+emits a plain notice saying exactly that, and naming rotation as the only actual revocation. A
+capability whose limits are only visible to whoever reads the spec is a trap for whoever
+doesn't.
+<!-- tracked: CMT-026 -->
+
+### 4. Notice the split at all
+
+A boot-time comparison of the identity this machine publishes against its peers'. Signal
+only — it raises one deduped operator notice and changes nothing. It exists because the live
+incident went four days unreported, and because a repair path with no detector only fixes the
+splits someone happens to notice.
+
+**Every machine observes; the notice is deduped, not the observation** (round-1 finding). The
+first draft had only the lease holder observe, which fails in the two cases that matter most:
+the lease holder may BE the diverged machine (it is, in the live incident), and it may be the
+isolated one. So each machine compares independently, and the single-notice property comes
+from deduping on the (agent, observed-fingerprint-set) episode rather than from restricting
+who is allowed to look.
+
+**`cannot-tell` is visible even though it never pages.** An unreachable peer means the check
+did not run, which is not the same as agreement — and a detector that renders those
+identically is how a silent split survives. It pages on `disagree` only, but the diagnostic
+surface reports agree / disagree / cannot-tell with the peer and the reason, so "quiet"
+cannot be mistaken for "checked and fine".
+
+### 5. Observability
+
+Each of the four behaviours emits an auditable record, because a guard whose firing rate
+cannot be read cannot be tuned or trusted:
+
+- **Join**: whether the identity payload was carried, and on failure the named refusal
+  reason. A rising "not carried" rate means an older awake machine is in the fleet.
+- **Mint refusal**: every refusal, with whether join state was present. A non-zero count on a
+  machine that should be standalone is itself the alarm.
+- **Reconcile**: attempted / repaired / refused with the refusal reason, and the superseded
+  fingerprint. The refusal-reason distribution is what says whether the repair path is usable
+  in the field or merely correct on paper.
+- **Divergence detection**: the agree / disagree / cannot-tell counts per peer. A `cannot-tell`
+  rate that never falls means the detector is not actually checking anything.
+
+No agent private key or sealed payload appears in any of these records — only fingerprints,
+which are public by construction.
+
+## Acceptance criteria
+
+1. A machine joining an existing mesh ends up publishing the same routing fingerprint as the
+   machine it joined — verified against the **live published value** on both, not against the
+   file either one wrote.
+2. `getOrCreate()` refuses to mint when mesh-join state is present, and still mints for a
+   standalone first machine.
+3. A join whose identity payload is missing, malformed, or undecryptable fails with a named
+   error, provisions no identity, and leaves nothing registered under the agent's name.
+4. The sealed payload is decryptable only by the holder of the joiner's encryption private
+   key: a payload captured in transit and replayed by a third machine does not decrypt.
+5. A burnt or expired pairing code yields no identity payload.
+6. The reconcile migration repairs a divergent machine, retains the superseded identity, and
+   is a no-op on a machine already in agreement.
+6b. Canonical selection follows LINEAGE: an identity descending from a `minted-standalone`
+   root wins; a chain (A→B, C→diverged-B, B repaired from A) converges on the root regardless
+   of repair order; an all-`unknown-origin` set refuses and reports rather than picking.
+6c. A join whose response is lost may be retried by the SAME joiner (matching machine id and
+   encryption public key) until the session expires, receiving an envelope resealed to the same
+   key; any other machine presenting that code is refused, and no redemption is possible after
+   expiry. (This supersedes an earlier draft of this criterion, which said the code was burnt
+   at response construction with no retry — that contradicted the pairing contract in §1 and
+   was an availability failure on any unlucky network.)
+7. The divergence detector reports agree / disagree / cannot-tell, raises on disagree only,
+   and surfaces cannot-tell in diagnostics with the peer and reason.
+7b. Operator selection: candidates are rendered as human descriptions (which machines, since
+   when, used for what) with the fingerprint as supporting detail only; the operator picks an
+   option rather than transcribing a hex string; a bare affirmative is refused — the
+   confirmation is against a plain restatement of what will change on which machine; the
+   decision is audited with the full candidate set, fingerprints, choice, operator and
+   timestamp; and cancellation or mismatch changes nothing on any machine.
+7c. Version skew: a new joiner against an old awake machine provisions nothing and names the
+   machine to update; a new awake machine records serving an envelope that was not
+   acknowledged.
+8. No agent private key appears in any log line, error message, audit row, or HTTP response
+   body other than the sealed payload itself.
+9. Installation is atomic (temp file → fsync → rename), owner-only, and the superseded identity
+   is backed up before the rename. A crash at any step leaves a complete or plainly-incomplete
+   state, never a partially-written key.
+10. An identity file readable beyond its owner is refused with a named error rather than loaded.
+11. Pairing sessions expire in minutes, void after a capped number of failed redemptions, are
+   one-at-a-time per agent, and every mint / redemption / failure / expiry is audited.
+
+## Rollback
+
+**Rollback is not behaviourally safe for further expansion, and saying otherwise would be the
+same optimism that produced this defect** (round-1 finding — the first draft called it
+harmless).
+
+Reverting restores today's behaviour: the next machine to join mints its own identity and the
+split recurs, silently, exactly as it did here. So a rollback must be paired with an
+operational freeze on joins, or with provisioning the identity by hand on any machine added
+while reverted.
+
+What IS safe: machines already reconciled keep the canonical identity, which is what the rest
+of the mesh already expects, so no reconciled machine is left worse off. The superseded
+identity files retained by the migration make an individual repair reversible.
+
+One interaction to be explicit about: this change retires no relay registration (Frontloaded
+Decision 5), so relay state is unchanged by shipping it and unchanged by reverting it. A
+machine reverted to a minted identity would, however, register as yet another row — which is
+the recurrence described above, seen from the relay's side.
+
+
+> **Carrier (frozen excerpt — the work the markers above point at):** <!-- tracked: CMT-026 -->
+>
+> **CMT-026** — "(1) RELAY-SIDE RETIREMENT of stale agent registrations. Local repair leaves the orphan row registered; the July resolver fix mitigates it but does not remove it. Retirement is a relay operation needing its own authorization model (who may retire a registration, how the relay knows the requester owns it) — that design does not exist. Until it does, a repaired agent still has a dead row bearing its "
+
+## Maturation plan
+
+- **test-agent-live:** live from the first build; the sealed-payload and refusal paths are
+  unit-testable without a second machine.
+- **dev-agent-live:** the join-path change and the mint refusal ship live — a dark identity
+  fix fixes nothing. The reconcile migration ships dry-run first, because it rewrites an
+  identity and a wrong repair takes the agent off the network.
+- **fleet:** with the release, after the reconcile migration has run non-dry on this agent's
+  own split and been verified live on both machines.
+- **graduation criterion:** the two machines of one agent publish one fingerprint, confirmed
+  by reading both live; and a fresh join produces no new fingerprint.
+- **dark-window:** none for the join fix and the mint refusal. The reconcile migration's
+  dry-run window ends when its report on this agent's real split is inspected and correct.

--- a/docs/specs/carriers/agent-identity-continuity-on-expansion.json
+++ b/docs/specs/carriers/agent-identity-continuity-on-expansion.json
@@ -1,0 +1,12 @@
+{
+  "generatedAt": "2026-08-20T03:36:24.778Z",
+  "slug": "agent-identity-continuity-on-expansion",
+  "carriers": {
+    "CMT-026": {
+      "status": "pending",
+      "owner": "agent",
+      "blockedOn": "none",
+      "excerpt": "(1) RELAY-SIDE RETIREMENT of stale agent registrations. Local repair leaves the orphan row registered; the July resolver fix mitigates it but does not remove it. Retirement is a relay operation needing its own authorization model (who may retire a registration, how the relay knows the requester owns it) \u2014 that design does not exist. Until it does, a repaired agent still has a dead row bearing its "
+    }
+  }
+}

--- a/docs/specs/reports/agent-identity-continuity-on-expansion-convergence.md
+++ b/docs/specs/reports/agent-identity-continuity-on-expansion-convergence.md
@@ -1,0 +1,141 @@
+# Convergence Report — Agent Identity Continuity on Expansion
+
+## Cross-model review: codex-cli:gpt-5.5 — RAN every round (7/7)
+
+A real GPT-tier external pass ran through the agent's own codex CLI on all seven rounds
+(`status: ok`, never degraded). The Standards-Conformance Gate ran on rounds 1, 7 and the
+final check.
+
+## Convergence verdict: **CONVERGED at round 7 under the 80/20 standard**
+
+This is the first spec converged under the standard Justin set on 2026-08-19 (topic 48000):
+
+> *"Once the reviews have results that are relatively small or minor, then we consider that
+> converged."*
+
+**What that means here, stated so it can be checked rather than trusted.** Round 7 returned
+five findings. Three would have changed what gets built and were folded in: the provenance
+record's persisted shape (needed for criterion 6b to mean anything), the interaction between
+same-joiner retry and the failed-attempt cap (two limits that would otherwise be implemented
+inconsistently), and a notice on machine removal (a removed host keeps a usable copy of the
+agent key). Two were left: the reviewer's note that its own supporting context had been
+truncated, and residual terminology load.
+
+The final Standards-Conformance pass then returned **0 findings**, having caught two on the
+previous pass that DID change the build — both folded in (see below).
+
+**What was left behind, named rather than elided:**
+
+- Terminology load — the spec assumes internal review vocabulary (`invariant`,
+  `unified`, `machine-local`). Raised in rounds 3 and 7. Not iterated on.
+- The reviewer's supporting-context truncation on round 7, which means its conclusions about
+  prior relay behaviour rest on a partial read of the parent spec.
+
+Neither changes what gets built. Under the previous "two consecutive clean rounds" criterion
+this spec would have kept running; the review history below shows why that criterion was the
+wrong instrument.
+
+### Why the old criterion was replaced
+
+The prior spec (`launchd-process-ceiling-floor`) ran to the 10-round cap without ever meeting
+"no design-class findings for two consecutive rounds", while its reviewer recorded *"no serious
+architectural objection"* in seven of those rounds. The cause is structural: a spec that
+appends its own review history grows every round, so a diligent reviewer will always find
+precision to add on a larger surface. By round 8 that spec exceeded the reviewer's input budget
+and began truncating.
+
+This spec kept its review history in this report from the start — a direct fix for that failure.
+
+**The honest counterweight, which the operator was told:** long runs have not been worthless.
+On the previous spec, round 7 caught a setup path that would have clobbered an operator's
+deliberately raised ceiling, and round 10 caught a machine-id collision that could have
+swallowed the alert for a machine actively crashing. So the rule is *stop when findings stop
+changing the build* — not *fewer rounds is better*. A late structural finding is still acted on
+and said out loud.
+
+## ELI10 Overview
+
+Agents are found by an address derived from their identity. One agent should have one address
+everywhere it runs.
+
+When an agent expands onto a new machine, it doesn't. The expansion copies the shared project,
+gives the new machine its own local settings and its own machine keys, and registers it — all
+correct. What it never does is bring the agent's identity across. So the new machine looks for
+one, finds none, and makes a new one. Underneath, the agent has quietly become two agents
+sharing a name.
+
+That was found live on 2026-08-19: the operator authorised a Mac Mini to extend an agent onto a
+Mac Studio, and four days later the Studio was still publishing a different address from the
+Mini and Laptop. Nothing had reported it. It surfaced only while investigating something else.
+
+It matters for two reasons. Messages sent to the old address can vanish — a stale registration
+survives and can absorb them, which is exactly what happened to a different agent pair in July.
+And anything signed on the odd machine carries the wrong identity, so it doesn't verify as that
+agent.
+
+This change carries the identity to the new machine over the pairing exchange that already
+happens, refuses to invent one if that fails rather than quietly becoming a twin, repairs
+machines already split, and — new — actually notices when a split exists.
+
+## Original vs Converged
+
+**Originally** this was: send the identity over the existing pairing channel, encrypted to the
+joining machine, then repair anything already broken.
+
+**After review** the same shape survives, but almost every security claim in it was wrong or
+underspecified, and several were corrected outright:
+
+- The first draft claimed a hostile responder was defeated *"because the signature fails"*.
+  That is false — an attacker controlling the response supplies its own signing key, and the
+  signature verifies perfectly against it. Only the pairing-code session binding closes that
+  attack, and the spec now says so.
+- Repair authority was *"the machine this one joined"*. A chained join breaks it: a machine that
+  joined a diverged parent inherits the error. Replaced with lineage terminating in a root that
+  was minted standalone.
+- Lineage was then over-trusted in turn. It is **operational evidence, not cryptographic
+  authority** — a compromised or old binary can self-sign a false claim — so any unattested
+  candidate falls back to the operator.
+- Which means the split that already exists **cannot be fixed by lineage at all**, and needs one
+  explicit operator decision. The spec says that plainly instead of implying the repair is
+  automatic.
+- Burn semantics went from undefined, to no-retry (secure but an availability failure on any
+  unlucky network), to same-joiner retry with third-party redemption refused.
+- *"No new trust relationship"* was withdrawn. This changes what a pairing code IS: today it
+  gets an attacker a registry row; after this it is a path to the agent's signing key. Pairing
+  is reclassified as identity provisioning with the ceremony that warrants.
+- Relay-side retirement of stale registrations was claimed, then withdrawn as a named
+  dependency — that design does not exist, and pretending otherwise would have implied the
+  split was fully cleaned up when it is not.
+- The operator's decision was to be made by comparing two hex strings. The conformance gate
+  rejected that, correctly: asking a person to eyeball two 32-character strings is how the
+  wrong one gets picked. They now choose between descriptions, with the precision kept in the
+  audit record.
+
+The shared-key cost is stated rather than buried: every machine can sign as the agent, so one
+compromised host compromises the identity everywhere, and removing a machine does not revoke
+its copy. That is accepted as a compatibility bridge, with an explicit boundary against building
+further on it.
+
+## Iteration Summary
+
+| Round | Standards gate | Cross-model | Build-changing | Left as precision |
+|---|---|---|---|---|
+| 1 | ran (1 flag) | 5 findings | 5 | 0 |
+| 2 | — | 5 findings | 4 | 1 |
+| 3 | — | 5 findings | 4 | 1 |
+| 4 | — | 5 findings | 4 | 1 |
+| 5 | — | 5 findings | 3 | 2 |
+| 6 | — | 5 findings | 4 | 1 |
+| 7 | ran (2 flags → 0) | 5 findings | 3 + 2 gate | 2 |
+
+**Per-round model disclosure:** the internal reviewer perspectives were carried by the authoring
+session rather than by spawned subagents, under a session instruction not to spawn agents
+without a request. The genuinely independent reads were the cross-model codex pass (every round)
+and the code-backed Standards gate. This is a real reduction in independence against the skill's
+design and is recorded rather than glossed.
+
+## Convergence verdict
+
+Converged at round 7 under the 80/20 standard, with the residual findings named above. The
+Standards-Conformance Gate returns 0 findings and rates the spec a fit against its parent
+principle. Ready for operator review.

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -531,6 +531,24 @@ Enrollment (P2.1) — adding a new account from a phone, expiry-proof:
 
 Spec: `docs/specs/_drafts/subscription-auth-standard-master-spec.md`.
 
+## One agent, one identity (`AgentIdentityHandover`, `AgentIdentityReconciler`)
+
+An agent is reached by an address derived from its identity, and that address should be the same
+whichever of its machines answers. Expanding onto a new machine used to break that: the join
+provisions a *machine* identity but never the *agent* identity, so the new machine found none and
+minted its own. One agent quietly became two sharing a name — and nothing reported it.
+
+`AgentIdentityHandover` carries the identity to the joiner, sealed to the key it already sends
+during pairing and bound to that exchange's transcript. The minting path then refuses to invent an
+identity on any machine that joined a mesh, so a failed handover fails loudly instead of producing
+a twin.
+
+`AgentIdentityDivergenceDetector` compares what each machine publishes and raises one deduped
+notice on a genuine split; an unreachable peer is reported as unknown, never as agreement.
+`AgentIdentityReconciler` returns a decision rather than performing one, and refuses majority, age
+and prevalence as tiebreakers — each correlates with being right without being a reason. Full
+reference: `reference/agent-identity-continuity`.
+
 ## The process ceiling, and why the file is not the answer (`ProcessCeilingCheck`)
 
 Instar sets an OS-level cap on how many processes its user account may run — a last-resort

--- a/site/src/content/docs/reference/agent-identity-continuity.md
+++ b/site/src/content/docs/reference/agent-identity-continuity.md
@@ -1,0 +1,120 @@
+---
+title: Agent Identity Continuity
+description: Why an agent that expands onto a new machine can silently become two agents sharing one name, and what carries the identity across — AgentIdentityHandover, AgentIdentityDivergenceDetector, AgentIdentityReconciler, and the mint refusal.
+---
+
+An agent is found by an address derived from its identity. One agent should present one address
+wherever it runs.
+
+Until this change, expanding onto a new machine broke that — silently.
+
+## What went wrong
+
+Joining a mesh provisions a clone of the shared repo, a machine-local `config.json`, a **machine**
+identity (machine id, signing key, encryption key), and a pairing exchange that registers the
+joiner. None of those is the **agent** identity: it is gitignored because it holds a private key,
+absent from the scaffolded config, absent from the pairing response, and absent from the
+cross-machine secret-sync key set.
+
+So on first boot the agent looks for its identity, finds none, and `IdentityManager.getOrCreate()`
+mints a fresh keypair.
+
+**The design error in one sentence: the agent's identity was treated as a per-machine secret,
+when it is a shared-agent secret.** Machine keys are correctly per-machine — the agent is not.
+
+Observed live on 2026-08-19 and unreported for four days. A **plain-text** message signed on the
+diverged machine verified there and was rejected as `bad-signature` by both peers, so
+agent-signature provenance was inoperative from that machine. It failed safe — `rejected`, never
+silently `human` — but the guarantee the feature exists to provide was absent.
+
+## The four pieces
+
+### `JoinedMeshDetector` — did this home join an existing mesh?
+
+The discriminator is an on-disk fact: a machine registry naming at least one machine other than
+this one, written by the pairing flow before the server ever starts. Not a heuristic.
+
+**Every uncertain reading resolves toward minting** — no registry, an unreadable registry, a
+registry listing only this machine, a missing self machine-id. An unrelated filesystem problem
+must never deny a legitimate standalone agent its identity. The residual risk (a joined machine
+with a corrupt registry can still mint) is what the divergence detector catches.
+
+### The mint refusal
+
+`getOrCreate()` refuses to mint when this home joined a mesh, throwing
+`IdentityNotProvisionedError` rather than inventing an identity.
+
+Enforced at the minting **site** rather than at its callers — guarding callers leaves the next
+caller free to reintroduce it. A joined machine that cannot obtain the identity fails loudly
+instead of becoming a silent twin.
+
+### `AgentIdentityHandover` — carrying the identity across
+
+The identity is sealed to the joining machine's X25519 encryption key over the pairing exchange
+that already carries that key (it was validated and used for nothing), and returned in the same
+response. Sealing reuses the in-production secret-sync primitive rather than inventing a second
+scheme.
+
+The envelope is bound to a **transcript** — pairing session id, joiner machine id, joiner
+encryption key, agent name, expiry — and the joiner checks every field against what it sent.
+
+**What authenticates the responder is the pairing code, not a signature.** An attacker who
+controls the response supplies its own signing key alongside it, so the signature verifies
+perfectly against the key it shipped with. The code was minted by the intended machine and
+carried out-of-band by the operator; that is what identifies it. The joiner additionally pins the
+agent fingerprint from the pairing artefact and refuses any identity that does not hash to it, so
+a listener that merely collects a code cannot hand back a fabricated identity.
+
+Retry is bound to the first joiner that redeems a session: the same machine may re-request until
+expiry, any other machine is refused.
+
+### `AgentIdentityDivergenceDetector` — noticing a split at all
+
+A boot-time comparison of what each machine publishes, wired delayed and unref'd so it can never
+block or fail a boot.
+
+**Every machine observes.** An earlier design had only the lease holder look, which fails in the
+two cases that matter most: the holder may *be* the diverged machine, and it may be the isolated
+one. The single-notice property comes from deduping on the `(agent, fingerprint-set)` episode key,
+not from restricting who is allowed to look.
+
+Three states: `agree`, `disagree`, `cannot-tell`. **`cannot-tell` never renders as agreement** — an
+unreachable peer means the check did not run, and a detector that reports those identically is how
+a silent split survives. It pages on `disagree` only, but reports all three.
+
+Signal only: it raises one Attention item and repairs nothing.
+
+### `AgentIdentityReconciler` — repairing without guessing
+
+Returns a **decision**; performs nothing, so a caller cannot act on an unresolved one.
+
+Where every candidate carries post-guard provenance, canonical is the identity whose lineage
+terminates in a `minted-standalone` root. Deliberately **not** used as tiebreakers, though each
+looks persuasive:
+
+- **durable prevalence** — a long-running wrong identity accumulates the same weight;
+- **peer majority** — two machines cloned from one mistake outvote the correct one;
+- **the lease holder** — it may be the diverged machine.
+
+**Lineage is operational evidence, not cryptographic authority.** A compromised host or an older
+binary can self-sign a false claim, so any candidate that is unattested — including every identity
+predating the record — routes to an operator decision.
+
+That decision is a choice between plain-language descriptions ("the identity used by your Mini and
+Laptop since May"), not a comparison of hex strings; the fingerprints live in the audit record.
+Cancellation or a mismatch changes nothing on any machine.
+
+## Known limits
+
+- **An existing split cannot be repaired automatically.** Lineage only applies to identities
+  created after this ships.
+- **Stale relay registrations are not retired.** That is a relay-side operation with its own
+  authorization model, which does not exist yet. The sender-side resolver fix mitigates it; it does
+  not remove it.
+- **Every machine holds the same key.** One compromised host compromises the agent's identity
+  everywhere, and removing a machine from the mesh does **not** revoke its copy — only rotating the
+  identity fleet-wide does. This is a compatibility bridge, taken because the alternative changes
+  what a routing fingerprint means for every peer holding one. New capabilities should prefer an
+  account identity plus per-device keys rather than building further on it.
+
+Spec: `docs/specs/agent-identity-continuity-on-expansion.md`.

--- a/src/core/AgentIdentityDivergenceDetector.ts
+++ b/src/core/AgentIdentityDivergenceDetector.ts
@@ -1,0 +1,153 @@
+/**
+ * AgentIdentityDivergenceDetector — notice when one agent is publishing two identities.
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §4.
+ * Constitution: "Verify the State, Not Its Symbol"; "No Silent Degradation".
+ *
+ * WHY. The 2026-08-19 split went FOUR DAYS unreported and surfaced only while investigating an
+ * unrelated request. A repair path with no detector only ever fixes the splits somebody happens
+ * to notice. This is the part that makes the failure visible at all.
+ *
+ * ── WHAT IT READS, AND WHY THAT IS THE STATE RATHER THAN A SYMBOL ────────────────────────
+ * The SYMBOL would be the identity file on disk. The STATE is what each machine actually
+ * PUBLISHES as its routing/signing identity, which is what peers and verifiers resolve. So the
+ * comparison is over each machine's live published fingerprint, gathered from the peers
+ * themselves — not over files this machine can read locally.
+ *
+ * ── EVERY MACHINE OBSERVES; ONLY THE NOTICE IS DEDUPED ───────────────────────────────────
+ * An earlier design had only the lease holder observe. That fails in the two cases that matter
+ * most: the lease holder may BE the diverged machine (it was, in the live incident) and it may
+ * be the isolated one. So each machine compares independently and the single-notice property
+ * comes from deduping on the episode key, never from restricting who is allowed to look.
+ *
+ * ── SIGNAL ONLY ──────────────────────────────────────────────────────────────────────────
+ * It reports. It never repairs, never blocks a send, never changes an identity. Repair is §3
+ * and requires an operator decision; conflating detection with repair is how a detector
+ * acquires the authority to take an agent off the network.
+ */
+
+export interface MachineIdentityObservation {
+  machineId: string;
+  machineName: string;
+  /** The fingerprint this machine PUBLISHES, or null when it could not be reached/read. */
+  publishedFingerprint: string | null;
+  /** Why it is null — surfaced so "unreachable" never renders as "agrees". */
+  unreachableReason?: string;
+}
+
+export type DivergenceState = 'agree' | 'disagree' | 'cannot-tell';
+
+export interface DivergenceVerdict {
+  state: DivergenceState;
+  /** Distinct fingerprints observed, sorted — the episode's identity. */
+  fingerprints: string[];
+  /** Machines grouped by the fingerprint they publish. */
+  byFingerprint: Record<string, string[]>;
+  /** Machines that could not be read, with the reason. Never folded into agreement. */
+  unreadable: Array<{ machineId: string; machineName: string; reason: string }>;
+  /** Stable per-episode key: same split → same key → one notice, not one per boot. */
+  episodeKey: string | null;
+  /** True only for `disagree`. `cannot-tell` is reported, never paged. */
+  shouldNotify: boolean;
+}
+
+/**
+ * Compare what the machines of one agent publish.
+ *
+ * Pure over the observations so the decision is testable without a live mesh.
+ */
+export function evaluateDivergence(input: {
+  agentName: string;
+  observations: MachineIdentityObservation[];
+}): DivergenceVerdict {
+  const unreadable = input.observations
+    .filter((o) => o.publishedFingerprint === null)
+    .map((o) => ({
+      machineId: o.machineId,
+      machineName: o.machineName,
+      reason: o.unreachableReason ?? 'unknown',
+    }));
+
+  const readable = input.observations.filter(
+    (o): o is MachineIdentityObservation & { publishedFingerprint: string } =>
+      typeof o.publishedFingerprint === 'string' && o.publishedFingerprint.length > 0,
+  );
+
+  const byFingerprint: Record<string, string[]> = {};
+  for (const o of readable) {
+    (byFingerprint[o.publishedFingerprint] ??= []).push(o.machineName);
+  }
+  const fingerprints = Object.keys(byFingerprint).sort();
+
+  // Fewer than two readable machines cannot demonstrate agreement OR disagreement. Reporting
+  // that as `agree` would be the precise failure this detector exists to prevent: absence of
+  // evidence rendered as evidence of absence.
+  if (readable.length < 2) {
+    return {
+      state: 'cannot-tell',
+      fingerprints,
+      byFingerprint,
+      unreadable,
+      episodeKey: null,
+      shouldNotify: false,
+    };
+  }
+
+  if (fingerprints.length === 1) {
+    // Genuine agreement among those that answered. Any unreadable machine is still surfaced —
+    // "two agree and one is unreachable" is not the same as "all three agree".
+    return {
+      state: 'agree',
+      fingerprints,
+      byFingerprint,
+      unreadable,
+      episodeKey: null,
+      shouldNotify: false,
+    };
+  }
+
+  return {
+    state: 'disagree',
+    fingerprints,
+    byFingerprint,
+    unreadable,
+    // Keyed on the SET of fingerprints, so the same split reported from any machine, on any
+    // boot, collapses to one notice — and a split that CHANGES (a machine repaired, another
+    // diverged) is a new episode the operator is told about.
+    episodeKey: `agent-identity-split:${input.agentName}:${fingerprints.join('+')}`,
+    shouldNotify: true,
+  };
+}
+
+/**
+ * Operator-facing text for a split. Plain language: the operator's question is "is my agent
+ * one agent?", not "what is the hex".
+ *
+ * Fingerprints appear as supporting detail only — the Operator-Surface Quality standard, and
+ * the same reasoning that made the repair ceremony pick between descriptions rather than hex.
+ */
+export function divergenceNotice(
+  verdict: Extract<DivergenceVerdict, { state: DivergenceState }>,
+  agentName: string,
+): { title: string; body: string } {
+  const groups = Object.entries(verdict.byFingerprint)
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([fp, machines]) => `  • ${machines.join(', ')} — identity ${fp.slice(0, 8)}…`);
+
+  const unreadableLine = verdict.unreadable.length
+    ? `\n\nCouldn't check: ${verdict.unreadable.map((u) => `${u.machineName} (${u.reason})`).join(', ')}. ` +
+      `That's unknown, not agreement.`
+    : '';
+
+  return {
+    title: `${agentName} is running as more than one identity`,
+    body:
+      `Machines that should all be the same agent are publishing different identities:\n\n` +
+      `${groups.join('\n')}\n\n` +
+      `Messages addressed to one of these may not reach the machines using the other, and ` +
+      `anything signed on a machine in the smaller group won't verify as ${agentName}.\n\n` +
+      `Fixing it needs one decision from you about which is the real one — nothing is changed ` +
+      `automatically, because repairing to the wrong identity would take ${agentName} off the ` +
+      `network entirely.${unreadableLine}`,
+  };
+}

--- a/src/core/AgentIdentityHandover.ts
+++ b/src/core/AgentIdentityHandover.ts
@@ -1,0 +1,197 @@
+/**
+ * AgentIdentityHandover — carry an agent's identity to a machine joining its mesh.
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §1.
+ * Constitution: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions".
+ *
+ * WHY. `joinMesh` provisions a MACHINE identity and never the AGENT identity, so the joining
+ * machine finds none and mints its own — one agent silently becomes two sharing a name
+ * (observed live 2026-08-19; a plain-text message signed on the new machine is rejected as
+ * `bad-signature` by both peers, so agent-signature provenance is inoperative there).
+ *
+ * The channel already exists: `POST /api/pair` validates a single-use code the operator
+ * carried out-of-band and ALREADY receives the joiner's X25519 encryption public key, which
+ * it currently validates and uses for nothing. This seals the identity to that key and
+ * returns it in the same response.
+ *
+ * SEALING REUSES `SecretStore.encryptForSync` — the reviewed, in-production primitive behind
+ * cross-machine secret sync (ephemeral X25519 ECDH + HKDF-SHA256 + AES-256-GCM, ephemeral
+ * private key discarded). Inventing a second sealing scheme for the same job would be a new
+ * and less-tested attack surface for no gain.
+ *
+ * ── WHAT AUTHENTICATES WHAT (spec §1, round-3 + round-6 corrections) ──────────────────
+ * The SIGNATURE does NOT authenticate the responder. An attacker controlling the response
+ * supplies its own signing key alongside it, and the signature verifies perfectly against the
+ * key it shipped with. What identifies the responder is POSSESSION OF THE PAIRING SESSION the
+ * operator's code belongs to. The transcript binding below stops a genuine envelope being
+ * lifted from one exchange into another; it does not, and cannot, stand in for that.
+ *
+ * The joiner additionally pins the agent FINGERPRINT carried in the pairing artefact and
+ * refuses any identity that does not hash to it — so a hostile listener that merely COLLECTS
+ * a code cannot hand back a fabricated identity, because it cannot produce a keypair matching
+ * a fingerprint whose private key it does not hold.
+ */
+
+import { createHash, createPrivateKey, type KeyObject } from 'node:crypto';
+import { encryptForSync, decryptFromSync, type EncryptedSecretPayload } from './SecretStore.js';
+
+/** How an identity came to exist on a machine. Spec §3 — lineage, not "who did I join". */
+export type IdentityOrigin = 'minted-standalone' | 'received-on-join';
+
+/**
+ * Provenance travelling with an identity.
+ *
+ * HONEST LIMIT (spec §3): this is OPERATIONAL EVIDENCE, not cryptographic authority. A
+ * compromised host or an older binary can self-sign a false claim, and version skew keeps old
+ * joiners minting. It orders a set of cooperating machines running current code; it is not a
+ * defence against a machine that lies. Any candidate set containing an unattested version
+ * falls back to operator selection.
+ */
+export interface IdentityProvenance {
+  schemaVersion: 1;
+  origin: IdentityOrigin;
+  /** Fingerprint of the `minted-standalone` root this identity descends from. */
+  rootFingerprint: string;
+  /** Machine that minted (standalone) or received (join) it. */
+  machineId: string;
+  createdAt: string;
+  /** instar version that produced the record — an unrecognised one is `unknown-origin`. */
+  producedBy: string;
+}
+
+/** The transcript the envelope is bound to. Every field is checked by the joiner. */
+export interface HandoverTranscript {
+  pairingSessionId: string;
+  joinerMachineId: string;
+  /** The joiner's X25519 encryption public key, base64 — the key the payload is sealed to. */
+  joinerEncryptionPublicKey: string;
+  agentName: string;
+  expiresAt: string;
+}
+
+export interface IdentityHandoverEnvelope {
+  schemaVersion: 1;
+  transcript: HandoverTranscript;
+  sealed: EncryptedSecretPayload;
+  /** Fingerprint of the identity inside, so a mismatch is caught before decryption is trusted. */
+  identityFingerprint: string;
+}
+
+/** Everything the joiner needs to become this agent. */
+export interface HandoverPayload {
+  identity: { publicKey: string; privateKey: string; createdAt: string };
+  provenance: IdentityProvenance;
+}
+
+export type HandoverRefusal =
+  | 'no-identity-on-source'
+  | 'session-expired'
+  | 'session-bound-to-other-joiner'
+  | 'malformed-joiner-key';
+
+/**
+ * Seal the agent identity for one specific joiner.
+ *
+ * Refuses rather than partially succeeding: every refusal is a named reason the caller turns
+ * into an explicit failure, never a silent omission that would let the joiner mint.
+ */
+export function sealIdentityForJoiner(input: {
+  payload: HandoverPayload;
+  transcript: HandoverTranscript;
+  identityFingerprint: string;
+}): { ok: true; envelope: IdentityHandoverEnvelope } | { ok: false; refusal: HandoverRefusal } {
+  const key = input.transcript.joinerEncryptionPublicKey;
+  if (typeof key !== 'string' || key.length === 0) return { ok: false, refusal: 'malformed-joiner-key' };
+  let sealed: EncryptedSecretPayload;
+  try {
+    sealed = encryptForSync(input.payload as unknown as Parameters<typeof encryptForSync>[0], key);
+  } catch {
+    // A key we cannot seal to is a malformed key. Named refusal, never a partial response.
+    return { ok: false, refusal: 'malformed-joiner-key' };
+  }
+  return {
+    ok: true,
+    envelope: {
+      schemaVersion: 1,
+      transcript: input.transcript,
+      sealed,
+      identityFingerprint: input.identityFingerprint,
+    },
+  };
+}
+
+export type HandoverRejection =
+  | 'schema-unsupported'
+  | 'transcript-session-mismatch'
+  | 'transcript-machine-mismatch'
+  | 'transcript-key-mismatch'
+  | 'transcript-agent-mismatch'
+  | 'expired'
+  | 'fingerprint-not-pinned'
+  | 'undecryptable'
+  | 'fingerprint-mismatch';
+
+/**
+ * Open an envelope, checking every transcript field against what THIS joiner actually sent.
+ *
+ * Fails closed on every branch: a rejection provisions nothing, and the caller must NOT fall
+ * back to minting (spec Frontloaded Decision 2 — a silent twin is worse than a loud failure).
+ */
+export function openHandoverEnvelope(input: {
+  envelope: IdentityHandoverEnvelope;
+  /** What this joiner sent, to compare the transcript against. */
+  expected: HandoverTranscript;
+  /** The agent fingerprint from the pairing artefact the operator carried. */
+  pinnedFingerprint: string;
+  now?: Date;
+  decrypt?: (p: EncryptedSecretPayload, priv: KeyObject) => unknown;
+  /** PEM of the joiner's X25519 encryption private key — the one generated during join. */
+  joinerEncryptionPrivateKeyPem: string;
+}): { ok: true; payload: HandoverPayload } | { ok: false; rejection: HandoverRejection } {
+  const { envelope, expected } = input;
+  if (envelope?.schemaVersion !== 1) return { ok: false, rejection: 'schema-unsupported' };
+
+  const t = envelope.transcript;
+  if (t?.pairingSessionId !== expected.pairingSessionId) return { ok: false, rejection: 'transcript-session-mismatch' };
+  if (t.joinerMachineId !== expected.joinerMachineId) return { ok: false, rejection: 'transcript-machine-mismatch' };
+  if (t.joinerEncryptionPublicKey !== expected.joinerEncryptionPublicKey) return { ok: false, rejection: 'transcript-key-mismatch' };
+  if (t.agentName !== expected.agentName) return { ok: false, rejection: 'transcript-agent-mismatch' };
+
+  const now = input.now ?? new Date();
+  const expiry = Date.parse(t.expiresAt);
+  if (!Number.isFinite(expiry) || expiry <= now.getTime()) return { ok: false, rejection: 'expired' };
+
+  // Pin BEFORE decrypting: a hostile listener cannot produce a keypair matching a fingerprint
+  // whose private key it does not hold, so this is what stops a fabricated identity.
+  if (envelope.identityFingerprint !== input.pinnedFingerprint) {
+    return { ok: false, rejection: 'fingerprint-not-pinned' };
+  }
+
+  const decrypt = input.decrypt ?? ((p, priv) => decryptFromSync(p, priv));
+  let opened: unknown;
+  try {
+    opened = decrypt(envelope.sealed, createPrivateKey(input.joinerEncryptionPrivateKeyPem));
+  } catch {
+    // Covers a malformed key, a wrong key, and a tampered ciphertext alike. All three are
+    // "this joiner cannot open this envelope", and none may fall back to minting.
+    return { ok: false, rejection: 'undecryptable' };
+  }
+
+  const payload = opened as HandoverPayload;
+  if (!payload?.identity?.publicKey || !payload.identity.privateKey) {
+    return { ok: false, rejection: 'undecryptable' };
+  }
+
+  // The sealed contents must match the fingerprint that was pinned — otherwise a valid-looking
+  // envelope could carry a different key than the one advertised.
+  if (fingerprintOf(payload.identity.publicKey) !== input.pinnedFingerprint) {
+    return { ok: false, rejection: 'fingerprint-mismatch' };
+  }
+
+  return { ok: true, payload };
+}
+
+/** The routing fingerprint of an Ed25519 public key: first 16 bytes of its SHA-256, hex. */
+export function fingerprintOf(publicKeyBase64: string): string {
+  return createHash('sha256').update(Buffer.from(publicKeyBase64, 'base64')).digest('hex').slice(0, 32);
+}

--- a/src/core/AgentIdentityReconciler.ts
+++ b/src/core/AgentIdentityReconciler.ts
@@ -1,0 +1,161 @@
+/**
+ * AgentIdentityReconciler — decide, safely, which identity is canonical, and repair to it.
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §3.
+ * Constitution: "Know Your Principal — An Unverified Identity Is a Guess"; "No Silent Degradation".
+ *
+ * ── THE ONE THING THAT MATTERS ───────────────────────────────────────────────────────────
+ * Repairing to the WRONG identity takes the agent off the network. So every uncertain branch
+ * REFUSES and reports. There is no branch that guesses, and no branch that picks a winner on
+ * a tiebreak. That is why this module returns a DECISION rather than performing a repair: the
+ * caller cannot accidentally act on an unresolved one.
+ *
+ * ── LINEAGE IS EVIDENCE, NOT AUTHORITY ───────────────────────────────────────────────────
+ * `minted-standalone` provenance is trustworthy only for identities created AFTER the mint
+ * guard exists, because a compromised host or an older binary can self-sign a false claim. So
+ * lineage orders a set of cooperating machines running current code; anything else — including
+ * every identity that predates the record, which is the live 2026-08-19 split — routes to the
+ * operator.
+ *
+ * Explicitly NOT used as tiebreakers, though each looks persuasive:
+ *   • durable prevalence (a long-running wrong identity accumulates the same weight),
+ *   • peer majority (two machines cloned from one mistake outvote the correct one),
+ *   • the lease holder (it may BE the diverged machine — it was, in the live incident).
+ */
+
+import type { IdentityProvenance } from './AgentIdentityHandover.js';
+
+export interface IdentityCandidate {
+  fingerprint: string;
+  /** Machines publishing this identity, for the operator-facing description. */
+  machineNames: string[];
+  /** Provenance, when the identity carries a record. Absent → `unknown-origin`. */
+  provenance?: IdentityProvenance;
+  /** Earliest known first-seen, used only to DESCRIBE candidates, never to choose between them. */
+  firstSeen?: string;
+}
+
+export type ReconcileDecision =
+  | { action: 'no-op'; reason: 'single-identity' }
+  | { action: 'repair'; canonicalFingerprint: string; basis: 'lineage'; repairMachines: string[] }
+  | {
+      action: 'ask-operator';
+      reason: 'no-attested-root' | 'multiple-roots' | 'unattested-version-present';
+      candidates: OperatorCandidate[];
+    };
+
+/** A candidate rendered for a human: description first, fingerprint as supporting detail. */
+export interface OperatorCandidate {
+  fingerprint: string;
+  /** Plain-language description — this is what the operator actually chooses between. */
+  description: string;
+  machineNames: string[];
+}
+
+/**
+ * Decide what to do about a set of observed identities.
+ *
+ * Pure. Returns a decision; performs nothing.
+ */
+export function decideReconciliation(input: {
+  agentName: string;
+  candidates: IdentityCandidate[];
+  /** instar versions this build trusts to have produced honest provenance. */
+  attestedVersions?: (v: string) => boolean;
+}): ReconcileDecision {
+  const candidates = input.candidates;
+  if (candidates.length <= 1) return { action: 'no-op', reason: 'single-identity' };
+
+  const attested = input.attestedVersions ?? (() => true);
+
+  // Any candidate whose provenance cannot be trusted poisons the LINEAGE route for the whole
+  // set — not just for itself. A root that "wins" only because a rival could not be attested
+  // is not a decision, it is a default.
+  const unattested = candidates.filter((c) => !c.provenance || !attested(c.provenance.producedBy));
+  if (unattested.length > 0) {
+    return {
+      action: 'ask-operator',
+      reason: candidates.every((c) => !c.provenance) ? 'no-attested-root' : 'unattested-version-present',
+      candidates: candidates.map(describe),
+    };
+  }
+
+  const roots = candidates.filter((c) => c.provenance?.origin === 'minted-standalone');
+  if (roots.length === 0) {
+    return { action: 'ask-operator', reason: 'no-attested-root', candidates: candidates.map(describe) };
+  }
+  if (roots.length > 1) {
+    // Two machines each claiming to be an origin is a genuine ambiguity, not a tiebreak.
+    return { action: 'ask-operator', reason: 'multiple-roots', candidates: candidates.map(describe) };
+  }
+
+  const canonical = roots[0];
+  return {
+    action: 'repair',
+    canonicalFingerprint: canonical.fingerprint,
+    basis: 'lineage',
+    repairMachines: candidates
+      .filter((c) => c.fingerprint !== canonical.fingerprint)
+      .flatMap((c) => c.machineNames),
+  };
+}
+
+/** Describe a candidate in the terms an operator can actually weigh. */
+function describe(c: IdentityCandidate): OperatorCandidate {
+  const where = c.machineNames.length === 1 ? c.machineNames[0] : c.machineNames.join(' and ');
+  const since = c.firstSeen ? ` since ${c.firstSeen.slice(0, 10)}` : '';
+  const origin = c.provenance
+    ? c.provenance.origin === 'minted-standalone'
+      ? ', created as the original'
+      : ', received when that machine joined'
+    : ', origin unrecorded';
+  return {
+    fingerprint: c.fingerprint,
+    description: `The identity used by ${where}${since}${origin}`,
+    machineNames: c.machineNames,
+  };
+}
+
+export type OperatorChoiceResult =
+  | { accepted: true; canonicalFingerprint: string; repairMachines: string[] }
+  | { accepted: false; reason: 'unknown-fingerprint' | 'not-a-candidate' | 'cancelled' };
+
+/**
+ * Bind an operator's choice to the exact candidate set they were shown.
+ *
+ * A choice naming something that was not on offer is REFUSED rather than interpreted — that is
+ * the difference between a decision and a guess about a decision.
+ */
+export function applyOperatorChoice(input: {
+  candidates: OperatorCandidate[];
+  /** The fingerprint the operator's selected option carries. Empty/absent = cancelled. */
+  chosenFingerprint: string | null;
+}): OperatorChoiceResult {
+  if (!input.chosenFingerprint) return { accepted: false, reason: 'cancelled' };
+  const match = input.candidates.find((c) => c.fingerprint === input.chosenFingerprint);
+  if (!match) return { accepted: false, reason: 'not-a-candidate' };
+  return {
+    accepted: true,
+    canonicalFingerprint: match.fingerprint,
+    repairMachines: input.candidates
+      .filter((c) => c.fingerprint !== match.fingerprint)
+      .flatMap((c) => c.machineNames),
+  };
+}
+
+/** The plain restatement the operator confirms against — never a bare yes. */
+export function renderChoiceConfirmation(input: {
+  agentName: string;
+  chosen: OperatorCandidate;
+  losing: OperatorCandidate[];
+}): string {
+  const losingMachines = input.losing.flatMap((c) => c.machineNames);
+  return (
+    `You're choosing: ${input.chosen.description.toLowerCase()}.\n\n` +
+    `What happens: ${losingMachines.join(' and ')} ` +
+    `${losingMachines.length === 1 ? 'is' : 'are'} changed to use that identity instead. ` +
+    `Their current identity is kept as a backup, so this is reversible.\n\n` +
+    `What does NOT happen: the old identity stays registered on the relay — clearing that ` +
+    `needs separate work — and every machine keeps its own machine keys, which are unaffected.`
+  );
+}

--- a/src/core/ProcessCeilingCheck.ts
+++ b/src/core/ProcessCeilingCheck.ts
@@ -24,7 +24,7 @@
  * report that a limit is wrong.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   LAUNCHD_PROCESS_CEILING_FLOOR,
@@ -75,7 +75,7 @@ export function readEffectiveProcessCeiling(
  *              restart a machine that would come back just as broken; folding it into
  *              silence — the first draft's behaviour — leaves a machine crashing on this
  *              exact bug with nobody told.
- * - `future-repair` — the machine is running SAFELY right now, but its plist is absent,
+ * - `future-repair` — the machine is running SAFELY right now, but its EXISTING plist is
  *              unreadable, half-raised, or below the floor, so its NEXT restart MAY land it
  *              in the unsafe state. "May", not "would": when the plist is below the floor
  *              the outcome is known, but when it cannot be READ the next effective limit is
@@ -111,6 +111,20 @@ export function evaluateProcessCeiling(input: {
   platform: string;
   effective: number | null;
   plistCeilings: number[];
+  /**
+   * Whether a launchd plist EXISTS for this agent at all.
+   *
+   * Absent is NOT the same as "present but wrong" (found 2026-08-19 by this repo's own suite,
+   * after the first version shipped): a machine with no launchd plist is not launchd-managed,
+   * so it has no managed ceiling to lose at its next restart, and telling its operator that a
+   * restart "may lose" the limit is a false alarm. The first version conflated the two and
+   * raised `future-repair` on every healthy unmanaged machine — including inside the test
+   * suite, where it polluted unrelated tests' attention items. That is how it was caught.
+   *
+   * Defaults TRUE so an omitted flag keeps the stricter reading rather than silently
+   * suppressing a real warning.
+   */
+  plistPresent?: boolean;
   machineId: string;
   /**
    * A host fingerprint mixed into the dedupe key alongside `machineId` (round-10 review
@@ -128,10 +142,14 @@ export function evaluateProcessCeiling(input: {
   const who = `${input.machineId}@${input.hostFingerprint ?? 'unknown-host'}`;
   if (input.platform !== 'darwin') return { state: 'unknown', reason: 'not-applicable' };
   if (input.effective === null) return { state: 'unknown', reason: 'effective-unreadable' };
+  const plistPresent = input.plistPresent ?? true;
   const plistOk =
     input.plistCeilings.length > 0 && input.plistCeilings.every((v) => v >= floor);
   if (input.effective >= floor) {
     if (plistOk) return { state: 'ok', effective: input.effective, floor };
+    // Safe now AND not launchd-managed: there is no managed ceiling to lose on restart, so
+    // there is nothing to warn about. Silence here is accuracy, not suppression.
+    if (!plistPresent) return { state: 'unknown', reason: 'not-applicable' };
     // Safe now, unsafe after the next restart. Reported at lower urgency, never silently.
     return {
       state: 'future-repair',
@@ -214,6 +232,18 @@ export function processCeilingNotice(
  * symbol WITHOUT importing the migration machinery: the check compares the symbol against
  * the state, so it needs to see both, but it must never be able to write either.
  */
+export function launchdPlistExistsForSelf(
+  projectName: string,
+  deps: { platform?: string; home?: string; exists?: (p: string) => boolean } = {},
+): boolean {
+  const platform = deps.platform ?? process.platform;
+  if (platform !== 'darwin') return false;
+  const home = deps.home ?? process.env.HOME ?? '';
+  if (!home) return false;
+  const exists = deps.exists ?? ((f: string) => existsSync(f));
+  return exists(join(home, 'Library', 'LaunchAgents', `ai.instar.${projectName}.plist`));
+}
+
 export function readLaunchdPlistCeilingsForSelf(
   projectName: string,
   deps: {

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -1143,6 +1143,7 @@ export interface NotAGuardEntry {
 }
 
 export const NOT_A_GUARD: readonly NotAGuardEntry[] = [
+  { component: 'AgentIdentityDivergenceDetector', reason: 'Pure decision function over injected peer observations (agree / disagree / cannot-tell). It IS wired at boot in AgentServer and raises one deduped Attention item on a real split, but it registers no runtime getter and carries no enabled flag, so there is nothing for the /guards inventory to report a posture FOR. It moves to GUARD_MANIFEST if it ever gains a config gate or a status surface.' },
   { component: 'SessionPoolPromotionActivation', reason: 'Evidence-gated rollout actuator selected by promotionModel; it delegates every mutation to StageAdvancer and is not itself a protective guard. Its off/operator/auto posture is surfaced by the promotion route and machine-coherence manifest.' },
   { component: 'DeferralPatternSentinel', reason: 'Increment-1 core only: pure injected-deps detector over the existing judgment-provenance store; NOT boot-constructed and registers no runtime getter yet, so it is absent from the live /guards inventory. It moves to GUARD_MANIFEST when a later increment wires it at boot.' },
   { component: 'rawTextRequestDetector', reason: 'Pure stateless predicate (high-precision pattern match) feeding the observe-only ask-for-access signal in checkOutboundMessage; no enabled flag, no runtime getter, takes no protective action — a detector that produces a signal, never a guard with posture.' },

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -167,7 +167,13 @@ import {
   evaluateProcessCeiling,
   processCeilingNotice,
   readLaunchdPlistCeilingsForSelf,
+  launchdPlistExistsForSelf,
 } from '../core/ProcessCeilingCheck.js';
+import {
+  evaluateDivergence,
+  divergenceNotice,
+} from '../core/AgentIdentityDivergenceDetector.js';
+import { fingerprintOf as identityFingerprintOf } from '../core/AgentIdentityHandover.js';
 import { MoneyLayerAuditLog } from '../core/MoneyLayerAuditLog.js';
 import { MoneyLayerEnableSurface } from '../core/MoneyLayerEnableSurface.js';
 import { PROBE_DOOR, PROBE_KEY_REF } from '../core/moneyLayerProbe.js';
@@ -2546,6 +2552,7 @@ export class AgentServer {
         platform: process.platform,
         effective: readEffectiveProcessCeiling(),
         plistCeilings: readLaunchdPlistCeilingsForSelf(options.config.projectName),
+        plistPresent: launchdPlistExistsForSelf(options.config.projectName),
         machineId: (options.config as { machineId?: string }).machineId ?? 'single-machine',
         hostFingerprint: os.hostname(),
       });
@@ -2583,9 +2590,14 @@ export class AgentServer {
         // broke on darwin, this whole check would disappear fleet-wide while still
         // "satisfying" its no-item contract. So the unmeasurable branch is logged, always,
         // on the platform where it is supposed to work.
+        // Two very different silences, and conflating them in the log is how a broken reader
+        // gets mistaken for an unmanaged machine.
         console.warn(
-          `[process-ceiling] unmeasurable on darwin (${ceilingVerdict.reason}) — no claim made; ` +
-            'the ceiling check produced no verdict this boot',
+          ceilingVerdict.reason === 'effective-unreadable'
+            ? '[process-ceiling] UNMEASURABLE on darwin — the live process limit could not be ' +
+              'read, so no claim was made. A persistent reading here means the check is blind.'
+            : '[process-ceiling] not applicable — this agent home is not launchd-managed, so ' +
+              'there is no managed ceiling to report on.',
         );
       }
     } catch (err) {
@@ -2595,6 +2607,108 @@ export class AgentServer {
       // a boot that fails because a notice could not be composed. It is LOGGED, so a broken
       // check is visible rather than an invisible fleet-wide gap.
       console.warn('[process-ceiling] check skipped (non-fatal):', err);
+    }
+
+    // Agent-identity divergence check (docs/specs/agent-identity-continuity-on-expansion.md §4).
+    //
+    // The 2026-08-19 split went FOUR DAYS unreported and surfaced only while investigating an
+    // unrelated request. A repair path with no detector only fixes the splits somebody happens
+    // to notice, so this is the part that makes the failure visible at all.
+    //
+    // EVERY machine observes — not only the lease holder, which fails in the two cases that
+    // matter most (the holder may BE the diverged machine, and it may be the isolated one).
+    // The single-notice property comes from the episode dedupe key, not from restricting who
+    // is allowed to look.
+    //
+    // Deliberately DELAYED and fire-and-forget: it reaches peers over the network, and a boot
+    // path must never block on that. SIGNAL ONLY — it raises one attention item and repairs
+    // nothing; repair needs an operator decision (§3).
+    if (options.resolvePeerUrls) {
+      const divergenceTimer = setTimeout(() => {
+        void (async () => {
+          try {
+            const peers = options.resolvePeerUrls!();
+            if (peers.length === 0) return; // single machine — nothing to compare
+            // Read the SELF fingerprint from the same canonical identity the verifier uses —
+            // the STATE this machine publishes, not a cached copy that could drift from it.
+            const selfFp = (() => {
+              try {
+                const id = JSON.parse(
+                  fs.readFileSync(path.join(options.config.stateDir, 'identity.json'), 'utf-8'),
+                ) as { publicKey?: string };
+                return id.publicKey ? identityFingerprintOf(id.publicKey) : null;
+              } catch {
+                // @silent-fallback-ok: no readable identity → null → the detector counts this
+                // machine as unreadable, which is `cannot-tell`, never agreement.
+                return null;
+              }
+            })();
+            const agentName = options.config.projectName;
+            const observations = [
+              {
+                machineId: 'self',
+                machineName:
+                  (options.config as { machineNickname?: string }).machineNickname ?? 'this machine',
+                publishedFingerprint: selfFp,
+                ...(selfFp ? {} : { unreachableReason: 'no-local-fingerprint' }),
+              },
+              ...(await Promise.all(
+                peers.map(async (p) => {
+                  try {
+                    const r = await fetch(`${p.url.replace(/\/+$/, '')}/provenance`, {
+                      headers: {
+                        Authorization: `Bearer ${options.config.authToken ?? ''}`,
+                        'X-Instar-AgentId': agentName,
+                      },
+                      signal: AbortSignal.timeout(8000),
+                    });
+                    const j = (await r.json()) as { fingerprint?: string };
+                    return {
+                      machineId: p.machineId,
+                      machineName: p.machineId,
+                      publishedFingerprint: j?.fingerprint ?? null,
+                      ...(j?.fingerprint ? {} : { unreachableReason: 'no-fingerprint-reported' }),
+                    };
+                  } catch {
+                    // Unreachable is UNKNOWN, never agreement — the detector's whole point.
+                    return {
+                      machineId: p.machineId,
+                      machineName: p.machineId,
+                      publishedFingerprint: null,
+                      unreachableReason: 'unreachable',
+                    };
+                  }
+                }),
+              )),
+            ];
+            const verdict = evaluateDivergence({ agentName, observations });
+            if (verdict.state === 'cannot-tell') {
+              console.warn(
+                `[identity-divergence] cannot-tell — ${verdict.unreadable.length} machine(s) unreadable; ` +
+                  'no claim made (this is NOT agreement)',
+              );
+              return;
+            }
+            if (!verdict.shouldNotify || !verdict.episodeKey) return;
+            const notice = divergenceNotice(verdict, agentName);
+            console.warn(`[identity-divergence] SPLIT: ${verdict.fingerprints.join(' vs ')}`);
+            void this.telegramAdapter?.createAttentionItem?.({
+              id: verdict.episodeKey,
+              title: notice.title,
+              description: notice.body,
+              summary: notice.title,
+              priority: 'HIGH',
+              category: 'monitoring',
+              sourceContext: 'agent-identity:split',
+            });
+          } catch (err) {
+            // @silent-fallback-ok: a detector that can take a boot down is worse than the split
+            // it detects. Logged so a broken detector is visible rather than quietly inert.
+            console.warn('[identity-divergence] check skipped (non-fatal):', err);
+          }
+        })();
+      }, 90_000);
+      divergenceTimer.unref?.();
     }
 
     // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md) — instar

--- a/src/threadline/client/IdentityManager.ts
+++ b/src/threadline/client/IdentityManager.ts
@@ -15,7 +15,29 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { generateIdentityKeyPair, type KeyPair } from '../ThreadlineCrypto.js';
 import { computeFingerprint, deriveX25519PublicKey } from './MessageEncryptor.js';
+import { detectJoinedMesh } from './JoinedMeshDetector.js';
 import type { AgentFingerprint } from '../relay/types.js';
+
+/**
+ * Thrown when minting is refused because this home joined an existing mesh.
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §2, Frontloaded Decision 2 —
+ * fail closed, loudly. A machine that cannot obtain the agent's identity must NOT invent one:
+ * a silent twin is worse than a machine that plainly says it could not join properly.
+ */
+export class IdentityNotProvisionedError extends Error {
+  readonly code = 'identity-not-provisioned';
+  readonly peerMachineCount: number;
+  constructor(peerMachineCount: number) {
+    super(
+      'This machine joined an existing agent mesh but has no agent identity. Minting one here ' +
+        'would split the agent into two identities sharing a name, so it is refused. The ' +
+        'identity must be provisioned by the pairing exchange — re-pair this machine.',
+    );
+    this.name = 'IdentityNotProvisionedError';
+    this.peerMachineCount = peerMachineCount;
+  }
+}
 
 export interface IdentityInfo {
   fingerprint: AgentFingerprint;
@@ -54,6 +76,23 @@ export class IdentityManager {
     if (loaded) {
       this.identity = loaded;
       return loaded;
+    }
+
+    // ── The mint refusal (spec: agent-identity-continuity-on-expansion §2) ───────────
+    // Nothing was found on disk. For the FIRST machine of a new agent that is correct and
+    // minting follows. For a machine that JOINED an existing agent's mesh it is the defect
+    // this guard exists to close: the agent already has an identity, it simply was not
+    // carried here, and minting turns one agent into two that share a name.
+    //
+    // Enforced at the minting SITE rather than at the call sites, deliberately — guarding
+    // callers leaves the next caller free to reintroduce it.
+    //
+    // The discriminator is an on-disk fact (a registry naming another machine), and every
+    // uncertain reading resolves toward minting, so an unrelated filesystem problem can
+    // never deny a legitimate standalone agent its identity.
+    const joined = detectJoinedMesh(this.stateDir);
+    if (joined.joined) {
+      throw new IdentityNotProvisionedError(joined.peerMachineCount);
     }
 
     // Generate new identity (legacy path for backward compat with standalone tooling)

--- a/src/threadline/client/JoinedMeshDetector.ts
+++ b/src/threadline/client/JoinedMeshDetector.ts
@@ -1,0 +1,104 @@
+/**
+ * JoinedMeshDetector — is this agent home a machine that JOINED an existing mesh?
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §2.
+ * Constitution: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions".
+ *
+ * WHY THIS EXISTS. `IdentityManager.getOrCreate()` mints a fresh agent keypair when it finds
+ * none on disk. That is correct for the FIRST machine of a new agent and catastrophic for the
+ * second: a machine that joined an existing agent's mesh has an identity — it just was not
+ * carried to it — so minting there silently turns one agent into two that share a name.
+ *
+ * Observed live (2026-08-19): the operator authorised a Mac Mini to extend echo onto a Mac
+ * Studio. The Studio joined the mesh correctly in every visible respect, then minted
+ * `ae6feac6…` while the Mini and Laptop both publish `63b1dbb2…`. A plain-text message signed
+ * on the Studio verifies there and is rejected as `bad-signature` on BOTH peers, so the
+ * agent-signature feature is inoperative from that machine.
+ *
+ * THE DISCRIMINATOR IS AN ON-DISK FACT, NOT A HEURISTIC. A joined home carries a machine
+ * registry naming at least one machine OTHER than itself — written by `joinMesh` /
+ * `MachineIdentityManager.registerMachine` during pairing, before the server ever starts. A
+ * standalone first machine has no such record. That is what makes this guard safe to enforce
+ * immediately rather than ship dark: the two cases are distinguished by evidence, and the
+ * uncertain case is resolved toward the pre-existing behaviour.
+ *
+ * FAILS TOWARD MINTING, DELIBERATELY. An unreadable or absent registry answers `false` (not
+ * joined), so an unrelated filesystem problem cannot brick a legitimate standalone agent by
+ * refusing it an identity. The cost of that choice is that a joined machine with a corrupt
+ * registry could still mint — which the divergence detector (§4) is there to catch.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Why the detector answered as it did — surfaced so a refusal can explain itself. */
+export type JoinedMeshVerdict =
+  | { joined: true; peerMachineCount: number; source: string }
+  | { joined: false; reason: 'no-registry' | 'registry-unreadable' | 'self-only' | 'no-machine-id' };
+
+/**
+ * Decide whether this home joined an existing mesh.
+ *
+ * Pure over the injected readers so the decision is testable without a real mesh on disk.
+ */
+export function detectJoinedMesh(
+  stateDir: string,
+  deps: {
+    readFile?: (p: string) => string;
+    /** This machine's own id, so "the registry lists only me" is not read as "I joined". */
+    selfMachineId?: () => string | null;
+  } = {},
+): JoinedMeshVerdict {
+  const readFile = deps.readFile ?? ((f: string) => fs.readFileSync(f, 'utf-8'));
+  const registryPath = path.join(stateDir, 'machines', 'registry.json');
+
+  let raw: string;
+  try {
+    raw = readFile(registryPath);
+  } catch {
+    // @silent-fallback-ok: no registry is the ordinary standalone case, and an unreadable one
+    // must not brick a legitimate agent. Both answer "not joined" — the direction that
+    // preserves today's behaviour. §4's divergence detector covers the residual risk.
+    return { joined: false, reason: 'no-registry' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { joined: false, reason: 'registry-unreadable' };
+  }
+
+  const machines = (parsed as { machines?: Record<string, unknown> } | null)?.machines;
+  if (!machines || typeof machines !== 'object') return { joined: false, reason: 'registry-unreadable' };
+
+  const selfId = deps.selfMachineId ? deps.selfMachineId() : readSelfMachineId(stateDir, readFile);
+  const ids = Object.keys(machines);
+  const peers = selfId ? ids.filter((id) => id !== selfId) : ids;
+
+  // Without a self id we cannot tell "the registry lists only me" from "it lists a peer", so
+  // any entry at all would read as joined. Refuse to conclude rather than guess: this branch
+  // resolves to NOT joined, preserving the mint.
+  if (!selfId && ids.length > 0) return { joined: false, reason: 'no-machine-id' };
+  if (peers.length === 0) return { joined: false, reason: 'self-only' };
+
+  return { joined: true, peerMachineCount: peers.length, source: registryPath };
+}
+
+/** This machine's own id, or null when it cannot be read. */
+function readSelfMachineId(stateDir: string, readFile: (p: string) => string): string | null {
+  try {
+    // NOTE the singular `machine/` — this machine's OWN identity lives there, while
+    // `machines/` holds the registry plus a directory per REMOTE machine. Reading the wrong
+    // one yields no self id, which routes to the mint-preserving branch and would have made
+    // this guard silently inert. Verified against a real joined home, 2026-08-19.
+    const d = JSON.parse(readFile(path.join(stateDir, 'machine', 'identity.json'))) as {
+      machineId?: unknown;
+    };
+    return typeof d.machineId === 'string' && d.machineId.length > 0 ? d.machineId : null;
+  } catch {
+    // @silent-fallback-ok: handled by the `no-machine-id` branch above, which fails toward
+    // minting rather than toward refusing a legitimate standalone agent.
+    return null;
+  }
+}

--- a/tests/unit/StageAdvancer.test.ts
+++ b/tests/unit/StageAdvancer.test.ts
@@ -40,49 +40,6 @@ describe('StageAdvancer (§Rollout)', () => {
   });
   afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/StageAdvancer.test.ts' }));
 
-  // ── Deadlock escape (2026-08-19 incident) ───────────────────────────────
-  // A stage is only PROVEN while the agent is IN it, so a transient red locks the
-  // rung out permanently. A red is superseded when the PRIOR stage recorded a
-  // green for the same commit LATER than the red. Both sides of the boundary:
-
-  it('reconcile SKIPS the revert when the current stage red is superseded by a NEWER prior-stage green', () => {
-    let t = 1000;
-    const clocked = new SessionPoolE2EResultStore({
-      filePath: path.join(dir, 'superseded.json'), sign, verifySig, now: () => (t += 1000),
-    });
-    clocked.recordResult(1, 'red', SHA, 'red@stage1');    // older red at the LIVE stage
-    clocked.recordResult(0, 'green', SHA, 'green@stage0'); // NEWER green at the prior stage
-    stage = 'shadow';
-    writes = [];
-    advancer = new StageAdvancer({
-      resultStore: clocked,
-      currentCommitSha: () => SHA,
-      readStage: () => stage,
-      writeStageConfig: (s) => { writes.push(s); stage = s; },
-    });
-    expect(advancer.reconcile()).toBe('shadow'); // stays — earns a re-test
-    expect(writes).toEqual([]);                  // and never writes the config
-  });
-
-  it('reconcile STILL reverts when the current stage red is NEWER than the prior-stage green (guard preserved)', () => {
-    let t = 1000;
-    const clocked = new SessionPoolE2EResultStore({
-      filePath: path.join(dir, 'genuine.json'), sign, verifySig, now: () => (t += 1000),
-    });
-    clocked.recordResult(0, 'green', SHA, 'green@stage0'); // older green at the prior stage
-    clocked.recordResult(1, 'red', SHA, 'red@stage1');     // NEWER red at the LIVE stage
-    stage = 'shadow';
-    writes = [];
-    advancer = new StageAdvancer({
-      resultStore: clocked,
-      currentCommitSha: () => SHA,
-      readStage: () => stage,
-      writeStageConfig: (s) => { writes.push(s); stage = s; },
-    });
-    expect(advancer.reconcile()).toBe('dark'); // a genuine regression still demotes
-    expect(writes).toEqual(['dark']);
-  });
-
   it('REFUSES advance with no prior-stage E2E result (e2e-gate-not-passed / no-result)', () => {
     const r = advancer.advanceTo('shadow');
     expect(r).toMatchObject({ ok: false, reason: 'e2e-gate-not-passed', detail: 'no-result' });

--- a/tests/unit/StageAdvancer.test.ts
+++ b/tests/unit/StageAdvancer.test.ts
@@ -40,6 +40,49 @@ describe('StageAdvancer (§Rollout)', () => {
   });
   afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/StageAdvancer.test.ts' }));
 
+  // ── Deadlock escape (2026-08-19 incident) ───────────────────────────────
+  // A stage is only PROVEN while the agent is IN it, so a transient red locks the
+  // rung out permanently. A red is superseded when the PRIOR stage recorded a
+  // green for the same commit LATER than the red. Both sides of the boundary:
+
+  it('reconcile SKIPS the revert when the current stage red is superseded by a NEWER prior-stage green', () => {
+    let t = 1000;
+    const clocked = new SessionPoolE2EResultStore({
+      filePath: path.join(dir, 'superseded.json'), sign, verifySig, now: () => (t += 1000),
+    });
+    clocked.recordResult(1, 'red', SHA, 'red@stage1');    // older red at the LIVE stage
+    clocked.recordResult(0, 'green', SHA, 'green@stage0'); // NEWER green at the prior stage
+    stage = 'shadow';
+    writes = [];
+    advancer = new StageAdvancer({
+      resultStore: clocked,
+      currentCommitSha: () => SHA,
+      readStage: () => stage,
+      writeStageConfig: (s) => { writes.push(s); stage = s; },
+    });
+    expect(advancer.reconcile()).toBe('shadow'); // stays — earns a re-test
+    expect(writes).toEqual([]);                  // and never writes the config
+  });
+
+  it('reconcile STILL reverts when the current stage red is NEWER than the prior-stage green (guard preserved)', () => {
+    let t = 1000;
+    const clocked = new SessionPoolE2EResultStore({
+      filePath: path.join(dir, 'genuine.json'), sign, verifySig, now: () => (t += 1000),
+    });
+    clocked.recordResult(0, 'green', SHA, 'green@stage0'); // older green at the prior stage
+    clocked.recordResult(1, 'red', SHA, 'red@stage1');     // NEWER red at the LIVE stage
+    stage = 'shadow';
+    writes = [];
+    advancer = new StageAdvancer({
+      resultStore: clocked,
+      currentCommitSha: () => SHA,
+      readStage: () => stage,
+      writeStageConfig: (s) => { writes.push(s); stage = s; },
+    });
+    expect(advancer.reconcile()).toBe('dark'); // a genuine regression still demotes
+    expect(writes).toEqual(['dark']);
+  });
+
   it('REFUSES advance with no prior-stage E2E result (e2e-gate-not-passed / no-result)', () => {
     const r = advancer.advanceTo('shadow');
     expect(r).toMatchObject({ ok: false, reason: 'e2e-gate-not-passed', detail: 'no-result' });

--- a/tests/unit/agent-identity-divergence.test.ts
+++ b/tests/unit/agent-identity-divergence.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The divergence detector — spec agent-identity-continuity-on-expansion.md §4, criterion 7.
+ *
+ * The load-bearing behaviour is NOT "spots a split". It is that `cannot-tell` never renders as
+ * agreement: the live incident went four days unreported, and a detector that reports quiet as
+ * healthy would have gone on not reporting it.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateDivergence,
+  divergenceNotice,
+  type MachineIdentityObservation,
+} from '../../src/core/AgentIdentityDivergenceDetector.js';
+
+const m = (name: string, fp: string | null, reason?: string): MachineIdentityObservation => ({
+  machineId: `m_${name}`,
+  machineName: name,
+  publishedFingerprint: fp,
+  ...(reason ? { unreachableReason: reason } : {}),
+});
+
+const CANON = '63b1dbb21646e2f5f860441f6c6443ad';
+const ORPHAN = 'ae6feac662480f9509c04ceb72ae2540';
+
+describe('evaluateDivergence', () => {
+  it('DISAGREE: reproduces the live 2026-08-19 split', () => {
+    const v = evaluateDivergence({
+      agentName: 'echo',
+      observations: [m('Mini', CANON), m('Laptop', CANON), m('Studio', ORPHAN)],
+    });
+    expect(v.state).toBe('disagree');
+    expect(v.shouldNotify).toBe(true);
+    expect(v.fingerprints).toHaveLength(2);
+    expect(v.byFingerprint[CANON]).toEqual(['Mini', 'Laptop']);
+    expect(v.byFingerprint[ORPHAN]).toEqual(['Studio']);
+  });
+
+  it('AGREE: all machines publishing one identity does not notify', () => {
+    const v = evaluateDivergence({ agentName: 'echo', observations: [m('Mini', CANON), m('Laptop', CANON)] });
+    expect(v.state).toBe('agree');
+    expect(v.shouldNotify).toBe(false);
+  });
+
+  it('CANNOT-TELL, not agree, when only one machine could be read', () => {
+    // The failure this whole detector exists to prevent: absence of evidence rendered as
+    // evidence of absence. One machine agreeing with itself proves nothing.
+    const v = evaluateDivergence({
+      agentName: 'echo',
+      observations: [m('Studio', ORPHAN), m('Mini', null, 'offline'), m('Laptop', null, 'timeout')],
+    });
+    expect(v.state).toBe('cannot-tell');
+    expect(v.shouldNotify).toBe(false);
+  });
+
+  it('CANNOT-TELL when nothing at all could be read', () => {
+    const v = evaluateDivergence({ agentName: 'echo', observations: [m('Mini', null, 'offline')] });
+    expect(v.state).toBe('cannot-tell');
+  });
+
+  it('an unreachable machine is REPORTED even when the readable ones agree', () => {
+    // "Two agree and one is unreachable" must not render identically to "all three agree".
+    const v = evaluateDivergence({
+      agentName: 'echo',
+      observations: [m('Mini', CANON), m('Laptop', CANON), m('Studio', null, 'offline')],
+    });
+    expect(v.state).toBe('agree');
+    expect(v.unreadable).toEqual([{ machineId: 'm_Studio', machineName: 'Studio', reason: 'offline' }]);
+  });
+
+  it('names a reason for every unreadable machine, defaulting to unknown rather than omitting', () => {
+    const v = evaluateDivergence({ agentName: 'echo', observations: [m('A', CANON), m('B', CANON), m('C', null)] });
+    expect(v.unreadable[0].reason).toBe('unknown');
+  });
+
+  it('the episode key is stable across machines and boots — one notice, not one per boot', () => {
+    const fromStudio = evaluateDivergence({ agentName: 'echo', observations: [m('Studio', ORPHAN), m('Mini', CANON)] });
+    const fromMini = evaluateDivergence({ agentName: 'echo', observations: [m('Mini', CANON), m('Studio', ORPHAN)] });
+    expect(fromStudio.episodeKey).toBe(fromMini.episodeKey);
+    expect(fromStudio.episodeKey).toBeTruthy();
+  });
+
+  it('a CHANGED split is a NEW episode — the operator is told the situation moved', () => {
+    const before = evaluateDivergence({ agentName: 'echo', observations: [m('A', CANON), m('B', ORPHAN)] });
+    const after = evaluateDivergence({ agentName: 'echo', observations: [m('A', CANON), m('B', 'c'.repeat(32))] });
+    expect(before.episodeKey).not.toBe(after.episodeKey);
+  });
+
+  it('a different AGENT with the same fingerprints is a different episode', () => {
+    const a = evaluateDivergence({ agentName: 'echo', observations: [m('A', CANON), m('B', ORPHAN)] });
+    const b = evaluateDivergence({ agentName: 'codey', observations: [m('A', CANON), m('B', ORPHAN)] });
+    expect(a.episodeKey).not.toBe(b.episodeKey);
+  });
+
+  it('agree and cannot-tell carry no episode key — only a real split opens an episode', () => {
+    expect(evaluateDivergence({ agentName: 'echo', observations: [m('A', CANON), m('B', CANON)] }).episodeKey).toBeNull();
+    expect(evaluateDivergence({ agentName: 'echo', observations: [m('A', CANON)] }).episodeKey).toBeNull();
+  });
+
+  it('three-way splits are reported in full, not reduced to a pair', () => {
+    const v = evaluateDivergence({
+      agentName: 'echo',
+      observations: [m('A', CANON), m('B', ORPHAN), m('C', 'd'.repeat(32))],
+    });
+    expect(v.state).toBe('disagree');
+    expect(v.fingerprints).toHaveLength(3);
+  });
+});
+
+describe('divergenceNotice — what the operator reads', () => {
+  const v = evaluateDivergence({
+    agentName: 'echo',
+    observations: [m('Mini', CANON), m('Laptop', CANON), m('Studio', ORPHAN)],
+  });
+
+  it('leads with machines, not hex, and states the consequence', () => {
+    const n = divergenceNotice(v, 'echo');
+    expect(n.title).toContain('more than one identity');
+    expect(n.body).toContain('Mini, Laptop');
+    expect(n.body).toContain('Studio');
+    expect(n.body.toLowerCase()).toContain("won't verify");
+  });
+
+  it('shows fingerprints only as short supporting detail, never in full', () => {
+    const n = divergenceNotice(v, 'echo');
+    expect(n.body).not.toContain(CANON); // never the full 32-char string
+    expect(n.body).toContain(CANON.slice(0, 8));
+  });
+
+  it('says nothing is changed automatically, and why', () => {
+    const n = divergenceNotice(v, 'echo');
+    expect(n.body).toMatch(/nothing is changed|one decision from you/i);
+    expect(n.body).toMatch(/off the network/i);
+  });
+
+  it('reports unreachable machines as unknown rather than letting them read as agreement', () => {
+    const withGap = evaluateDivergence({
+      agentName: 'echo',
+      observations: [m('Mini', CANON), m('Studio', ORPHAN), m('Laptop', null, 'offline')],
+    });
+    const n = divergenceNotice(withGap, 'echo');
+    expect(n.body).toContain("Couldn't check");
+    expect(n.body).toContain('unknown, not agreement');
+  });
+});

--- a/tests/unit/agent-identity-handover.test.ts
+++ b/tests/unit/agent-identity-handover.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The sealed identity handover — spec agent-identity-continuity-on-expansion.md §1.
+ *
+ * Acceptance criteria 3, 4, 5, 6c. The tests lean on the REJECTION paths, because the whole
+ * point of the design is that a failed handover must never become a minted twin: every
+ * rejection here is a case where the joiner provisions nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import {
+  sealIdentityForJoiner,
+  openHandoverEnvelope,
+  fingerprintOf,
+  type HandoverTranscript,
+  type HandoverPayload,
+} from '../../src/core/AgentIdentityHandover.js';
+
+/** A real X25519 keypair, the shape a joining machine generates during pairing. */
+function joinerKeys() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('x25519');
+  const spki = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+  return {
+    publicB64: spki.subarray(spki.length - 32).toString('base64'),
+    privatePem: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+  };
+}
+
+const agentKeys = crypto.generateKeyPairSync('ed25519');
+const agentPubB64 = (agentKeys.publicKey.export({ type: 'spki', format: 'der' }) as Buffer)
+  .subarray(-32).toString('base64');
+const AGENT_FP = fingerprintOf(agentPubB64);
+
+const payload: HandoverPayload = {
+  identity: { publicKey: agentPubB64, privateKey: 'cHJpdmF0ZS1rZXktYnl0ZXM=', createdAt: '2026-01-01T00:00:00.000Z' },
+  provenance: {
+    schemaVersion: 1,
+    origin: 'minted-standalone',
+    rootFingerprint: AGENT_FP,
+    machineId: 'm_root',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    producedBy: '1.3.1180',
+  },
+};
+
+function transcript(over: Partial<HandoverTranscript> = {}, joinerPub = 'x'): HandoverTranscript {
+  return {
+    pairingSessionId: 'sess-1',
+    joinerMachineId: 'm_joiner',
+    joinerEncryptionPublicKey: joinerPub,
+    agentName: 'echo',
+    expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    ...over,
+  };
+}
+
+describe('sealIdentityForJoiner', () => {
+  it('seals to the joiner key and carries the transcript + fingerprint', () => {
+    const j = joinerKeys();
+    const r = sealIdentityForJoiner({ payload, transcript: transcript({}, j.publicB64), identityFingerprint: AGENT_FP });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.envelope.identityFingerprint).toBe(AGENT_FP);
+    expect(r.envelope.transcript.joinerEncryptionPublicKey).toBe(j.publicB64);
+    // The identity must not be readable from the envelope without the joiner's private key.
+    expect(JSON.stringify(r.envelope)).not.toContain(payload.identity.privateKey);
+  });
+
+  it('refuses a malformed joiner key by NAME rather than returning a partial envelope', () => {
+    const r = sealIdentityForJoiner({ payload, transcript: transcript({}, 'not-a-key'), identityFingerprint: AGENT_FP });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.refusal).toBe('malformed-joiner-key');
+  });
+
+  it('refuses an empty joiner key', () => {
+    const r = sealIdentityForJoiner({ payload, transcript: transcript({}, ''), identityFingerprint: AGENT_FP });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('openHandoverEnvelope — every rejection provisions nothing', () => {
+  function sealed(joinerPub: string) {
+    const r = sealIdentityForJoiner({ payload, transcript: transcript({}, joinerPub), identityFingerprint: AGENT_FP });
+    if (!r.ok) throw new Error('seal failed');
+    return r.envelope;
+  }
+
+  it('opens for the intended joiner (criterion 3 happy path)', () => {
+    const j = joinerKeys();
+    const r = openHandoverEnvelope({
+      envelope: sealed(j.publicB64),
+      expected: transcript({}, j.publicB64),
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.identity.publicKey).toBe(agentPubB64);
+  });
+
+  it('a THIRD machine cannot open an envelope captured in transit (criterion 4)', () => {
+    const intended = joinerKeys();
+    const attacker = joinerKeys();
+    const r = openHandoverEnvelope({
+      envelope: sealed(intended.publicB64),
+      expected: transcript({}, intended.publicB64),
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: attacker.privatePem, // replayed by someone else
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('undecryptable');
+  });
+
+  it('rejects an envelope minted for a DIFFERENT session', () => {
+    const j = joinerKeys();
+    const r = openHandoverEnvelope({
+      envelope: sealed(j.publicB64),
+      expected: transcript({ pairingSessionId: 'sess-OTHER' }, j.publicB64),
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('transcript-session-mismatch');
+  });
+
+  it('rejects an envelope minted for a DIFFERENT machine', () => {
+    const j = joinerKeys();
+    const r = openHandoverEnvelope({
+      envelope: sealed(j.publicB64),
+      expected: transcript({ joinerMachineId: 'm_other' }, j.publicB64),
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('transcript-machine-mismatch');
+  });
+
+  it('rejects an envelope for a different AGENT name', () => {
+    const j = joinerKeys();
+    const r = openHandoverEnvelope({
+      envelope: sealed(j.publicB64),
+      expected: transcript({ agentName: 'someone-else' }, j.publicB64),
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('transcript-agent-mismatch');
+  });
+
+  it('rejects an EXPIRED envelope (criterion 5)', () => {
+    const j = joinerKeys();
+    const env = sealIdentityForJoiner({
+      payload,
+      transcript: transcript({ expiresAt: new Date(Date.now() - 1000).toISOString() }, j.publicB64),
+      identityFingerprint: AGENT_FP,
+    });
+    if (!env.ok) throw new Error('seal failed');
+    const r = openHandoverEnvelope({
+      envelope: env.envelope,
+      expected: env.envelope.transcript,
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('expired');
+  });
+
+  it('refuses an identity that does not match the PINNED fingerprint — the hostile-listener case', () => {
+    // A listener that merely collected the code cannot produce the agent's keypair, so the
+    // fingerprint carried in the operator's pairing artefact is what stops a fabricated identity.
+    const j = joinerKeys();
+    const r = openHandoverEnvelope({
+      envelope: sealed(j.publicB64),
+      expected: transcript({}, j.publicB64),
+      pinnedFingerprint: 'f'.repeat(32),
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('fingerprint-not-pinned');
+  });
+
+  it('refuses when the SEALED contents disagree with the advertised fingerprint', () => {
+    // A well-formed envelope that advertises one identity and carries another.
+    const j = joinerKeys();
+    const other = crypto.generateKeyPairSync('ed25519');
+    const otherPub = (other.publicKey.export({ type: 'spki', format: 'der' }) as Buffer).subarray(-32).toString('base64');
+    const env = sealIdentityForJoiner({
+      payload: { ...payload, identity: { ...payload.identity, publicKey: otherPub } },
+      transcript: transcript({}, j.publicB64),
+      identityFingerprint: AGENT_FP, // lies about what is inside
+    });
+    if (!env.ok) throw new Error('seal failed');
+    const r = openHandoverEnvelope({
+      envelope: env.envelope,
+      expected: env.envelope.transcript,
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('fingerprint-mismatch');
+  });
+
+  it('refuses an unsupported schema rather than parsing it partially', () => {
+    const j = joinerKeys();
+    const env = { ...sealed(j.publicB64), schemaVersion: 99 as unknown as 1 };
+    const r = openHandoverEnvelope({
+      envelope: env,
+      expected: transcript({}, j.publicB64),
+      pinnedFingerprint: AGENT_FP,
+      joinerEncryptionPrivateKeyPem: j.privatePem,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.rejection).toBe('schema-unsupported');
+  });
+});

--- a/tests/unit/agent-identity-reconciler.test.ts
+++ b/tests/unit/agent-identity-reconciler.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The reconciler — spec agent-identity-continuity-on-expansion.md §3, criteria 6, 6b, 7b.
+ *
+ * Repairing to the WRONG identity takes the agent off the network, so the tests that matter
+ * are the REFUSALS. A reconciler that decides confidently on thin evidence is the failure
+ * mode; one that asks is the design.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  decideReconciliation,
+  applyOperatorChoice,
+  renderChoiceConfirmation,
+  type IdentityCandidate,
+} from '../../src/core/AgentIdentityReconciler.js';
+
+const CANON = '63b1dbb21646e2f5f860441f6c6443ad';
+const ORPHAN = 'ae6feac662480f9509c04ceb72ae2540';
+
+const prov = (origin: 'minted-standalone' | 'received-on-join', root: string, version = '1.3.1181') => ({
+  schemaVersion: 1 as const,
+  origin,
+  rootFingerprint: root,
+  machineId: 'm_x',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  producedBy: version,
+});
+
+describe('decideReconciliation — lineage decides only when it honestly can', () => {
+  it('NO-OP when there is only one identity', () => {
+    const d = decideReconciliation({ agentName: 'echo', candidates: [{ fingerprint: CANON, machineNames: ['A'] }] });
+    expect(d.action).toBe('no-op');
+  });
+
+  it('REPAIRS to the attested minted-standalone root', () => {
+    const candidates: IdentityCandidate[] = [
+      { fingerprint: CANON, machineNames: ['Mini', 'Laptop'], provenance: prov('minted-standalone', CANON) },
+      { fingerprint: ORPHAN, machineNames: ['Studio'], provenance: prov('received-on-join', CANON) },
+    ];
+    const d = decideReconciliation({ agentName: 'echo', candidates });
+    expect(d.action).toBe('repair');
+    if (d.action !== 'repair') return;
+    expect(d.canonicalFingerprint).toBe(CANON);
+    expect(d.repairMachines).toEqual(['Studio']);
+  });
+
+  it('ASKS THE OPERATOR for the LIVE 2026-08-19 split — no provenance anywhere', () => {
+    // This is the actual case on the operator's machines: both identities predate the record.
+    // Lineage cannot decide it, and the spec says so rather than inventing a tiebreak.
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['Mini', 'Laptop'], firstSeen: '2026-05-02T00:00:00Z' },
+        { fingerprint: ORPHAN, machineNames: ['Studio'], firstSeen: '2026-08-19T01:40:38Z' },
+      ],
+    });
+    expect(d.action).toBe('ask-operator');
+    if (d.action !== 'ask-operator') return;
+    expect(d.reason).toBe('no-attested-root');
+    expect(d.candidates).toHaveLength(2);
+  });
+
+  it('ASKS when ANY candidate is unattested — a win by default is not a decision', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['Mini'], provenance: prov('minted-standalone', CANON) },
+        { fingerprint: ORPHAN, machineNames: ['Studio'] }, // no record at all
+      ],
+    });
+    expect(d.action).toBe('ask-operator');
+    if (d.action === 'ask-operator') expect(d.reason).toBe('unattested-version-present');
+  });
+
+  it('ASKS when a candidate was produced by a version this build does not trust', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['Mini'], provenance: prov('minted-standalone', CANON, '1.3.1181') },
+        { fingerprint: ORPHAN, machineNames: ['Studio'], provenance: prov('minted-standalone', ORPHAN, '0.9.0') },
+      ],
+      attestedVersions: (v) => v === '1.3.1181',
+    });
+    expect(d.action).toBe('ask-operator');
+  });
+
+  it('ASKS when TWO candidates each claim to be an origin', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['Mini'], provenance: prov('minted-standalone', CANON) },
+        { fingerprint: ORPHAN, machineNames: ['Studio'], provenance: prov('minted-standalone', ORPHAN) },
+      ],
+    });
+    expect(d.action).toBe('ask-operator');
+    if (d.action === 'ask-operator') expect(d.reason).toBe('multiple-roots');
+  });
+
+  it('ASKS when every candidate merely RECEIVED its identity — no root present', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['A'], provenance: prov('received-on-join', CANON) },
+        { fingerprint: ORPHAN, machineNames: ['B'], provenance: prov('received-on-join', ORPHAN) },
+      ],
+    });
+    expect(d.action).toBe('ask-operator');
+    if (d.action === 'ask-operator') expect(d.reason).toBe('no-attested-root');
+  });
+
+  it('does NOT let majority decide — two wrong machines cannot outvote one right one', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: ORPHAN, machineNames: ['A', 'B', 'C'] }, // the majority
+        { fingerprint: CANON, machineNames: ['D'] },
+      ],
+    });
+    expect(d.action).toBe('ask-operator');
+  });
+
+  it('does NOT let age decide — an older identity is described, never preferred', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['A'], firstSeen: '2020-01-01T00:00:00Z' },
+        { fingerprint: ORPHAN, machineNames: ['B'], firstSeen: '2026-08-19T00:00:00Z' },
+      ],
+    });
+    expect(d.action).toBe('ask-operator');
+  });
+
+  it('describes candidates in human terms, with the machines named', () => {
+    const d = decideReconciliation({
+      agentName: 'echo',
+      candidates: [
+        { fingerprint: CANON, machineNames: ['Mini', 'Laptop'], firstSeen: '2026-05-02T00:00:00Z' },
+        { fingerprint: ORPHAN, machineNames: ['Studio'], firstSeen: '2026-08-19T01:40:38Z' },
+      ],
+    });
+    if (d.action !== 'ask-operator') throw new Error('expected ask-operator');
+    expect(d.candidates[0].description).toContain('Mini and Laptop');
+    expect(d.candidates[0].description).toContain('2026-05-02');
+    expect(d.candidates[1].description).toContain('Studio');
+  });
+});
+
+describe('applyOperatorChoice — bound to the set actually shown', () => {
+  const candidates = [
+    { fingerprint: CANON, description: 'The identity used by Mini and Laptop', machineNames: ['Mini', 'Laptop'] },
+    { fingerprint: ORPHAN, description: 'The identity used by Studio', machineNames: ['Studio'] },
+  ];
+
+  it('accepts a choice from the offered set and names what gets repaired', () => {
+    const r = applyOperatorChoice({ candidates, chosenFingerprint: CANON });
+    expect(r.accepted).toBe(true);
+    if (r.accepted) expect(r.repairMachines).toEqual(['Studio']);
+  });
+
+  it('REFUSES a fingerprint that was never on offer — never interprets it', () => {
+    const r = applyOperatorChoice({ candidates, chosenFingerprint: 'f'.repeat(32) });
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('not-a-candidate');
+  });
+
+  it('treats no answer as CANCELLED, changing nothing', () => {
+    const r = applyOperatorChoice({ candidates, chosenFingerprint: null });
+    expect(r.accepted).toBe(false);
+    if (!r.accepted) expect(r.reason).toBe('cancelled');
+  });
+});
+
+describe('renderChoiceConfirmation — the plain restatement, not a bare yes', () => {
+  it('states what changes, that it is reversible, and what does NOT change', () => {
+    const text = renderChoiceConfirmation({
+      agentName: 'echo',
+      chosen: { fingerprint: CANON, description: 'The identity used by Mini and Laptop', machineNames: ['Mini', 'Laptop'] },
+      losing: [{ fingerprint: ORPHAN, description: 'The identity used by Studio', machineNames: ['Studio'] }],
+    });
+    expect(text).toContain('Studio');
+    expect(text.toLowerCase()).toContain('reversible');
+    expect(text.toLowerCase()).toContain('backup');
+    // The honest limits must be in the confirmation, not only in the spec.
+    expect(text.toLowerCase()).toContain('stays registered on the relay');
+    expect(text.toLowerCase()).toContain('machine keys');
+  });
+});

--- a/tests/unit/joined-mesh-mint-refusal.test.ts
+++ b/tests/unit/joined-mesh-mint-refusal.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The mint refusal — a machine that joined an existing mesh must never invent an agent identity.
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §2, acceptance criterion 2.
+ *
+ * This is the guard that makes the whole fix stick. The handover in §1 can fail for ordinary
+ * reasons (an old awake machine, a dropped response); what must NEVER follow from that is a
+ * silently minted second identity. So the refusal is tested harder than the happy path.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { detectJoinedMesh } from '../../src/threadline/client/JoinedMeshDetector.js';
+import { IdentityManager, IdentityNotProvisionedError } from '../../src/threadline/client/IdentityManager.js';
+
+/** Build a state dir with an optional machine registry + self identity. */
+function stateDir(opts: { selfId?: string; registryIds?: string[] } = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'joined-mesh-'));
+  if (opts.selfId) {
+    fs.mkdirSync(path.join(dir, 'machine'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'machine', 'identity.json'),
+      JSON.stringify({ machineId: opts.selfId, name: 'test' }),
+    );
+  }
+  if (opts.registryIds) {
+    fs.mkdirSync(path.join(dir, 'machines'), { recursive: true });
+    const machines: Record<string, unknown> = {};
+    for (const id of opts.registryIds) machines[id] = { name: id, role: 'awake' };
+    fs.writeFileSync(path.join(dir, 'machines', 'registry.json'), JSON.stringify({ version: 1, machines }));
+  }
+  return dir;
+}
+
+describe('detectJoinedMesh — the discriminator is an on-disk fact', () => {
+  it('JOINED: the registry names a machine other than this one', () => {
+    const d = stateDir({ selfId: 'm_self', registryIds: ['m_self', 'm_peer'] });
+    const v = detectJoinedMesh(d);
+    expect(v.joined).toBe(true);
+    if (v.joined) expect(v.peerMachineCount).toBe(1);
+  });
+
+  it('NOT joined: a standalone first machine has no registry at all', () => {
+    const v = detectJoinedMesh(stateDir({ selfId: 'm_self' }));
+    expect(v.joined).toBe(false);
+    if (!v.joined) expect(v.reason).toBe('no-registry');
+  });
+
+  it('NOT joined: a registry listing only THIS machine is not a mesh', () => {
+    const v = detectJoinedMesh(stateDir({ selfId: 'm_self', registryIds: ['m_self'] }));
+    expect(v.joined).toBe(false);
+    if (!v.joined) expect(v.reason).toBe('self-only');
+  });
+
+  it('fails toward MINTING when the registry is unreadable — never bricks a real agent', () => {
+    const d = stateDir({ selfId: 'm_self' });
+    fs.mkdirSync(path.join(d, 'machines'), { recursive: true });
+    fs.writeFileSync(path.join(d, 'machines', 'registry.json'), '{ not json');
+    const v = detectJoinedMesh(d);
+    expect(v.joined).toBe(false);
+    if (!v.joined) expect(v.reason).toBe('registry-unreadable');
+  });
+
+  it('refuses to CONCLUDE joined when the self id is missing — cannot tell self from peer', () => {
+    // Without a self id, "the registry lists one machine" is ambiguous: it could be this one.
+    // Guessing "joined" there would deny a standalone agent its identity, so it resolves the
+    // other way and the divergence detector covers the residual risk.
+    const v = detectJoinedMesh(stateDir({ registryIds: ['m_unknown'] }));
+    expect(v.joined).toBe(false);
+    if (!v.joined) expect(v.reason).toBe('no-machine-id');
+  });
+
+  it('an empty registry object is not a mesh', () => {
+    const v = detectJoinedMesh(stateDir({ selfId: 'm_self', registryIds: [] }));
+    expect(v.joined).toBe(false);
+  });
+});
+
+describe('IdentityManager.getOrCreate — refuses to mint on a joined machine', () => {
+  it('THROWS rather than minting when this home joined a mesh (criterion 2)', () => {
+    const d = stateDir({ selfId: 'm_self', registryIds: ['m_self', 'm_peer'] });
+    expect(() => new IdentityManager(d).getOrCreate()).toThrow(IdentityNotProvisionedError);
+  });
+
+  it('writes NO identity file when it refuses — a refusal must leave no residue', () => {
+    const d = stateDir({ selfId: 'm_self', registryIds: ['m_self', 'm_peer'] });
+    try {
+      new IdentityManager(d).getOrCreate();
+    } catch { /* expected */ }
+    expect(fs.existsSync(path.join(d, 'identity.json'))).toBe(false);
+    expect(fs.existsSync(path.join(d, 'threadline', 'identity.json'))).toBe(false);
+  });
+
+  it('the refusal names the condition and the remedy, not an internal error', () => {
+    const d = stateDir({ selfId: 'm_self', registryIds: ['m_self', 'm_peer'] });
+    try {
+      new IdentityManager(d).getOrCreate();
+      throw new Error('should have refused');
+    } catch (err) {
+      expect(err).toBeInstanceOf(IdentityNotProvisionedError);
+      const e = err as IdentityNotProvisionedError;
+      expect(e.code).toBe('identity-not-provisioned');
+      expect(e.peerMachineCount).toBe(1);
+      expect(e.message).toMatch(/re-pair/i);
+    }
+  });
+
+  it('STILL MINTS for a genuinely standalone first machine — the guard is not a blanket ban', () => {
+    const d = stateDir({ selfId: 'm_self' });
+    const id = new IdentityManager(d).getOrCreate();
+    expect(id.fingerprint).toMatch(/^[0-9a-f]{32}$/);
+    expect(fs.existsSync(path.join(d, 'threadline', 'identity.json'))).toBe(true);
+  });
+
+  it('LOADS an existing identity on a joined machine — the guard only blocks MINTING', () => {
+    // The provisioned case: identity already carried across. The guard must be invisible.
+    const d = stateDir({ selfId: 'm_self' });
+    const provisioned = new IdentityManager(d).getOrCreate();
+    fs.mkdirSync(path.join(d, 'machines'), { recursive: true });
+    fs.writeFileSync(
+      path.join(d, 'machines', 'registry.json'),
+      JSON.stringify({ version: 1, machines: { m_self: {}, m_peer: {} } }),
+    );
+    const reloaded = new IdentityManager(d).getOrCreate();
+    expect(reloaded.fingerprint).toBe(provisioned.fingerprint);
+  });
+});

--- a/tests/unit/process-ceiling-check.test.ts
+++ b/tests/unit/process-ceiling-check.test.ts
@@ -14,6 +14,7 @@ import {
   evaluateProcessCeiling,
   processCeilingNotice,
   readLaunchdPlistCeilingsForSelf,
+  launchdPlistExistsForSelf,
 } from '../../src/core/ProcessCeilingCheck.js';
 import { LAUNCHD_PROCESS_CEILING_FLOOR } from '../../src/core/PostUpdateMigrator.js';
 
@@ -322,5 +323,39 @@ describe('processCeilingNotice — the future-repair variant does not manufactur
     for (const forbidden of ['launchctl', 'ulimit', 'NumberOfProcesses', '.plist', '/Users/', 'sudo']) {
       expect(text).not.toContain(forbidden);
     }
+  });
+});
+
+describe('a machine with NO launchd plist is not warned (regression, found 2026-08-19)', () => {
+  // The first shipped version conflated "no plist at all" with "plist present but wrong", so a
+  // perfectly healthy machine that simply is not launchd-managed got a `future-repair` notice.
+  // It surfaced by polluting an unrelated test's attention items — the suite caught what the
+  // review did not.
+  const base = { platform: 'darwin', machineId: 'm1' };
+
+  it('SILENT when safe and not launchd-managed — nothing to lose on restart', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: 2048, plistCeilings: [], plistPresent: false });
+    expect(v.state).toBe('unknown');
+    if (v.state === 'unknown') expect(v.reason).toBe('not-applicable');
+  });
+
+  it('still WARNS when safe and the plist EXISTS but is wrong — the real risk is unchanged', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: 4096, plistCeilings: [512, 512], plistPresent: true });
+    expect(v.state).toBe('future-repair');
+  });
+
+  it('still warns when the plist exists but could not be parsed', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: 4096, plistCeilings: [], plistPresent: true });
+    expect(v.state).toBe('future-repair');
+  });
+
+  it('an UNSAFE machine is still reported even with no plist — it needs looking at either way', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: 512, plistCeilings: [], plistPresent: false });
+    expect(v.state).toBe('repair');
+  });
+
+  it('defaults to the STRICTER reading when the flag is omitted — no silent suppression', () => {
+    const v = evaluateProcessCeiling({ ...base, effective: 4096, plistCeilings: [] });
+    expect(v.state).toBe('future-repair');
   });
 });

--- a/upgrades/next/r6-agent-identity-continuity.md
+++ b/upgrades/next/r6-agent-identity-continuity.md
@@ -1,0 +1,84 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**An agent expanding onto a new machine silently became two agents sharing one name.**
+
+Joining a mesh provisions a clone of the shared project, a machine-local config, and a MACHINE
+identity. None of those is the AGENT identity — it is gitignored (it holds a private key),
+absent from the scaffolded config, absent from the pairing response, and absent from the
+cross-machine secret-sync set. So on first boot the agent looks for its identity, finds none,
+and mints a fresh one.
+
+The design error in one sentence: **the agent's identity was treated as a per-machine secret,
+when it is a shared-agent secret.** Machine keys are correctly per-machine — the agent is not.
+
+Observed live (2026-08-19) and unreported for four days.
+
+### The consequence, measured rather than argued
+
+A **plain-text** message signed on the diverged machine:
+
+| Verifier | Verdict |
+|---|---|
+| the machine that signed it | `agent-verified` |
+| peer 1 | `rejected` — `bad-signature` |
+| peer 2 | `rejected` — `bad-signature` |
+
+Plain text deliberately: a separate known limitation rejects signed *markdown*, and would have
+confounded the result. Agent-signature provenance is therefore **inoperative** from a diverged
+machine. It fails safe — `rejected`, never silently accepted as operator-typed — but the
+guarantee the feature exists to give is absent.
+
+### What ships
+
+- **The identity travels with the expansion**, sealed to the joining machine's encryption key
+  over the pairing exchange that already carries it, bound to a transcript (session, machine,
+  key, agent name, expiry). Sealing reuses the existing in-production secret-sync primitive.
+- **A machine that joined a mesh may no longer mint an identity.** Enforced at the minting site
+  rather than its callers. If the handover fails, the join fails loudly instead of producing a
+  silent twin.
+- **A split is now noticed.** Every machine compares what its peers publish and one deduped
+  notice is raised. `cannot-tell` — an unreachable peer — is never rendered as agreement.
+- **A repair path that refuses to guess.** Majority, age, durable prevalence and lease-holder
+  are all rejected as tiebreakers: each correlates with being right without being a reason.
+
+### Also fixed: a false positive shipped earlier the same day
+
+The process-ceiling check conflated "this machine has no launchd plist" with "it has one and
+it's wrong", warning healthy unmanaged machines that a restart might lose their limit. Found by
+the test suite, not by review — it was raising an attention item inside an unrelated end-to-end
+test and failing it.
+
+## Evidence
+
+- 88 tests across five suites: joined-mesh detection (11), sealed handover (12), divergence
+  detection (15), reconciliation (14), process-ceiling incl. 5 new regressions (36).
+- Verified against the **live split**, not fixtures: the detector reproduces it and renders the
+  notice; the reconciler returns `ask-operator / no-attested-root`; the joined-mesh detector
+  returns `joined: true, peerMachineCount: 2`.
+- Full suite: 25 failures / 10 files — byte-identical to the pre-change baseline.
+- Spec: 7 cross-model rounds, Standards-Conformance Gate 0 findings.
+
+## What to Tell Your User
+
+- **If you run one agent on more than one machine, it may quietly be more than one agent — and
+  you would have no way of knowing.** After this update, machines compare identities and tell
+  you if they disagree. New machines inherit the identity properly instead of inventing one.
+- **An existing split needs one decision from you.** The rule that works out which identity is
+  correct only applies to identities created after this ships. Older ones are shown to you as
+  plain descriptions ("the identity used by your Mini and Laptop since May") and you pick — no
+  comparing strings of hex.
+- **Two things this does not fix, stated plainly.** Stale copies of an agent already registered
+  on the relay are not cleaned up; that needs separate work. And every machine ends up holding
+  the same key, so a stolen or retired machine keeps a working copy until the identity is
+  replaced everywhere.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Agent identity carried on join | Automatic. Sealed to the joining machine over the existing pairing exchange. |
+| Refusal to mint on a joined machine | Automatic. A failed handover fails loudly instead of creating a second identity. |
+| Split detection | Automatic at boot. One deduped notice per split; unreachable peers are reported as unknown, never as agreement. |
+| Repair that asks rather than guesses | Surfaced as a plain-language choice when a split cannot be resolved from provenance. |

--- a/upgrades/side-effects/agent-identity-continuity-on-expansion.md
+++ b/upgrades/side-effects/agent-identity-continuity-on-expansion.md
@@ -1,0 +1,228 @@
+# Side-Effects Review — Agent identity continuity on expansion
+
+**Version / slug:** `agent-identity-continuity-on-expansion`
+**Date:** `2026-08-19`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `cross-model codex-cli:gpt-5.5 (7 rounds) + Standards-Conformance Gate`
+
+## Summary of the change
+
+An agent expanding onto a new machine silently became two agents sharing one name: `joinMesh`
+provisions a MACHINE identity and never the AGENT identity, so the joining machine finds none
+and `IdentityManager.getOrCreate()` mints a fresh keypair. Four modules close it: a joined-mesh
+detector, a mint refusal at the minting site, a sealed handover over the existing pairing
+exchange, a divergence detector wired at boot, and a reconciler that refuses to guess which
+identity is canonical.
+
+Files: `src/threadline/client/JoinedMeshDetector.ts` (new), `src/threadline/client/IdentityManager.ts`,
+`src/core/AgentIdentityHandover.ts` (new), `src/core/AgentIdentityDivergenceDetector.ts` (new),
+`src/core/AgentIdentityReconciler.ts` (new), `src/server/AgentServer.ts` (boot wiring),
+`src/monitoring/guardManifest.ts`, plus a false-positive fix in `src/core/ProcessCeilingCheck.ts`.
+
+## Decision-point inventory
+
+- `IdentityManager.getOrCreate` — **modify** — refuses to mint when mesh-join state is present.
+- `AgentIdentityHandover.openHandoverEnvelope` — **add** — accepts or rejects an identity payload.
+- `AgentIdentityDivergenceDetector.evaluateDivergence` — **add** — agree / disagree / cannot-tell.
+- `AgentIdentityReconciler.decideReconciliation` — **add** — repair / ask-operator / no-op.
+- `ProcessCeilingCheck.evaluateProcessCeiling` — **modify** — `plistPresent` added (bug fix).
+
+---
+
+## 1. Over-block
+
+The mint refusal is the one genuine over-block risk: a machine wrongly judged "joined" would be
+denied an identity it is entitled to mint, and would not start.
+
+Closed by making every uncertain reading resolve toward minting. No registry, unreadable
+registry, registry listing only this machine, and a missing self machine-id all answer "not
+joined". The only path to refusal is a parseable registry naming another machine — written by
+the pairing flow before the server ever starts.
+
+Verified against the live Studio (`joined: true, peerMachineCount: 2`) and against six fixture
+cases including the ambiguous ones.
+
+---
+
+## 2. Under-block
+
+Named, not implied:
+
+1. **A joined machine with a corrupt registry can still mint.** Direct consequence of failing
+   toward minting. The divergence detector is what catches it afterwards.
+2. **Version skew leaves old joiners minting.** An old joiner against a new awake machine
+   ignores the envelope and mints as before. That is today's defect, not a new one, and the new
+   awake machine records that it served an envelope nobody acknowledged.
+3. **Lineage is evidence, not authority.** A compromised host can self-sign false provenance.
+   Any unattested candidate routes to operator selection rather than being decided.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The refusal sits at the minting SITE, not at its two call sites (`ThreadlineClient`,
+`mcp-stdio-entry`) — guarding callers would leave the next caller free to reintroduce it.
+
+The handover rides `POST /api/pair`, which already validates the operator-carried code and
+already receives the joiner's encryption key (validated, previously unused). No new endpoint and
+no new trust relationship at the protocol level — though the CONSEQUENCE of pairing-code
+compromise rises sharply, which §6 covers.
+
+Sealing reuses `SecretStore.encryptForSync`, the reviewed in-production primitive behind
+cross-machine secret sync. A second sealing scheme for the same job would be new attack surface
+for no gain.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+The divergence detector raises one Attention item and does nothing else — it never repairs,
+blocks a send, or changes an identity. The reconciler returns a DECISION and performs nothing,
+so a caller cannot accidentally act on an unresolved one.
+
+The mint refusal IS a block, and deliberately so: it is a safety guard on an irreversible
+action (minting an identity that splits the agent), deterministic, on an on-disk fact, failing
+toward the permissive direction. That is the compliant shape for blocking authority.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The reconciler is the one place
+signals could compete — majority, age, prevalence, lease-holder all "suggest" an answer — and
+the design's core move is to refuse all of them and ask the operator. Rather than a static
+heuristic at a judgment point, it declines to be a judgment point at all.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the mint refusal runs after both load paths, so a provisioned identity is
+  returned before the guard is reached. Verified by test.
+- **Double-fire:** the divergence detector runs once per boot, 90s delayed, deduped on the
+  episode key so every machine observing produces one item, not N.
+- **Races:** the detector is fire-and-forget with an unref'd timer and cannot delay or fail a
+  boot. The reconciler is pure.
+- **Feedback loops:** none — nothing the detector emits changes what it reads.
+
+**Interaction found by the suite, not by review:** the process-ceiling boot check (shipped
+earlier today) was raising a `future-repair` attention item on machines with no launchd plist,
+which polluted an unrelated e2e test's attention items and failed it. That is a false positive
+in already-merged code; fixed here with `plistPresent` and five regression tests.
+
+---
+
+## 6. External surfaces
+
+- **Other agents:** none — this is intra-agent.
+- **Other users of the install base:** joining machines behave differently (identity carried,
+  or a loud failure instead of a silent twin). Single-machine agents are unaffected: no
+  registry means no refusal, and no peers means the detector returns before fetching.
+- **External systems:** none. No new network call except the detector's peer reads, which use
+  the existing authenticated `/provenance` route.
+- **Persistent state:** the identity file and its provenance record. A repair backs up the
+  superseded identity before replacing it.
+- **Timing:** one delayed, bounded, unref'd boot timer.
+- **Operator surface (Mobile-Complete Operator Actions):** the reconciler's decision is
+  phone-completable — the operator picks between plain-language descriptions, not hex strings,
+  and confirms against a restatement of what changes on which machine.
+
+**The trust-consequence change, stated because it is easy to miss:** a pairing code today gets
+an attacker a registry row; after this it is a path to the agent's signing key. The spec
+reclassifies pairing as identity provisioning with a short expiry, a failed-attempt cap, and
+one-at-a-time sessions.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer or form is staged. The operator-facing output is notice text and the
+reconciler's choice rendering, held to the same bar:
+
+1. **Leads with the primary action** — the split notice names the machines and the decision;
+   the reconciler leads with descriptions of each candidate.
+2. **Zero raw internals as primary content** — the conformance gate rejected an earlier draft
+   that made the operator compare two 32-character fingerprints. Fingerprints now appear
+   truncated as supporting detail; the full values live in the audit record. Asserted by test.
+3. **Destructive actions de-emphasized** — none offered; repair requires an explicit choice.
+4. **Plain language** — asserted by test: the notice states the consequence in ordinary words
+   and says plainly that nothing changes automatically and why.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**`unified` for the agent identity — that is the entire point of the change.** The current
+per-machine behaviour is the defect.
+
+The **machine** identity stays `machine-local`.
+`machine-local-justification: hardware-bound-resource` — the machine id and its signing and
+encryption keys identify one physical host, are used to verify that host's own signatures, and
+are meaningless elsewhere. Replicating them would make two hosts indistinguishable to the lease
+layer.
+
+- **User-facing notices:** one per split, not one per machine. Every machine observes (the lease
+  holder may BE the diverged one — it is, here); the episode key does the deduping.
+- **Durable state on topic transfer:** none introduced.
+- **Generated URLs:** none.
+
+---
+
+## 8. Rollback cost
+
+- **Code:** revert and ship a patch.
+- **Behavioural risk, stated honestly:** reverting restores the minting, so the next machine to
+  join splits again, silently. A rollback must be paired with a freeze on joins or manual
+  identity provisioning. This is NOT a harmless revert.
+- **On-disk state:** repaired machines keep the canonical identity, which is what the rest of
+  the mesh expects. Superseded identity files are retained, so an individual repair is
+  reversible.
+- **Relay state:** unchanged either way — this change retires no registration.
+
+---
+
+## Conclusion
+
+The review changed this substantially and the changes were not cosmetic: it corrected a security
+claim of mine that was simply false (an impersonator is NOT defeated by a signature check —
+they supply the signature too), replaced a repair rule that broke on chained joins, rejected a
+burn policy that would have cost a full re-pairing on any dropped packet, withdrew "no new trust
+relationship", withdrew a claim to retire relay rows that this change cannot make, and rejected
+an operator ceremony built on comparing hex strings.
+
+Then the test suite caught three things review did not, including a false positive in code that
+had already shipped today.
+
+Built and verified against the real live split rather than fixtures: the detector reproduces it
+and renders the notice; the reconciler refuses to decide it and produces the operator question.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** cross-model `codex-cli:gpt-5.5`, 7 rounds
+**Independent read: concur** — converged at round 7 under the operator's 80/20 standard, with
+the residual findings named in the convergence report. Standards-Conformance Gate: 0 findings.
+
+Disclosure on independence: the internal reviewer perspectives were carried by the authoring
+session rather than spawned subagents, under a session instruction not to spawn agents without a
+request. The genuinely independent reads were the cross-model pass and the code-backed gate.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/joined-mesh-mint-refusal.test.ts` — 11 tests.
+- `tests/unit/agent-identity-handover.test.ts` — 12 tests.
+- `tests/unit/agent-identity-divergence.test.ts` — 15 tests.
+- `tests/unit/agent-identity-reconciler.test.ts` — 14 tests.
+- `tests/unit/process-ceiling-check.test.ts` — 36 tests (5 new regressions).
+- Live: the detector run against the real three machines returns `disagree` with the correct
+  grouping; the reconciler returns `ask-operator / no-attested-root`; the joined-mesh detector
+  returns `joined: true, peerMachineCount: 2` on the Studio.
+- Full suite: 25 failures / 10 files — byte-identical to the pre-change baseline (CMT-016), so
+  none introduced.


### PR DESCRIPTION
## Problem

An agent expanding onto a new machine **silently became two agents sharing one name.**

`joinMesh` provisions a clone of the mesh repo, a machine-local `config.json`, a **machine** identity, and a `POST /api/pair` exchange. None of those is the **agent** identity: it is gitignored (it holds a private key), absent from the scaffolded config, absent from the pairing response, and absent from the cross-machine secret-sync key set. So on first boot `IdentityManager.getOrCreate()` finds nothing and mints a fresh keypair.

**The design error in one sentence: the agent's identity was treated as a per-machine secret, when it is a shared-agent secret.** Machine keys are correctly per-machine — the agent is not.

Observed live 2026-08-19: the operator authorised a Mini to extend `echo` onto a Studio. The Studio joined correctly in every visible respect and publishes `ae6feac6…` while the Mini and Laptop publish `63b1dbb2…`. It went **four days unreported** and surfaced only while investigating an unrelated request.

### The consequence, measured

A **plain-text** message signed on the Studio:

| Verifier | Verdict |
|---|---|
| Studio (the signer) | `agent-verified` |
| Laptop | `rejected` — `bad-signature` |
| Mini | `rejected` — `bad-signature` |

Plain text deliberately: a separate known limitation rejects signed *markdown* (the Telegram send path rewrites the covered bytes) and would have confounded the result. Agent-signature provenance is **inoperative** from the diverged machine. It fails safe — `rejected`, never silently `human` — but the guarantee is absent.

## Fix

1. **`JoinedMeshDetector`** — did this home join an existing mesh? An on-disk fact (a registry naming another machine), not a heuristic. **Every uncertain reading resolves toward minting**, so a filesystem problem can never deny a standalone agent its identity.
2. **The mint refusal**, at the minting **site** rather than its two callers — guarding callers leaves the next caller free to reintroduce it.
3. **`AgentIdentityHandover`** — the identity sealed to the joiner's X25519 key over the pairing exchange that *already carries it* (validated today, used for nothing), bound to a transcript: session id, joiner machine id, joiner key, agent name, expiry. Sealing reuses `SecretStore.encryptForSync`, the in-production primitive behind secret sync.
4. **`AgentIdentityDivergenceDetector`** — wired at boot, delayed and unref'd. **Every machine observes** (the lease holder may *be* the diverged one — it is, here); the episode key does the deduping. `cannot-tell` is never rendered as agreement.
5. **`AgentIdentityReconciler`** — returns a **decision**, performs nothing. Rejects majority, age, durable prevalence and lease-holder as tiebreakers: each correlates with being right without being a reason.

### Also fixed: a false positive shipped earlier the same day

`ProcessCeilingCheck` conflated "no launchd plist" with "plist present but wrong", warning healthy unmanaged machines that a restart might lose their limit. **Found by the suite, not by review** — it was raising an attention item inside an unrelated e2e test and failing it.

## What the review corrected

Seven cross-model rounds changed the design substantially. The corrections worth naming:

- **A security claim of mine was false.** The first draft said a hostile responder is defeated "because the signature fails". It isn't — an attacker controlling the response supplies its own signing key. Only the pairing-code session binding closes it.
- **The repair rule broke on chained joins.** "The machine this one joined" inherits a diverged parent's error. Replaced with lineage terminating in a `minted-standalone` root.
- **Then lineage was over-trusted in turn** — a compromised or old binary can self-sign a false claim, so it is **operational evidence, not cryptographic authority**, and any unattested candidate asks the operator.
- **Burn semantics** went from undefined → no-retry (an availability failure on any dropped packet) → same-joiner retry with third-party redemption refused.
- **"No new trust relationship" was withdrawn.** A pairing code today gets an attacker a registry row; after this it is a path to the agent's signing key.
- **A claim to retire stale relay rows was withdrawn** as a named dependency — that design does not exist, and implying the split is fully cleaned up would be false.
- **The conformance gate rejected the operator ceremony**: an earlier draft had the operator compare two 32-character hex strings. They now pick between plain-language descriptions.

## Honest limits

- The **existing split cannot be repaired automatically** — lineage only applies to identities created after this ships. It takes one operator decision.
- **Stale relay registrations are not retired.** The July resolver fix mitigates; it does not remove.
- **Every machine holds the same key.** One compromised host compromises the agent everywhere, and removing a machine does not revoke its copy. A compatibility bridge, marked as one, with an explicit boundary against building further on it.

All three are tracked (`CMT-026`) and stated in the operator-facing notice, not just the spec.

## Testing

- **88 tests** across five suites: joined-mesh detection (11), sealed handover (12), divergence detection (15), reconciliation (14), process-ceiling incl. 5 new regressions (36).
- **Verified against the live split, not fixtures:** the detector reproduces it and renders the notice; the reconciler returns `ask-operator / no-attested-root`; the joined-mesh detector returns `joined: true, peerMachineCount: 2` on the Studio.
- Full suite: **25 failures / 10 files — byte-identical to the pre-change baseline**, so none introduced.
- Spec: 7 cross-model rounds (`codex-cli:gpt-5.5`, `status: ok` every round), Standards-Conformance Gate **0 findings**, converged under the operator's 80/20 standard, approved.

---

## ELI16 — An agent that spreads to a new machine should still be the same agent; right now it quietly becomes a second one

Agents are found by an address, the way a phone number reaches a person. One agent should have one address, whichever of its machines is answering.

When an agent expands onto a new machine, the new machine doesn't receive that address — so it makes one up. Nothing says anything. The agent is now two agents wearing one name.

That happened here on Monday and nobody noticed until Friday, while looking into something else entirely.

It matters for two reasons. Messages sent to the old address can vanish — a stale registration survives and can swallow them. And anything signed on the odd machine carries the wrong identity, so it doesn't verify as that agent. That was tested rather than argued: a message signed on the new machine was accepted there and rejected by both of the others.

This change carries the identity to the new machine over the pairing step that already happens, refuses to invent one if that fails rather than quietly becoming a twin, notices when a split exists — which nothing did before — and offers a repair that refuses to guess which identity is the real one.

Three things it deliberately doesn't do, said out loud rather than discovered later: the split that already exists still needs one human decision, stale copies already registered on the network aren't cleaned up, and every machine ends up holding the same key — so a stolen machine keeps a working copy until the identity is replaced everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
