### PR TITLE
fix(reroute): completion sentinel must not appear literally in the injected prompt

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-20T21-39-00-012Z-reroute-sentinel-echo-collision.json
+++ b/.instar/instar-dev-decisions/2026-08-20T21-39-00-012Z-reroute-sentinel-echo-collision.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-20T21:39:00.012Z",
+  "slug": "reroute-sentinel-echo-collision",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 18,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts"
+    ],
+    "addedLines": 17,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "brittle-keyword-authority",
+    "closure": "gap",
+    "gapItem": "ACT-1798",
+    "prNumber": 1951,
+    "component": "SessionManager"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-20T21-39-52-822Z-reroute-sentinel-echo-collision.json
+++ b/.instar/instar-dev-decisions/2026-08-20T21-39-52-822Z-reroute-sentinel-echo-collision.json
@@ -1,0 +1,31 @@
+{
+  "ts": "2026-08-20T21:39:52.822Z",
+  "slug": "reroute-sentinel-echo-collision",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 18,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts"
+    ],
+    "addedLines": 17,
+    "deletedLines": 1
+  },
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "Introduced with the june15-headless-spawn-reroute lane itself (spec O1, 'the crux'). The completion sentinel was designed as a per-session literal printed by the model and matched on the pane, but the prompt CARRYING that instruction is injected into the same pane, so the assembled literal was present from render time. Not a regression from a later PR and not an environment shift - the collision existed from the lane's first commit and was invisible because its symptom is a FALSE SUCCESS, which no status surface distinguishes from a real one. The two unit tests that covered the halves in isolation both passed and one actively pinned the defect (asserting the prompt must END with the assembled sentinel), so the guard rail confirmed the bug rather than catching it."
+  },
+  "classClosure": {
+    "defectClass": "brittle-keyword-authority",
+    "closure": "gap",
+    "gapItem": "ACT-1798",
+    "prNumber": 1951,
+    "component": "SessionManager"
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/reroute-sentinel-echo-collision.eli16.md
+++ b/docs/specs/reroute-sentinel-echo-collision.eli16.md
@@ -1,0 +1,98 @@
+# ELI16 — The job watcher was reading its own instruction back and calling the work finished
+
+## What this is about
+
+Instar can run a background job by opening a normal chat session with the model and
+typing a task into it, rather than running a one-shot command. This is the
+"rerouted-interactive" lane, and it exists so background work bills through a
+subscription instead of a separate credit pot.
+
+A one-shot command has an obvious way to know the job is over: the program exits.
+An open chat session never exits. So instar needed another way to tell "finished"
+from "still working".
+
+## The way it worked, and why it broke
+
+The chosen approach was a codeword. When instar starts one of these jobs it appends
+a line to the task:
+
+> *When you have fully completed this task, print exactly this marker as your final
+> line: INSTAR_JOB_COMPLETE_1a2b3c4d*
+
+Instar then watches the session's screen and, when it sees that codeword, concludes
+the job is done and shuts the session down.
+
+The flaw is that **the task is typed into the session**, so everything in it —
+including that instruction — appears on the very screen being watched. The codeword
+was therefore sitting there from the moment the task was pasted in, before the model
+had done a single thing. The watcher looked, saw the codeword, and shut the job down
+as a success.
+
+It is a machine reading its own instruction back and mistaking it for the answer.
+
+## How bad it was in practice
+
+Measured on a real three-machine setup, on the machine running the scheduled work:
+
+- **31 out of 31** of these jobs were killed between 15 and 41 seconds. Every single
+  one was recorded as `completed`.
+- That included **25 scheduled maintenance jobs** — the health check, the commitment
+  sweep, the maintenance overseers — all reporting `success` with `0` consecutive
+  failures, while each did roughly sixteen seconds of work.
+- The machine's shutdown log covered about 43 hours and held **1,074** of these kills.
+
+Nothing looked broken. Every status surface was green. That is the worst property of
+this bug: it did not fail, it *reported success*.
+
+There is a partial safeguard that declines to shut a session down while a command is
+visibly running. That is why the death time varied instead of being a flat sixteen
+seconds — it delayed the false verdict, it did not prevent it.
+
+Jobs run the old one-shot way were never affected, because "the program exited" cannot
+be faked by something written on the screen.
+
+## What changes
+
+Instead of handing the model the finished codeword, instar now hands it the pieces and
+asks it to join them:
+
+> piece 1: `INSTAR_JOB_COMPLETE`
+> piece 2: `_`
+> piece 3: `1a2b3c4d`
+
+The joined codeword now appears on the screen **only if the model actually types it**.
+The instruction itself no longer matches.
+
+The model is also told to write the marker only on that final line and never to quote
+it back while narrating.
+
+## What happens if the model gets the joining wrong
+
+It doesn't get shut down early — it runs to the existing hard time limit and is recorded
+as a **timeout**. That is deliberate: a loud non-completion is a far better failure than
+a silent false success. We checked the assembly behaviour against the real model on the
+affected machine before relying on it, and it assembled the marker correctly.
+
+## Why the existing tests did not catch this
+
+Both halves were already tested, separately, and both passed:
+
+- "the rerouted prompt gets the completion sentinel appended" ✅
+- "a pane containing the sentinel is detected as complete" ✅
+
+Neither test knew that the prompt *is* screen content. Their **composition** was the
+defect. One of them actually asserted that the codeword must be the last thing in the
+instruction — the bug was written down as intended behaviour and guarded as such.
+
+The new test puts the two halves together: it takes the real prompt instar would inject
+and feeds it to the real matcher as screen content, and requires "not finished". It was
+confirmed to fail on the unfixed code before being trusted, and it carries a positive
+control so a matcher that simply never fires cannot pass it.
+
+## What this does not fix
+
+The deeper issue is that a plain text search holds the authority to kill a session. It
+still cannot tell the model's own output from an instruction, a quotation, or a user
+repeating the codeword back. This change removes the collision that made that dangerous
+in practice; it does not change who holds the authority. That is tracked separately as
+ACT-1798.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -3260,7 +3260,23 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // is keyed on the session id suffix so two concurrent rerouted sessions
     // can't false-trigger each other.
     const sentinel = `INSTAR_JOB_COMPLETE_${sessionId.slice(-8)}`;
-    const promptWithSentinel = `${withClaudeUltracodePrompt(options.prompt, options.ultracode)}\n\nWhen you have fully completed this task, print exactly this marker as your final line: ${sentinel}`;
+    // ── The sentinel must NOT appear literally in the prompt (2026-08-20) ──
+    // The prompt is INJECTED into the REPL, so every character of it is echoed
+    // onto the pane the monitor scans. Emitting the assembled sentinel inside
+    // the instruction made the pane satisfy `detectSessionCompletion` from the
+    // moment the prompt rendered: the monitor read its own instruction back and
+    // reaped the session as SUCCESS on its first look after the 15s grace.
+    // Measured on a live 3-machine fleet: 31/31 rerouted sessions killed at
+    // 15-41s, ALL recorded `completed`, incl. 25 scheduled jobs reporting
+    // "success, 0 failures" while doing ~16s of work each.
+    // Fix: hand the model the two halves and have it join them. The assembled
+    // literal then exists ONLY when the model actually prints it. If the model
+    // mis-joins, the session is NOT detected and falls through to the hard
+    // lifetime cap — recorded as a timeout, i.e. the SAFE direction (a loud
+    // non-completion) rather than a silent false success.
+    const sentinelPrefix = 'INSTAR_JOB_COMPLETE';
+    const sentinelSuffix = sessionId.slice(-8);
+    const promptWithSentinel = `${withClaudeUltracodePrompt(options.prompt, options.ultracode)}\n\nWhen you have fully completed this task, your FINAL line must be a completion marker assembled from these three pieces joined together with no spaces and nothing else on the line:\n  piece 1: ${sentinelPrefix}\n  piece 2: _\n  piece 3: ${sentinelSuffix}\nWrite the assembled marker ONLY on that final line — never earlier in your output, and never quote it back while describing what you are doing.`;
 
     // ── Build the INTERACTIVE launch (no `-p`) ──
     // Carry the resolved model + the A2A continuity flag through. sessionId

--- a/tests/unit/headless-spawn-reroute.test.ts
+++ b/tests/unit/headless-spawn-reroute.test.ts
@@ -270,8 +270,8 @@ describe('headless-spawn reroute', () => {
     expect(launch).not.toContain('--allowedTools');
   });
 
-  it('V2: rerouted prompt gets the completion sentinel appended', async () => {
-    const { manager } = makeManager({ mode: 'force' }, tmpDir);
+  it('V2: rerouted prompt carries the sentinel HALVES, never the assembled literal', async () => {
+    const { manager, state } = makeManager({ mode: 'force' }, tmpDir);
     const captured: string[] = [];
     (manager as unknown as { injectMessage: (t: string, text: string) => boolean }).injectMessage =
       (_t, text) => { captured.push(text); return true; };
@@ -282,8 +282,17 @@ describe('headless-spawn reroute', () => {
     const sentinel = `INSTAR_JOB_COMPLETE_${s.id.slice(-8)}`;
     expect(captured.length).toBe(1);
     expect(captured[0]).toContain('ORIGINAL PROMPT');
-    expect(captured[0]).toContain(sentinel);
-    expect(captured[0].trimEnd().endsWith(sentinel)).toBe(true);
+    // THE LOAD-BEARING ASSERTION (2026-08-20 regression): the injected prompt is
+    // echoed onto the pane the completion monitor scans, so it must NEVER contain
+    // the ASSEMBLED sentinel — otherwise the monitor reads its own instruction
+    // back and reaps the session as a success before any work happens.
+    expect(captured[0]).not.toContain(sentinel);
+    // It must still carry both halves so the model can assemble the marker.
+    expect(captured[0]).toContain('INSTAR_JOB_COMPLETE');
+    expect(captured[0]).toContain(s.id.slice(-8));
+    // And the session's match target remains the assembled literal.
+    const saved3 = state.getSession(s.id)!;
+    expect(saved3.completionPatterns).toEqual([sentinel]);
   });
 
   // ── V4: A2A continuity — resumeSessionId path ──
@@ -401,6 +410,43 @@ describe('detectSessionCompletion (V3 decision boundary)', () => {
       startedAt: new Date().toISOString(), completionMode: 'pattern' as const,
       completionPatterns: ['INSTAR_JOB_COMPLETE_abcd1234'],
     };
+    expect(manager.detectSessionCompletion(session)).toBe(true);
+  });
+
+  // ── REGRESSION (2026-08-20): the prompt echo must not satisfy the matcher ──
+  // Both halves of this feature were already unit-tested IN ISOLATION and both
+  // passed: "the prompt gets the sentinel appended" and "a pane containing the
+  // sentinel is detected". Their COMPOSITION was the bug — the injected prompt
+  // IS pane content, so appending the assembled sentinel made every rerouted
+  // session self-satisfy the completion check on the monitor's first look.
+  // Field evidence: 31/31 rerouted sessions reaped at 15-41s, all recorded
+  // `completed`, incl. 25 scheduled jobs reporting "success, 0 failures".
+  // This test couples the two halves, which is the only way to catch it.
+  it('REGRESSION: the injected prompt, seen as pane output, is NOT completion', async () => {
+    const { manager } = makeManager({ mode: 'force' }, tmpDir);
+    const captured: string[] = [];
+    (manager as unknown as { injectMessage: (t: string, text: string) => boolean }).injectMessage =
+      (_t, text) => { captured.push(text); return true; };
+    const s = await manager.spawnSession({ name: 'job-echo-regression', prompt: 'DO THE WORK' });
+    await new Promise((r) => setTimeout(r, 1200));
+    expect(captured.length).toBe(1);
+    const injectedPrompt = captured[0];
+
+    // The pane shows the echoed prompt and nothing else — the session has done
+    // no work yet. Feed EXACTLY that to the real matcher.
+    (manager as unknown as { captureOutput: () => string }).captureOutput = () => injectedPrompt;
+    const sentinel = `INSTAR_JOB_COMPLETE_${s.id.slice(-8)}`;
+    const session = {
+      id: s.id, name: s.name, status: 'running' as const, tmuxSession: s.tmuxSession,
+      startedAt: new Date().toISOString(), completionMode: 'pattern' as const,
+      completionPatterns: [sentinel],
+    };
+    expect(manager.detectSessionCompletion(session)).toBe(false);
+
+    // Positive control: the matcher is not simply broken — once the model
+    // actually prints the assembled marker, it IS detected.
+    (manager as unknown as { captureOutput: () => string }).captureOutput =
+      () => `${injectedPrompt}\n...did the work...\n${sentinel}\n`;
     expect(manager.detectSessionCompletion(session)).toBe(true);
   });
 

--- a/upgrades/next/reroute-sentinel-echo-collision.md
+++ b/upgrades/next/reroute-sentinel-echo-collision.md
@@ -1,0 +1,40 @@
+## What Changed
+
+**Background jobs on the subscription lane were being killed ~16 seconds in and recorded as successful.**
+
+When instar runs a background job through the rerouted-interactive lane (`intelligence.subscriptionPath.mode` = `force`, or `auto` where the reroute gate allows), it opens a real chat session and asks the model to print a per-session completion marker as its final line. The monitor watches the session's terminal and reaps it when that marker appears.
+
+The prompt carrying that instruction is *injected into the session*, so the assembled marker landed on the very terminal the monitor scans — before any work started. The monitor read its own instruction back and reaped the session as `completed` on its first check after the 15-second grace period.
+
+Nothing failed loudly. Every job recorded `success`.
+
+The fix hands the model the marker's pieces and asks it to join them, so the assembled literal reaches the terminal only when the model actually prints it. If a model ever joins it incorrectly, the session falls through to the existing hard lifetime cap and is recorded as a **timeout** — a loud non-completion instead of a silent false success.
+
+Agents on the headless lane (`completionMode: 'exit'`) were never affected: there, "finished" means the process exited, which screen content cannot fake.
+
+## What to Tell Your User
+
+If your agent runs background jobs on the subscription lane, those jobs have most likely not been completing — they were stopped a few seconds in and logged as successful, so every status surface stayed green.
+
+After this update they run properly. Expect two visible changes: scheduled jobs now take their real time instead of finishing almost instantly, and they consume their real share of your quota. That is the intended cost of the work actually happening. If a job now reports a **timeout**, that is genuine information rather than a new fault — previously it would have claimed success.
+
+Nothing to configure, and nothing to clean up.
+
+## Summary of New Capabilities
+
+No new capabilities — this restores intended behaviour for scheduled and background jobs on the rerouted-interactive lane.
+
+## Evidence
+
+Measured on a live three-machine fleet, on the machine holding the serving lease, before the fix:
+
+- **31 of 31** rerouted-interactive sessions killed between **15.3s and 41.3s**; every one recorded `completed`. No exceptions.
+- **25 scheduled jobs** at `lastResult: success`, `consecutiveFailures: 0` — health-check, commitment-detection, the maintenance overseers, feedback-factory-process — each doing roughly sixteen seconds of work.
+- **1,074** `sentinel-complete` reaps in the ~43 hours the machine's reap-log covers.
+- Live reproduction: polling `GET /sessions/:name/output?lines=30` showed the marker inside the scanned window continuously from ~10s after spawn, followed by the reap. The reap-log recorded `skipped:active-process` at 16s (a partial guard delaying, not preventing, the false verdict) and `reaped | sentinel-complete | terminal` at 41s.
+- Control: a comparable job on the headless lane ran 3m38s and completed correctly.
+- The marker-assembly instruction was verified against the real model on the affected machine before being relied on.
+
+Tests: unit 27 passed (both new assertions confirmed to **fail** on the unfixed source), integration passed, e2e 4 passed, `tsc --noEmit` clean.
+
+Scope: this closes the collision at the producer. The underlying signal-vs-authority issue — a literal-token matcher holding kill authority over terminal text, unable to tell the model's output from an echo or a quotation — is unchanged and tracked as ACT-1798.

--- a/upgrades/side-effects/reroute-sentinel-echo-collision.md
+++ b/upgrades/side-effects/reroute-sentinel-echo-collision.md
@@ -1,0 +1,281 @@
+# Side-Effects Review — rerouted-session completion sentinel must not appear literally in the injected prompt
+
+**Version / slug:** `reroute-sentinel-echo-collision`
+**Date:** `2026-08-20`
+**Author:** `echo`
+**Second-pass reviewer:** `required (session lifecycle + sentinel) — see below`
+
+## Summary of the change
+
+`SessionManager.spawnReroutedInteractive` appended the ASSEMBLED completion sentinel
+(`INSTAR_JOB_COMPLETE_<id8>`) to the prompt it injects into the interactive REPL. That
+prompt is typed into the session, so every character of it lands on the tmux pane that
+`detectSessionCompletion` scans. The sentinel therefore satisfied the completion check
+from the moment the prompt rendered — before any work happened — and the monitor loop
+reaped the session as `completed` on its first look after the 15s grace.
+
+The change hands the model the sentinel's three pieces (`INSTAR_JOB_COMPLETE`, `_`,
+`<id8>`) and instructs it to join them, so the assembled literal reaches the pane only
+when the model actually prints it. Files: `src/core/SessionManager.ts` (prompt
+construction only) and `tests/unit/headless-spawn-reroute.test.ts`.
+
+Field evidence gathered before the fix, on a live 3-machine fleet, on the lease holder:
+31/31 rerouted-interactive sessions killed at 15.3–41.3s, ALL recorded `completed`;
+25 scheduled jobs reporting `lastResult: success`, `consecutiveFailures: 0`; 1,074
+`sentinel-complete` reaps in the ~43h the machine's reap-log covers.
+
+## Decision-point inventory
+
+- `SessionManager.detectSessionCompletion` (`src/core/SessionManager.ts`) — **pass-through**
+  — unchanged. It still substring-matches `session.completionPatterns` against the last
+  30 captured pane lines and still holds reap authority. This change alters only what
+  reaches its input, not the check itself.
+- `SessionManager.spawnReroutedInteractive` prompt construction — **modify** — the
+  assembled sentinel is removed from the injected text; the pieces are supplied instead.
+- Monitor-loop reap path (`completionMode === 'pattern'` branch) — **pass-through** —
+  untouched, including the `protectedSessions` exemption and the hard lifetime cap.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface is added. The relevant risk is the inverse of over-block: a
+session that HAS finished failing to be recognised, because the model assembled the
+marker incorrectly (e.g. printed `INSTAR_JOB_COMPLETE _1a2b3c4d` with a space, or wrote
+only the prefix). That session is not reaped on sentinel, runs to the existing
+`subscriptionReroutedLifetimeMinutes` cap (default 45), and is recorded as a **timeout**
+via `finalStatus: 'killed'`.
+
+That is the deliberate direction. A timeout is loud, appears in the job's
+`consecutiveFailures`, and reruns on the next trigger. The pre-fix behaviour — a silent
+false `success` — was undetectable by any status surface, which is precisely how it
+survived ~43 hours across 25 jobs.
+
+Verified empirically rather than assumed: a probe job on the affected machine, given the
+same three-piece instruction, assembled `ASSEMBLY_PROBE_OK_7f3a2b91` correctly.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+Three, all pre-existing and none newly introduced:
+
+1. **Model quotes the assembled marker mid-run.** If the model writes the joined literal
+   while narrating ("I'll print INSTAR_JOB_COMPLETE_1a2b3c4d when done"), the matcher
+   still fires early. Mitigated but NOT eliminated by the added instruction "Write the
+   assembled marker ONLY on that final line — never earlier in your output, and never
+   quote it back while describing what you are doing." This is model compliance, not a
+   structural guarantee.
+2. **A task whose own content contains the marker.** A job asked to grep for
+   `INSTAR_JOB_COMPLETE_*` would put a matching literal on the pane. Pre-existing;
+   narrowed, since the per-session `<id8>` suffix makes an accidental collision unlikely.
+3. **The literal matcher still cannot distinguish assertive output from quoted or echoed
+   context.** That is the class-level defect and is explicitly NOT closed here — see §4
+   and the Class-Closure Declaration.
+
+## 3. Level-of-abstraction fit
+
+The change sits at the **prompt-construction** layer, which is the correct place for it:
+the defect is that a producer wrote into a channel a consumer scans. Fixing it at the
+producer removes the collision without touching reap authority, session lifecycle, or the
+monitor loop — the smallest surface that resolves the observed failure.
+
+It is explicitly NOT the right layer for the deeper problem. A literal-token detector
+holding kill authority over screen text is an authority-placement defect, and the correct
+fix there is either a terminal-line-equality contract, demotion of the matcher to a signal
+feeding a completion authority, or moving completion off the screen channel entirely (a
+file the model touches). Doing that here would be a lifecycle-behaviour change riding on a
+bugfix; it is tracked as ACT-1798 instead.
+
+Nothing is re-implemented: the existing `completionPatterns` mechanism, matcher, grace
+period and lifetime cap are all reused unchanged.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No** — this change has no block/allow surface. It removes a false input from an
+  existing detector; it neither adds a detector nor grants authority.
+
+Narrative, stated honestly: the surrounding design **is** a signal-vs-authority violation
+and this change does not repair it. `detectSessionCompletion` is a brittle literal matcher
+that owns reap authority directly, with no context-rich authority between detection and
+the kill. That is exactly the shape `docs/signal-vs-authority.md` forbids, and it is why a
+single string on a screen could terminate 31 sessions and mark them successful.
+
+This change is deliberately scoped to the collision, not the authority, because the
+authority repair changes session-lifecycle behaviour and deserves its own spec and review.
+Declaring compliance here would be false; the honest declaration is "no new authority, the
+existing violation persists, and it is tracked as ACT-1798 (high)."
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The change adds no
+decision logic at all — it edits a prompt string. The pre-existing completion decision is
+a single-signal check (marker present / absent), not a competing-signals judgment point;
+whether it *should* become one is the question ACT-1798 carries.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The prompt is built before injection; nothing else reads or
+  rewrites it. `withClaudeUltracodePrompt` still wraps the caller's prompt first and its
+  output is unchanged.
+- **Double-fire:** none. `completionPatterns` remains a single-element array holding the
+  assembled sentinel, so the matcher's behaviour is identical for any given pane content.
+  The per-session `<id8>` keying that prevents two concurrent rerouted sessions
+  false-triggering each other is preserved (verified by the V2 test asserting
+  `completionPatterns === [sentinel]`).
+- **Races:** none introduced. The 15s grace, the `alive === false` branch, the CAS re-read
+  before mutation, and the `skipped:active-process` guard are all untouched.
+- **Feedback loops:** this closes one. The pre-fix arrangement was a genuine loop — the
+  system's own instruction was fed back into its completion sensor.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none. Per-session state only.
+- **Install base:** yes, and this is the point — every agent running
+  `intelligence.subscriptionPath.mode` in `force` or `auto` (where the reroute gate
+  allows) is affected today. They will see rerouted jobs actually run to completion
+  instead of being reaped at ~16s. Job durations, token spend and wall-clock for these
+  jobs all rise from near-zero to their true cost. That is a restoration of intended
+  behaviour, but it is a real change in observed load and should be expected.
+- **External systems:** none. No API, route, schema, or wire format changes.
+- **Persistent state:** none. No migration. Existing sessions keep their stored
+  `completionPatterns`; only newly-spawned sessions get the new prompt.
+- **Timing / runtime conditions:** the fix depends on model compliance with an assembly
+  instruction. Checked live against the real model rather than assumed (see §1).
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing actions
+  added or touched.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. No dashboard renderer, approval page, or
+grant/revoke/secret-drop form is touched.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local BY DESIGN.**
+
+Reason: a session's completion sentinel is scoped to one tmux pane on one host. The
+prompt is constructed at spawn time by the machine that owns the session; the matcher
+reads that machine's own pane. There is no cross-machine state to replicate and no
+merged read that would be meaningful — another machine cannot observe this pane, and
+should not.
+
+- **User-facing notices:** none emitted. No one-voice gating needed.
+- **Durable state:** none introduced, so nothing strands on topic transfer. Session
+  records already move with the existing transfer machinery, unchanged by this.
+- **Generated URLs:** none.
+
+Worth recording, because it shaped the investigation: the *impact* is decidedly not
+machine-local. Only the machine holding the serving lease runs the scheduler, so the
+fleet-wide symptom concentrated entirely on one machine while its peers looked healthy —
+and the affected machine's own status surfaces reported success throughout.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit, ship as the next patch. The change is a single
+  prompt string plus tests.
+- **Data migration:** none. No persistent state, no schema, no ledger column.
+- **Agent state repair:** none. Sessions spawned under either version carry their own
+  `completionPatterns` and are handled identically by the unchanged matcher.
+- **User visibility during rollback:** reverting restores the defect — rerouted jobs
+  would again be reaped at ~16s and marked successful. So rollback is cheap mechanically
+  and expensive behaviourally; the correct response to a problem with this change is
+  almost certainly to fix forward, not revert.
+
+---
+
+## Conclusion
+
+The review produced no design change, and one deliberate scope decision worth naming: the
+fix removes the collision at the producer rather than repairing the authority placement at
+the consumer, because the latter changes session-lifecycle behaviour and needs its own
+spec. §4 therefore records a *persisting* signal-vs-authority violation rather than
+claiming compliance, and ACT-1798 tracks it at high priority.
+
+The review also changed how the fix is evidenced. The original tests passed both before
+and after, which is worthless as a regression guard, so the new test was checked against
+the unfixed source and confirmed to fail. The model's ability to assemble the marker — the
+one assumption unit tests cannot validate — was checked live on the affected machine
+rather than assumed.
+
+Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `echo (independent audit pass — see note)`
+**Independent read of the artifact: concur, with one concern recorded**
+
+- **Concur** that the change is minimal, has no block/allow surface, introduces no
+  persistent state, and fails in the safe direction (timeout, not false success).
+- **Concern raised:** §2 under-block item 1 — the "quote it back mid-run" failure mode is
+  mitigated only by model compliance with a prompt instruction, which is precisely the
+  kind of guarantee this codebase treats as a wish rather than a structure. **Resolution:**
+  accepted as a residual risk for this change, because it is strictly narrower than the
+  pre-fix behaviour (which fired with certainty on every session rather than occasionally
+  on a narrating one), and because the structural repair is the same one ACT-1798 carries.
+  This does not block the fix; it raises the priority of ACT-1798, which is filed `high`.
+- **Note on reviewer independence:** no second agent was available to audit this at the
+  time of the fix, so this pass was conducted by the same agent against the artifact and
+  the diff rather than by an independent reviewer. That is a weaker guarantee than the
+  skill intends and is recorded here rather than presented as a genuine second pass.
+
+---
+
+## Evidence pointers
+
+- Live reproduction: probe session on the affected machine, polling
+  `GET /sessions/:name/output?lines=30` — sentinel present in the scanned window
+  continuously from ~10s after spawn, followed by the reap.
+- Reap-log corroboration: two entries for the probe —
+  `skipped:active-process` at 16s, then `reaped | sentinel-complete | terminal` at 41s.
+- Population evidence: 31/31 rerouted sessions 15.3–41.3s, all `completed`; 25 jobs at
+  `lastResult: success`, `consecutiveFailures: 0`; 1,074 `sentinel-complete` reaps over
+  the ~43h of reap-log held on that machine.
+- Contrast/control: the headless lane (`completionMode: 'exit'`) on another machine ran a
+  comparable job for 3m38s and completed correctly.
+- Assembly check: probe returned `ASSEMBLY_PROBE_OK_7f3a2b91` correctly joined.
+- Test-tier results: unit 27 passed, integration passed, e2e 4 passed, `tsc --noEmit` clean.
+- Negative control: both new assertions fail on the unfixed source.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `brittle-keyword-authority`. A literal-token detector
+  (`detectSessionCompletion`) assigns a consequential classification (session complete →
+  reap) over raw pane text without distinguishing the model's assertive output from
+  non-assertive context — here, the system's own echoed instruction.
+- **`closure`** — `gap`. This change closes the INSTANCE (the producer no longer writes
+  the matching literal into the consumer's channel) but not the CLASS (the brittle matcher
+  still holds kill authority and still cannot tell assertion from echo or quotation).
+  Claiming `guard` on the strength of an instance-level regression test would overstate
+  what was built.
+- **`gap`** — `ACT-1798` (priority `high`, dueBy 2026-09-10): promote the literal sentinel
+  matcher from authority to signal, or pin completion to a terminal-line-equality contract,
+  or move completion off the screen channel entirely.
+- **`guardEvidence`** — not claimed (see `closure: gap`). For the record, the
+  instance-level ratchet added here is
+  `tests/unit/headless-spawn-reroute.test.ts` →
+  `"REGRESSION: the injected prompt, seen as pane output, is NOT completion"`, which feeds
+  the real injected prompt to the real matcher and was verified to fail on the unfixed
+  source. It guards this lane's collision, not the class.


### PR DESCRIPTION
## ELI16 — The job watcher was reading its own instruction back and calling the work finished

Instar can run a background job by opening a real chat session and typing the task into it, rather than running a one-shot command. A one-shot command has an obvious way to know the job is over: the program exits. A chat session never exits — so instar appends an instruction to the task:

> *When you have fully completed this task, print exactly this marker as your final line: `INSTAR_JOB_COMPLETE_1a2b3c4d`*

…and then watches the session's screen for that marker.

The flaw is that **the task is typed into the session**, so the instruction — marker and all — appears on the very screen being watched. The marker was sitting there before the model had done anything. The watcher looked, saw it, and shut the job down as a success. A machine reading its own instruction back and mistaking it for the answer.

It never failed loudly. It *reported success*, which is why it survived unnoticed.

**The fix:** hand the model the marker's pieces and ask it to join them. The joined marker can only appear on screen if the model actually types it. If a model ever joins it wrong, the session runs to its existing time limit and is recorded as a **timeout** — a loud non-completion instead of a silent false success.

**What it does not fix:** a plain text search still holds the authority to kill a session, and still cannot tell the model's output from a quotation or an echo. That is tracked as ACT-1798.

---

## The bug

The rerouted-interactive lane (`spawnReroutedInteractive`) tells the model to print a per-session sentinel as its final line, and the monitor loop reaps the session when that sentinel appears in the captured pane.

But the prompt carrying that instruction is **injected into the REPL** — so every character of it is echoed onto the very pane the monitor scans. The assembled sentinel was therefore present from the moment the prompt rendered. The monitor read its own instruction back and reaped the session as **success** on its first look after the 15s grace period.

## Field evidence (measured, not inferred)

On a live 3-machine fleet, on the machine holding the serving lease:

- **31 of 31** rerouted-interactive sessions died between **15.3s and 41.3s**. Every one recorded `completed`. Zero exceptions.
- That includes **25 scheduled jobs** — health-check, commitment-detection, the maintenance overseers, feedback-factory-process — all reporting `lastResult: success`, `consecutiveFailures: 0`, while doing ~16 seconds of work each.
- The machine's reap-log covers ~43 hours and contains **1,074** `sentinel-complete` reaps. The log's first entry is one of them, so the behaviour may predate the log.

Reproduced directly: spawning a probe job and polling `GET /sessions/:name/output?lines=30` showed the sentinel present in the scanned window continuously from ~10s after spawn, followed by the reap.

A partial guard (`skipped:active-process`) declines to reap while a command is visibly running — which is why the death time varies rather than being a constant 16s. It delays the false positive; it does not prevent it.

Unaffected: the headless lane (`completionMode: 'exit'`), where completion means the process exited and cannot be spoofed by screen content.

## The fix

Hand the model the sentinel's pieces and have it join them. The assembled literal then exists on the pane **only when the model actually prints it**.

If the model mis-joins, the session is not detected and falls through to the existing hard lifetime cap — recorded as a **timeout**. That is the safe direction: a loud non-completion instead of a silent false success.

## Why the existing tests missed it

Both halves were already unit-tested **in isolation**, and both passed:

- "the rerouted prompt gets the completion sentinel appended" ✅
- "a pane containing the sentinel is detected as complete" ✅

Their **composition** was the bug — the injected prompt *is* pane content. One test even asserted `captured[0].trimEnd().endsWith(sentinel)`, which pinned the defect in place as intended behaviour.

The new regression test couples the two halves: it takes the **real injected prompt** and feeds it to the **real matcher** as pane output, asserting no completion — plus a positive control proving the matcher still fires once the marker is genuinely printed.

**Verified the test is real:** it fails on the unfixed source and passes on the fix.

## Test tiers

- Unit — `tests/unit/headless-spawn-reroute.test.ts` — 27 passed (V2 rewritten, regression added)
- Integration — `tests/integration/sessions-launch-lane.test.ts` — passed
- E2E — `tests/e2e/june15-headless-spawn-reroute.test.ts` — 4 passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
