### PR TITLE
chore(ci): a manually-started job to deprecate one published version

### DIFF
--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -1,0 +1,137 @@
+# deprecate-version — mark ONE already-published version of this package deprecated.
+#
+# Why this exists: a release run can leave an ORPHAN on the registry — a version
+# published by a race whose release commit and tag never landed in history (live
+# case 2026-08-21: 1.3.1183, published between two racing publish runs, no tag,
+# no release commit, superseded four and a half minutes later by 1.3.1184).
+# Removing such a version is the destructive option and is deliberately NOT
+# available here; marking it deprecated with a pointer to the good version is.
+#
+# DELIBERATE LIMITS — this job's capability is exactly one npm write:
+#   * It is started BY HAND only. There is no push, schedule or other trigger.
+#   * It NEVER checks out the repository, so no repository code runs beside the
+#     publish-capable credential this job is handed.
+#   * `npm deprecate` is the only npm write it performs. It cannot publish and
+#     it cannot unpublish.
+#   * The version and the pointer text are supplied when it is started. Nothing
+#     about the target is baked into this file.
+#   * The version input must be ONE exact published version. A range or a tag
+#     (`*`, `<1.3.1184`, `latest`) would deprecate MANY versions in a single
+#     call, so those are refused before the credential is used at all.
+#   * The current `latest` version is refused, so the version everyone installs
+#     can never be deprecated by a mistyped input.
+#
+# Reversal is NOT in this job: npm clears a deprecation when the message is
+# empty, and this job requires a non-empty message. Clearing one therefore still
+# needs a credential outside this workflow. That is a known, accepted limit of
+# the approved scope, not an oversight.
+
+name: deprecate-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'ONE exact published version to deprecate, e.g. 1.3.1183. Ranges and tags are refused.'
+        required: true
+        type: string
+      message:
+        description: 'Plain-English pointer shown at install time, e.g. "orphaned release, never tagged — use 1.3.1184 instead".'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deprecate-version
+  cancel-in-progress: false
+
+jobs:
+  deprecate:
+    name: Deprecate a published version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Every check that could refuse the request runs BEFORE the credential is
+      # ever put on disk, and reads the registry rather than trusting the input.
+      - name: Check the request and record the before state
+        id: before
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_MESSAGE: ${{ inputs.message }}
+        run: |
+          node --input-type=module -e '
+            import fs from "node:fs";
+
+            const version = (process.env.INPUT_VERSION ?? "").trim();
+            const message = (process.env.INPUT_MESSAGE ?? "").trim();
+            const fail = (why) => { console.error("REFUSED: " + why); process.exit(1); };
+
+            // One exact semver. Anything a range or tag could hide is refused here.
+            if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+              fail(`"${version}" is not one exact version. Ranges and tags are refused because they deprecate many versions at once.`);
+            }
+            if (message.length === 0) fail("the pointer message is empty.");
+            if (message.length > 512) fail(`the pointer message is ${message.length} characters; the limit is 512.`);
+            if (/[\r\n]/.test(message)) fail("the pointer message must be a single line.");
+
+            const res = await fetch("https://registry.npmjs.org/instar", { headers: { "Cache-Control": "no-cache" } });
+            if (!res.ok) fail(`the registry answered ${res.status} when asked about this package.`);
+            const pkg = await res.json();
+            const latest = pkg["dist-tags"]?.latest;
+            if (!pkg.versions?.[version]) fail(`${version} is not published on the registry, so there is nothing to deprecate.`);
+            if (version === latest) fail(`${version} is the current latest version. Deprecating what everyone installs is never this jobs purpose.`);
+
+            const before = pkg.versions[version].deprecated;
+            console.log(`package:  ${pkg.name}`);
+            console.log(`version:  ${version}`);
+            console.log(`latest:   ${latest}`);
+            console.log(`before:   ${before === undefined ? "not deprecated" : JSON.stringify(before)}`);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `### Before\n\n- version: \`${version}\`\n- latest: \`${latest}\`\n- deprecated: ${before === undefined ? "no" : "`" + before + "`"}\n`);
+          '
+        shell: bash
+
+      - name: Mark it deprecated
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_MESSAGE: ${{ inputs.message }}
+        run: npm deprecate "instar@$INPUT_VERSION" "$INPUT_MESSAGE"
+
+      # The command exiting zero is not the answer. The registry is.
+      - name: Read the registry back and prove it took
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_MESSAGE: ${{ inputs.message }}
+        run: |
+          node --input-type=module -e '
+            import fs from "node:fs";
+            const version = process.env.INPUT_VERSION.trim();
+            const expected = process.env.INPUT_MESSAGE.trim();
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            // The registry is a cache in front of a database; a fresh write can
+            // take a few seconds to be visible. Retry rather than call a
+            // propagation delay a failure.
+            for (let attempt = 1; attempt <= 10; attempt++) {
+              const res = await fetch("https://registry.npmjs.org/instar", { headers: { "Cache-Control": "no-cache" } });
+              const pkg = await res.json();
+              const after = pkg.versions?.[version]?.deprecated;
+              if (after === expected) {
+                console.log(`after: ${JSON.stringify(after)}`);
+                console.log(`latest is still ${pkg["dist-tags"]?.latest}`);
+                fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `### After\n\n- deprecated: \`${after}\`\n- latest: \`${pkg["dist-tags"]?.latest}\`\n`);
+                process.exit(0);
+              }
+              console.log(`attempt ${attempt}: registry still reads ${JSON.stringify(after)}`);
+              await sleep(6000);
+            }
+            console.error("The registry did not come back with the expected message. Nothing here retried the write; check the version by hand before running this again.");
+            process.exit(1);
+          '
+        shell: bash

--- a/upgrades/next/w22-deprecate-version-job.md
+++ b/upgrades/next/w22-deprecate-version-job.md
@@ -1,0 +1,34 @@
+<!-- bump: patch -->
+
+## What Changed
+
+A new manually-started maintenance job was added to this repository's own
+pipeline: it marks ONE already-published version of the package deprecated,
+with a plain-English pointer to the version people should use instead.
+
+It exists because a release race can leave an ORPHAN on the registry — a
+version that was published, but whose release commit and tag never landed in
+history. Cleaning one up requires a publish-capable credential, and that
+credential lives only inside this repository's pipeline. This job is the one
+place it can be used for that purpose, and its capability is exactly one write.
+
+The job is started by hand only. It never checks out the repository, so no
+repository code runs beside the credential. It can deprecate; it cannot publish
+and it cannot unpublish. The version and the message are supplied when it is
+started, so nothing about the target is baked into the file. A range or a tag
+is refused before the credential is touched, because those would deprecate many
+versions in a single call, and the current recommended version is refused so
+that what everyone installs can never be hit by a typo. Afterwards the result
+is read back from the registry — the command exiting cleanly is not accepted as
+proof on its own.
+
+## What to Tell Your User
+
+Nothing. This is repository maintenance for the people who publish this
+package; it changes no behaviour on any installed agent and adds no capability
+an agent can reach.
+
+## Summary of New Capabilities
+
+None for agents or users. One maintenance job for maintainers of this
+repository.


### PR DESCRIPTION
## ELI16 — what this does, in plain English

When we publish a new version of this package, a script cuts the release: it bumps the version, tags it in our history, and pushes the package to the public registry. On 21 August two of those release runs raced each other. Both published. Only one of them finished writing the history. The result is a version sitting on the public registry — 1.3.1183 — that has no tag and no release commit anywhere in our project. It is an orphan: real to anyone installing it, invisible to anyone reading our history.

We want to leave a sign on it saying "this one was an accident, use 1.3.1184 instead". The registry has a built-in way to do that: a version can be marked deprecated with a message, and anyone who installs it sees the message. Nothing is deleted, nothing breaks for anyone who already has it, and it can be undone.

The problem is that leaving that sign requires a publishing credential, and the only live one we have lives inside this repository's release pipeline where no person and no agent can read it. So this pull request adds one small job that can use it — for that single purpose and nothing else.

The job only runs when a person starts it by hand. It is told which version to mark and what message to leave; neither is written into the file, so the job has no opinion about any particular version. Before it touches the credential at all it checks the request against the registry itself: the version has to be one exact version that really exists, never a pattern like "everything below 1.3.1184" — a pattern would mark hundreds of versions in one go — and never the version everyone is currently installing. If any of those checks fails, the job stops and explains why, and the credential is never used.

After it leaves the sign, it does not trust the command's success. It reads the registry back and requires the message to actually be there before it reports success, retrying for a minute in case the registry is slow to catch up. The job never checks out this repository, so no project code runs next to that credential, and the only registry-changing command it can run is the one that marks a version deprecated. It cannot publish and it cannot remove anything.

## What is in the diff

Two files, both new, nothing modified or deleted:

| file | why |
|---|---|
| `.github/workflows/deprecate-version.yml` | the job itself (137 lines, mostly the comment block explaining the limits and the two checking steps) |
| `upgrades/next/w22-deprecate-version-job.md` | required by this repo's own pre-push gate — see the disclosure below |

## Disclosures — things to know before reading the diff, not after

**1. The approved scope was ONE additive workflow file. There are two files.** The pre-push gate refuses any change under `.github/workflows/` that ships no release-note fragment, because the publish pipeline silently skips a release when none exists — omitting it would have blocked the next release of unrelated work. The second file is that fragment. It grants nothing and states plainly that there is nothing to tell users.

**2. This job can mark a version deprecated but cannot un-mark one.** The registry clears a deprecation when the message is empty; this job requires a non-empty message, per the approved scope. So reversing a deprecation still needs a credential outside this workflow. That is a real limit of what was approved, disclosed rather than left to be discovered. Say the word and allowing an empty message is a one-line change.

**3. There are no unit tests, deliberately.** The approved scope is one workflow file; a test would require a second code file and a harness for something GitHub executes. Instead every decision boundary was exercised locally against the live registry document before commit — see below.

## Evidence — every refusal exercised, and each one exits non-zero

Run locally against the real registry document. A gate that prints a refusal and then exits zero is worse than no gate, so the exit code is the thing being checked here, not the message:

| input | outcome | exit |
|---|---|---|
| `1.3.1183` + a real message | accepted; records before state (`not deprecated`, latest `1.3.1184`) | 0 |
| `1.3.1184` (the current latest) | refused — deprecating what everyone installs is never the purpose | 1 |
| `*` | refused — not one exact version | 1 |
| `<1.3.1184` | refused — not one exact version | 1 |
| `latest` | refused — not one exact version | 1 |
| `9.9.9` | refused — not published, nothing to deprecate | 1 |
| empty message | refused | 1 |
| multi-line message | refused | 1 |

The read-back step was also exercised in its FAILING direction: given a message the registry does not carry, it retried ten times and then exited 1, writing no success record. A verification step that cannot fail is decoration.

## Hold

Held deliberately. The title carries the hold, the `do-not-merge` label is applied, and automatic merge is not enabled. This touches release machinery, so the merge is a human's — do not let the automatic merge machinery take it.
