### PR TITLE
fix: pair the pre-push side-effects check to the work, not the wall clock

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-22T00-17-07-780Z-pre-push-side-effects-freshness.json
+++ b/.instar/instar-dev-decisions/2026-08-22T00-17-07-780Z-pre-push-side-effects-freshness.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-22T00:17:07.780Z",
+  "slug": "pre-push-side-effects-freshness",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 74,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/pre-push-gate.js"
+    ],
+    "addedLines": 61,
+    "deletedLines": 13
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/pre-push-side-effects-freshness.eli16.md
+++ b/docs/specs/pre-push-side-effects-freshness.eli16.md
@@ -1,0 +1,88 @@
+# Pre-Push Review Check: Pair It to the Work, Not the Clock — ELI16
+
+## The one-sentence version
+
+A safety check that asks "has this work been reviewed?" was actually asking "was any
+review written in the last 24 hours?" — so completed reviews stopped counting as time
+passed, and the check began blocking pushes for work that had already been reviewed.
+
+## What already exists
+
+Before anyone pushes to the instar repo, a gate runs. One of its checks (check 5) looks
+at the release notes waiting to ship. If those notes claim a fix or a feature, the gate
+insists that a **side-effects review** exists — the written analysis of what a change
+might break. No review, no push. That part is correct and stays exactly as it is.
+
+Release notes are written as small files, one per change, that pile up in a folder until
+a release is cut. At that point they are folded into a single version file and the folder
+is emptied. So the pile can hold a week of already-reviewed work.
+
+## What was wrong
+
+To decide whether a review existed, the check looked for **any** review file modified in
+the last 24 hours.
+
+That question answers itself differently depending on what day you ask it. A batch of
+work reviewed on Tuesday passes on Tuesday, passes on Wednesday morning, and then starts
+**failing** on Thursday — not because anything changed, but because the clock moved.
+
+Seen for real on 2026-08-21: nine changes waiting to ship, nine matching reviews written
+the same day as the work, and the gate refusing every push — including one that only
+touched a documentation file. The newest review was about 41 hours old.
+
+The nasty part is the advice it gave. It said "add a review for this change." But the
+change already had one. The only way to literally satisfy it was to write a **second**
+review for already-reviewed work, or re-save an old file to reset the clock. The check's
+own source code carries a warning about this: three separate times, someone hit a similar
+dead end and wrote a placeholder file to get past it. Two of those files admit it in
+their own text.
+
+A gate whose only available remedy is to produce a junk document is teaching people to
+produce junk documents.
+
+## What changed
+
+One question replaced another.
+
+- **Before:** "Was a review written recently?" (compared against today)
+- **After:** "Is there a review at least as recent as the newest thing waiting to ship?"
+
+The second question has a stable answer. If everything waiting to ship was reviewed when
+it was written, that stays true tomorrow, next week, and next month.
+
+The error message was rewritten too, because it described the old rule. A message that
+misstates its own check is its own small version of this bug.
+
+## The safeguards, in plain terms
+
+**It still refuses unreviewed work.** Add a new change without reviewing it, and its
+note becomes the newest file in the pile — newer than every review — so the gate stops
+you. This was tested directly: a temporary unreviewed note was added, the gate refused,
+the note was removed, and the gate passed again.
+
+**A ten-minute grace window.** When someone freshly clones the repository, every file
+gets the same timestamp and their relative order is essentially random. Without a small
+tolerance, a clean checkout could fail for no reason — the same cry-wolf problem wearing
+a different hat. Ten minutes is far shorter than the gap between writing a change and
+forgetting to review it, so it cannot hide a real omission.
+
+**Nothing else moved.** Per-change enforcement at commit time is untouched. The rule
+that a release-relevant push must ship notes at all is untouched. Continuous integration
+still skips this check entirely, as it did before.
+
+## What you actually need to decide
+
+Whether the replacement question is the right one.
+
+If you think "is there a review at least as new as the newest pending change?" is too
+loose, the alternative is matching each note to its own review by name. That is stricter,
+but the names do not reliably correspond — one note called `r6-agent-identity-continuity`
+pairs with a review called `agent-identity-continuity-on-expansion` — so name-matching
+would produce a new class of false refusals, which is the failure being removed.
+
+## Honest limitation
+
+Re-saving an unrelated old review for any reason lifts the bar for the whole batch. That
+exposure existed before and is strictly smaller now: the old rule accepted any touch of
+any review as proof for any change. This is a real gap, not a solved one — closing it
+properly needs reliable note-to-review pairing, which does not exist today.

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -379,23 +379,71 @@ if (!process.env.CI) {
       const sideEffectsDir = path.join(ROOT, 'upgrades', 'side-effects');
       let artifactFound = false;
 
-      if (fs.existsSync(sideEffectsDir)) {
-        const files = fs.readdirSync(sideEffectsDir).filter((f) => f.endsWith('.md'));
-        // Any fresh artifact from the last 24h counts — the in-flight notes name
-        // the change, the artifact reviews it, and the two are paired by the PR
-        // rather than by filename.
-        const recent = files.filter((f) => {
-          const stat = fs.statSync(path.join(sideEffectsDir, f));
-          return Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000;
-        });
-        artifactFound = recent.length > 0;
+      // Pair the review to the WORK, not to the wall clock.
+      //
+      // This used to be "any artifact modified in the last 24h counts". That
+      // asks the wrong question. The in-flight fragments accumulate across many
+      // already-reviewed PRs until a release cut folds them away, so a batch
+      // that was fully reviewed on Tuesday starts FAILING on Thursday for no
+      // reason but elapsed time — the review did not stop existing, the window
+      // moved. Observed 2026-08-21: nine in-flight fragments, nine matching
+      // slug-named artifacts written the same day, gate refusing every push
+      // (including docs-only ones) because the newest artifact was ~41h old.
+      //
+      // The only way to satisfy a decayed window is to write a NEW artifact for
+      // work that already has one — which is precisely the placeholder-writing
+      // this check's own history warns about (see the comment above). A gate
+      // whose sole remedy is to produce a redundant document is teaching the
+      // wrong habit twice over.
+      //
+      // Compare instead against the newest thing actually waiting to ship: is
+      // there a review at least as recent as the newest in-flight fragment?
+      // Nothing is weakened — add an unreviewed fragment and the newest
+      // fragment outruns the newest artifact, and this still refuses — but the
+      // verdict no longer rots on its own while the facts stay unchanged.
+      const newestMtime = (dir, filter) => {
+        if (!fs.existsSync(dir)) return null;
+        let newest = null;
+        for (const f of fs.readdirSync(dir)) {
+          if (!filter(f)) continue;
+          try {
+            const m = fs.statSync(path.join(dir, f)).mtimeMs;
+            if (newest === null || m > newest) newest = m;
+          } catch {
+            // Unreadable entry: skip it rather than let one bad stat decide.
+          }
+        }
+        return newest;
+      };
+
+      const newestArtifact = newestMtime(sideEffectsDir, (f) => f.endsWith('.md'));
+      const newestFragment = newestMtime(
+        path.join(ROOT, 'upgrades', 'next'),
+        (f) => f.endsWith('.md')
+      );
+
+      if (newestArtifact !== null) {
+        if (newestFragment === null) {
+          // Legacy NEXT.md-only state (no fragment dir): fall back to the
+          // original freshness rule rather than passing on no evidence.
+          artifactFound = Date.now() - newestArtifact < 24 * 60 * 60 * 1000;
+        } else {
+          // Tolerance absorbs checkout/clone mtime ordering, where every file
+          // lands within the same moment and their relative order is arbitrary.
+          // It is far shorter than the gap between authoring a fragment and
+          // neglecting its review, so it cannot mask a genuinely missing one.
+          const SKEW_MS = 10 * 60 * 1000;
+          artifactFound = newestArtifact >= newestFragment - SKEW_MS;
+        }
       }
 
       if (!artifactFound) {
         errors.push(
-          `Your release-note fragment claims a fix/feature but no side-effects review artifact was written in the last 24h. ` +
-          `Add upgrades/side-effects/<slug>.md for this change (produced via the /instar-dev skill) — ` +
-          `do NOT create a version-named file to satisfy this check. ` +
+          `Your release-note fragment claims a fix/feature but no side-effects review artifact is as recent as it. ` +
+          `The newest upgrades/next/ fragment is newer than every file in upgrades/side-effects/, ` +
+          `which means the most recently added work has not been reviewed. ` +
+          `Add upgrades/side-effects/<slug>.md for THAT change (produced via the /instar-dev skill) — ` +
+          `do NOT create a version-named file, and do NOT re-touch an existing artifact, to satisfy this check. ` +
           `See skills/instar-dev/SKILL.md and docs/signal-vs-authority.md.`
         );
       }

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -515,7 +515,12 @@ describe('Pre-push gate integration — release-note fragments', () => {
 
     const { status, stdout } = runGate();
     expect(status).not.toBe(0);
-    expect(stdout).toContain('side-effects review artifact was written in the last 24h');
+    // The refusal now names the PAIRING failure, not a wall-clock window: this
+    // change replaced "…written in the last 24h" with "…as recent as it", so a
+    // reviewed backlog stops aging into a false refusal. The case still asserts
+    // the same behaviour — an unreviewed in-flight fragment is refused — via the
+    // wording the gate actually emits.
+    expect(stdout).toContain('no side-effects review artifact is as recent as it');
     // And the remedy it names must be the slug form, never a version-named file.
     expect(stdout).toContain('upgrades/side-effects/<slug>.md');
   });

--- a/upgrades/next/r8-pre-push-side-effects-freshness.md
+++ b/upgrades/next/r8-pre-push-side-effects-freshness.md
@@ -1,0 +1,26 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+**The pre-push gate refused every push once its review check aged out, even when every
+pending change had already been reviewed.** The check asked whether any side-effects
+review had been written in the last 24 hours. Release notes accumulate across many
+already-reviewed changes until a release folds them away, so a fully-reviewed batch
+started failing purely because time passed. It now asks whether a review is at least as
+recent as the newest pending change — which never rots on its own.
+
+## Why It Matters
+
+The only way to satisfy the old rule was to write a redundant review for work that
+already had one, or re-touch an existing file to reset a clock. The gate's own source
+records three prior occasions where someone wrote a placeholder to get past it. A check
+whose sole remedy is to produce a junk document trains the wrong habit while pretending
+to enforce a standard.
+
+Unreviewed work is still refused: a new note outruns every existing review and the gate
+still stops the push.
+
+## Action Required
+
+None. Behaviour is automatic and local to each machine's pre-push hook.

--- a/upgrades/side-effects/pre-push-side-effects-freshness.md
+++ b/upgrades/side-effects/pre-push-side-effects-freshness.md
@@ -1,0 +1,188 @@
+# Side-Effects Review — Pair the side-effects check to the work, not the wall clock
+
+**Version / slug:** `pre-push-side-effects-freshness`
+**Date:** `2026-08-21`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `self-conducted adversarial pass — see Second-pass review (a subagent was NOT spawned; disclosed there)`
+
+## Summary of the change
+
+`scripts/pre-push-gate.js` check 5 refuses a push when the assembled in-flight release
+notes claim a fix/feature and no side-effects artifact is present. It located that
+artifact by asking "was ANY file in `upgrades/side-effects/` modified in the last 24
+hours?"
+
+That question decays. In-flight fragments accumulate across many already-reviewed PRs
+until a release cut folds them into `upgrades/<version>.md`. A batch reviewed on Tuesday
+therefore begins FAILING on Thursday purely because the window moved — the reviews did
+not stop existing.
+
+Observed 2026-08-21: nine fragments in `upgrades/next/`, nine slug-matched artifacts in
+`upgrades/side-effects/` written the same day, and the gate refusing every push —
+including a documentation-only one — because the newest artifact was ~41h old.
+
+The check now compares the newest artifact against the newest in-flight fragment
+(10-minute skew tolerance), and the operator-facing message was rewritten to describe
+the rule it actually applies.
+
+## Phase 1 — Principle check (signal vs authority)
+
+**Does this touch a decision point?** Yes. `pre-push-gate.js` check 5 holds real blocking
+AUTHORITY — it refuses a push.
+
+**Does the change comply with `docs/signal-vs-authority.md`?** Yes, and it moves toward
+compliance rather than away. No authority is added: the gate could already refuse, and
+still refuses on exactly the same trigger (an in-flight fragment claiming a fix/feature
+with no corresponding review). What changed is the *evidence predicate* behind that
+authority, from one whose verdict decayed with wall-clock time to one that is a function
+only of the repository's own contents.
+
+The principle's core warning is brittle logic wielding blocking authority. The predicate
+here was brittle in the specific way the principle names — it produced confident refusals
+from a signal that carried no information about the question being asked ("was this
+reviewed?" answered by "what time is it?"). The replacement is strictly less brittle. It
+is still a heuristic over filesystem timestamps, and §2 states the residual honestly.
+
+## Correction to the precipitating incident (recorded after the fix was written)
+
+The push refusal that prompted this change came from a checkout 5 versions stale
+(v1.3.1180) still holding 9 un-released fragments. On current `main` (v1.3.1185) the
+release cut has already emptied `upgrades/next/`, so `inFlight` is false and check 5 is
+skipped entirely — that tree was never blocked.
+
+This is stated because the fix's justification must not rest on a misread cause. The
+logic defect is real and independently verifiable, and it WILL recur on any tree where
+fragments accumulate for more than 24h before a release cut — the normal condition during
+an active week. But the acute blocker was staleness, not this defect, and the change is
+therefore prevention rather than the remedy it was originally framed as.
+
+## Decision-point inventory
+
+| Decision | Who decides | Authority |
+|---|---|---|
+| Does an in-flight fragment claim a fix/feature? | `FIX_PATTERNS` regex | unchanged |
+| Is the newest work reviewed? | mtime comparison, fragment vs artifact | CHANGED |
+| Refuse the push | the gate | unchanged |
+
+## 1. Over-block
+
+**Before:** systematically over-blocked. Any push, of any content, refused once the
+newest artifact aged past 24h with fragments still in flight. The refusal named a
+remedy — "add an artifact for this change" — that was unsatisfiable, because the change
+already had one. The only literal way through was a redundant document.
+
+**After:** the over-block is removed at its source. A fully-reviewed batch passes
+indefinitely, because nothing about it changes as time passes.
+
+**Residual:** an artifact touched for an unrelated reason (an edit to old prose) lifts
+the bar for the whole batch. Same exposure as before, and strictly smaller — the old
+rule accepted ANY touch of ANY artifact as proof for ANY fragment.
+
+## 2. Under-block
+
+The load-bearing question: can unreviewed work now pass?
+
+No. Adding a fragment makes it the newest file in `upgrades/next/`, so it outruns every
+artifact and the gate refuses. Verified live (test 2 below): the gate exits 1.
+
+The 10-minute skew tolerance is the one deliberate softening. It exists because a fresh
+clone or checkout writes every file within the same instant and their relative order is
+arbitrary — without it the gate would fail spuriously on a clean checkout, which is the
+same cry-wolf failure in a new costume. Ten minutes is far shorter than the interval
+between authoring a fragment and neglecting its review, so it cannot mask a real gap.
+
+## 3. Level-of-abstraction fit
+
+Correct level. The gate already owns "is this shipment reviewed?"; only its proxy for
+recency changed. No new concept, surface, or config is introduced.
+
+## 4. Signal vs authority compliance
+
+The gate remains AUTHORITY (it refuses a push) and its scope is unchanged. This change
+narrows a false-positive class; it grants no new power and relaxes no existing refusal.
+
+## 4b. Judgment-point check (Judgment Within Floors)
+
+No judgment point added. The comparison is deterministic, with a constant tolerance.
+
+## 5. Interactions
+
+- Per-change enforcement is unaffected: `scripts/instar-dev-precommit.js` still refuses
+  in-scope staged files without an ELI16 + side-effects artifact. This check remains the
+  release-level re-check.
+- Check 3b (release-relevant push shipping no fragment) is untouched.
+- CI still skips check 5 entirely (`process.env.CI`).
+- Legacy `NEXT.md`-only trees (no `upgrades/next/` fragments) fall back to the original
+  24h freshness rule rather than passing on absent evidence.
+
+## 6. External surfaces
+
+None. No route, no config key, no user-visible behaviour. The only surface is the
+operator-facing error text, which was corrected in the same change — a message that
+misdescribes its own rule is the defect class this repo has been repeatedly bitten by.
+
+## 6b. Operator-surface quality
+
+The message now names the real condition ("no artifact is as recent as the newest
+fragment"), points at the specific change needing review, and explicitly forbids both
+known cheats: a version-named file, and re-touching an existing artifact to reset a
+clock.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+`machine-local-justification: hardware-bound-resource` — the check reads the local
+working tree's filesystem timestamps to decide whether THIS machine's push may proceed.
+It holds no state, replicates nothing, and every machine evaluates its own checkout. No
+cross-machine surface exists to unify.
+
+## 8. Rollback cost
+
+One function replaced in one file, no state and no migration. Reverting the commit
+restores the previous behaviour exactly.
+
+## Conclusion
+
+Ship. The change removes a self-inflicted refusal whose only remedy taught the exact
+habit the check's own source comment warns against, while leaving the refusal it exists
+to make fully intact.
+
+## Second-pass review
+
+**Required.** Phase 5 mandates an independent second pass for anything with "gate" in it.
+
+**Disclosure:** no reviewer subagent was spawned. A standing session constraint forbids
+delegating to subagents unless the operator asks. What follows is a self-conducted
+adversarial pass, which is weaker evidence than an independent reviewer and is labelled
+as such rather than presented as a concurrence.
+
+**Concern raised — mtime is not authorship time.** A `git checkout`, rebase, or merge
+rewrites the mtime of any file it touches. An operation that rewrites a fragment without
+rewriting an artifact makes that fragment the newest file and produces a refusal for work
+that was in fact reviewed — the same false-positive class this change removes, in a
+rarer form.
+
+**Weighed, not dismissed:**
+- Frequency: far rarer than the defect being fixed. The old predicate failed on a fixed
+  schedule (every batch, every time, 24h after review). This one requires a specific
+  git operation that touches fragments and spares artifacts.
+- Direction: it fails toward refusing a push, never toward accepting unreviewed work.
+- Remedy quality: the remedy it names is still "write a review that is not needed",
+  which is the habit this change exists to stop. That is the part that genuinely bothers
+  me and is why it is recorded here rather than waived.
+
+**The correct long-term fix** is to read git commit timestamps instead of filesystem
+mtimes, which are immune to checkout effects. Not done here: it needs a git call per
+file inside a hook that must stay fast, and it is a materially larger change than the
+one under review, and it belongs in its own PR with its own review. <!-- tracked: topic-52222 -->
+
+**Verdict:** ship, with the residual named in §2 and above rather than papered over. The
+change strictly reduces false refusals; it does not eliminate the class.
+
+## Evidence pointers
+
+- Test 1 — nine reviewed fragments present, gate exits 0 (previously 1).
+- Test 2 — temporary unreviewed fragment added, gate exits 1 with the corrected message.
+- Test 3 — temporary fragment removed, gate returns to exit 0.
+- Population at time of change: 9 fragments in `upgrades/next/`, each with a slug-matched
+  artifact; newest artifact `wire-agent-identity-handover.md` (2026-08-20 00:25), ~41h
+  old at the time of the observed refusal.


### PR DESCRIPTION
## ELI16 — a safety check that turned finished work into "unreviewed" after a day

Before anything is pushed, a check asks whether the pending work has had its review written. It used to ask that by looking at the clock: "has any review been written in the last 24 hours?"

That question rots. Reviews pile up alongside their work until a release folds them away, so a batch that was fully reviewed starts failing the check purely because a day went by. Nothing changed except the time.

The only way to satisfy a check like that is to write a second review for work that already has one, or touch a file to reset the clock. The check's own source comments record three prior occasions where someone did exactly that, and two of those placeholder files admit it in their own text. A gate whose only remedy is a junk document teaches the wrong habit while looking like it enforces a standard.

It now asks a question about the repository rather than the calendar: "is there a review at least as recent as the newest piece of pending work?" That answers the thing we actually care about, never goes stale on its own, and still fails if someone adds work tomorrow without reviewing it. A ten-minute tolerance keeps a fresh clone — where every file has the same timestamp — from failing for no reason.

## What

`pre-push-gate.js` check 5 asked *"was ANY side-effects artifact modified in the last 24h?"* to decide whether pending work had been reviewed. That question decays: release-note fragments accumulate across many already-reviewed PRs until a release cut folds them away, so a fully-reviewed batch begins **failing** purely because the window moved.

Now it asks *"is there a review at least as recent as the newest in-flight fragment?"* — a function of repository contents only, with a 10-minute skew tolerance so a fresh clone (all mtimes in the same instant) cannot fail spuriously.

The operator-facing message was rewritten too; it described the old rule.

## Why it matters

The only way to satisfy a decayed window is to write a **second** review for work that already has one, or re-touch a file to reset a clock. This check's own source comment records three prior occasions where someone did exactly that — two of those placeholder files admit it in their own text. A gate whose sole remedy is a junk document teaches the wrong habit while appearing to enforce a standard.

## Scope honesty

Current `main` had already cut v1.3.1185, emptying `upgrades/next/`, so `inFlight` is false and check 5 is skipped — **main was never blocked.** The refusal was observed on a 5-versions-stale checkout still holding 9 fragments. This is prevention of a recurrence (normal whenever fragments sit >24h before a cut), not a fix for an acute outage.

## Non-weakening

An unreviewed fragment becomes the newest file in `upgrades/next/`, outruns every artifact, and is still refused.

- Reviewed batch → exit 0
- Temporary unreviewed fragment added → exit 1, corrected message
- Fragment removed → exit 0

## Known residual (named, not waived)

`mtime` is not authorship time — a checkout/rebase that rewrites a fragment but not an artifact can still produce a false refusal. Rarer than the defect removed, and it fails toward refusing rather than toward accepting unreviewed work. The correct long-term fix is reading git commit timestamps; that is a materially larger change and belongs in its own PR.

## Review note

Phase 5 mandates an independent second pass for gate changes. No reviewer subagent was spawned (standing session constraint); a self-conducted adversarial pass was done instead and is labelled as such in the artifact, with `reviewerConcurred: false` in the trace. **This PR would benefit from a human second read.**

Tier 1: ELI16 + side-effects artifact staged, no spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
