### PR TITLE
fix(messaging): the relay reported suppressed duplicates as sent

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-20T17-44-39-141Z-relay-suppressed-duplicate-honesty.json
+++ b/.instar/instar-dev-decisions/2026-08-20T17-44-39-141Z-relay-suppressed-duplicate-honesty.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-08-20T17:44:39.141Z",
+  "slug": "relay-suppressed-duplicate-honesty",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts",
+      "src/templates/scripts/telegram-reply.sh"
+    ],
+    "addedLines": 17,
+    "deletedLines": 0
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      946,
+      1358
+    ],
+    "notes": "Latent since the server's duplicate-suppression path shipped (#946 introduced the suppressedDuplicate response; #1358 added the in-flight reservation arm). The server deliberately answers HTTP 200 - a suppressed send is not an error from its side - and puts the real outcome in a body field. telegram-reply.sh had only ever branched on the status line, so the new field was never read and the success print was reached anyway. Nothing regressed: the reporting gap shipped alongside the suppression feature and stayed invisible because a false success produces no error, no retry and no log entry. Found by direct observation on a live agent - a message reported as sent that the user never received."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-20T17-51-11-553Z-relay-suppressed-duplicate-honesty.json
+++ b/.instar/instar-dev-decisions/2026-08-20T17-51-11-553Z-relay-suppressed-duplicate-honesty.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-08-20T17:51:11.553Z",
+  "slug": "relay-suppressed-duplicate-honesty",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts",
+      "src/templates/scripts/telegram-reply.sh"
+    ],
+    "addedLines": 17,
+    "deletedLines": 0
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      946,
+      1358
+    ],
+    "notes": "Latent since the server's duplicate-suppression path shipped (#946 introduced the suppressedDuplicate response; #1358 added the in-flight reservation arm). The server deliberately answers HTTP 200 - a suppressed send is not an error from its side - and puts the real outcome in a body field. telegram-reply.sh had only ever branched on the status line, so the new field was never read and the success print was reached anyway. Nothing regressed: the reporting gap shipped alongside the suppression feature and stayed invisible because a false success produces no error, no retry and no log entry. Found by direct observation on a live agent - a message reported as sent that the user never received."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/RELAY-SUPPRESSED-DUPLICATE-HONESTY.md
+++ b/docs/eli16/RELAY-SUPPRESSED-DUPLICATE-HONESTY.md
@@ -1,0 +1,100 @@
+# The relay said "sent" for messages nobody received — Plain-English Overview
+
+> The one-line version: when the server quietly drops a repeated message, the script that sends it used to report success anyway, so the agent believed it had answered when the user had heard nothing.
+
+## The problem in one breath
+
+Your agent has a duplicate guard: if it tries to send the exact same text to the
+same conversation twice in a short window, the server drops the second copy so you
+don't get spammed. That part is working as intended. The bug is what the agent was
+told afterwards. The server replies "OK" — and includes a note in the reply saying
+*"I suppressed that one, it was a duplicate."* The little script that does the
+sending read only the "OK" and threw the note away. It then printed `Sent 412 chars`
+and reported success.
+
+So the agent ticked the task off and moved on, genuinely believing it had replied
+to you. From your side, nothing arrived. There was no error, no warning, and no
+record anywhere that the agent could later check. The failure was completely
+silent, and it was silent in the worst possible direction: the agent was confident.
+
+## What already exists
+
+- **The duplicate guard** — lives in the server. It decides what counts as a
+  repeat and drops it. This is unchanged; it was never the broken part.
+- **The reply script** — a small shell script on every agent's disk that actually
+  performs the send. It already knows how to report several other outcomes
+  honestly: a timeout, an ambiguous transport failure, a blocked message. The
+  suppressed-duplicate case was simply missing from that list.
+- **The update migrator** — the thing that upgrades files on agents that already
+  exist. Instar agents update in place, so shipping a new file into the source code
+  is not enough on its own; the migrator is what actually puts it on their disks.
+
+## What this adds
+
+**The script now reads the note it was already being sent.** If the server says the
+message was suppressed, the script prints `NOT SENT — suppressed duplicate for
+topic 12345; an identical message was already delivered to that topic recently`
+and exits with a failure status instead of a success one. That failure status is
+the part that matters most, because it is the signal most callers actually check.
+
+The second half is less visible and more important:
+
+- **Existing agents actually receive the fix.** The migrator identifies deployed
+  copies of the script by their exact fingerprint, and only upgrades ones it
+  recognises as genuinely shipped by us. The fingerprint of the current (broken)
+  version had to be registered, or the migrator would treat every agent in the
+  field as "someone edited this, leave it alone", drop a `.new` file beside it, and
+  every existing agent would keep the lying script forever. This registration is
+  the real deliverable — the seven-line script change is inert without it.
+- **Tests at all three levels**, including one that stands up a fake pre-existing
+  agent, confirms it has the bug, runs the real update, and then runs that agent's
+  own upgraded script to prove it now tells the truth.
+
+## The new pieces
+
+- **The suppression branch** — seven lines inside the existing "the server said OK"
+  path. It is allowed to *report* an outcome. It is deliberately NOT allowed to
+  decide anything: it cannot cause a send, prevent one, or retry one. The server
+  had already made the decision and already written it down; the only bug was that
+  nobody read it. Keeping this line sharp matters, because a piece of code that
+  merely reports can be simple and cheap, whereas anything that *decides* has to be
+  much more careful about being wrong.
+
+## The safeguards
+
+**Prevents a false "not sent" from ever appearing.** The reverse mistake would be
+worse than the original bug: if the script wrongly claimed a delivered message had
+been suppressed, the agent would send it to you a second time. So the check is
+strict rather than generous. It requires the value to be exactly the boolean
+`true`; the *word* "true" as text does not count. If the reply is unreadable, if
+the field is missing, or if the tool used to read it isn't installed, the script
+falls back to its old behaviour rather than guessing. Every uncertain case resolves
+toward the way things worked before, never toward a false alarm.
+
+**Prevents the fix from quietly reaching nobody.** This is the failure this project
+has hit before: a change lands in the source code, every test passes, and not one
+agent in the field ever receives it. The test suite now fails if the fingerprint
+registration is missing, so "shipped" and "actually delivered to existing agents"
+cannot drift apart silently.
+
+**Prevents anyone's customised script from being overwritten.** If an operator has
+hand-edited their own copy, the migrator leaves it exactly where it is, writes the
+new version alongside as a `.new` file, and raises a notice so a human can merge
+the two. Being helpful never justifies stomping on someone's work.
+
+**Prevents it from disturbing anything else.** The new branch sits inside the
+existing "OK" path only, so the timeout path, the ambiguous-transport path and the
+blocked-message path all behave exactly as they did. A test pins each of those.
+
+## What ships when
+
+All of it ships together, in one change: the script fix, the registration that
+delivers it to existing agents, and the three tiers of tests. Splitting them would
+be worse than useless — the script fix alone reaches only newly created agents,
+which is precisely the gap this closes.
+
+Rolling it back is a plain revert with no data to clean up. One honest wrinkle
+worth knowing: agents that already updated would keep the fixed script after a
+revert, since the migrator would no longer recognise it and would leave it in
+place. That is the safe direction — a rollback stops new agents from getting the
+fix, but does not push anyone back to being told their unsent messages were sent.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -15833,6 +15833,16 @@ process.stdin.on('end', async () => {
     // the swallowing version in place with a `.new` beside it, and every agent
     // keeps mis-sending a misplaced (or typo'd) flag as message body.
     'a2cf02154a6023725f15480a575f54a5231278c70396cd12051b7d7055b72d98',
+    // The flag-position-guard version, shipped immediately BEFORE the
+    // suppressed-duplicate honesty fix. In this version the relay read only
+    // the HTTP status: the server answers 200 with `suppressedDuplicate: true`
+    // when it drops an exact repeat, and the script discarded that body,
+    // printed "Sent N chars" and exited 0 — reporting a message the user
+    // never saw as delivered. Registering this SHA is what lets a deployed
+    // agent RECEIVE the fix: without it the SHA-history migrator leaves the
+    // mis-reporting version in place with a `.new` beside it, and every
+    // existing agent keeps being told its suppressed sends succeeded.
+    '4464581188f5c736a62edac5e6a2edecfcfcd365557a18e514b741731bed6e0b',
   ]);
 
   /**

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -519,6 +519,13 @@ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 
 if [ "$HTTP_CODE" = "200" ]; then
+  if printf '%s' "$BODY" | python3 -c 'import sys,json; raise SystemExit(0 if json.load(sys.stdin).get("suppressedDuplicate") is True else 1)' 2>/dev/null; then
+    SUPPRESSED_DELIVERY_ID=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("deliveryId", ""))' 2>/dev/null || echo "")
+    DELIVERY_ID_DETAIL=""
+    [ -n "$SUPPRESSED_DELIVERY_ID" ] && DELIVERY_ID_DETAIL="; delivery id $SUPPRESSED_DELIVERY_ID"
+    echo "NOT SENT — suppressed duplicate for topic $TOPIC_ID${DELIVERY_ID_DETAIL}; an identical message was already delivered to that topic recently"
+    exit 1
+  fi
   echo "Sent $(echo "$MSG" | wc -c | tr -d ' ') chars to topic $TOPIC_ID"
 elif [ "$HTTP_CODE" = "408" ]; then
   # Request timeout on the server side — the outbound path (tone gate + Telegram API)

--- a/tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts
+++ b/tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts
@@ -1,0 +1,207 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for the suppressed-duplicate
+ * honesty fix.
+ *
+ * Per TESTING-INTEGRITY-SPEC this is the tier that catches a feature which
+ * passes every unit test and is inert in production. For a change that ships
+ * as a TEMPLATE plus a MIGRATION, "inert in production" has a very specific
+ * shape: the template is fixed in the repo, the unit tests are green, and yet
+ * every agent in the field keeps running the old lying script forever, because
+ * instar agents update IN PLACE. A template-only change reaches only agents
+ * created after it.
+ *
+ * So this test does not stop at "the migrator wrote a file". It drives the
+ * REAL public `migrate()` entry point — the same call the production update
+ * path makes — against a realistic agent home that already exists, and then
+ * EXECUTES the relay script from that agent's own disk. The final assertion is
+ * the one that matters: after updating in place, an existing agent's own
+ * script tells the truth about a suppressed send.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const TEMPLATE = path.resolve('src/templates/scripts/telegram-reply.sh');
+const PRIOR_SHIPPED_SHA =
+  '4464581188f5c736a62edac5e6a2edecfcfcd365557a18e514b741731bed6e0b';
+const TOPIC = '29723';
+
+/** The pre-fix shipped script: the current template minus the 7-line branch. */
+function priorShippedContent(): string {
+  const lines = fs.readFileSync(TEMPLATE, 'utf-8').split('\n');
+  const start = lines.findIndex(l => l.includes('get("suppressedDuplicate") is True'));
+  if (start === -1) throw new Error('suppression branch not found in template');
+  return [...lines.slice(0, start), ...lines.slice(start + 7)].join('\n');
+}
+
+/**
+ * Execute a relay script AS THE AGENT WOULD, against a stubbed curl that
+ * returns the server's real suppressed-duplicate response shape (HTTP 200 +
+ * `suppressedDuplicate: true`, per src/server/routes.ts).
+ */
+function runDeployedScript(
+  scriptPath: string,
+  agentHome: string,
+  body: string,
+): Promise<{ status: number | null; stdout: string }> {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'suppressed-dup-e2e-bin-'));
+  const curlStub = path.join(binDir, 'curl');
+  fs.writeFileSync(
+    curlStub,
+    `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    *"/telegram/reply/"*) printf '%s\\n%s' '${body}' '200'; exit 0 ;;
+  esac
+done
+exit 1
+`,
+  );
+  fs.chmodSync(curlStub, 0o755);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [scriptPath, TOPIC, 'the overnight summary'], {
+      cwd: agentHome,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        INSTAR_SENDER_CLASS: 'script',
+        INSTAR_PORT: '',
+        INSTAR_AUTH_TOKEN: '',
+      },
+    });
+    let stdout = '';
+    child.stdout.on('data', c => { stdout += c.toString(); });
+    child.on('error', reject);
+    child.on('close', status => {
+      SafeFsExecutor.safeRmSync(binDir, {
+        recursive: true, force: true,
+        operation: 'tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts:bin',
+      });
+      resolve({ status, stdout });
+    });
+  });
+}
+
+const SUPPRESSED_BODY = '{"ok":true,"topicId":29723,"suppressedDuplicate":true}';
+
+describe('Suppressed-duplicate honesty E2E lifecycle (an existing agent updates in place)', () => {
+  let agentHome: string;
+  let claudePath: string;
+  let neutralPath: string;
+  let migrateResult: { upgraded: string[]; skipped: string[]; errors: string[] };
+  let preUpdate: { status: number | null; stdout: string };
+
+  beforeAll(async () => {
+    // ---- An instar agent that ALREADY EXISTS, on the shipped pre-fix relay.
+    agentHome = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-agent-preexisting-'));
+    const stateDir = path.join(agentHome, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ port: 49999, projectName: 'preexisting-agent' }),
+    );
+
+    claudePath = path.join(agentHome, '.claude', 'scripts', 'telegram-reply.sh');
+    neutralPath = path.join(stateDir, 'scripts', 'telegram-reply.sh');
+    const prior = priorShippedContent();
+    for (const p of [claudePath, neutralPath]) {
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, prior, { mode: 0o755 });
+    }
+
+    // ---- Capture the DEFECT on this agent, before the update.
+    preUpdate = await runDeployedScript(claudePath, agentHome, SUPPRESSED_BODY);
+
+    // ---- The production update path: the real public migrate() entry point.
+    migrateResult = new PostUpdateMigrator({
+      projectDir: agentHome,
+      stateDir,
+      port: 49999,
+      hasTelegram: true,
+      projectName: 'preexisting-agent',
+    }).migrate();
+  });
+
+  afterAll(() => {
+    SafeFsExecutor.safeRmSync(agentHome, {
+      recursive: true, force: true,
+      operation: 'tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts',
+    });
+  });
+
+  it('the pre-existing agent really did have the defect before updating', () => {
+    // Guards the whole test from passing vacuously against an agent that was
+    // never broken: pre-update, a suppressed send is reported as sent, exit 0.
+    expect(preUpdate.status).toBe(0);
+    expect(preUpdate.stdout).toMatch(/Sent \d+ chars/);
+    expect(preUpdate.stdout).not.toContain('NOT SENT');
+  });
+
+  it('the shipped pre-fix script is the version the migrator claims to recognise', () => {
+    expect(crypto.createHash('sha256').update(priorShippedContent()).digest('hex'))
+      .toBe(PRIOR_SHIPPED_SHA);
+  });
+
+  it('the full migrate() run reports no errors on a realistic agent home', () => {
+    const relayErrors = migrateResult.errors.filter(e => e.includes('telegram-reply'));
+    expect(relayErrors).toEqual([]);
+  });
+
+  it('both deployed copies carry the fix after updating in place', () => {
+    for (const p of [claudePath, neutralPath]) {
+      const onDisk = fs.readFileSync(p, 'utf-8');
+      expect(onDisk).toContain('NOT SENT — suppressed duplicate for topic');
+      expect(onDisk).toBe(fs.readFileSync(TEMPLATE, 'utf-8'));
+      // No stranded `.new` candidate — that would mean the migration missed.
+      expect(fs.existsSync(`${p}.new`)).toBe(false);
+    }
+  });
+
+  it('THE ALIVE TEST: the updated agent\'s OWN script now reports a suppressed send honestly', async () => {
+    const res = await runDeployedScript(claudePath, agentHome, SUPPRESSED_BODY);
+
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('NOT SENT');
+    expect(res.stdout).toContain('suppressed duplicate for topic 29723');
+    expect(res.stdout).not.toMatch(/Sent \d+ chars/);
+  });
+
+  it('the framework-neutral copy is honest too (Codex/Gemini installs resolve that path)', async () => {
+    const res = await runDeployedScript(neutralPath, agentHome, SUPPRESSED_BODY);
+
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('NOT SENT');
+  });
+
+  it('a genuine send still succeeds on the updated agent (the fix is not a blanket refusal)', async () => {
+    const res = await runDeployedScript(claudePath, agentHome, '{"ok":true,"topicId":29723}');
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/Sent \d+ chars to topic 29723/);
+  });
+
+  it('updating a second time is a no-op — the agent stays fixed', () => {
+    const again = new PostUpdateMigrator({
+      projectDir: agentHome,
+      stateDir: path.join(agentHome, '.instar'),
+      port: 49999,
+      hasTelegram: true,
+      projectName: 'preexisting-agent',
+    }).migrate();
+
+    expect(again.errors.filter(e => e.includes('telegram-reply'))).toEqual([]);
+    expect(again.skipped.some(s => s.includes('telegram-reply.sh') && s.includes('already current')))
+      .toBe(true);
+    expect(fs.readFileSync(claudePath, 'utf-8')).toContain('NOT SENT — suppressed duplicate');
+  });
+});

--- a/tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts
+++ b/tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tier-2 integration tests for the suppressed-duplicate honesty MIGRATION.
+ *
+ * Per the Migration Parity Standard (CLAUDE.md), an instar agent updates in
+ * place: a template-only change reaches ONLY newly created agents. Every agent
+ * that already exists keeps the version on its disk unless the SHA-history
+ * migrator recognises it. That recognition is the whole deliverable here — the
+ * seven-line script fix is inert in the field without it.
+ *
+ * These tests drive the REAL `migrateScripts()` against a real script already
+ * on disk, in both deployed locations, and pin the three branches the migrator
+ * distinguishes: known-shipped (upgrade), already-current (no-op), and
+ * locally-modified (preserve + `.new` candidate).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+const TEMPLATE = path.resolve('src/templates/scripts/telegram-reply.sh');
+
+/**
+ * The SHA this PR registers — the version shipped immediately BEFORE the fix.
+ * Every agent in the field is running this exact content.
+ */
+const PRIOR_SHIPPED_SHA =
+  '4464581188f5c736a62edac5e6a2edecfcfcd365557a18e514b741731bed6e0b';
+
+const SUPPRESSION_MARKER = 'suppressedDuplicate';
+
+/**
+ * Reconstruct the pre-fix shipped script by removing the seven-line
+ * suppression branch from the current template.
+ *
+ * Deriving it (rather than pasting a 42KB literal) is deliberate: the
+ * reconstruction is only valid if it hashes to the SHA actually registered in
+ * the migrator, which the first test asserts. That single assertion is what
+ * proves the registered constant is genuinely "current template minus this
+ * fix" — a typo'd or stale hash there would silently strand every deployed
+ * agent on a `.new` candidate, which is exactly the failure this PR fixes.
+ */
+function priorShippedContent(): string {
+  const lines = fs.readFileSync(TEMPLATE, 'utf-8').split('\n');
+  const start = lines.findIndex(l => l.includes(`get("${SUPPRESSION_MARKER}") is True`));
+  if (start === -1) throw new Error('suppression branch not found in template');
+  const removed = lines.slice(start, start + 7);
+  if (removed[6].trim() !== 'fi') {
+    throw new Error(`expected the 7-line branch to close with "fi", got: ${removed[6]}`);
+  }
+  return [...lines.slice(0, start), ...lines.slice(start + 7)].join('\n');
+}
+
+function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function createMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: true,
+    projectName: 'test-agent',
+  });
+}
+
+function runMigrateScripts(m: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateScripts(r: MigrationResult): void }).migrateScripts(result);
+  return result;
+}
+
+describe('suppressed-duplicate honesty — post-update migration', () => {
+  let projectDir: string;
+  let claudePath: string;
+  let neutralPath: string;
+  let backupsDir: string;
+
+  /** Stand up an agent that ALREADY EXISTS, running the pre-fix relay. */
+  function deployPriorShippedAgent(content = priorShippedContent()): void {
+    for (const p of [claudePath, neutralPath]) {
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, content, { mode: 0o755 });
+    }
+  }
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-suppressed-dup-migration-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudePath = path.join(projectDir, '.claude', 'scripts', 'telegram-reply.sh');
+    neutralPath = path.join(projectDir, '.instar', 'scripts', 'telegram-reply.sh');
+    backupsDir = path.join(projectDir, '.instar', 'backups');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts',
+    });
+  });
+
+  it('registers the EXACT sha of the shipped pre-fix template', () => {
+    // If this fails, the migrator's registered hash does not describe any real
+    // deployed script, and the migration reaches nobody.
+    expect(sha256(priorShippedContent())).toBe(PRIOR_SHIPPED_SHA);
+    expect(PostUpdateMigrator.TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS.has(PRIOR_SHIPPED_SHA)).toBe(true);
+  });
+
+  it('the pre-fix script genuinely lacks the fix (the "before" state is real)', () => {
+    const prior = priorShippedContent();
+    expect(prior).not.toContain(SUPPRESSION_MARKER);
+    expect(prior).toContain('Sent $(echo "$MSG" | wc -c | tr -d \' \') chars to topic $TOPIC_ID');
+  });
+
+  it('patches a pre-fix script already on disk, in BOTH deployed locations', () => {
+    deployPriorShippedAgent();
+    const template = fs.readFileSync(TEMPLATE, 'utf-8');
+
+    const result = runMigrateScripts(createMigrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    for (const p of [claudePath, neutralPath]) {
+      const after = fs.readFileSync(p, 'utf-8');
+      expect(after).toBe(template);
+      expect(after).toContain('NOT SENT — suppressed duplicate for topic');
+    }
+    expect(result.upgraded.some(u => u.includes('scripts/telegram-reply.sh'))).toBe(true);
+    expect(result.upgraded.some(u => u.includes('.instar/scripts/telegram-reply.sh'))).toBe(true);
+  });
+
+  it('keeps the migrated script executable', () => {
+    deployPriorShippedAgent();
+    runMigrateScripts(createMigrator(projectDir));
+
+    // A relay the agent cannot execute is as broken as one that lies.
+    for (const p of [claudePath, neutralPath]) {
+      expect(fs.statSync(p).mode & 0o111).not.toBe(0);
+    }
+  });
+
+  it('backs the prior version up before overwriting', () => {
+    deployPriorShippedAgent();
+    runMigrateScripts(createMigrator(projectDir));
+
+    const backups = fs.readdirSync(backupsDir).filter(f => f.startsWith('telegram-reply.sh.'));
+    expect(backups.length).toBeGreaterThan(0);
+    expect(sha256(fs.readFileSync(path.join(backupsDir, backups[0]), 'utf-8')))
+      .toBe(PRIOR_SHIPPED_SHA);
+  });
+
+  it('is idempotent — a second update run changes nothing and adds no backup', () => {
+    deployPriorShippedAgent();
+    runMigrateScripts(createMigrator(projectDir));
+    const afterFirst = fs.readFileSync(claudePath, 'utf-8');
+    const backupsAfterFirst = fs.readdirSync(backupsDir).length;
+
+    const second = runMigrateScripts(createMigrator(projectDir));
+
+    expect(second.errors).toEqual([]);
+    expect(fs.readFileSync(claudePath, 'utf-8')).toBe(afterFirst);
+    expect(fs.readdirSync(backupsDir).length).toBe(backupsAfterFirst);
+    expect(second.skipped.some(s => s.includes('already current'))).toBe(true);
+    expect(second.upgraded.some(u => u.includes('telegram-reply.sh'))).toBe(false);
+  });
+
+  it('does NOT clobber a locally customised script — writes a .new candidate instead', () => {
+    deployPriorShippedAgent(`${priorShippedContent()}\n# operator's local customisation\n`);
+    const before = fs.readFileSync(claudePath, 'utf-8');
+
+    const result = runMigrateScripts(createMigrator(projectDir));
+
+    // The operator's file is untouched...
+    expect(fs.readFileSync(claudePath, 'utf-8')).toBe(before);
+    // ...and the fix is offered alongside for them to reconcile.
+    const candidate = fs.readFileSync(`${claudePath}.new`, 'utf-8');
+    expect(candidate).toBe(fs.readFileSync(TEMPLATE, 'utf-8'));
+    expect(candidate).toContain('NOT SENT — suppressed duplicate for topic');
+    expect(result.skipped.some(s => s.includes('user-modified'))).toBe(true);
+  });
+
+  it('installs the fixed script outright on an agent that has none', () => {
+    // New-agent path — no prior file. Covers the other half of Migration
+    // Parity: new agents must not be left behind either.
+    const result = runMigrateScripts(createMigrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    for (const p of [claudePath, neutralPath]) {
+      expect(fs.readFileSync(p, 'utf-8')).toContain('NOT SENT — suppressed duplicate for topic');
+    }
+  });
+});

--- a/tests/unit/telegram-reply-suppressed-duplicate.test.ts
+++ b/tests/unit/telegram-reply-suppressed-duplicate.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tier-1 unit tests for the suppressed-duplicate honesty branch in
+ * `src/templates/scripts/telegram-reply.sh`.
+ *
+ * The defect this covers: the server answers HTTP **200** with
+ * `{ suppressedDuplicate: true }` when it drops an exact repeat of a message
+ * already delivered to that topic recently (src/server/routes.ts). The relay
+ * script read only the status line and discarded the body, so it printed
+ * "Sent N chars" and exited 0 — reporting a message the user never saw as
+ * delivered. An agent has no other way to learn the send was dropped, so it
+ * moved on believing it had answered.
+ *
+ * The branch is a REPORTER, not an authority (docs/signal-vs-authority.md):
+ * the suppression decision was already made by the server. These tests pin
+ * both directions — it must speak up on a real suppression, and it must stay
+ * silent on every other 200 — because a false "NOT SENT" would push an agent
+ * into re-sending a message the user DID receive.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const SCRIPT = path.resolve('src/templates/scripts/telegram-reply.sh');
+const TOPIC = '458';
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, {
+      recursive: true,
+      force: true,
+      operation: 'telegram-reply-suppressed-duplicate:test-cleanup',
+    });
+  }
+});
+
+/**
+ * Run the REAL relay script against a stubbed `curl` that returns `body` for
+ * the outbound reply POST. The stub routes on the URL so the unrelated
+ * advisory-preflight call cannot consume the canned response; that call is
+ * failed deliberately, which the script treats as fail-open.
+ */
+function runWithReplyBody(
+  body: string,
+  httpCode = '200',
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'telegram-suppressed-dup-'));
+  tmpDirs.push(dir);
+  const binDir = path.join(dir, 'bin');
+  const instarDir = path.join(dir, '.instar');
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(instarDir);
+  fs.writeFileSync(
+    path.join(instarDir, 'config.json'),
+    JSON.stringify({ port: 49999, projectName: 'test-agent' }),
+  );
+
+  // `printf '%s'` (not echo) so the body is emitted byte-exactly; the script
+  // appends the status line via curl's -w, which the stub reproduces.
+  const curlStub = path.join(binDir, 'curl');
+  fs.writeFileSync(
+    curlStub,
+    `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    *"/telegram/reply/"*)
+      printf '%s\\n%s' '${body}' '${httpCode}'
+      exit 0
+      ;;
+  esac
+done
+exit 1
+`,
+  );
+  fs.chmodSync(curlStub, 0o755);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [SCRIPT, TOPIC, 'a message the user may or may not have seen'], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        INSTAR_SENDER_CLASS: 'script',
+        INSTAR_PORT: '',
+        INSTAR_AUTH_TOKEN: '',
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c.toString(); });
+    child.stderr.on('data', (c) => { stderr += c.toString(); });
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('telegram-reply.sh — suppressed-duplicate honesty', () => {
+  it('reports NOT SENT and exits non-zero when the server suppressed the duplicate', async () => {
+    const res = await runWithReplyBody('{"ok":true,"topicId":458,"suppressedDuplicate":true}');
+
+    // Exit 1 is the load-bearing half: an agent that only checks the exit
+    // status must not conclude the message was delivered.
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('NOT SENT');
+    expect(res.stdout).toContain('suppressed duplicate for topic 458');
+    // The old lie must be gone from this path entirely.
+    expect(res.stdout).not.toMatch(/Sent \d+ chars/);
+  });
+
+  it('names the delivery id when the server supplied one', async () => {
+    const res = await runWithReplyBody(
+      '{"ok":true,"topicId":458,"suppressedDuplicate":true,"deliveryId":"dlv-abc123"}',
+    );
+
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('delivery id dlv-abc123');
+  });
+
+  it('omits the delivery-id clause when the server supplied none', async () => {
+    // The 200-with-suppression responses in routes.ts do NOT carry a
+    // deliveryId, so this is the common shape, not an edge case.
+    const res = await runWithReplyBody('{"ok":true,"topicId":458,"suppressedDuplicate":true}');
+
+    expect(res.status).toBe(1);
+    expect(res.stdout).not.toContain('delivery id');
+    expect(res.stdout).toContain('an identical message was already delivered');
+  });
+
+  it('still reports a genuine send as sent (no regression on the normal path)', async () => {
+    const res = await runWithReplyBody('{"ok":true,"topicId":458}');
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/Sent \d+ chars to topic 458/);
+    expect(res.stdout).not.toContain('NOT SENT');
+  });
+
+  it('treats an explicit suppressedDuplicate:false as a genuine send', async () => {
+    const res = await runWithReplyBody('{"ok":true,"topicId":458,"suppressedDuplicate":false}');
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/Sent \d+ chars/);
+    expect(res.stdout).not.toContain('NOT SENT');
+  });
+
+  it('does not claim suppression on a truthy-but-not-true value', async () => {
+    // The check is `is True`, not a truthiness test. A string "true" is not a
+    // suppression verdict, and guessing that it is would strand a delivered
+    // message as NOT SENT.
+    const res = await runWithReplyBody('{"ok":true,"suppressedDuplicate":"true"}');
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).not.toContain('NOT SENT');
+  });
+
+  it('fails toward the send report when the 200 body is not JSON', async () => {
+    // Fail-open is the correct direction here: an unparseable body is not
+    // evidence of suppression, and a false NOT SENT would provoke a re-send
+    // of a message the user already received.
+    const res = await runWithReplyBody('not json at all');
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).not.toContain('NOT SENT');
+  });
+
+  it('does not hijack a non-200 outcome', async () => {
+    // 408 has its own AMBIGUOUS branch; the suppression check lives strictly
+    // inside the 200 arm and must not shadow it.
+    const res = await runWithReplyBody('{"suppressedDuplicate":true}', '408');
+
+    expect(res.stdout).not.toContain('NOT SENT — suppressed duplicate');
+    expect(`${res.stdout}${res.stderr}`).toContain('AMBIGUOUS');
+  });
+});

--- a/upgrades/next/relay-suppressed-duplicate-honesty.md
+++ b/upgrades/next/relay-suppressed-duplicate-honesty.md
@@ -1,0 +1,71 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**When the server suppresses a duplicate message, the relay now says so instead of reporting it
+as sent.** Instar drops an exact repeat of a message already delivered to a topic recently — that
+guard works and is unchanged. What was broken is what the agent was told afterwards.
+
+The server answers that case with HTTP **200** and `suppressedDuplicate: true` in the response
+body: 200 because a suppressed send is not an error from the server's side, with the real outcome
+carried in the body. `telegram-reply.sh` branched only on the status line and discarded the body,
+so it printed `Sent N chars to topic N` and exited **0**.
+
+The exit status is the only delivery signal most callers check, which made a suppressed send
+indistinguishable from a delivered one. The agent ticked the reply off and moved on; the user
+received nothing. There was no error, no retry, and no log entry — the failure was silent in the
+worst direction, because the agent was confident.
+
+The relay now reads the field it was already being sent. On a genuine suppression it prints
+`NOT SENT — suppressed duplicate for topic <id>; an identical message was already delivered to
+that topic recently` (naming the delivery id when the server supplies one) and exits **1**.
+
+The check is deliberately strict rather than generous, because the opposite mistake is worse: a
+false `NOT SENT` would make an agent re-send a message the user already has. It requires the value
+to be exactly boolean `true` (the string `"true"` does not count), and a missing field, an
+explicit `false`, an unparseable body, or a missing `python3` all fall through to the previous
+behaviour. Every uncertain input resolves toward the old path, never toward a false alarm.
+
+**Existing agents receive this, not just newly created ones.** Instar agents update in place, so a
+template change alone would have reached only agents created after it. The pre-fix script's
+sha256 is now registered in the migrator's known-shipped set, which is what lets it recognise a
+deployed copy and upgrade it. Without that entry the migrator would classify every agent in the
+field as locally-modified, drop a `.new` file beside the old script, and every existing agent would
+keep the mis-reporting version. A locally-customised script is still never overwritten — it keeps
+its place and gets the new version alongside for the operator to reconcile.
+
+## Evidence
+
+- **Unit (8 tests)** — drives the real script against a stubbed transport: suppression reported and
+  non-zero exit, delivery id named when present and omitted when absent, plus the fail-open
+  guards (string `"true"`, explicit `false`, non-JSON body, and a 408 that must keep its existing
+  AMBIGUOUS branch). Verified to fail for the right reason: against the pre-fix template the 3
+  detection tests fail while the 5 no-regression guards pass in both directions.
+- **Integration (8 tests)** — runs the real `migrateScripts()` against a pre-fix script already on
+  disk in both deployed locations; asserts the upgrade, the backup, executability, double-run
+  idempotency, and that a customised script is preserved with a `.new` candidate. Verified
+  load-bearing: removing only the registered sha fails 4 of the 8, including the one asserting a
+  deployed script is actually patched.
+- **E2E (8 tests)** — stands up an agent that already exists on the pre-fix relay, confirms it
+  exhibits the defect, runs the real public `migrate()`, then executes that agent's own upgraded
+  script and asserts it reports the suppression honestly. Both the `.claude/` and the
+  framework-neutral `.instar/` copies are covered, and a genuine send still succeeds.
+- The patched template is byte-identical to a version proven in live operation before being
+  carried upstream.
+
+## What to Tell Your User
+
+- **Some replies you never received were reported to me as sent — this fixes the reporting, and
+  you don't need to do anything.** If I tried to send you the same text twice in quick succession,
+  the second copy was dropped on purpose (that part is a feature). The bug was that I was told the
+  drop had succeeded, so I believed I had answered you when nothing had arrived. I now find out,
+  and can tell you or send something different instead.
+- **This reaches agents that already exist, not just new ones**, so no reinstall is needed — it
+  arrives with your next update.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Suppressed duplicates reported as `NOT SENT` with a non-zero exit | Automatic. `telegram-reply.sh` reads `suppressedDuplicate` from the 200 response instead of discarding it. |
+| The fix reaches agents that already exist | Automatic on update. The pre-fix script's sha256 is registered in the migrator's known-shipped set, so deployed copies are recognised and upgraded (a customised script is preserved with a `.new` candidate). |

--- a/upgrades/side-effects/relay-suppressed-duplicate-honesty.md
+++ b/upgrades/side-effects/relay-suppressed-duplicate-honesty.md
@@ -1,0 +1,269 @@
+# Side-Effects Review — relay reports a suppressed duplicate as NOT SENT
+
+**Version / slug:** `relay-suppressed-duplicate-honesty`
+**Date:** `2026-08-20`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (see reasoning under §4)
+
+## Summary of the change
+
+The outbound Telegram relay reported messages as delivered that the user never
+saw. When the server drops an exact repeat of a message already sent to a topic
+recently, it answers **HTTP 200** with `{ suppressedDuplicate: true }`
+(`src/server/routes.ts`, four call sites). `src/templates/scripts/telegram-reply.sh`
+read only the status line, discarded the body, printed `Sent N chars to topic N`
+and exited **0**. The exit status is the only delivery signal most callers check,
+so a suppressed send was indistinguishable from a successful one — the agent
+moved on believing it had answered.
+
+Three changes:
+
+1. `src/templates/scripts/telegram-reply.sh` — seven lines inside the existing
+   `HTTP 200` arm: if the body carries `suppressedDuplicate: true`, print
+   `NOT SENT — suppressed duplicate for topic <id>…` (naming the delivery id when
+   the server supplied one) and exit **1**.
+2. `src/core/PostUpdateMigrator.ts` — register the pre-fix template's sha256
+   (`4464581188f5c736…`) in `TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS`. Instar agents
+   update in place, so a template-only change reaches only newly created agents.
+   Without this entry the SHA-history migrator classifies every deployed copy as
+   locally-modified, writes a `.new` candidate beside it, and every existing agent
+   keeps the mis-reporting script. **The registration is the deliverable, not an
+   extra** — `tests/integration/…-migration.test.ts` fails without it.
+3. Tests at all three tiers (unit / integration / e2e).
+
+## Decision-point inventory
+
+The suppression decision itself is **not** touched. It is made server-side and
+already exists; this change only reports it.
+
+- `src/server/routes.ts` duplicate suppression — **pass-through** — unchanged; the
+  server still decides what to suppress and still answers 200.
+- `telegram-reply.sh` outcome rendering — **modify** — a reporting branch, not a
+  gate. It renders an outcome the server already chose.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — the script blocks nothing.** By the time this branch
+runs, the send has already happened or already been dropped by the server.
+
+The analogous risk is a **false NOT SENT**: if the branch claimed suppression on a
+message that was genuinely delivered, an agent would re-send text the user already
+has. Three properties bound this, each pinned by a test:
+
+- The check is Python's `is True`, not a truthiness test. `"suppressedDuplicate":
+  "true"` (a string) does **not** trigger it.
+- A missing key, an explicit `false`, or a non-JSON 200 body fails toward
+  `Sent …` — the status quo — because an unparseable body is not evidence of
+  suppression.
+- If `python3` is absent, `2>/dev/null` makes the `if` false and the script falls
+  through to the old behavior. `python3` is already a hard dependency of this
+  script (31 pre-existing uses, documented at line ~311), so this adds none.
+
+Every uncertain input therefore resolves to the pre-change behavior, never to a
+false refusal.
+
+---
+
+## 2. Under-block
+
+Honest gaps that remain after this change:
+
+- **A caller that ignores the exit status still learns nothing.** The signal is
+  stdout plus exit 1; anything discarding both is unaffected.
+- **Only the `suppressedDuplicate` shape is covered.** Other ways a send can end
+  without reaching the user (a tone-gate hold, the 408 ambiguous path) keep their
+  existing separate branches; this change neither improves nor degrades them.
+- **`.claude/scripts/` and `.instar/scripts/` are the two copies migrated.** A copy
+  an operator placed elsewhere is not reached, by the same rule that has always
+  governed this migrator.
+- **A locally-customised script is deliberately not fixed.** It gets a `.new`
+  candidate and a degradation event; the operator reconciles it. Preserving
+  customisation is the existing contract and is worth the residual dishonesty on
+  those installs.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is at the **reporting** layer, which is exactly where the information was
+being destroyed. The server already computed and transmitted the correct verdict;
+the script threw it away. Moving the fix lower (into the server) would mean
+changing the response status code away from 200 — a wider blast radius touching
+every other caller of `/telegram/reply`, to fix a defect that lives entirely in
+one consumer. Moving it higher (an LLM gate) would be absurd for reading a boolean
+the server already decided.
+
+It re-uses the primitive already present: `BODY` is captured two lines above and
+was simply unread. No new parsing machinery, no new dependency, no new state.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No — this change has no block/allow surface.**
+
+The branch holds no authority: it cannot cause or prevent a send. It transcribes a
+verdict an existing authority (the server's suppression logic) already reached and
+already put in the response body. This is the opposite of the anti-pattern the
+principle guards against — rather than a brittle detector acquiring blocking power,
+an existing authority's decision stops being silently discarded.
+
+Because there is no block/allow surface and no gate/sentinel/watchdog behavior, the
+Phase-5 second-pass trigger list does not apply. Recorded as `not-required` rather
+than skipped: the change modifies outbound-messaging *reporting*, which is adjacent
+to the trigger list, so the reasoning is stated explicitly here for review.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+**No new static heuristic at a competing-signals decision point.** There are no
+competing signals to weigh: exactly one authority (the server) produces exactly one
+unambiguous boolean, transmitted in the same response. Reading a field is not a
+judgment; the domain is enumerable and the invariant is "report what the server
+said."
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the branch is the first statement inside the `HTTP 200` arm and
+  can shadow only the `Sent …` line in that arm — which is precisely the
+  intent, and only when the server says the message was suppressed. It cannot
+  shadow the `408`, `409`, `422` or transport-ambiguity branches, which are
+  `elif`/earlier arms. A test asserts a 408 response still renders `AMBIGUOUS`.
+- **Double-fire:** none. It emits at most one line and then exits; it enqueues
+  nothing and posts no delivery-failure event.
+- **Races:** none. It reads a local shell variable already captured from a
+  completed HTTP response, and shares no state with concurrent code.
+- **Feedback loops:** exit 1 is the intended new input to the caller. The relevant
+  question is whether it could provoke a retry storm: it cannot, because the
+  condition is *this exact text was already delivered to this topic recently* — a
+  retry of the same text hits the same suppression and reports the same honest
+  refusal, rather than being silently absorbed. That is strictly better than the
+  prior behavior, where the agent believed the first send had landed.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / install base:** every agent that updates receives the new script.
+  The user-visible change is that a previously-silent failure now announces itself.
+- **Callers parsing stdout:** the `Sent N chars` line is unchanged on the success
+  path. The new line appears only on suppression, where the old output was a false
+  success.
+- **Exit-status contract:** this is the one genuine behavioral change — a case that
+  used to exit 0 now exits 1. That is the fix. Wrappers treating any non-zero exit
+  as "relay broken" will now surface a suppressed duplicate as a relay error, which
+  is a truthful, if blunt, improvement over reporting it as sent.
+- **External systems:** none. No Telegram API change, no new endpoint, no network
+  call added.
+- **Persistent state:** the migrator writes one backup under
+  `.instar/backups/telegram-reply.sh.<ts>` on upgrade — the pre-existing behavior of
+  this migrator, not new.
+- **Operator surface (Mobile-Complete):** no operator-facing action is added or
+  touched. Nothing to complete from a phone.
+
+---
+
+## 6b. Operator-surface quality
+
+**No operator surface — not applicable.** No dashboard renderer, approval page, or
+grant/revoke/secret-drop form is staged.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, with the reason: the relay script is a file on each
+machine's own disk, executed by that machine's sessions, and the duplicate
+suppression it reports is a decision made by *that machine's* server about *that
+machine's* recent sends. There is no shared state to replicate and no merged read
+that would be meaningful — "which machines have the fixed script?" is answered by
+each machine running its own `PostUpdateMigrator` on its own update, which is the
+existing distribution path for every shipped script.
+
+- **User-facing notices:** none emitted by this change. The line goes to the
+  calling session's stdout, not to a user channel, so no one-voice gating applies.
+- **Durable state:** the only durable artifact is the machine-local backup file,
+  which is not conversation state and cannot strand on topic transfer.
+- **Generated URLs:** none.
+
+A second machine changes nothing about this feature's correctness: each machine
+independently updates and independently reports its own suppressions.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert both source changes and ship as the next patch. Pure
+  code and template; no data migration, no agent state repair.
+- **Honest rollback asymmetry worth knowing:** agents that already migrated keep the
+  fixed script. On a revert their on-disk copy would no longer match any registered
+  SHA, so the migrator would leave it in place and drop a `.new` candidate beside
+  it. The practical effect is that a rollback stops *new* agents from getting the
+  fix but does not un-fix already-updated ones. That is the safe direction (nobody
+  regresses to being lied to), and it costs one stray `.new` file per agent, which
+  the existing degradation event already surfaces.
+- **User visibility during rollback:** none — no user-facing surface changes.
+
+---
+
+## Conclusion
+
+The review found no over-block surface, because the change adds no authority: it
+reports a decision the server had already made and the script had been discarding.
+The one genuine behavioral change is the exit status on a previously-silent failure
+path, which is the point of the fix. The review's substantive contribution was
+forcing the fail-open direction to be checked explicitly — a false `NOT SENT` is
+the only way this could harm a user, and it is bounded by an `is True` identity
+test plus fail-through on unparseable, missing, and non-boolean values, each pinned
+by a test.
+
+The second finding worth recording is that the migration, not the script edit, is
+the load-bearing half. This was verified rather than asserted: removing only the
+registered SHA and re-running the integration tier fails four tests, including the
+one asserting a deployed pre-fix script is actually patched. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required — see §4. The change adds no block/allow decision, no
+session-lifecycle behavior, and no gate, sentinel, guard, or watchdog. The Phase-5
+trigger list does not match.
+
+---
+
+## Evidence pointers
+
+- The fix is byte-identical to a version proven in live operation on the authoring
+  machine before being carried upstream; the patched template matches that running
+  script exactly (`diff` clean).
+- `tests/unit/telegram-reply-suppressed-duplicate.test.ts` — 8 tests. Verified to
+  fail for the right reason: against the pre-fix template the 3 detection tests
+  fail while the 5 no-regression guards pass in both directions.
+- `tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts` —
+  8 tests. Verified load-bearing: removing only the registered SHA fails 4.
+- `tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts` — 8 tests. Captures
+  the defect on a pre-existing agent, runs the real public `migrate()`, then
+  executes that agent's own migrated script and asserts it now reports honestly.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+**Not applicable — no agent-authored-artifact defect.** The defect is in a shipped
+shell template's handling of an HTTP response body, not in an LLM prompt, hook,
+config, skill, or standards text. The registry at `docs/defect-classes.json` was
+read and carries no class matching a shell consumer discarding a response field.
+
+Explicitly on the `unbounded-self-action` class: **not applicable.** This change
+adds and modifies no self-triggered controller — no loop, monitor, sentinel,
+reaper, scheduler, or recovery path, and it fires no restart, swap, respawn, spawn,
+notify, retry, re-drive, or kill. It is a synchronous report of an
+already-completed request, executed only when a caller invokes the script.


### PR DESCRIPTION
## ⛔ HOLD — do not merge

The ship call on this belongs to Observer 1. The title prefix and the
`do-not-merge` label are both deliberate: the green-PR auto-merge watcher is live
on the authoring machine, and the title prefix is what excludes this PR from ever
being armed. Auto-merge has been verified to be **not** enabled.

## ELI16 — the relay said "sent" for messages nobody received

When the server quietly drops a repeated message, the script that sends it used to
report success anyway — so the agent believed it had answered when the user had
heard nothing.

Your agent has a duplicate guard: if it tries to send the exact same text to the
same conversation twice in a short window, the server drops the second copy so you
don't get spammed. That part works as intended. The bug is what the agent was told
afterwards. The server replies "OK" — and includes a note saying *"I suppressed
that one, it was a duplicate."* The little script that does the sending read only
the "OK" and threw the note away. It printed `Sent 412 chars` and reported success.

So the agent ticked the task off and moved on, genuinely believing it had replied.
From your side, nothing arrived. No error, no warning, no record anywhere the agent
could later check. The failure was completely silent, and silent in the worst
possible direction: the agent was confident.

**What this adds.** The script now reads the note it was already being sent. On a
suppression it prints `NOT SENT — suppressed duplicate for topic 12345…` and exits
with a failure status instead of a success one. That exit status is the part that
matters most, because it is the signal most callers actually check.

The second half is less visible and more important: **existing agents actually
receive the fix.** Instar agents update in place, so new source code is not enough
on its own. The migrator identifies deployed copies by their exact fingerprint and
only upgrades ones it recognises as genuinely shipped by us. The fingerprint of the
current broken version had to be registered — otherwise the migrator treats every
agent in the field as "someone edited this, leave it alone", drops a `.new` file
beside it, and every existing agent keeps the lying script forever. **That
registration is the real deliverable; the seven-line script change is inert without
it.**

**The safeguards.** A false "not sent" would be worse than the original bug — the
agent would send you the same message twice — so the check is strict rather than
generous. It requires exactly the boolean `true`; the *word* "true" as text does not
count. If the reply is unreadable, the field is missing, or the tool used to read it
isn't installed, the script falls back to its old behaviour rather than guessing.
Every uncertain case resolves toward the way things worked before, never toward a
false alarm. A hand-customised script is never overwritten — it gets a `.new`
alongside and a notice for a human. The new branch sits inside the existing "OK"
path only, so the timeout, ambiguous-transport and blocked-message paths behave
exactly as before; a test pins each.

**Rollback** is a plain revert with no data to clean up. One honest wrinkle: agents
that already updated keep the fixed script, since the migrator would no longer
recognise it. That is the safe direction — a rollback stops new agents getting the
fix, but pushes nobody back to being told their unsent messages were sent.

Full companion: `docs/eli16/RELAY-SUPPRESSED-DUPLICATE-HONESTY.md` (in this commit).

## What the defect was

The server answers a suppressed duplicate send with **HTTP 200** and
`suppressedDuplicate: true` — 200 because a suppressed send is not an error from
its side, with the real outcome carried in the response body
(`src/server/routes.ts`, four call sites).

`telegram-reply.sh` captured `BODY` and then branched only on the status line. It
printed `Sent N chars to topic N` and exited **0**. The exit status is the only
delivery signal most callers check, so a suppressed send was indistinguishable
from a delivered one: the agent ticked the reply off and moved on while the user
received nothing — no error, no retry, no log entry. Silent in the worst
direction, because the agent was confident.

## The three changes (additions only)

1. **`src/templates/scripts/telegram-reply.sh`** (+7) — a branch inside the existing
   `HTTP 200` arm: on a genuine suppression it prints
   `NOT SENT — suppressed duplicate for topic <id>…` (naming the delivery id when
   present) and exits **1**. The check is strict rather than generous, because a
   false NOT SENT would make an agent re-send a message the user already has: it
   requires exactly boolean `true`, and a missing field, an explicit `false`, an
   unparseable body or a missing `python3` all fall through to the previous
   behaviour.

2. **`src/core/PostUpdateMigrator.ts`** (+10: 1 constant + 9 comment lines) —
   registers the pre-fix script's sha256 in `TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS`.
   Instar agents update in place, so the template change alone would reach only
   newly created agents. Without this registration every agent in the field is
   classified locally-modified, gets a `.new` candidate, and keeps the
   mis-reporting script. **The registration is the deliverable, not an extra** —
   removing it alone fails 4 of the 8 integration tests. A genuinely customised
   script is still never overwritten; no migrator logic was changed.

3. **Three test tiers — 24 tests, none skipped.**

| Tier | File | Tests |
|---|---|---|
| Unit | `tests/unit/telegram-reply-suppressed-duplicate.test.ts` | 8 |
| Integration | `tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts` | 8 |
| E2E | `tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts` | 8 |

Each tier was verified to **fail for the right reason**, not merely to pass:

- Reverting only the template → the 3 unit detection tests fail; the 5 fail-open /
  no-regression guards pass in **both** directions (they pin behaviour that must
  not change).
- Removing only the registered SHA → 4 of 8 integration tests fail, including the
  one asserting a deployed pre-fix script is actually patched.
- The e2e stands up a pre-existing agent, **confirms it exhibits the defect**, runs
  the real public `migrate()`, then executes that agent's own upgraded script and
  asserts it reports honestly. Both deployed copies (`.claude/scripts/` and the
  framework-neutral `.instar/scripts/`) are covered.

## Provenance

The patched template is byte-identical to a version proven in live use — the fix
was lifted from the deployed script rather than retyped. Done through
`/instar-dev`; the commit passed the real pre-commit gate with no `--no-verify`,
and its side-effects review, ELI16 overview, release fragment and decision-audit
record are inside the commit.

**Recorded, not hidden:** Tier 1 was declared below a risk floor of 2. The floor
fires on `PostUpdateMigrator.ts` as fleet-migration machinery. Reasoning: the edit
is one string in a data set; the migrator only overwrites content whose sha256 it
recognises as verbatim-shipped, and backs it up first, so it is reversible by
construction. Observer 1 may prefer a converged spec instead — that call is theirs.

## Honest note on the local pre-push tier

The local smoke tier reported `SKIPPED` (`reason=affected-set-indeterminate`,
tests run: 0) because the affected-test listing timed out. That is neither a pass
nor a fail — CI is the authority here and runs the full suite.
