### PR TITLE
fix: actually wire the agent-identity handover — it shipped unreachable

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-20T07-00-26-436Z-agent-identity-continuity-on-expansion.json
+++ b/.instar/instar-dev-decisions/2026-08-20T07-00-26-436Z-agent-identity-continuity-on-expansion.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-20T07:00:26.436Z",
+  "slug": "agent-identity-continuity-on-expansion",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 261,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/machine.ts",
+      "src/core/AgentIdentityHandover.ts",
+      "src/server/AgentServer.ts",
+      "src/server/machineRoutes.ts"
+    ],
+    "addedLines": 260,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-20T07-01-49-810Z-wire-agent-identity-handover.json
+++ b/.instar/instar-dev-decisions/2026-08-20T07-01-49-810Z-wire-agent-identity-handover.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-20T07:01:49.810Z",
+  "slug": "wire-agent-identity-handover",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 261,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/machine.ts",
+      "src/core/AgentIdentityHandover.ts",
+      "src/server/AgentServer.ts",
+      "src/server/machineRoutes.ts"
+    ],
+    "addedLines": 260,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'node:fs';
+import { installAgentIdentityFromPairing } from '../core/AgentIdentityHandover.js';
 import path from 'node:path';
 import pc from 'picocolors';
 import { loadConfig } from '../core/Config.js';
@@ -326,6 +327,14 @@ interface JoinOptions {
   code?: string;
   name?: string;
   port?: number;
+  /**
+   * The agent fingerprint from the operator's pairing artefact
+   * (agent-identity-continuity-on-expansion §1). When supplied, the joiner pins it and
+   * refuses any identity that does not hash to it — the check that stops a hostile
+   * listener returning a fabricated identity. Optional, and its absence is a weaker
+   * posture rather than an error.
+   */
+  agentFingerprint?: string;
 }
 
 /**
@@ -483,7 +492,56 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
         process.exit(1);
       }
 
-      const result = await resp.json() as { machineIdentity?: any; status?: string };
+      const result = await resp.json() as {
+        machineIdentity?: any;
+        agentIdentityEnvelope?: any;
+        status?: string;
+      };
+
+      // ── Install the AGENT identity carried by the pairing response ──────────────────
+      // Spec: docs/specs/agent-identity-continuity-on-expansion.md §1.
+      //
+      // This must happen BEFORE the server first starts, so the boot finds an identity and
+      // never reaches the minting branch. A failure here is LOUD and provisions nothing —
+      // the joiner must never fall back to minting, because a silent twin is worse than a
+      // join that plainly did not finish (Frontloaded Decision 2).
+      const agentIdentityOutcome = installAgentIdentityFromPairing({
+        envelope: result.agentIdentityEnvelope,
+        stateDir: config.stateDir,
+        expected: {
+          pairingSessionId: String(options.code),
+          joinerMachineId: identity.machineId,
+          joinerEncryptionPublicKey: identity.encryptionPublicKey,
+          agentName: config.projectName,
+          expiresAt: '',
+        },
+        encryptionPrivateKeyPem: (() => {
+          try {
+            return mgr.loadEncryptionKey();
+          } catch {
+            // @silent-fallback-ok: reported as `no-encryption-key`, which is a LOUD refusal
+            // in the caller — never a fallback to minting.
+            return null;
+          }
+        })(),
+        pinnedFingerprint: options.agentFingerprint ?? null,
+      });
+      if (agentIdentityOutcome.ok) {
+        console.log(pc.green('  Agent identity received — this machine is the same agent.'));
+      } else if (agentIdentityOutcome.reason === 'not-offered') {
+        console.log(
+          pc.red('  This mesh did not provide an agent identity.') +
+            '\n  The machine you paired with is likely on an older version. Update it and re-pair.' +
+            '\n  NOT minting an identity here: that would silently split the agent in two.',
+        );
+      } else {
+        console.log(
+          pc.red(`  Agent identity handover REFUSED: ${agentIdentityOutcome.reason}`) +
+            '\n  Nothing was provisioned. Re-pair with a fresh code; if it repeats, the ' +
+            'response is not coming from the machine you think it is.',
+        );
+      }
+
       if (result.machineIdentity) {
         // Store the remote machine's identity
         mgr.storeRemoteIdentity(result.machineIdentity);

--- a/src/core/AgentIdentityHandover.ts
+++ b/src/core/AgentIdentityHandover.ts
@@ -33,6 +33,13 @@
  */
 
 import { createHash, createPrivateKey, type KeyObject } from 'node:crypto';
+import {
+  readFileSync as nodeReadFileSync,
+  writeFileSync as nodeWriteFileSync,
+  renameSync as nodeRenameSync,
+  mkdirSync as nodeMkdirSync,
+} from 'node:fs';
+import { join as nodeJoin, dirname as nodeDirname } from 'node:path';
 import { encryptForSync, decryptFromSync, type EncryptedSecretPayload } from './SecretStore.js';
 
 /** How an identity came to exist on a machine. Spec §3 — lineage, not "who did I join". */
@@ -194,4 +201,141 @@ export function openHandoverEnvelope(input: {
 /** The routing fingerprint of an Ed25519 public key: first 16 bytes of its SHA-256, hex. */
 export function fingerprintOf(publicKeyBase64: string): string {
   return createHash('sha256').update(Buffer.from(publicKeyBase64, 'base64')).digest('hex').slice(0, 32);
+}
+
+/**
+ * Read this machine's agent identity in the shape the handover seals.
+ *
+ * Returns null when there is none — a real state on a machine that never had one, which the
+ * caller reports rather than papering over: the joiner will refuse to mint, and the operator
+ * deserves to know which end lacked the identity.
+ */
+export function readAgentIdentityForHandover(
+  stateDir: string,
+  deps: { readFile?: (p: string) => string } = {},
+): { payload: HandoverPayload; fingerprint: string } | null {
+  const readFile = deps.readFile ?? ((f: string) => nodeReadFileSync(f, 'utf-8'));
+  for (const rel of ['identity.json', nodeJoin('threadline', 'identity.json')]) {
+    try {
+      const d = JSON.parse(readFile(nodeJoin(stateDir, rel))) as {
+        publicKey?: string;
+        privateKey?: string;
+        createdAt?: string;
+        provenance?: IdentityProvenance;
+      };
+      if (!d.publicKey || !d.privateKey) continue;
+      const fingerprint = fingerprintOf(d.publicKey);
+      return {
+        fingerprint,
+        payload: {
+          identity: {
+            publicKey: d.publicKey,
+            privateKey: d.privateKey,
+            createdAt: d.createdAt ?? new Date(0).toISOString(),
+          },
+          // An identity predating the provenance record is honestly UNKNOWN-origin: it is
+          // recorded as received-on-join with its own fingerprint as root, which never wins a
+          // lineage comparison and therefore routes any future split to the operator rather
+          // than letting an unverifiable claim decide.
+          provenance: d.provenance ?? {
+            schemaVersion: 1,
+            origin: 'received-on-join',
+            rootFingerprint: fingerprint,
+            machineId: 'unknown',
+            createdAt: d.createdAt ?? new Date(0).toISOString(),
+            producedBy: 'pre-provenance',
+          },
+        },
+      };
+    } catch {
+      // @silent-fallback-ok: try the next location; an absent identity is handled by the
+      // null return, which the caller logs.
+    }
+  }
+  return null;
+}
+
+export type InstallOutcome =
+  | { ok: true; fingerprint: string }
+  | { ok: false; reason: 'not-offered' | HandoverRejection | 'write-failed' | 'no-encryption-key' };
+
+/**
+ * Open a pairing response's identity envelope and install it — atomically, owner-only.
+ *
+ * Called by `joinMesh` BEFORE the server first starts, so the boot finds an identity and never
+ * reaches the minting branch.
+ *
+ * NEVER falls back to minting on any failure path. A silent twin is worse than a join that
+ * plainly did not finish (spec Frontloaded Decision 2), and the whole point of the mint guard
+ * is that this function's failure cannot be routed around.
+ *
+ * `pinnedFingerprint` is the agent fingerprint from the operator's pairing artefact. When it is
+ * absent the pin check is skipped and the envelope's own fingerprint is used — weaker, and
+ * honest about being weaker: it still resists a wrong-joiner or replayed envelope (the
+ * transcript and the sealing key cover those) but not a hostile listener fabricating one.
+ */
+export function installAgentIdentityFromPairing(input: {
+  envelope: unknown;
+  stateDir: string;
+  expected: HandoverTranscript;
+  encryptionPrivateKeyPem: string | null;
+  pinnedFingerprint: string | null;
+  now?: Date;
+  writeFile?: (p: string, data: string) => void;
+}): InstallOutcome {
+  if (!input.envelope) return { ok: false, reason: 'not-offered' };
+  if (!input.encryptionPrivateKeyPem) return { ok: false, reason: 'no-encryption-key' };
+
+  const env = input.envelope as IdentityHandoverEnvelope;
+  const pinned = input.pinnedFingerprint ?? env?.identityFingerprint ?? '';
+
+  const opened = openHandoverEnvelope({
+    envelope: env,
+    // The joiner cannot know the expiry the sealer chose, so it is taken from the envelope and
+    // then CHECKED against the clock inside openHandoverEnvelope. Every other transcript field
+    // is compared against what this joiner actually sent.
+    expected: { ...input.expected, expiresAt: env?.transcript?.expiresAt ?? '' },
+    pinnedFingerprint: pinned,
+    joinerEncryptionPrivateKeyPem: input.encryptionPrivateKeyPem,
+    ...(input.now ? { now: input.now } : {}),
+  });
+  if (!opened.ok) return { ok: false, reason: opened.rejection };
+
+  try {
+    const write = input.writeFile ?? defaultAtomicWrite;
+    write(
+      nodeJoin(input.stateDir, 'identity.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          publicKey: opened.payload.identity.publicKey,
+          privateKey: opened.payload.identity.privateKey,
+          createdAt: opened.payload.identity.createdAt,
+          provenance: {
+            ...opened.payload.provenance,
+            origin: 'received-on-join' as const,
+            machineId: input.expected.joinerMachineId,
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } catch {
+    return { ok: false, reason: 'write-failed' };
+  }
+  return { ok: true, fingerprint: fingerprintOf(opened.payload.identity.publicKey) };
+}
+
+/**
+ * Atomic, owner-only write: temp file in the destination directory → rename.
+ *
+ * A half-written identity is worse than none — it is an agent that starts with a corrupt key.
+ */
+function defaultAtomicWrite(target: string, data: string): void {
+  const dir = nodeDirname(target);
+  nodeMkdirSync(dir, { recursive: true });
+  const tmp = nodeJoin(dir, `.identity.${process.pid}.${Date.now()}.tmp`);
+  nodeWriteFileSync(tmp, data, { mode: 0o600 });
+  nodeRenameSync(tmp, target);
 }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1114,6 +1114,10 @@ export class AgentServer {
         },
         localMachineId: coord.identity!.machineId,
         localSigningKeyPem: options.localSigningKeyPem ?? '',
+        // Agent-identity handover on pairing (agent-identity-continuity-on-expansion §1) —
+        // without these the pair route hands over nothing and a joiner fails loudly.
+        stateDir: options.config.stateDir,
+        agentName: options.config.projectName,
         onDemote: () => coord.demoteToStandby('Remote heartbeat: another machine took over'),
         onPromote: () => coord.promoteToAwake('Remote handoff: awake machine handed off to us'),
         onHandoffRequest: async () => ({

--- a/src/server/machineRoutes.ts
+++ b/src/server/machineRoutes.ts
@@ -16,6 +16,7 @@
  */
 
 import { Router } from 'express';
+import { sealIdentityForJoiner, readAgentIdentityForHandover } from '../core/AgentIdentityHandover.js';
 import crypto from 'node:crypto';
 import { sign, verify } from '../core/MachineIdentity.js';
 import type { MachineIdentityManager } from '../core/MachineIdentity.js';
@@ -43,6 +44,14 @@ export interface MachineRouteContext {
   localMachineId: string;
   /** This machine's signing private key (PEM) */
   localSigningKeyPem: string;
+  /**
+   * Agent state dir + agent name, for the agent-identity handover on pairing
+   * (docs/specs/agent-identity-continuity-on-expansion.md §1). Optional so an
+   * embedder that omits them simply hands over nothing and the joiner fails
+   * loudly — never mints.
+   */
+  stateDir?: string;
+  agentName?: string;
   /** Callback when this machine should demote to standby */
   onDemote?: () => void;
   /** Callback when this machine should promote to awake */
@@ -375,9 +384,53 @@ export function createMachineRoutes(ctx: MachineRouteContext): Router {
 
     // Return this machine's identity so the joiner can register us as awake.
     const localIdentity = ctx.identityManager.loadIdentity();
+
+    // ── Carry the AGENT identity to the joiner ────────────────────────────────────
+    // Spec: docs/specs/agent-identity-continuity-on-expansion.md §1.
+    //
+    // Without this the joiner finds no agent identity and (post-guard) refuses to mint,
+    // so the join fails — and pre-guard it minted one, silently splitting the agent in
+    // two. `ephemeralPublicKey` has always arrived here and was validated and unused;
+    // this is what it was for.
+    //
+    // Sealed to that key, bound to a transcript the joiner re-checks against what it
+    // sent. A refusal is NAMED and the field is simply absent — never a partial or
+    // fabricated envelope, because the joiner must be able to tell "not provided" from
+    // "provided and wrong".
+    let agentIdentityEnvelope: unknown;
+    try {
+      const agentIdentity = ctx.stateDir ? readAgentIdentityForHandover(ctx.stateDir) : null;
+      if (agentIdentity) {
+        const sealed = sealIdentityForJoiner({
+          payload: agentIdentity.payload,
+          identityFingerprint: agentIdentity.fingerprint,
+          transcript: {
+            pairingSessionId: String(stored.code),
+            joinerMachineId: machineIdentity.machineId,
+            joinerEncryptionPublicKey: String(ephemeralPublicKey),
+            agentName: ctx.agentName ?? '',
+            expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+          },
+        });
+        if (sealed.ok) agentIdentityEnvelope = sealed.envelope;
+        else console.warn(`[pair] agent-identity handover refused: ${sealed.refusal}`);
+      } else {
+        // No agent identity to hand over is a REAL state on a machine that never had
+        // one. Logged rather than silent, because the joiner will refuse to mint and
+        // the operator deserves to know which end lacked it.
+        console.warn('[pair] no agent identity on this machine to hand over');
+      }
+    } catch (err) {
+      // @silent-fallback-ok: pairing the MACHINE must still succeed even if the agent
+      // identity cannot be sealed — the joiner then fails loudly with a named reason
+      // rather than minting, which is the safe direction.
+      console.warn('[pair] agent-identity handover failed (non-fatal):', err);
+    }
+
     res.json({
       status: 'paired',
       machineIdentity: localIdentity,
+      ...(agentIdentityEnvelope ? { agentIdentityEnvelope } : {}),
       message: 'Paired.',
     });
   });

--- a/tests/unit/agent-identity-handover-wiring.test.ts
+++ b/tests/unit/agent-identity-handover-wiring.test.ts
@@ -1,0 +1,182 @@
+/**
+ * WIRING integrity — the pieces are actually CONNECTED, not merely correct.
+ *
+ * Spec: docs/specs/agent-identity-continuity-on-expansion.md §1, acceptance criterion 3.
+ *
+ * WHY THIS SUITE EXISTS. The first version of this change shipped `sealIdentityForJoiner` and
+ * `openHandoverEnvelope` with twelve passing tests — and nothing called either of them. The
+ * mint guard shipped wired, so joining a mesh refused to mint and had no way to receive the
+ * identity: joining was broken by the very change meant to fix it.
+ *
+ * Every gate passed. Unit tests exercised the piece in isolation and the piece was correct.
+ * The cross-model review examined the design and the design was right. The suite ran the code
+ * that existed, not the code that was absent. All of them answered a narrower question than
+ * the one that mattered: is it plugged in?
+ *
+ * So these tests assert REACHABILITY through the real seams rather than behaviour of a part.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {
+  sealIdentityForJoiner,
+  installAgentIdentityFromPairing,
+  readAgentIdentityForHandover,
+  fingerprintOf,
+} from '../../src/core/AgentIdentityHandover.js';
+
+const SRC = path.resolve(__dirname, '..', '..', 'src');
+const read = (rel: string) => fs.readFileSync(path.join(SRC, rel), 'utf-8');
+
+describe('the handover is reachable from the real callers', () => {
+  it('the pair ROUTE calls the sealer — without this the response carries nothing', () => {
+    const route = read('server/machineRoutes.ts');
+    expect(route).toContain('sealIdentityForJoiner');
+    expect(route).toContain('agentIdentityEnvelope');
+  });
+
+  it('the JOIN command calls the installer — without this the joiner ignores the envelope', () => {
+    const join = read('commands/machine.ts');
+    expect(join).toContain('installAgentIdentityFromPairing');
+    expect(join).toContain('agentIdentityEnvelope');
+  });
+
+  it('the server passes stateDir + agentName to the route, or the sealer has nothing to read', () => {
+    const server = read('server/AgentServer.ts');
+    expect(server).toMatch(/stateDir: options\.config\.stateDir/);
+    expect(server).toMatch(/agentName: options\.config\.projectName/);
+  });
+
+  it('the joiner NEVER falls back to minting on a handover failure', () => {
+    const join = read('commands/machine.ts');
+    // The refusal path must not reach for getOrCreate or any local mint.
+    const afterInstall = join.slice(join.indexOf('installAgentIdentityFromPairing'));
+    expect(afterInstall).not.toContain('getOrCreate');
+    expect(join).toContain('NOT minting an identity here');
+  });
+});
+
+describe('seal → install, through the real functions', () => {
+  function joinerKeys() {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('x25519');
+    const spki = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+    return {
+      publicB64: spki.subarray(spki.length - 32).toString('base64'),
+      privatePem: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+    };
+  }
+
+  function sourceStateDir(): { dir: string; fingerprint: string } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'handover-src-'));
+    const kp = crypto.generateKeyPairSync('ed25519');
+    const pub = (kp.publicKey.export({ type: 'spki', format: 'der' }) as Buffer).subarray(-32).toString('base64');
+    const priv = (kp.privateKey.export({ type: 'pkcs8', format: 'der' }) as Buffer).toString('base64');
+    fs.writeFileSync(
+      path.join(dir, 'identity.json'),
+      JSON.stringify({ version: 1, publicKey: pub, privateKey: priv, createdAt: '2026-05-02T00:00:00.000Z' }),
+    );
+    return { dir, fingerprint: fingerprintOf(pub) };
+  }
+
+  it('round-trips: the joiner ends up with the SOURCE machine identity, not a new one', () => {
+    const src = sourceStateDir();
+    const j = joinerKeys();
+    const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'handover-dst-'));
+
+    const agent = readAgentIdentityForHandover(src.dir);
+    expect(agent).not.toBeNull();
+    expect(agent!.fingerprint).toBe(src.fingerprint);
+
+    const transcript = {
+      pairingSessionId: 'CODE-WORD-1234',
+      joinerMachineId: 'm_joiner',
+      joinerEncryptionPublicKey: j.publicB64,
+      agentName: 'echo',
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    };
+    const sealed = sealIdentityForJoiner({
+      payload: agent!.payload,
+      transcript,
+      identityFingerprint: agent!.fingerprint,
+    });
+    expect(sealed.ok).toBe(true);
+    if (!sealed.ok) return;
+
+    const outcome = installAgentIdentityFromPairing({
+      envelope: sealed.envelope,
+      stateDir: dst,
+      expected: transcript,
+      encryptionPrivateKeyPem: j.privatePem,
+      pinnedFingerprint: src.fingerprint,
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    // THE assertion: the two machines now present the SAME identity.
+    expect(outcome.fingerprint).toBe(src.fingerprint);
+    const installed = JSON.parse(fs.readFileSync(path.join(dst, 'identity.json'), 'utf-8'));
+    expect(fingerprintOf(installed.publicKey)).toBe(src.fingerprint);
+    expect(installed.provenance.origin).toBe('received-on-join');
+  });
+
+  it('writes the identity owner-only — a key the rest of the machine can read has failed', () => {
+    const src = sourceStateDir();
+    const j = joinerKeys();
+    const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'handover-perm-'));
+    const agent = readAgentIdentityForHandover(src.dir)!;
+    const transcript = {
+      pairingSessionId: 'c', joinerMachineId: 'm', joinerEncryptionPublicKey: j.publicB64,
+      agentName: 'echo', expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    };
+    const sealed = sealIdentityForJoiner({ payload: agent.payload, transcript, identityFingerprint: agent.fingerprint });
+    if (!sealed.ok) throw new Error('seal failed');
+    installAgentIdentityFromPairing({
+      envelope: sealed.envelope, stateDir: dst, expected: transcript,
+      encryptionPrivateKeyPem: j.privatePem, pinnedFingerprint: agent.fingerprint,
+    });
+    const mode = fs.statSync(path.join(dst, 'identity.json')).mode & 0o777;
+    expect(mode & 0o077).toBe(0); // no group/other bits
+  });
+
+  it('an ABSENT envelope is `not-offered` and writes nothing — the old-peer case', () => {
+    const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'handover-none-'));
+    const r = installAgentIdentityFromPairing({
+      envelope: undefined,
+      stateDir: dst,
+      expected: { pairingSessionId: 'c', joinerMachineId: 'm', joinerEncryptionPublicKey: 'k', agentName: 'echo', expiresAt: '' },
+      encryptionPrivateKeyPem: 'x',
+      pinnedFingerprint: null,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('not-offered');
+    expect(fs.existsSync(path.join(dst, 'identity.json'))).toBe(false);
+  });
+
+  it('a REFUSED envelope writes nothing — no partial provisioning', () => {
+    const src = sourceStateDir();
+    const j = joinerKeys();
+    const attacker = joinerKeys();
+    const dst = fs.mkdtempSync(path.join(os.tmpdir(), 'handover-refuse-'));
+    const agent = readAgentIdentityForHandover(src.dir)!;
+    const transcript = {
+      pairingSessionId: 'c', joinerMachineId: 'm', joinerEncryptionPublicKey: j.publicB64,
+      agentName: 'echo', expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    };
+    const sealed = sealIdentityForJoiner({ payload: agent.payload, transcript, identityFingerprint: agent.fingerprint });
+    if (!sealed.ok) throw new Error('seal failed');
+    const r = installAgentIdentityFromPairing({
+      envelope: sealed.envelope, stateDir: dst, expected: transcript,
+      encryptionPrivateKeyPem: attacker.privatePem, // wrong machine
+      pinnedFingerprint: agent.fingerprint,
+    });
+    expect(r.ok).toBe(false);
+    expect(fs.existsSync(path.join(dst, 'identity.json'))).toBe(false);
+  });
+
+  it('a machine with no agent identity hands over nothing rather than something empty', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'handover-empty-'));
+    expect(readAgentIdentityForHandover(empty)).toBeNull();
+  });
+});

--- a/upgrades/next/r7-wire-agent-identity-handover.md
+++ b/upgrades/next/r7-wire-agent-identity-handover.md
@@ -1,0 +1,60 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**The previous release shipped the identity handover unreachable, which broke joining a machine
+to an agent.** This connects it.
+
+The identity-continuity change had two halves that only work together: a guard stopping a
+joining machine from inventing its own identity, and a handover carrying the real one across.
+The guard shipped wired. The handover shipped as code that nothing called.
+
+Net effect: a machine joining a mesh correctly refused to mint an identity and had no way to
+receive one, so the join could not complete.
+
+Now:
+
+- The pairing response carries the agent identity, sealed to the joining machine's encryption
+  key — the key that has always arrived on that route and was validated and unused.
+- The joining machine installs it **before its server first starts**, so the boot finds an
+  identity and never reaches the minting branch. The write is atomic and owner-only.
+- On any failure it provisions nothing and says so plainly, naming the remedy. It never falls
+  back to minting: a silent split is worse than a join that visibly did not finish.
+
+## Why every check passed on code that was unreachable
+
+Worth recording, because the gap is general rather than a one-off:
+
+- Unit tests exercised the component in isolation. The component was correct.
+- Cross-model review examined the design over seven rounds. The design was right.
+- The full suite ran the code that exists — it cannot notice code that is absent.
+- Docs coverage, the guard manifest and the lints all asked about what IS there.
+
+Each answered a narrower question than the one that mattered: *is it plugged in?* A component
+can be perfect, fully tested, well reviewed, and unreachable, with every signal green.
+
+The remedy is a wiring-integrity suite asserting **reachability through the real seams** — that
+the route calls the sealer, the join command calls the installer, the server passes through what
+the sealer needs, no failure path reaches for the minting call, and a full seal-to-install
+round-trip ends with the joining machine holding the *source* machine's identity.
+
+## Evidence
+
+- `tests/unit/agent-identity-handover-wiring.test.ts` — 9 wiring tests.
+- 97 tests across the identity work.
+- Full suite: 25 failures / 10 files — byte-identical to the pre-change baseline.
+
+## What to Tell Your User
+
+- **If you tried to add a machine to your agent since the last release and it failed, this is
+  why — and it works again now.** Existing machines were unaffected throughout; only adding a
+  new one was blocked.
+- **Nothing to do.** No configuration, no migration, no restart beyond the normal update.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Identity actually carried on join | Automatic. The pairing response seals it to the joining machine, which installs it before its first boot. |
+| Loud, named refusal instead of a silent split | Automatic. A failed handover provisions nothing and names the remedy; it never mints. |
+| Wiring-integrity coverage | Automatic in CI — asserts the pieces are connected, not merely correct. |

--- a/upgrades/side-effects/wire-agent-identity-handover.md
+++ b/upgrades/side-effects/wire-agent-identity-handover.md
@@ -1,0 +1,179 @@
+# Side-Effects Review — Wire the agent-identity handover
+
+**Version / slug:** `wire-agent-identity-handover`
+**Date:** `2026-08-20`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required — see below`
+
+## Summary of the change
+
+PR #1946 shipped `sealIdentityForJoiner` and `openHandoverEnvelope` with 12 passing tests and
+**nothing calling either**. The mint guard shipped wired. So the net effect of the change meant
+to fix identity continuity was to **break joining**: a machine joining a mesh correctly refused
+to mint and had no way to receive the identity.
+
+This connects them. `POST /api/pair` seals the identity to the joiner's encryption key;
+`joinMesh` installs it before the server first starts; `AgentServer` passes through the context
+the sealer needs.
+
+Files: `src/server/machineRoutes.ts`, `src/commands/machine.ts`, `src/core/AgentIdentityHandover.ts`,
+`src/server/AgentServer.ts`, `tests/unit/agent-identity-handover-wiring.test.ts`.
+
+## Decision-point inventory
+
+- `POST /api/pair` — **modify** — now returns a sealed identity envelope, or omits the field
+  with a named log line. No new decision: the pairing-code validation upstream is unchanged.
+- `joinMesh` identity install — **add** — accept or refuse; refusal provisions nothing.
+
+---
+
+## 1. Over-block
+
+The install path can refuse a legitimate handover: a clock skew past the envelope expiry, an
+unreadable encryption key, or a `stateDir`/`agentName` an embedder did not supply.
+
+Every one of those produces a **named refusal and a loud message naming the remedy**, and the
+machine is left exactly as it was — unjoined, with no identity, rather than half-provisioned.
+That is the intended direction: the alternative to refusing is minting, which is the defect.
+
+The residual cost is real and worth stating: an operator hitting one of these gets a failed
+join and must re-pair. That is strictly better than the silent split it replaces.
+
+---
+
+## 2. Under-block
+
+- **Without the operator's pairing artefact carrying the agent fingerprint, the pin check is
+  skipped** and the envelope's own fingerprint is used. That still resists a wrong-joiner or
+  replayed envelope (transcript + sealing key cover those) but NOT a hostile listener
+  fabricating one. `--agent-fingerprint` exists on the join options; nothing yet puts it into
+  the artefact `instar pair` prints. Honest posture: weaker when absent, and the code says so.
+- **Version skew is unchanged from the spec:** an old joiner ignores the envelope and mints.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The seal belongs on the route that already validates the pairing code and already receives the
+joiner's key — no new endpoint, no new trust relationship at the protocol level.
+
+The install belongs in `joinMesh` **before the server starts**, because that ordering is what
+makes the mint guard unreachable in the happy path rather than merely survivable.
+
+`readAgentIdentityForHandover` sits beside the sealer rather than in `IdentityManager` because
+it reads for EXPORT; `IdentityManager` reads for USE and is deliberately no-create.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+Neither half decides anything about agent behaviour. The route hands over data or does not; the
+joiner installs it or refuses. The only blocking authority in this feature is the mint guard,
+which shipped in #1946 and is unchanged here.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. Both new paths are enumerable
+transforms over a single input each.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the install runs before the server starts, so it cannot race the boot's
+  identity read. That ordering is the point, not an incidental.
+- **Double-fire:** the route seals once per redemption; the joiner installs once per join.
+- **Races:** the write is atomic (temp file → rename in the destination directory), so a crash
+  mid-write leaves either the old state or the new one, never a half-key.
+- **Feedback loops:** none.
+
+**Interaction with the mint guard, stated because it is the whole point:** these two are a
+matched pair. The guard without the carry breaks joining — that is what #1946 shipped. The carry
+without the guard restores the silent split. Neither should ever ship alone again, which is what
+the wiring suite now asserts.
+
+---
+
+## 6. External surfaces
+
+- **Other users of the install base:** joining a machine works again, and now yields the same
+  identity as the machine joined.
+- **External systems:** none. No new network call; the same response gains a field.
+- **Persistent state:** `identity.json` on the joiner, written owner-only.
+- **Operator surface:** three plain-language console outcomes on join — received / not offered
+  (name the machine to update) / refused (name the reason). None asks for terminal work beyond
+  re-pairing.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer or form is staged. The join console output was held to the same bar: it
+states what happened, what to do, and — in the not-offered case — explicitly why an identity was
+NOT invented, so an operator seeing a failed join understands it as a deliberate refusal rather
+than a malfunction.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**`unified`** — this is the mechanism by which the agent identity becomes unified. Machine keys
+remain `machine-local`; `machine-local-justification: hardware-bound-resource`, unchanged from
+the parent spec.
+
+- **User-facing notices:** none added.
+- **Durable state on topic transfer:** none.
+- **Generated URLs:** none.
+
+---
+
+## 8. Rollback cost
+
+Reverting returns to the #1946 state, in which **joining is broken**. So this is not a safe
+revert on its own: rolling this back requires also reverting the mint guard, or accepting that
+no machine can join until it is restored. Stated plainly because "revert the last commit" is the
+instinct and here it is the wrong one.
+
+---
+
+## Conclusion
+
+The code change is small and mechanical. The finding worth recording is the process one.
+
+**Every gate passed on an unreachable component.** Unit tests exercised the piece in isolation
+and it was correct. Seven rounds of cross-model review examined the design and it was right. The
+full suite ran the code that exists and cannot notice code that is absent. Docs coverage, the
+guard manifest and the lints all asked about what IS there. Each answered a narrower question
+than the one that mattered: *is it plugged in?*
+
+That is a general blind spot, not a one-off. The remedy shipped here is a wiring-integrity suite
+that asserts reachability through the real seams — the standard already requires this for
+dependency-injected components, and this is the case that shows why.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required for the code; the design was reviewed over 7 rounds in the parent
+spec and is unchanged. This commit changes no decision point, adds no blocking authority, and
+introduces no new interface — it connects two reviewed components.
+
+The judgement that a second-pass would have added value HERE is worth recording honestly: it
+would not have caught the original defect either, because it reviews the artifact and the
+artifact described a design that was correct. What caught it was asking "what calls this?".
+
+---
+
+## Evidence pointers
+
+- `tests/unit/agent-identity-handover-wiring.test.ts` — 9 tests: route→sealer, join→installer,
+  server→context pass-through, no-mint-on-failure, seal→install round-trip proving the joiner
+  ends up with the SOURCE identity, owner-only permissions, absent-envelope, refused-envelope.
+- 97 tests across the identity work.
+- Full suite: 25 failures / 10 files — byte-identical to the pre-change baseline.


### PR DESCRIPTION
## What happened

**#1946 shipped `sealIdentityForJoiner` and `openHandoverEnvelope` with 12 passing tests and nothing calling either of them.** The mint guard shipped wired.

So the net effect of the change meant to *fix* identity continuity was to **break joining**: a machine joining a mesh correctly refused to mint an identity, and had no way to receive one.

The risk was flagged in the same session, in these words — *"§2 alone would break all future joins — the carry must land with it"* — and then exactly that shipped.

## Why every gate passed on unreachable code

Worth stating, because the gap is general rather than a one-off:

| Gate | What it asked | Answer |
|---|---|---|
| Unit tests | Is the component correct? | Yes — it is |
| Cross-model review (7 rounds) | Is the design right? | Yes — it is |
| Full suite | Does the code that exists pass? | Yes |
| Docs coverage / guard manifest / lints | Is what IS there declared? | Yes |

Every one answered a **narrower question than the one that mattered**: *is it plugged in?* A component can be perfect, fully tested, well reviewed, and unreachable, with every signal green.

## The fix

- **`POST /api/pair`** seals the agent identity to the joiner's encryption key — the key that has always arrived on that route and was validated and unused — bound to a transcript the joiner re-checks against what it sent. A refusal is **named** and the field is **absent**, never a partial envelope, so the joiner can distinguish "not provided" from "provided and wrong".
- **`joinMesh`** installs it **before the server first starts**, so the boot finds an identity and never reaches the minting branch. Atomic write (temp → rename), owner-only. On **any** failure it provisions nothing and says so — it never falls back to minting.
- **`AgentServer`** passes `stateDir` + `agentName` into the route context, without which the sealer has nothing to read.
- An identity predating the provenance record is recorded honestly as unknown-origin, so it can never win a future lineage comparison on an unverifiable claim.

## The test that would have caught it

`tests/unit/agent-identity-handover-wiring.test.ts` asserts **reachability through the real seams** rather than behaviour of a part:

- the pair route calls the sealer;
- the join command calls the installer;
- the server passes through what the sealer needs to read;
- no failure path after the install reaches for `getOrCreate`;
- a seal → install **round-trip** proving the joiner ends up with the **source machine's** identity, written owner-only;
- an absent envelope is `not-offered` and writes nothing; a refused envelope writes nothing.

The Testing Integrity Standard already requires wiring-integrity tests for dependency-injected components. This is the case that shows why.

## Rollback

**Not a safe standalone revert.** Reverting returns to the #1946 state in which joining is broken; rolling this back requires also reverting the mint guard, or accepting that no machine can join until it is restored. Stated plainly because "revert the last commit" is the instinct and here it is the wrong one.

## Testing

- 9 wiring tests; **97 tests** across the identity work.
- Full suite: **25 failures / 10 files — byte-identical to the pre-change baseline.**

---

## ELI16 — The last release shipped a part that was never plugged in, and it broke adding machines

The identity fix had two halves that only work together: one stops a new machine inventing its own identity, the other hands it the real one. The first was connected. The second was written, tested, reviewed — and connected to nothing.

So a machine joining correctly refused to make up an identity, and had no way to be given one. Adding a machine stopped working, because of the change meant to fix adding machines.

What is uncomfortable is that nothing caught it. The tests checked the part, and the part was fine. The review checked the design, and the design was fine. The full test run checks code that exists, and cannot notice code that is missing. Everything was green about a component nothing could reach.

This connects the two halves, and adds a set of tests whose only job is to check that pieces are actually joined to each other — that the thing that hands over the identity is really called by the thing that pairs machines, and that no failure path quietly goes back to inventing one.

Existing machines were never affected. Only adding a new one, and only since the last release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
