### PR TITLE
fix(follow-me): the outermost timeout in the cross-machine sign-in chain was the smallest

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-20T19-12-21-240Z-followme-timeout-budget-chain.json
+++ b/.instar/instar-dev-decisions/2026-08-20T19-12-21-240Z-followme-timeout-budget-chain.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-08-20T19:12:21.240Z",
+  "slug": "followme-timeout-budget-chain",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 138,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/server/AgentServer.ts",
+      "src/server/middleware.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 131,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1197,7 +1197,17 @@ export class AgentServer {
     // window with it — see buildRequestTimeoutOverrides() for the live incident.
     const paritySourceTotalTimeoutMs = (options.config as { feedbackMigration?: { paritySource?: { totalTimeoutMs?: number } } })
       .feedbackMigration?.paritySource?.totalTimeoutMs;
-    this.app.use(requestTimeout(options.config.requestTimeoutMs, buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs })));
+    // The account-follow-me cross-machine sign-in chain derives its four nested
+    // budgets from this one operator knob — widening the remote scrape budget
+    // must widen every budget above it, or the chain silently re-inverts and the
+    // operator gets a bare 408 instead of the handler's classified outcome.
+    const followMeRemoteScrapeTimeoutMs = (options.config as {
+      multiMachine?: { accountFollowMe?: { remoteScrapeTimeoutMs?: number } };
+    }).multiMachine?.accountFollowMe?.remoteScrapeTimeoutMs;
+    this.app.use(requestTimeout(
+      options.config.requestTimeoutMs,
+      buildRequestTimeoutOverrides({ paritySourceTotalTimeoutMs, followMeRemoteScrapeTimeoutMs }),
+    ));
 
     // ── Token Ledger ──────────────────────────────────────────────────
     // Read-only token-usage observability. Reads Claude Code's per-session

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -437,6 +437,96 @@ export const POOL_TRANSFER_TIMEOUT_MS = 75_000;
 export const PARITY_ROUTE_SLACK_MS = 60_000;
 
 /**
+ * ── Account-follow-me cross-machine sign-in: the BUDGET CHAIN ──────────────
+ *
+ * A single "Set up" tap on the Subscriptions grid nests FOUR budgets. Each
+ * outer one must strictly exceed everything it wraps, or a dumb timer kills a
+ * still-legitimate operation and REPLACES the handler's honest, classified
+ * outcome (`502 login-did-not-start / retryable`, `409 cannot-resolve-email`,
+ * `201 reused`) with a bare "Request timeout" the operator cannot act on:
+ *
+ *   L1  POST /subscription-pool/matrix/start-cell   (fronting machine, this map)
+ *   L2  ├─ mandate delivery over the mesh           (FOLLOWME_MANDATE_DELIVERY_BUDGET_MS)
+ *       └─ relay fetch → the target's enroll/start  (followMeRelayFetchMs)
+ *   L3     POST /subscription-pool/follow-me/enroll/start  (TARGET machine, this map)
+ *   L4       FrameworkLoginDriver.drive() pane scrape      (remoteScrapeTimeoutMs)
+ *
+ * Shipped state (2026-08-20, reported by the operator as "Couldn't start:
+ * Request timeout" on a cross-machine cell): L1 and L3 both inherited the 30s
+ * DEFAULT while L2's relay was hard-coded to 40s and L4 was configured to
+ * 180s. So the outermost budget was the SMALLEST — the inversion fired on every
+ * cross-machine tap slower than 30s, which on a Cloudflare-routed peer is the
+ * normal case, not the edge case.
+ *
+ * This is the SAME "408 while the handler keeps running" failure class that
+ * OUTBOUND_MESSAGING_TIMEOUT_MS, PARITY_PASS_TIMEOUT_MS and
+ * POOL_TRANSFER_TIMEOUT_MS each already exist to prevent. It recurred here
+ * because those three were fixed as individual constants, so a NEW nested route
+ * had nothing to inherit. Deriving the whole chain from one source — and
+ * asserting the ordering in a test — is what makes the fix structural instead
+ * of a fourth spot-fix waiting for a fifth.
+ */
+
+/** Mesh bound on `deliverMandateToMachine` (commands/server.ts `timeoutMs: 15_000`).
+ *  Mirrored here because start-cell spends it BEFORE its relay fetch begins. */
+export const FOLLOWME_MANDATE_DELIVERY_BUDGET_MS = 15_000;
+
+/** Driver default when `remoteScrapeTimeoutMs` is unset (FrameworkLoginDriver). */
+export const FOLLOWME_DEFAULT_SCRAPE_TIMEOUT_MS = 60_000;
+
+/** Spawn + artifact-parse + store-write the target does AROUND the pane scrape. */
+export const FOLLOWME_ENROLL_START_SLACK_MS = 30_000;
+
+/** Slack so the relay fetch outlives the target ROUTE it is waiting on. */
+export const FOLLOWME_RELAY_SLACK_MS = 10_000;
+
+/** Slack so start-cell's route budget outlives mandate delivery + its relay. */
+export const FOLLOWME_START_CELL_SLACK_MS = 10_000;
+
+/**
+ * Budget for the two SIMPLE fronting relays (`follow-me/submit-code`,
+ * `follow-me/cancel`). Their target-side work never drives a login — it types a
+ * code into a live pane (bounded by the identity oracle's own 10s) or kills one
+ * — so they keep the fixed 40s relay fetch and need only a route budget above
+ * it. submit-code is the one that MUST NOT 408: a verification code is
+ * single-use, so a timeout there leaves the operator unable to tell whether
+ * their one shot was spent.
+ */
+export const FOLLOWME_SIMPLE_RELAY_FETCH_MS = 40_000;
+export const FOLLOWME_SIMPLE_RELAY_ROUTE_MS = 60_000;
+
+export interface FollowMeBudgets {
+  /** L4 — the pane-scrape budget actually in force on the target. */
+  scrapeMs: number;
+  /** L3 — route budget for the target's `follow-me/enroll/start`. */
+  enrollStartRouteMs: number;
+  /** L2 — the fronting machine's relay fetch to that route. */
+  relayFetchMs: number;
+  /** L1 — route budget for `matrix/start-cell`. */
+  startCellRouteMs: number;
+}
+
+/**
+ * Derive the whole chain from the ONE operator-tunable value
+ * (`multiMachine.accountFollowMe.remoteScrapeTimeoutMs`), so widening the scrape
+ * budget for a slow remote widens every budget above it instead of silently
+ * re-inverting the chain. Strict `<` ordering is asserted in the unit test.
+ */
+export function resolveFollowMeBudgets(remoteScrapeTimeoutMs?: number): FollowMeBudgets {
+  const scrapeMs =
+    typeof remoteScrapeTimeoutMs === 'number' &&
+    Number.isFinite(remoteScrapeTimeoutMs) &&
+    remoteScrapeTimeoutMs > 0
+      ? remoteScrapeTimeoutMs
+      : FOLLOWME_DEFAULT_SCRAPE_TIMEOUT_MS;
+  const enrollStartRouteMs = scrapeMs + FOLLOWME_ENROLL_START_SLACK_MS;
+  const relayFetchMs = enrollStartRouteMs + FOLLOWME_RELAY_SLACK_MS;
+  const startCellRouteMs =
+    relayFetchMs + FOLLOWME_MANDATE_DELIVERY_BUDGET_MS + FOLLOWME_START_CELL_SLACK_MS;
+  return { scrapeMs, enrollStartRouteMs, relayFetchMs, startCellRouteMs };
+}
+
+/**
  * The production per-path request-timeout overrides. Exported as the single
  * source of truth so wiring-integrity tests assert against the SAME map the
  * server actually wires — never a hand-rolled copy that could pass while the
@@ -450,8 +540,12 @@ export const PARITY_ROUTE_SLACK_MS = 60_000;
  * live 2026-06-05: 600s/page configured, 360s route → four concurrent passes).
  * The constant stays the floor; the derived budget never shrinks below it.
  */
-export function buildRequestTimeoutOverrides(opts?: { paritySourceTotalTimeoutMs?: number }): Record<string, number> {
+export function buildRequestTimeoutOverrides(opts?: {
+  paritySourceTotalTimeoutMs?: number;
+  followMeRemoteScrapeTimeoutMs?: number;
+}): Record<string, number> {
   const configuredTotal = opts?.paritySourceTotalTimeoutMs;
+  const followMe = resolveFollowMeBudgets(opts?.followMeRemoteScrapeTimeoutMs);
   const parityBudgetMs = typeof configuredTotal === 'number' && Number.isFinite(configuredTotal) && configuredTotal > 0
     ? Math.max(PARITY_PASS_TIMEOUT_MS, configuredTotal + PARITY_ROUTE_SLACK_MS)
     : PARITY_PASS_TIMEOUT_MS;
@@ -473,6 +567,20 @@ export function buildRequestTimeoutOverrides(opts?: { paritySourceTotalTimeoutMs
     // WS1.2: the deterministic transfer awaits the owner-side drain (≤ drain
     // bound + the 50s remote-call cap) synchronously — see POOL_TRANSFER_TIMEOUT_MS.
     '/pool/transfer': POOL_TRANSFER_TIMEOUT_MS,
+    // Account-follow-me cross-machine sign-in chain — see the FollowMeBudgets
+    // block above. These four entries are what stop the outermost budget from
+    // being the smallest one in the stack.
+    //
+    // NOTE the prefix matcher is longest-prefix over `path` OR `path + '/'`, and
+    // the target-side submit-code/cancel routes are PARAMETERISED
+    // (`/follow-me/enroll/:id/submit-code`), so they sit UNDER the
+    // '/subscription-pool/follow-me/enroll' prefix and inherit the enroll-start
+    // budget. That is deliberate: the target-side completion runs the S7 email
+    // gate and must not 408 mid-add either.
+    '/subscription-pool/follow-me/enroll': followMe.enrollStartRouteMs,
+    '/subscription-pool/matrix/start-cell': followMe.startCellRouteMs,
+    '/subscription-pool/follow-me/submit-code': FOLLOWME_SIMPLE_RELAY_ROUTE_MS,
+    '/subscription-pool/follow-me/cancel': FOLLOWME_SIMPLE_RELAY_ROUTE_MS,
   };
 }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -120,7 +120,7 @@ import {
 } from '../core/PlaywrightProfileRegistry.js';
 import { PlaywrightSeatLease } from '../core/PlaywrightSeatLease.js';
 import { writeConfigAtomic, readSelfKnowledgeFlags } from '../core/BootSelfKnowledge.js';
-import { rateLimiter, signViewPath, OUTBOUND_GATE_REVIEW_BUDGET_MS } from './middleware.js';
+import { rateLimiter, signViewPath, OUTBOUND_GATE_REVIEW_BUDGET_MS, resolveFollowMeBudgets, FOLLOWME_SIMPLE_RELAY_FETCH_MS } from './middleware.js';
 import { reviewWithinBudget } from './outboundGateBudget.js';
 import { resolveToneRecipientClass } from './toneRecipientClass.js';
 import { RULE_DISPOSITIONS, buildDegradedToneResult, resolveToneGateOperatorConfig, fingerprintAutomatedTemplate } from '../core/MessagingToneGate.js';
@@ -30530,7 +30530,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         method: 'POST',
         headers: { Authorization: `Bearer ${ctx.config.authToken}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ code }),
-        signal: AbortSignal.timeout(40_000),
+        signal: AbortSignal.timeout(FOLLOWME_SIMPLE_RELAY_FETCH_MS),
       });
       const body = await r.json().catch(() => ({}));
       res.status(r.status).json(body);
@@ -30571,7 +30571,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       const r = await fetch(`${baseUrl}/subscription-pool/follow-me/enroll/${encodeURIComponent(id)}/cancel`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${ctx.config.authToken}`, 'Content-Type': 'application/json' },
-        signal: AbortSignal.timeout(40_000),
+        signal: AbortSignal.timeout(FOLLOWME_SIMPLE_RELAY_FETCH_MS),
       });
       const body = await r.json().catch(() => ({}));
       res.status(r.status).json(body);
@@ -30592,7 +30592,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // fingerprints or raw mandate JSON. Idempotent: a re-tap reuses an existing valid pending login
   // for this pair (no duplicate, no stacked mandate). Dark behind multiMachine.accountFollowMe.
   router.post('/subscription-pool/matrix/start-cell', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/matrix/start-cell'), async (req, res) => {
-    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
+    const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean; remoteScrapeTimeoutMs?: number } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
       return;
@@ -30724,11 +30724,17 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       baseUrl = peer.url;
     }
     try {
+      // The relay must OUTLIVE the target's own enroll/start route budget, which
+      // in turn outlives its pane-scrape budget. All three derive from the one
+      // `remoteScrapeTimeoutMs` knob (resolveFollowMeBudgets) — a hard-coded 40s
+      // here aborted a peer that was still legitimately working (the 2026-08-20
+      // "Couldn't start: Request timeout" report).
+      const relayFetchMs = resolveFollowMeBudgets(afmCfg?.remoteScrapeTimeoutMs).relayFetchMs;
       const r = await fetch(`${baseUrl}/subscription-pool/follow-me/enroll/start`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${ctx.config.authToken}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ mandateId, accountId }),
-        signal: AbortSignal.timeout(40_000),
+        signal: AbortSignal.timeout(relayFetchMs),
       });
       const body = await r.json().catch(() => ({})) as {
         login?: { id?: string; verificationUrl?: string; expectedEmail?: string; ttlExpiresAt?: string; notice?: string; kind?: string };

--- a/tests/unit/AgentServer-outbound-timeout.test.ts
+++ b/tests/unit/AgentServer-outbound-timeout.test.ts
@@ -97,8 +97,16 @@ describe('request-timeout override map (production wiring)', () => {
     // Regression guard: the global default is still passed as the first arg, and
     // the overrides come from the shared builder (so this test's map == prod's) —
     // fed the configured parity-source total budget so the parity routes' windows
-    // track the operator's degraded-source tuning.
-    expect(agentServerSrc).toMatch(/requestTimeout\(options\.config\.requestTimeoutMs,\s*buildRequestTimeoutOverrides\(\{ paritySourceTotalTimeoutMs \}\)\)/);
+    // track the operator's degraded-source tuning, and the follow-me remote-scrape
+    // budget so the cross-machine sign-in chain cannot re-invert (2026-08-20).
+    // Whitespace-tolerant: the call is formatted across lines, but it must still be
+    // the SHARED BUILDER receiving BOTH config-derived budgets — never an inline literal.
+    expect(agentServerSrc).toMatch(
+      /requestTimeout\(\s*options\.config\.requestTimeoutMs,\s*buildRequestTimeoutOverrides\(\{[^}]*paritySourceTotalTimeoutMs[^}]*\}\),?\s*\)/,
+    );
+    expect(agentServerSrc).toMatch(
+      /buildRequestTimeoutOverrides\(\{[^}]*followMeRemoteScrapeTimeoutMs[^}]*\}\)/,
+    );
     expect(agentServerSrc).toMatch(/feedbackMigration\?\.paritySource\?\.totalTimeoutMs/);
   });
 

--- a/tests/unit/followme-timeout-budget-chain.test.ts
+++ b/tests/unit/followme-timeout-budget-chain.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Wiring-integrity guard for the account-follow-me cross-machine sign-in
+ * BUDGET CHAIN.
+ *
+ * A single "Set up" tap on the Subscriptions grid nests four budgets:
+ *
+ *   L1  POST /subscription-pool/matrix/start-cell        (fronting machine route)
+ *   L2  ├─ mandate delivery over the mesh (15s)
+ *       └─ relay fetch → the target's enroll/start
+ *   L3     POST /subscription-pool/follow-me/enroll/start (target machine route)
+ *   L4       FrameworkLoginDriver.drive() pane scrape     (remoteScrapeTimeoutMs)
+ *
+ * Each outer budget MUST strictly exceed everything it wraps. When it doesn't,
+ * a dumb timer kills a still-legitimate operation and REPLACES the handler's
+ * honest classified outcome with a bare "Request timeout" — the operator loses
+ * the diagnosis entirely.
+ *
+ * Regression under test (2026-08-20, operator report "Couldn't start: Request
+ * timeout" on a cross-machine cell): L1 and L3 inherited the 30s DEFAULT while
+ * L2's relay was hard-coded to 40s and L4 was configured to 180s — the
+ * outermost budget was the SMALLEST in the stack.
+ *
+ * Asserted against the PRODUCTION map + matcher imported directly, never a
+ * hand-rolled copy (PR-#334 dead-code lesson).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildRequestTimeoutOverrides,
+  resolveRequestTimeout,
+  resolveFollowMeBudgets,
+  FOLLOWME_MANDATE_DELIVERY_BUDGET_MS,
+  FOLLOWME_DEFAULT_SCRAPE_TIMEOUT_MS,
+  FOLLOWME_SIMPLE_RELAY_FETCH_MS,
+  FOLLOWME_SIMPLE_RELAY_ROUTE_MS,
+} from '../../src/server/middleware.js';
+
+const DEFAULT_MS = 30_000;
+
+/** The operator-tunable knob, including the value that produced the live report. */
+const SCRAPE_BUDGETS = [undefined, 60_000, 180_000, 240_000];
+
+describe('account-follow-me cross-machine budget chain', () => {
+  describe.each(SCRAPE_BUDGETS)('remoteScrapeTimeoutMs = %s', (scrape) => {
+    const b = resolveFollowMeBudgets(scrape);
+    const overrides = buildRequestTimeoutOverrides({ followMeRemoteScrapeTimeoutMs: scrape });
+    const routeFor = (p: string) => resolveRequestTimeout(p, DEFAULT_MS, overrides);
+
+    it('orders the chain strictly outermost-largest', () => {
+      // L4 < L3
+      expect(b.enrollStartRouteMs).toBeGreaterThan(b.scrapeMs);
+      // L3 < L2
+      expect(b.relayFetchMs).toBeGreaterThan(b.enrollStartRouteMs);
+      // L2 (+ mandate delivery) < L1
+      expect(b.startCellRouteMs).toBeGreaterThan(
+        b.relayFetchMs + FOLLOWME_MANDATE_DELIVERY_BUDGET_MS,
+      );
+    });
+
+    it('honours the configured scrape budget as the chain floor', () => {
+      expect(b.scrapeMs).toBe(scrape ?? FOLLOWME_DEFAULT_SCRAPE_TIMEOUT_MS);
+    });
+
+    it('routes start-cell to its derived budget, never the 30s default', () => {
+      const ms = routeFor('/subscription-pool/matrix/start-cell');
+      expect(ms).toBe(b.startCellRouteMs);
+      expect(ms).toBeGreaterThan(DEFAULT_MS);
+    });
+
+    it('routes the target-side enroll/start above its own pane scrape', () => {
+      const ms = routeFor('/subscription-pool/follow-me/enroll/start');
+      expect(ms).toBe(b.enrollStartRouteMs);
+      expect(ms).toBeGreaterThan(b.scrapeMs);
+    });
+
+    it('covers the parameterised target-side completion routes', () => {
+      // These sit UNDER the '/subscription-pool/follow-me/enroll' prefix; the
+      // S7 email gate runs here, so a 408 mid-add would strand the enrollment.
+      for (const p of [
+        '/subscription-pool/follow-me/enroll/codex-sagemindai/submit-code',
+        '/subscription-pool/follow-me/enroll/codex-sagemindai/cancel',
+      ]) {
+        expect(routeFor(p)).toBeGreaterThan(DEFAULT_MS);
+      }
+    });
+
+    it('start-cell outlives the whole peer round-trip it awaits', () => {
+      expect(routeFor('/subscription-pool/matrix/start-cell')).toBeGreaterThan(
+        routeFor('/subscription-pool/follow-me/enroll/start'),
+      );
+    });
+  });
+
+  describe('simple fronting relays (submit-code, cancel)', () => {
+    const overrides = buildRequestTimeoutOverrides();
+    const routeFor = (p: string) => resolveRequestTimeout(p, DEFAULT_MS, overrides);
+
+    it.each([
+      '/subscription-pool/follow-me/submit-code',
+      '/subscription-pool/follow-me/cancel',
+    ])('%s outlives its own relay fetch', (p) => {
+      const ms = routeFor(p);
+      expect(ms).toBe(FOLLOWME_SIMPLE_RELAY_ROUTE_MS);
+      expect(ms).toBeGreaterThan(FOLLOWME_SIMPLE_RELAY_FETCH_MS);
+      expect(ms).toBeGreaterThan(DEFAULT_MS);
+    });
+  });
+
+  it('leaves unrelated subscription-pool routes on the default budget', () => {
+    const overrides = buildRequestTimeoutOverrides();
+    // Guards against a too-greedy prefix swallowing the whole namespace.
+    for (const p of ['/subscription-pool', '/subscription-pool/poll', '/subscription-pool/swap']) {
+      expect(resolveRequestTimeout(p, DEFAULT_MS, overrides)).toBe(DEFAULT_MS);
+    }
+  });
+
+  it('widening the operator knob widens every budget above it', () => {
+    const small = resolveFollowMeBudgets(60_000);
+    const large = resolveFollowMeBudgets(180_000);
+    expect(large.enrollStartRouteMs).toBeGreaterThan(small.enrollStartRouteMs);
+    expect(large.relayFetchMs).toBeGreaterThan(small.relayFetchMs);
+    expect(large.startCellRouteMs).toBeGreaterThan(small.startCellRouteMs);
+  });
+
+  it('ignores a non-finite or non-positive knob rather than inverting the chain', () => {
+    for (const bad of [0, -1, NaN, Infinity] as number[]) {
+      const r = resolveFollowMeBudgets(bad);
+      expect(r.scrapeMs).toBe(FOLLOWME_DEFAULT_SCRAPE_TIMEOUT_MS);
+      expect(r.enrollStartRouteMs).toBeGreaterThan(r.scrapeMs);
+    }
+  });
+});

--- a/upgrades/next/followme-timeout-budget-chain.md
+++ b/upgrades/next/followme-timeout-budget-chain.md
@@ -1,0 +1,33 @@
+---
+change_type: fix
+---
+
+## What Changed
+
+A cross-machine "Set up" tap on the Subscriptions grid nests four timeout budgets, and the outermost was the smallest. `POST /subscription-pool/matrix/start-cell` and the target machine's `POST /subscription-pool/follow-me/enroll/start` both inherited the 30s global default, while the relay fetch between them was hard-coded to 40s and the pane scrape underneath ran on `multiMachine.accountFollowMe.remoteScrapeTimeoutMs` (default 60s, commonly tuned to 180s for a remote peer). Any cross-machine sign-in slower than 30s therefore returned a bare `408 Request timeout` from the middleware while the handler was still legitimately working — discarding the handler's own classified outcome (`502 login-did-not-start / retryable`, `409 cannot-resolve-email`, `201 reused`).
+
+The same inversion was present on two sibling relays found by sweeping every `AbortSignal.timeout` in route scope: `follow-me/submit-code` and `follow-me/cancel`. The submit-code case is the more severe one — a verification code is single-use, so a 408 there leaves the operator unable to determine whether their one attempt was spent.
+
+All four budgets now derive from the single `remoteScrapeTimeoutMs` knob through `resolveFollowMeBudgets()`, so widening the scrape budget widens every budget above it instead of silently re-inverting the chain. The three hard-coded relay literals are gone.
+
+This is the same "408 while the handler keeps running" class that `OUTBOUND_MESSAGING_TIMEOUT_MS`, `PARITY_PASS_TIMEOUT_MS` and `POOL_TRANSFER_TIMEOUT_MS` each already fixed one instance of. It recurred because those were three independent constants, leaving a newly nested route nothing to inherit.
+
+## Evidence
+
+Reverting the four override entries fails the new unit test with 18 failures naming each inverted route; restoring passes 29/29 across four knob values including the operator's 180s. A prefix-containment assertion confirms `/subscription-pool`, `/subscription-pool/poll` and `/subscription-pool/swap` remain on the 30s default, so the new prefix does not swallow the namespace. The four affected integration suites (`account-matrix-start-cell-route`, `account-follow-me-submit-code-route`, `account-follow-me-cancel-route`, `account-follow-me-enroll-start-route`) pass — 51 tests. The existing `AgentServer-outbound-timeout` wiring assertion was widened for the now multi-line call and additionally asserts the new config-derived argument reaches the shared builder.
+
+## Known Limits
+
+Budgets are computed per machine from that machine's own knob, deliberately — the bound must cover work on that machine's hardware and network path. If the fronting machine's knob is set lower than the target's, its relay can still abort early; that degrades to the honest retryable `502` and never a false success, and retrying is safe because the target reuses a live pending login rather than starting a second. Operators running a non-default knob should set it on every machine.
+
+`FOLLOWME_MANDATE_DELIVERY_BUDGET_MS` mirrors the `timeoutMs: 15_000` literal in `src/commands/server.ts` rather than importing it; raising that literal without updating the constant would erode slack without failing a test.
+
+A wedged peer now surfaces later than before — up to roughly four minutes at a 180s knob, versus 30 seconds. That is the intended trade: the previous behaviour "noticed" quickly by declaring every slow-but-healthy sign-in dead.
+
+## What to Tell Your User
+
+If tapping **Set up** on the Subscriptions grid for another machine gave you "Couldn't start: Request timeout", that was a wrapper giving up on a sign-in that was still running — not the sign-in failing. It is fixed, along with the same problem on the code-paste and cancel steps of that flow. You will now get a real explanation when something genuinely goes wrong, and slow machines (particularly any reachable only over the tunnel rather than a direct network route) get the time they actually need.
+
+## Summary of New Capabilities
+
+No new capabilities — this restores the intended behaviour of the existing account × machine setup grid on multi-machine agents.

--- a/upgrades/side-effects/followme-timeout-budget-chain.eli16.md
+++ b/upgrades/side-effects/followme-timeout-budget-chain.eli16.md
@@ -1,0 +1,71 @@
+# Plain-English overview — why "Set up" said "Request timeout"
+
+## What you were trying to do
+
+On the dashboard's Subscriptions page there's a grid: your accounts down the side, your machines across the top. An empty cell means "this account isn't signed in on that machine yet," and tapping **Set up** is supposed to run the whole sign-in for you without leaving the page.
+
+You tapped Set up on a cell for your Laptop and got **"Couldn't start: Request timeout."** Nothing else. No hint about whether anything had started over there, and no way to tell whether trying again was safe.
+
+## What was actually happening
+
+A single tap on that button sets off a chain of four nested waits. Think of them as nested stopwatches — each one has to outlast everything happening inside it:
+
+1. The **browser's request** to the machine serving your dashboard.
+2. That machine **delivering permission** to the target machine, then **calling it**.
+3. The **target machine's own request handler**.
+4. The target machine **actually launching the sign-in** and reading the code off the screen.
+
+For this to work, the outermost stopwatch has to be the longest. It was the **shortest**.
+
+The two outer waits had never been given their own limits, so they quietly used the system-wide default of **30 seconds**. The call between machines was hard-coded to **40**. And the innermost step — the one doing the real work — was set to **180 seconds**, deliberately, because a remote machine talking to a login provider is genuinely slow.
+
+So the outermost stopwatch stopped at 30 seconds while the real work was still legitimately running, with 150 seconds of its allowance left. The error you saw wasn't the sign-in failing. It was the wrapper giving up on a sign-in that was still going.
+
+Worse: the code underneath already knew how to explain itself. It has real answers ready — "the login didn't start, try again," "I couldn't work out which account this is," "one's already running, here it is." The 30-second wrapper fired first and threw all of that away, replacing it with two useless words.
+
+## Why your Laptop hit it and the others didn't
+
+Your machines talk to each other over several possible routes. The Laptop is currently the only one without a direct one, so its traffic takes a slower path. That's enough to push a normal sign-in past 30 seconds. Your other machines usually squeak under the limit — which is exactly why this looked like "the Laptop is broken" rather than "this button is broken."
+
+## What already existed, and what's new
+
+**Already existed:** the ability to give a specific request a longer allowance. Three other parts of the system had already hit this exact problem and been fixed one at a time — sending messages, a big data-comparison job, and moving a conversation between machines. Each fix was its own hardcoded number.
+
+**That's why it happened again.** Three separate patches meant a newly-added nested request had nothing to inherit. It defaulted to 30 seconds like everything else, and nobody noticed the thing it was wrapping had been given 180.
+
+**What's new:** instead of adding a fourth hardcoded number, all four waits in this chain are now calculated from the single setting you already control — the one that says how long a remote machine gets to start a login. Turn that up and every wait above it grows to match. There is no longer a number anyone can change in isolation to break the ordering.
+
+Plus a test that fails the build if the ordering is ever inverted again, checked across four different settings including yours.
+
+## What I found beyond what you reported
+
+Rather than patch the button you pressed, I checked every cross-machine call in this area for the same mistake. **Three had it**, not one:
+
+- starting the sign-in (what you hit)
+- **pasting your code back**
+- cancelling
+
+The middle one matters more than the one you reported. Your verification code is single-use. A timeout there would leave you genuinely unable to tell whether the code had been spent — retry and it might be rejected as already-used, or might work, with no way to know which. Had I fixed only what you reported, you'd have walked straight into that one step later, holding a code of unknown status.
+
+## Something I checked and did NOT change
+
+I initially believed retrying a timed-out sign-in could start a second one on the far machine, and told you I'd fix it. I was wrong, and I checked before writing code. The target machine already refuses to start a second sign-in when one is live — it hands back the existing one instead. That protection lives on the receiving end rather than the sending end, which is why it wasn't obvious, but it works for every machine.
+
+So retrying was always safe. I dropped that change rather than adding a redundant cross-machine lookup into the very path being fixed.
+
+## The safeguards, in plain terms
+
+- **Nothing gets less time than before.** Every limit moved up. No request that used to succeed can now be cut short.
+- **The system still can't hang forever.** The inner limits are unchanged and still fire first, so a genuinely stuck machine still gets cut off — just after the real work has had its fair chance, not before.
+- **A stuck machine is noticed later than it used to be.** At your 180-second setting, a wedged peer now takes up to ~4 minutes to surface instead of 30 seconds. That's the deliberate trade: the old behaviour "noticed" it fast by declaring every slow-but-healthy sign-in dead.
+- **If your machines disagree about the setting, it fails safe.** If the machine serving your dashboard has a shorter allowance than the one doing the login, you get the honest "couldn't reach that machine — try again," never a false success. And retrying is safe, per above.
+- **Nothing is stored, so nothing needs cleaning up.** Undoing this is deleting the change and restarting.
+
+## What you actually need to decide
+
+**Nothing about this fix** — it has no options and no rollout choice.
+
+Two things do want a decision from you, both separate from this change:
+
+1. **The duplicate Codex row.** Your Laptop registered `justin@sagemindai.io` under its own internal name back in August, while your other two machines share one. Same subscription, two records, so the grid honestly draws two rows. The repair is re-registering the Laptop's copy under the shared name. Until then, **don't tap Set up on the Laptop cell of the second Codex row** — that cell looks empty but isn't, and tapping it would create a *third* registration.
+2. **If you ever change the remote sign-in allowance, set it on every machine.** Mismatched settings still fail safely, just less gracefully than they need to.

--- a/upgrades/side-effects/followme-timeout-budget-chain.md
+++ b/upgrades/side-effects/followme-timeout-budget-chain.md
@@ -1,0 +1,166 @@
+# Side-Effects Review — Account-follow-me cross-machine sign-in budget chain
+
+**Version / slug:** `followme-timeout-budget-chain`
+**Date:** `2026-08-20`
+**Author:** `Echo (instar-dev)`
+**Second-pass reviewer:** `required — see Phase 5 below`
+
+## Summary of the change
+
+A cross-machine "Set up" tap on the Subscriptions grid nests FOUR timeout budgets, and the outermost was the SMALLEST. `POST /subscription-pool/matrix/start-cell` and the target's `POST /subscription-pool/follow-me/enroll/start` both inherited the 30s global default, while the relay fetch between them was hard-coded to 40s and the pane-scrape underneath was configured to 180s (`multiMachine.accountFollowMe.remoteScrapeTimeoutMs`). Every cross-machine tap slower than 30s therefore got a bare `408 {"error":"Request timeout"}` from the middleware while the handler was still legitimately working — destroying the handler's own classified outcome (`502 login-did-not-start / retryable`, `409 cannot-resolve-email`, `201 reused`). Reported live by the operator (Justin, topic 50436, 2026-08-20) as "Couldn't start: Request timeout" against a Cloudflare-routed peer.
+
+The fix derives the whole chain from the single operator knob via `resolveFollowMeBudgets()` in `src/server/middleware.ts`, wires four per-path overrides into `buildRequestTimeoutOverrides()`, threads the config value through `src/server/AgentServer.ts`, and replaces the three hard-coded `AbortSignal.timeout(40_000)` literals in `src/server/routes.ts` with derived/named values. A new unit test asserts strict outermost-largest ordering across four knob values so the chain cannot silently re-invert.
+
+Files touched: `src/server/middleware.ts`, `src/server/AgentServer.ts`, `src/server/routes.ts`, `tests/unit/followme-timeout-budget-chain.test.ts` (new), `tests/unit/AgentServer-outbound-timeout.test.ts` (wiring assertion widened for the multi-line call + the new arg).
+
+## Decision-point inventory
+
+- `requestTimeout` middleware (`src/server/middleware.ts`) — **modify** — a timer-based terminal authority; its threshold for four follow-me paths changes from the 30s default to derived budgets. No new decision surface, no new condition; only the numeric bound moves.
+- `matrix/start-cell` relay abort (`src/server/routes.ts`) — **modify** — hard-coded 40s becomes `resolveFollowMeBudgets(...).relayFetchMs`.
+- `follow-me/submit-code` + `follow-me/cancel` relay aborts — **pass-through** — same 40s value, now the named `FOLLOWME_SIMPLE_RELAY_FETCH_MS` constant instead of a bare literal.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None — the change moves exclusively in the permissive direction. Every affected budget strictly increases (30s → ≥100s for start-cell at the default knob; 30s → ≥90s for enroll/start; 30s → 60s for the two simple relays). No request that previously completed can now be cut short.
+
+The specific over-block being REMOVED: a cross-machine sign-in on a peer reachable only over Cloudflare routinely needs 30–60s just to spawn the CLI and scrape the device code. Every one of those was rejected with a message carrying no diagnostic value.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **A genuinely hung peer now holds a socket longer.** At the operator's configured 180s knob, `start-cell` holds up to 235s before the middleware fires. That is the intended trade — the alternative is cutting off legitimate work — but a wedged peer is now discovered later. Bounded, never unbounded: the relay's own `AbortSignal` fires first, so the handler always returns before the route budget.
+- **The 15s mandate-delivery bound is mirrored, not imported.** `FOLLOWME_MANDATE_DELIVERY_BUDGET_MS` duplicates the `timeoutMs: 15_000` literal in `src/commands/server.ts`. If someone raises that literal without touching the constant, the chain loses slack silently. The test cannot catch this (the value lives behind a closure in a different module). Flagged for the second-pass reviewer; the honest mitigation today is the comment naming the source line.
+- **Nothing here bounds the pane scrape itself.** If `remoteScrapeTimeoutMs` is set absurdly high, the whole chain scales with it. That is the operator's knob and deliberately so.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and the change is specifically about restoring layer precedence.
+
+The `requestTimeout` middleware is the lowest-context participant in this stack: it knows only elapsed milliseconds. The route handler is the high-context one — it knows which peer it is waiting on, holds its own bounded sub-budgets, and produces classified, actionable outcomes. The bug was the low-context timer pre-empting the high-context handler and overwriting its verdict with a contentless one.
+
+The fix does not add a layer or move logic between layers. It makes the outer bound a function of the inner bounds so the smart layer always gets to answer first. Deriving from one source (rather than adding a fourth independent constant) is what stops this from being the fourth spot-fix in the same family — `OUTBOUND_MESSAGING_TIMEOUT_MS`, `PARITY_PASS_TIMEOUT_MS` and `POOL_TRANSFER_TIMEOUT_MS` each fixed one instance of this class and left the next nested route nothing to inherit.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No — this change has no block/allow surface** (in the sense the principle governs).
+
+The principle governs *judgment* decisions — blocking based on what a message means or what an agent intends. A request timeout is explicitly named in the doc's "When this principle does NOT apply" section: it is transport-layer mechanics, not a judgment call, and it evaluates no content.
+
+That said, the bug has a genuine signal-vs-authority shape worth recording: a brittle, zero-context detector (an elapsed-time counter) held terminal authority over a context-rich authority (the handler) and replaced its reasoned verdict with a contentless one. This change removes brittle authority's ability to pre-empt the contextual one. It adds no new blocking power anywhere.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. There are no competing live signals here — the ordering constraint is an arithmetic invariant (an outer bound must exceed the inner bounds it wraps), the domain is fully enumerable, and the invariant is named and asserted in the unit test rather than tuned.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The four new entries are matched by the existing longest-prefix matcher (`resolveRequestTimeout`). `'/subscription-pool/follow-me/enroll'` deliberately covers the parameterised target-side `enroll/:id/submit-code` and `enroll/:id/cancel`, because the S7 email gate runs there and a 408 mid-add would strand an enrollment. Verified the prefix does NOT swallow unrelated siblings: an explicit test asserts `/subscription-pool`, `/subscription-pool/poll` and `/subscription-pool/swap` stay on the 30s default. The matcher's `path === prefix || path.startsWith(prefix + '/')` rule means `'/subscription-pool/follow-me/submit-code'` (the FRONTING relay) is a distinct, longer-matching key from the enroll prefix and gets its own budget — confirmed by test.
+- **Double-fire:** None. A route resolves exactly one budget; the map is a plain lookup.
+- **Races:** None. `buildRequestTimeoutOverrides()` is called once at server construction and produces an immutable map. `resolveFollowMeBudgets()` is pure.
+- **Feedback loops:** None. Nothing consumes these budgets as input to anything that adjusts them.
+- **Retry interaction (checked, no change needed):** the earlier concern that a timeout could strand or duplicate a pending login on the peer proved unfounded. The target's `enroll/start` already reuses a live pending login unconditionally for self AND peer targets (`src/server/routes.ts`, the D5 single-attempt block), so the spec's "a retry never duplicates a pending login" invariant already held end-to-end. No idempotency change was made; the `if (isSelf)` guard on the coordinator's pre-check is correct as written.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the machine / install base:** no behavioural change unless account-follow-me is enabled AND the agent is multi-machine. Single-machine agents never take the peer branch.
+- **External systems:** none. No provider, Telegram, or GitHub surface is touched.
+- **Persistent state:** none. No new files, columns, or ledger entries.
+- **Timing/runtime conditions:** yes, by definition — the change is about time budgets. Sockets on the fronting machine are held longer for cross-machine taps (see §2).
+- **HTTP response shapes:** unchanged. The same statuses are produced; operators simply now receive the handler's real one instead of a 408 that pre-empted it.
+- **Operator surface (Mobile-Complete Operator Actions):** no new operator-facing action. The change makes an EXISTING phone-completable action (the grid's "Set up" / code-paste / cancel cells) actually complete on a slow peer. Nothing moves off the phone.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. No file under `dashboard/` is staged; the dashboard's rendering, wording, and layout are untouched. The change is confined to server-side timeout budgets that the existing grid consumes through unchanged response shapes.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local BY DESIGN, with a derived cross-machine contract.**
+
+Each machine computes its own budgets from its OWN `remoteScrapeTimeoutMs`, because the budget must bound work happening on THAT machine's hardware and network path. Replicating a single pool-wide budget would be wrong: a Cloudflare-only peer legitimately needs a larger scrape budget than a Tailscale-local one.
+
+The cross-machine contract that DOES matter is the ordering between the fronting machine's relay budget and the target's route budget. This is the one genuine multi-machine finding, and it is stated honestly rather than assumed away:
+
+- **If the fronting machine's knob is set LOWER than the target's**, the fronting relay can abort while the target is still legitimately working. The result is the honest, retryable `502 "could not reach the machine doing the login"` — degraded but truthful, and the target's pending login is reused on retry rather than duplicated (§5). It is never a silent success or a fabricated state.
+- The safe direction is therefore preserved under skew, which is why this ships without a cross-machine budget negotiation. Negotiating the budget over the mesh would put another round-trip inside the very path being fixed.
+- Operators who set a non-default knob should set it on every machine. <!-- tracked: CMT-036 -->
+
+**User-facing notices:** none emitted — no one-voice gating needed.
+**Durable state:** none held — nothing to strand on topic transfer.
+**Generated URLs:** none. The `verificationUrl` is produced by the provider and passed through unchanged.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the code change, ship as next patch. Pure code change.
+- **Data migration:** none. No persistent state is written or read.
+- **Agent state repair:** none. Budgets are computed at server construction; a restart fully reverts.
+- **User visibility:** reverting restores the 2026-08-20 bug (cross-machine "Set up" 408s on slow peers). No NEW regression is introduced by rolling back, and no state written under the fix would be left behind.
+
+---
+
+## Conclusion
+
+The review produced two design changes. First, the fix was widened from the one reported route to the whole four-level chain after a sweep of every `AbortSignal.timeout` in route scope found three inverted routes, not one — including `follow-me/submit-code`, which is the more severe instance because a verification code is single-use and a 408 there leaves the operator unable to tell whether their one shot was spent. Fixing only the reported route would have moved the operator's failure one step later in the same flow. Second, an intended idempotency change was DROPPED after verification showed the invariant already held on the target side; the original premise (a self-only carve-out breaking spec conformance) was wrong.
+
+One honest weakness is carried rather than hidden: the 15s mandate-delivery bound is mirrored as a constant rather than imported, so a change to the source literal would erode slack without failing a test (§2). Flagged for second-pass.
+
+Clear to ship pending second-pass review, which IS required — this change touches session/enrollment lifecycle and a gate-adjacent middleware.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Echo (SELF-review — NOT independent)
+**Independent read of the artifact: not obtained**
+
+**Honest status.** Phase 5 requires an INDEPENDENT reviewer subagent for changes touching session lifecycle and gate-adjacent middleware, and this change qualifies. This session operates under a standing constraint prohibiting subagent spawning, so no independent reviewer read this artifact. What follows is an adversarial self-review. It is recorded as such rather than as a concurrence, because a self-review labelled "independent" is exactly the confabulation the cross-agent discipline forbids — the reviewer here shares every blind spot of the author. **A genuine second pass is still owed on this change** and should happen at PR review. <!-- tracked: CMT-036 -->
+
+**Adversarial checks actually run (each verified against the code, not reasoned about):**
+
+1. **Is the router mounted at a prefix that would break path matching?** No — `this.app.use(routes)` at `AgentServer.ts:4179` mounts at root, so `req.path` carries the full path and the new prefixes match. Had it been mounted under e.g. `/api`, all four entries would have been silently dead. Checked because a dead override would leave the bug in place while the unit test passed against the map in isolation.
+2. **Does the timeout middleware actually wrap these routes?** Yes — registered at ~line 1200, routes at 4179. Registration order is the wrapping order in Express.
+3. **Does `'/subscription-pool/follow-me/enroll'` over-match?** It intentionally covers the parameterised `enroll/:id/submit-code` and `enroll/:id/cancel` on the target. It does NOT match the fronting relays `follow-me/submit-code` / `follow-me/cancel` (different segment), which carry their own keys. Asserted by test, including a containment test that `/subscription-pool`, `/subscription-pool/poll`, `/subscription-pool/swap` stay on the default.
+4. **The self-target loopback case.** When `machineId === selfMachineId`, start-cell calls its OWN server's enroll/start, so two nested requests hit the same middleware. Ordering still holds (`startCellRouteMs > relayFetchMs > enrollStartRouteMs`), so the inner request cannot outlive the outer one. This case is easy to miss because it is not the reported scenario.
+5. **Could a timeout evade the sweep via `AbortController` + `setTimeout`?** One such site exists in `routes.ts` (`/telemetry/disable`, 5s) — well under the default, not an inversion. No other route-scope instance.
+6. **Does the change move any budget DOWN?** No. Every affected value strictly increases; no previously-succeeding request can now be cut short.
+
+**Concerns raised by this pass, carried into the artifact rather than resolved:**
+
+- **The mirrored 15s constant (§2).** `FOLLOWME_MANDATE_DELIVERY_BUDGET_MS` duplicates a literal in another module behind a closure. No test can bind them. This is a real, if small, drift surface and the honest mitigation today is only a comment naming the source.
+- **Cross-machine knob skew (§7).** Fails safe, but degrades. Not resolved here because negotiating budgets over the mesh would add a round-trip inside the path being fixed.
+- **Later detection of a wedged peer (§2).** Accepted trade, stated plainly rather than buried.
+
+**Self-review verdict:** the change is sound and its weaknesses are stated rather than hidden — but this verdict carries the weight of a self-review only.
+
+---
+
+## Evidence pointers
+
+- Negative control: reverting the four override entries fails the new test with 18 failures naming each inverted route; restoring passes 29/29.
+- Affected integration suites green: `account-matrix-start-cell-route`, `account-follow-me-submit-code-route`, `account-follow-me-cancel-route`, `account-follow-me-enroll-start-route` — 51 tests.
+- Live diagnosis: `GET /subscription-pool?scope=pool` on the reporting agent; `/mesh/rope-health` showing the target peer carrying only `lan` + `cloudflare` ropes (no Tailscale), i.e. the slow path that made a 30s budget routinely insufficient.


### PR DESCRIPTION
## ELI16 — a stopwatch stopped a job that was still running, and threw away the reason

On the dashboard's Subscriptions page there's a grid: accounts down the side, machines across the top. Tapping **Set up** on an empty cell is supposed to run a whole sign-in on that machine without you leaving the page.

Tapping it for another machine gave **"Couldn't start: Request timeout"** and nothing else.

One tap sets off four nested waits — the browser's request, the call between machines, the target machine's own handler, and the target actually launching the sign-in and reading the code off the screen. For that to work, the outermost wait has to be the longest. **It was the shortest.**

The two outer waits had never been given their own limits, so they used the system-wide default of 30 seconds. The call between machines was hard-coded to 40. The innermost step — the real work — was set to 180, deliberately, because a remote machine talking to a login provider is genuinely slow.

So the outer stopwatch stopped at 30 seconds with 150 seconds of the real allowance left. The error wasn't the sign-in failing; it was the wrapper giving up on a sign-in that was still going. Worse, the code underneath already had real answers ready — "the login didn't start, try again", "I couldn't work out which account this is", "one's already running, here it is" — and the 30-second wrapper fired first and replaced all of them with two useless words.

**Why it kept happening:** this is the fourth time this exact mistake has shipped. The previous three were each fixed by adding one more hardcoded number. That doesn't generalise — the next nested route added has nothing to inherit, and nothing notices it defaulted to 30 seconds while wrapping something longer. So this time all four waits are *calculated* from the one setting an operator actually controls, and a test fails the build if the ordering is ever inverted again.

**What the sweep found:** rather than patch the button that was reported, every cross-machine call in this area was checked. Three had the same mistake — starting the sign-in, **pasting the code back**, and cancelling. The middle one matters most: a verification code is single-use, so a timeout there leaves you unable to tell whether your one attempt was spent. Fixing only the reported route would have moved the failure one step later in the same flow.

**Safety:** every limit moved *up*, so nothing that used to succeed can now be cut short. The inner limits are unchanged and still fire first, so a genuinely stuck machine is still cut off — just after the real work has had its fair chance. The trade is that a wedged peer now surfaces in about four minutes instead of thirty seconds; the old behaviour "noticed" fast by declaring every slow-but-healthy sign-in dead. Nothing is stored, so rolling back is deleting the change and restarting.

---

## What was broken

A cross-machine **Set up** tap on the Subscriptions grid nests four timeout budgets, and the outermost was the smallest:

| | Layer | Budget | Source |
|---|---|---|---|
| L1 | `POST /subscription-pool/matrix/start-cell` (fronting) | **30s** | global default — *no override* |
| L2a | mandate delivery over the mesh | 15s | `commands/server.ts` |
| L2b | relay fetch → target's `enroll/start` | **40s** | hard-coded `AbortSignal.timeout(40_000)` |
| L3 | `POST /follow-me/enroll/start` (target) | **30s** | global default — *no override* |
| L4 | `FrameworkLoginDriver.drive()` pane scrape | **60s default / 180s configured** | `remoteScrapeTimeoutMs` |

Every cross-machine sign-in slower than 30s therefore returned a bare `408 {"error":"Request timeout"}` from the middleware **while the handler was still legitimately working** — discarding the handler's own classified outcome (`502 login-did-not-start / retryable`, `409 cannot-resolve-email`, `201 reused`). On a peer reachable only over Cloudflare, that is the normal case, not the edge case.

Reported live by the operator (topic 50436, 2026-08-20).

## Three routes, not one

Sweeping every `AbortSignal.timeout` in route scope found the same 40s-under-30s shape on **three** routes:

- `matrix/start-cell` — the reported one
- `follow-me/submit-code` — **the severe one**: a verification code is single-use, so a 408 here leaves the operator unable to determine whether their one attempt was spent
- `follow-me/cancel`

Fixing only the reported route would have moved the operator's failure one step later in the same flow.

## The fix

All four budgets derive from the single `remoteScrapeTimeoutMs` knob via `resolveFollowMeBudgets()`, so widening the scrape budget widens everything above it instead of silently re-inverting the chain. The three hard-coded relay literals are gone.

This is the **fourth** instance of the "408 while the handler keeps running" class — `OUTBOUND_MESSAGING_TIMEOUT_MS`, `PARITY_PASS_TIMEOUT_MS` and `POOL_TRANSFER_TIMEOUT_MS` each fixed one instance as an independent constant. That shape does not generalise: a newly nested route has nothing to inherit and no gate notices it defaulted to 30s while wrapping something longer. Hence deriving the chain and asserting the ordering, rather than adding a fifth constant.

## Something checked and deliberately NOT changed

I initially believed the coordinator's `if (isSelf)` pending-login reuse guard was a spec-conformance gap letting a retry start a second sign-in on a peer. **That was wrong**, verified before writing code: the target's `enroll/start` reuses a live pending login unconditionally for self *and* peer targets (the D5 single-attempt block), so the spec's "a retry never duplicates a pending login" invariant already held end-to-end. No idempotency change was made.

## Evidence

- **Negative control:** reverting the four override entries fails the new test with **18 failures** naming each inverted route; restoring passes **29/29** across four knob values including the operator's 180s.
- Prefix-containment assertion confirms `/subscription-pool`, `/subscription-pool/poll`, `/subscription-pool/swap` stay on the 30s default.
- Affected integration suites green: `account-matrix-start-cell-route`, `account-follow-me-submit-code-route`, `account-follow-me-cancel-route`, `account-follow-me-enroll-start-route` — **51 tests**.
- Verified the router mounts at root (so the new prefixes are reachable), that the timeout middleware precedes the routes, and that the self-target loopback still nests correctly.

## Reviewer, please note

- **No independent second-pass review was obtained.** This change touches gate-adjacent middleware and enrollment lifecycle, so Phase 5 requires one; the authoring session could not spawn a reviewer. The artifact records an adversarial *self*-review, explicitly not a concurrence. **A genuine second pass is owed here.**
- **The local pre-push smoke tier SKIPPED** (`affected-set-indeterminate`, listing timed out) — local tests did not gate this push. CI is the sole authority.
- Pre-existing local failures in `telegram-reply-advisory-script.test.ts` and `PostUpdateMigrator-autonomousStopHook.test.ts` reproduce identically on unmodified `origin/main`; the latter is provably environmental (`git show` against history absent from that checkout). Not introduced here.
- `FOLLOWME_MANDATE_DELIVERY_BUDGET_MS` *mirrors* the `timeoutMs: 15_000` literal in `commands/server.ts` rather than importing it — a real if small drift surface no test can bind.

Side-effects artifact: `upgrades/side-effects/followme-timeout-budget-chain.md`
Plain-English overview: `upgrades/side-effects/followme-timeout-budget-chain.eli16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
