### PR TITLE
fix(gate): decision-audit check requires scope coverage, not mere presence

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-21T08-14-41-139Z-w22-decision-audit-scope-coverage.json
+++ b/.instar/instar-dev-decisions/2026-08-21T08-14-41-139Z-w22-decision-audit-scope-coverage.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-21T08:14:41.139Z",
+  "slug": "w22-decision-audit-scope-coverage",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 86,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/decision-audit-presence-check.mjs"
+    ],
+    "addedLines": 66,
+    "deletedLines": 20
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/w22-decision-audit-scope-coverage.eli16.md
+++ b/docs/specs/w22-decision-audit-scope-coverage.eli16.md
@@ -1,0 +1,61 @@
+# Plain-English overview — the audit gate now checks that the paperwork matches the work
+
+## What this is
+
+Every time this agent changes its own source code, a local check runs before the change is saved and
+writes a small record: what was changed, and which files it covered. When the change later becomes a
+pull request, a second check on the server side confirms that record came along for the ride. That
+second check is what this change is about.
+
+## What was wrong
+
+The server-side check only asked whether *a* record was present. It never compared the record to the
+change. So a pull request that touched five files could carry a record describing one completely
+different file, and the check would report everything in order. Anyone reading the green tick would
+reasonably conclude the change had been reviewed by the local gate. It might not have been.
+
+That is not a hypothetical. The record is written per gate run, and a pull request can easily contain
+commits from more than one run — or commits made in a workspace where the local gate never ran at
+all. The check existed precisely to catch that second case, and a stale record from an unrelated
+commit was enough to satisfy it.
+
+## What changes
+
+The check now reads the records the pull request carries, collects the file paths each one declares
+it covers, and requires every in-scope changed file to appear somewhere in that collection. If a file
+was changed and no record claims it, the check fails and names the specific files that are not
+covered, along with what to do about it: re-run the local gate so the record declares them.
+
+## What is deliberately kept
+
+Three existing escapes are untouched. Pull requests opened by a bot are still exempt. Release-cut
+pull requests are still exempt. A pull request that changes no in-scope files still passes without
+needing any record at all. The older single-file record format still satisfies the check, so any
+pull request already in flight on the old format is unaffected.
+
+## The safeguards, in plain terms
+
+If a record is missing the list of files it covers, or that list is unreadable or malformed, the
+record contributes nothing. It does not get the benefit of the doubt. A guard whose failure costs
+someone a re-run, but whose false pass lets an unreviewed change through, should err toward the
+re-run.
+
+The strictest choice made here is that naming a folder does not count as covering the files inside
+it. The local gate writes concrete file paths, so this only matters for a hand-written record, and in
+that case being strict is the safer default.
+
+## What this does not claim
+
+This is a correction to one check's logic, reviewed by a human before it lands. It is **not** proven
+effective in the formal sense this project uses that word. The measuring instrument that would let
+anyone call a guard properly fixed — a test that mutates a guard and confirms the guard notices —
+exists only as a draft document; the tool it describes was never built. So the honest label here is
+review-grade: better than it was, checked by tests on both sides of the boundary, and not blessed by
+an instrument that does not yet exist.
+
+## What the reader actually needs to decide
+
+Whether requiring the paperwork to match the work is worth the friction of occasionally re-running a
+local gate before opening a pull request. The failure is loud, names the exact files, and takes a
+minute to resolve. The alternative is a check that reports "reviewed" when nothing reviewed the
+change — which is worse than having no check, because the green tick is trusted.

--- a/scripts/decision-audit-presence-check.mjs
+++ b/scripts/decision-audit-presence-check.mjs
@@ -26,6 +26,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 // Keep in sync with inScope() in scripts/instar-dev-precommit.js — the gate
 // this check detects bypasses OF. (A drift here only weakens detection, never
@@ -40,18 +41,43 @@ export function isInScopeFile(file) {
   return false;
 }
 
-function isGateEvidence(change) {
-  // Post-#827 per-entry file (added per gate evaluation)…
-  if (/^\.instar\/instar-dev-decisions\/.+\.json$/.test(change.file)) return true;
-  // …or the pre-#827 legacy JSONL append (transition grace for in-flight PRs).
-  if (change.file === '.instar/instar-dev-decisions.jsonl') return true;
-  return false;
+function isPerEntryDecisionFile(change) {
+  return /^\.instar\/instar-dev-decisions\/.+\.json$/.test(change.file);
+}
+
+function isLegacyDecisionFile(change) {
+  return change.file === '.instar/instar-dev-decisions.jsonl';
+}
+
+function recordScopeFiles(record) {
+  const files = record?.scope?.files;
+  return Array.isArray(files) ? files.filter((file) => typeof file === 'string') : [];
+}
+
+function coverageFiles(records) {
+  const covered = new Set();
+  for (const record of Array.isArray(records) ? records : []) {
+    for (const file of recordScopeFiles(record)) covered.add(file);
+  }
+  return covered;
+}
+
+function readDecisionAuditRecords(changes) {
+  const records = [];
+  for (const change of changes.filter(isPerEntryDecisionFile)) {
+    try {
+      records.push(JSON.parse(readFileSync(change.file, 'utf8')));
+    } catch {
+      records.push({});
+    }
+  }
+  return records;
 }
 
 /**
  * Pure evaluation — exported for unit tests.
- * @param {{ changes: Array<{status: string, file: string}>, title?: string, authorType?: string }} input
- * @returns {{ ok: boolean, exempt?: string, reason?: string, inScopeFiles?: string[] }}
+ * @param {{ changes: Array<{status: string, file: string}>, records?: unknown[], title?: string, authorType?: string }} input
+ * @returns {{ ok: boolean, exempt?: string, reason?: string, inScopeFiles?: string[], uncoveredFiles?: string[] }}
  */
 export function evaluateDecisionAuditPresence(input) {
   const title = String(input?.title ?? '');
@@ -64,21 +90,39 @@ export function evaluateDecisionAuditPresence(input) {
     return { ok: true, reason: 'no in-scope changes — local gate not required' };
   }
 
-  const hasEvidence = changes.some(isGateEvidence);
-  if (hasEvidence) {
-    return { ok: true, reason: 'gate evidence present', inScopeFiles };
+  if (changes.some(isLegacyDecisionFile)) {
+    return { ok: true, reason: 'legacy decision-audit evidence present', inScopeFiles };
+  }
+
+  const recordChanges = changes.filter(isPerEntryDecisionFile);
+  if (recordChanges.length === 0) {
+    return {
+      ok: false,
+      inScopeFiles,
+      reason:
+        `This PR changes ${inScopeFiles.length} in-scope file(s) but carries NO decision-audit record — ` +
+        `the local instar-dev pre-commit gate did not run for these commits. The usual cause is a build ` +
+        `worktree without the husky shim (created with raw 'git worktree add' instead of 'instar worktree ` +
+        `create'). Fix: in the worktree run 'npm run prepare' (wires .husky/_), then re-commit so the gate ` +
+        `evaluates the change and its audit entry (.instar/instar-dev-decisions/<ts>-<slug>.json) rides the ` +
+        `commit. See tasks #81/#80 and PRs #827/#829.`,
+    };
+  }
+
+  const covered = coverageFiles(input?.records);
+  const uncoveredFiles = inScopeFiles.filter((file) => !covered.has(file));
+  if (uncoveredFiles.length === 0) {
+    return { ok: true, reason: 'decision-audit scope covers in-scope changes', inScopeFiles };
   }
 
   return {
     ok: false,
     inScopeFiles,
+    uncoveredFiles,
     reason:
-      `This PR changes ${inScopeFiles.length} in-scope file(s) but carries NO decision-audit record — ` +
-      `the local instar-dev pre-commit gate did not run for these commits. The usual cause is a build ` +
-      `worktree without the husky shim (created with raw 'git worktree add' instead of 'instar worktree ` +
-      `create'). Fix: in the worktree run 'npm run prepare' (wires .husky/_), then re-commit so the gate ` +
-      `evaluates the change and its audit entry (.instar/instar-dev-decisions/<ts>-<slug>.json) rides the ` +
-      `commit. See tasks #81/#80 and PRs #827/#829.`,
+      `This PR changes ${inScopeFiles.length} in-scope file(s), but its decision-audit record scope ` +
+      `does not cover ${uncoveredFiles.length} in-scope file(s). Re-run the local instar-dev ` +
+      `pre-commit gate for this change so the decision-audit record declares the changed path(s).`,
   };
 }
 
@@ -114,8 +158,10 @@ if (invokedDirectly) {
     console.error(`decision-audit gate: git diff failed — ${err instanceof Error ? err.message : String(err)}`);
     process.exit(2);
   }
+  const changes = parseNameStatus(diffOut);
   const res = evaluateDecisionAuditPresence({
-    changes: parseNameStatus(diffOut),
+    changes,
+    records: readDecisionAuditRecords(changes),
     title: process.env.PR_TITLE,
     authorType: process.env.PR_AUTHOR_TYPE,
   });
@@ -126,7 +172,7 @@ if (invokedDirectly) {
   console.error('decision-audit gate: FAIL');
   console.error(res.reason);
   console.error('');
-  console.error('In-scope files without gate evidence:');
-  for (const f of res.inScopeFiles ?? []) console.error(`  - ${f}`);
+  console.error('In-scope files lacking decision-audit coverage:');
+  for (const f of res.uncoveredFiles ?? res.inScopeFiles ?? []) console.error(`  - ${f}`);
   process.exit(1);
 }

--- a/tests/unit/decision-audit-presence-check.test.ts
+++ b/tests/unit/decision-audit-presence-check.test.ts
@@ -52,17 +52,63 @@ describe('evaluateDecisionAuditPresence', () => {
   const entry = { status: 'A', file: '.instar/instar-dev-decisions/2026-06-05T12-00-00-000Z-slug.json' };
   const legacy = { status: 'M', file: '.instar/instar-dev-decisions.jsonl' };
   const srcChange = { status: 'M', file: 'src/core/Config.ts' };
+  const scriptChange = { status: 'M', file: 'scripts/instar-dev-precommit.js' };
   const docsChange = { status: 'M', file: 'docs/specs/foo.md' };
 
-  it('passes when in-scope changes carry a per-entry decision file', () => {
-    const r = evaluateDecisionAuditPresence({ changes: [srcChange, entry] });
+  it('passes when in-scope changes carry a per-entry decision file whose scope covers them', () => {
+    const r = evaluateDecisionAuditPresence({
+      changes: [srcChange, entry],
+      records: [{ scope: { files: ['src/core/Config.ts'] } }],
+    });
     expect(r.ok).toBe(true);
-    expect(r.reason).toContain('evidence');
+    expect(r.reason).toContain('covers');
+  });
+
+  it('passes when multiple per-entry decision file scopes cover the in-scope changes as a union', () => {
+    const r = evaluateDecisionAuditPresence({
+      changes: [srcChange, scriptChange, entry],
+      records: [
+        { scope: { files: ['src/core/Config.ts'] } },
+        { scope: { files: ['scripts/instar-dev-precommit.js'] } },
+      ],
+    });
+    expect(r.ok).toBe(true);
   });
 
   it('passes when in-scope changes carry a legacy jsonl modification (transition grace)', () => {
     const r = evaluateDecisionAuditPresence({ changes: [srcChange, legacy] });
     expect(r.ok).toBe(true);
+  });
+
+  it('fails when a per-entry decision file scopes different files', () => {
+    const r = evaluateDecisionAuditPresence({
+      changes: [srcChange, entry],
+      records: [{ scope: { files: ['scripts/instar-dev-precommit.js'] } }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.uncoveredFiles).toEqual(['src/core/Config.ts']);
+    expect(r.reason).toContain('does not cover');
+  });
+
+  it('fails closed when a per-entry decision file has absent or malformed scope files', () => {
+    const withoutScope = evaluateDecisionAuditPresence({ changes: [srcChange, entry], records: [{}] });
+    const malformedScope = evaluateDecisionAuditPresence({
+      changes: [srcChange, entry],
+      records: [{ scope: { files: 'src/core/Config.ts' } }],
+    });
+    expect(withoutScope.ok).toBe(false);
+    expect(withoutScope.uncoveredFiles).toEqual(['src/core/Config.ts']);
+    expect(malformedScope.ok).toBe(false);
+    expect(malformedScope.uncoveredFiles).toEqual(['src/core/Config.ts']);
+  });
+
+  it('does not treat a directory scope string as covering descendant files', () => {
+    const r = evaluateDecisionAuditPresence({
+      changes: [srcChange, entry],
+      records: [{ scope: { files: ['src/core'] } }],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.uncoveredFiles).toEqual(['src/core/Config.ts']);
   });
 
   it('FAILS when in-scope changes carry no gate evidence — the bypass shape', () => {
@@ -82,8 +128,11 @@ describe('evaluateDecisionAuditPresence', () => {
     expect(r.reason).toContain('no in-scope changes');
   });
 
-  it('exempts bot authors and the release-cut PR', () => {
+  it('exempts bot authors', () => {
     expect(evaluateDecisionAuditPresence({ changes: [srcChange], authorType: 'Bot' }).exempt).toBe('bot-author');
+  });
+
+  it('exempts the release-cut PR', () => {
     expect(evaluateDecisionAuditPresence({ changes: [srcChange], title: 'chore: release v1.3.300 [skip ci]' }).exempt).toBe('release-cut');
   });
 

--- a/upgrades/next/w22-decision-audit-scope-coverage.md
+++ b/upgrades/next/w22-decision-audit-scope-coverage.md
@@ -1,0 +1,45 @@
+<!-- internal-only -->
+
+## What Changed
+
+The PR-boundary decision-audit gate now verifies that the audit record a pull request carries
+actually **covers** the in-scope files that pull request changed, instead of only verifying that
+some audit record was present.
+
+Previously `evaluateDecisionAuditPresence()` asked one question — did any decision-audit record
+change in this PR? — so an unrelated or stale-scoped record satisfied the gate while covering none
+of the changed files. The gate reported "covered" while covering nothing.
+
+The evaluator now accepts caller-supplied decision records, unions their readable `scope.files`, and
+requires every in-scope changed path to appear in that union. The pure function still performs no
+filesystem I/O; the CLI reads the per-entry JSON records and passes the parsed content in. A record
+whose `scope.files` is absent, malformed, or unreadable contributes no coverage — the check fails
+closed. Directory strings do not cover their descendants.
+
+Unchanged: the bot-author, release-cut and no-in-scope-changes exemptions, and the legacy
+`.instar/instar-dev-decisions.jsonl` transition allowance, which still short-circuits to a pass.
+
+The failure output now names the specific uncovered files and the remedy (re-run the local gate so
+the record declares those paths) rather than listing every in-scope file.
+
+This is a CI-only gate script. There is no runtime surface, no route, no message, and no
+agent-visible or user-visible behaviour change.
+
+**Verdict is review-grade, not proven.** The five-property signature runner that would let a guard
+be called fixed does not exist yet — `scratchpad/phaseB/B0.1-THE-BAR.md` is marked
+`DRAFT-FOR-LANES` and its B0.2 implementation was never built — so nothing here is described as
+fixing, verifying or proving the guard effective.
+
+## Evidence
+
+- `npx vitest run tests/unit/decision-audit-presence-check.test.ts` — 14/14 passing, covering both
+  sides of the boundary: covering scope passes, stale scope fails, malformed scope fails closed,
+  directory strings do not cover descendants, multiple records union, and each existing exemption
+  still exempts.
+- Side-effects review: `upgrades/side-effects/w22-decision-audit-scope-coverage.md`, including an
+  independent second-pass review that concurred and separately confirmed the diff introduces no new
+  schema, config, protocol surface or plumbing.
+- Plain-English overview: `docs/specs/w22-decision-audit-scope-coverage.eli16.md`.
+- The gap was identified by the Window-22 guard survey (`.instar/w22/branch-b-guard-ground-truth.md`),
+  which located this guard as one of four that prove less than they claim and rated this
+  identification the highest-confidence of the four.

--- a/upgrades/side-effects/w22-decision-audit-scope-coverage.md
+++ b/upgrades/side-effects/w22-decision-audit-scope-coverage.md
@@ -1,0 +1,150 @@
+# Side-Effects Review — decision-audit gate: scope coverage, not mere presence
+
+**Change:** `scripts/decision-audit-presence-check.mjs` (+ its unit test)
+**Tier:** 1 (declared). See "Tier declaration" at the bottom — the gate's advisory signal said 2.
+**Branch:** `w22-b-audit-scope-coverage` · **Base:** `7d4076a53` (JKHeadley/main, v1.3.1182)
+
+## Summary of the change
+
+The decision-audit presence gate ran on every PR and asked one question: did *some* decision-audit
+record change in this PR? It never asked whether that record's declared scope covered the in-scope
+files the PR actually touched. Any unrelated or stale-scoped record satisfied it. The gate reported
+"covered" while covering nothing — a known false positive, and the exact shape the Window-22 guard
+survey was chartered to find.
+
+The evaluator now accepts caller-supplied decision records, unions their readable `scope.files`, and
+requires every in-scope changed path to be covered by that union. The pure function does no
+filesystem I/O; the CLI reads the per-entry JSON records and passes parsed content in.
+
+## Decision-point inventory
+
+One decision point, already existing: pass/fail of the `decision-audit-gate` CI check on a PR. This
+change does not create a decision point; it corrects the predicate of one that already blocks.
+
+## 1. Over-block
+
+**What it now rejects that it did not before:** a PR that carries a decision-audit record whose
+`scope.files` does not list every in-scope changed path. In practice this is a PR where the gate ran
+for *some* of the commits but not the one that touched the extra file, or where files were added
+after the last gate run.
+
+This is the intended new rejection, but it is a genuine behaviour change for authors: previously the
+presence of any record was enough. The failure message names the uncovered paths and tells the
+author to re-run the local gate so the record declares them. Cost of a false block is "re-run the
+gate and re-commit" — recoverable, local, no data loss.
+
+**Deliberate non-tightening:** directory strings do *not* count as covering their descendants. That
+choice makes the gate stricter than a permissive reading. It is recorded here because it is the one
+place a reasonable reviewer might want the opposite; the writer emits concrete staged file paths, so
+descendant-coverage would only matter for hand-written records.
+
+## 2. Under-block
+
+Still missed, explicitly:
+
+- A record whose `scope.files` lists the right paths but whose *content* is boilerplate. Coverage is
+  a structural claim, not a quality claim; nothing here reads the reasoning.
+- A PR that changes an in-scope file, reverts it in a later commit, and carries a record scoped to
+  the intermediate state. The union is computed over declared paths, not over diff history.
+- Files outside the in-scope predicate (`isInScopeFile`) are unaffected — this change does not widen
+  what counts as in-scope, and should not be read as doing so.
+- Bot-authored and release-cut PRs remain exempt, unchanged.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The check runs at the PR boundary, which is where the bypass it detects becomes
+visible; the local pre-commit gate is the layer that *produces* the record, and it already does its
+job. Pushing coverage down into the pre-commit writer would not help — the failure mode is commits
+that never reached the writer at all.
+
+No smarter gate exists that this should feed instead. The verdict is a set-membership fact, not a
+judgment, so there is no authority for it to inform.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md` applies to **judgment** decisions — blocking on what a message *means*
+or what an agent's *intent* appears to be. This is not one. "Do the record's declared paths cover the
+diff's paths?" is set membership over enumerable inputs, with no context required to separate the
+legitimate case from the illegitimate one. It sits in the document's own excluded category:
+structural validation at a boundary.
+
+The change also moves the check in the *safe* direction relative to the principle: the check already
+held blocking authority with a brittle predicate; this narrows a false-positive **pass**. It does not
+add brittle authority, and it does not add a new blocker.
+
+**Fails closed** on an absent, malformed, or unreadable `scope.files` — that record contributes no
+coverage. Justified by the same document: a guard whose false-pass is cheap to exploit and whose
+false-block costs a re-run should fail closed.
+
+## 5. Interactions
+
+- **Legacy JSONL transition path** (`.instar/instar-dev-decisions.jsonl`) is checked *before* the
+  coverage logic and still short-circuits to pass. In-flight PRs on the old format are unaffected.
+- **The "no record at all" branch** is preserved verbatim, including its long remediation message.
+  Only the new "record present but scope does not cover" branch is added.
+- **The local pre-commit gate** is the producer of these records; nothing in this change alters what
+  it writes.
+- No double-fire: the gate runs once per PR in one workflow.
+- **Self-referential note:** this PR changes an in-scope file, so it must itself carry a record whose
+  scope covers `scripts/decision-audit-presence-check.mjs`. The change is therefore exercised against
+  itself at merge time.
+
+## 6. External surfaces
+
+CI-visible only. The check's failure output changes (it now prints "In-scope files lacking
+decision-audit coverage" and lists uncovered paths rather than all in-scope paths). No route, no
+message, no agent-visible behaviour, no user-visible surface. No timing or runtime-state dependence.
+
+## 6b. Operator-surface quality
+
+The failure message names the specific uncovered files and the concrete remedy (re-run the local
+gate so the record declares the path). It does not require the reader to know the internals of the
+record format. No operator action is required by this change itself.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correctly so:** this runs in GitHub Actions against a PR, not on any
+agent machine. There is no per-machine state, no replication path, and nothing to strand on a topic
+transfer. The decision records it reads are repository content, identical on every checkout.
+
+## 8. Rollback cost
+
+Single-file revert of `scripts/decision-audit-presence-check.mjs` (plus its test). No migration, no
+persisted state, no agent repair. A PR blocked by the new predicate is unblocked by reverting or by
+adding a covering record. Worst realistic case: a burst of PRs fail the gate until authors re-run
+the local gate — visible immediately, recoverable in minutes.
+
+## Conclusion
+
+Bounded correction of an existing gate's predicate, in the direction of fewer false passes, with a
+recoverable false-block cost. No new decision point, no new authority, no runtime surface.
+
+**Verdict is REVIEW-GRADE, not proven.** The five-property signature test that would let a guard be
+called *fixed* does not exist — `scratchpad/phaseB/B0.1-THE-BAR.md` is marked `DRAFT-FOR-LANES` and
+its B0.2 runner was never built. Nothing in this change may be described as fixing, verifying, or
+proving the guard is effective.
+
+## Tier declaration (recorded because the signal disagreed)
+
+The gate's advisory printed `suggestedTier=2 (size=2, riskFloor=1, 86 LOC across 1 file(s))` — the
+**risk** floor is 1; **size** raised the suggestion to 2, and the size is mostly added tests.
+Observer-1 ruling ten (2026-08-21, topic 29723) declared this change tier 1, reasoning on the record:
+the higher tier exists to force design convergence before code, and that convergence exists for this
+change in the Window-22 causal map, the charter, and rulings eight through ten — mechanism proven,
+predicted after-state stated, falsification condition stated. The ruling is void if the diff carries
+new plumbing, a schema, config, or a protocol surface; it does not (one script, one test file).
+
+This paragraph exists so the disagreement between the signal and the declaration is auditable rather
+than suppressed.
+
+## Evidence pointers
+
+- 14/14 targeted tests pass: `npx vitest run tests/unit/decision-audit-presence-check.test.ts`
+- Guard survey that identified the gap: `.instar/w22/branch-b-guard-ground-truth.md`
+- Findings ledger entry 36: view `6e25dfa2-f374-409b-9e85-57aa210adfe0`
+
+## Second-pass review
+
+Concur with the review. I checked the artifact, docs/signal-vs-authority.md, and the actual git diff for the worktree: the diff is limited to scripts/decision-audit-presence-check.mjs and its unit test, and it changes the existing PR gate from per-entry record presence to exact in-scope-path coverage by the union of parsed scope.files. The over-block section is honest: absent, malformed, unreadable, different-file, and directory-only scopes now contribute no coverage and can reject the PR, while legacy JSONL still passes before coverage logic. The signal-vs-authority argument is sound because this is structural boundary validation over enumerable changed paths and declared record paths, not a judgment about message meaning or intent. I found no unmentioned behavioral surface in the diff and no new schema, config, protocol surface, or tier-voiding plumbing beyond local parsing/passing of the already-existing decision-record content.
+
+Independent reviewer, 2026-08-21T01:10:23-07:00


### PR DESCRIPTION
## ⛔ HOLD — do not merge

This PR is deliberately held for an observer review of the diff. Do not merge and do not enable
auto-merge until that review is recorded. The HOLD title is the mechanism that keeps it out of the
green-PR auto-merge pool.

## ELI16 — the audit gate now checks that the paperwork matches the work

Every time this agent changes its own source code, a local check runs before the change is saved and
writes a small record: what was changed, and which files it covered. When the change later becomes a
pull request, a second check confirms that record came along. That second check is what this changes.

**What was wrong.** It only asked whether *a* record was present. It never compared the record to the
change. So a pull request touching five files could carry a record describing one completely
different file, and the check would report everything in order. Anyone reading the green tick would
reasonably conclude the local gate had reviewed the change. It might never have run at all — which is
the exact case this check exists to catch, and a stale record from an unrelated commit was enough to
satisfy it.

**What changes.** The check now reads the records the pull request carries, collects the file paths
each one declares it covers, and requires every in-scope changed file to appear somewhere in that
collection. If a file was changed and no record claims it, the check fails, names the specific
uncovered files, and says what to do: re-run the local gate so the record declares them.

**What is deliberately kept.** Bot-authored pull requests are still exempt. Release-cut pull requests
are still exempt. A pull request changing no in-scope files still needs no record. The older
single-file record format still satisfies the check, so anything already in flight is unaffected.

**The safeguards, plainly.** If a record is missing its list of covered files, or that list is
unreadable or malformed, the record counts for nothing — it does not get the benefit of the doubt. A
guard whose failure costs someone a re-run, but whose false pass lets an unreviewed change through,
should err toward the re-run. Naming a folder does not count as covering the files inside it; the
local gate writes concrete paths, so strictness only affects hand-written records.

**What this does not claim.** This is a correction to one check's logic, reviewed by a human before it
lands. It is **not** proven effective in the formal sense this project uses that word — the instrument
that would let anyone call a guard properly fixed exists only as a draft; the tool it describes was
never built. The honest label is review-grade.

**What the reader decides.** Whether requiring the paperwork to match the work is worth occasionally
re-running a local gate before opening a pull request. The failure is loud, names the exact files, and
takes a minute to resolve. The alternative is a check that reports "reviewed" when nothing reviewed the
change — worse than no check, because the green tick is trusted.

## What changed

The decision-audit presence gate accepted that *some* decision record changed in a PR and never
checked that the record's declared scope covered the in-scope files the PR touched. Any unrelated or
stale-scoped record satisfied it — a known false positive: the gate reported "covered" while
covering nothing.

`evaluateDecisionAuditPresence()` now takes caller-supplied decision records, unions their readable
`scope.files`, and requires every in-scope changed path to be covered by that union. The pure
function still performs no filesystem I/O; the CLI reads the per-entry JSON records and passes the
parsed content in.

**Fails closed:** a record with an absent, malformed or unreadable `scope.files` contributes no
coverage. Directory strings do not cover their descendants.

**Unchanged:** the bot-author, release-cut and no-in-scope-changes exemptions, and the legacy
`.instar/instar-dev-decisions.jsonl` transition allowance.

## Evidence

- 14/14 targeted tests, both sides of the boundary: covering scope passes; stale scope now fails;
  malformed scope fails closed; directory strings do not cover descendants; multiple records union;
  each existing exemption still exempts.
- Side-effects review with an independent second-pass reviewer who concurred and separately
  confirmed the diff carries no new schema, config, protocol surface or plumbing:
  `upgrades/side-effects/w22-decision-audit-scope-coverage.md`
- Plain-English overview: `docs/specs/w22-decision-audit-scope-coverage.eli16.md`
- The gap was located by a guard survey that rated this the highest-confidence identification of
  four guards that prove less than they claim.

## Self-referential note

Committing this change generated exactly the kind of decision-audit record its own new check
demands, so this PR carries the covering record its own change requires — the check is exercised
against itself.

## Tier declaration (recorded because the signal disagreed)

The gate's advisory printed `suggestedTier=2 (size=2, riskFloor=1, 86 LOC across 1 file)` — the
**risk** floor is 1; **size** raised the suggestion, and the size is mostly added tests. Declared
tier 1 per an observer ruling whose reasoning is recorded in the trace and the artifact: the higher
tier exists to force design convergence before code, and that convergence exists on the record
(mechanism proven, predicted after-state stated, falsification condition stated). Recorded here so
the disagreement is auditable rather than suppressed.

## Verdict is REVIEW-GRADE, not proven

The five-property signature runner that would let a guard be called *fixed* does not exist —
`scratchpad/phaseB/B0.1-THE-BAR.md` is marked `DRAFT-FOR-LANES` and its B0.2 implementation was
never built. Nothing here is described as fixing, verifying or proving the guard effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
