### PR TITLE
fix(tests): stop the suite reaching live agent state, and two host-dependent tests

### DIFF
--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -159,9 +159,16 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
     });
 
     it('passes --model gpt-5.5 + --dangerously-bypass-approvals-and-sandbox by default (parity with Claude\'s --dangerously-skip-permissions)', () => {
-      const spec = buildInteractiveLaunch('codex-cli', {
-        binaryPath: '/usr/local/bin/codex',
-      });
+      // The binary is a FAKE whose --help advertises no hook-trust flag, so this
+      // asserts the DEFAULT argv deterministically. It previously passed the real
+      // '/usr/local/bin/codex' path, which made the assertion depend on whichever
+      // codex happens to be installed: `codexSupportsHookTrustBypass` shells out to
+      // `<binary> --help`, so on a host with codex >=0.133 the builder appended
+      // `--dangerously-bypass-hook-trust` and this exact-array comparison failed —
+      // green in CI (no codex on the runner), red on a maintainer's machine. The
+      // sibling tests below already use this helper; this one just hadn't adopted it.
+      const bin = fakeCodexBinary(false);
+      const spec = buildInteractiveLaunch('codex-cli', { binaryPath: bin });
       // The explicit `--model` flag avoids Codex CLI's own historical
       // default `gpt-5.2-codex` (retired from ChatGPT-subscription auth
       // 2026-04-14). The session default is gpt-5.5 as of 2026-05-23
@@ -172,7 +179,7 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
       // drops the sandbox (which would otherwise block the agent from
       // reaching localhost where instar's server lives).
       expect(spec.argv).toEqual([
-        '/usr/local/bin/codex',
+        bin,
         '--model',
         'gpt-5.5',
         '--dangerously-bypass-approvals-and-sandbox',

--- a/tests/unit/resolveNodeBinary.test.ts
+++ b/tests/unit/resolveNodeBinary.test.ts
@@ -67,7 +67,22 @@ describe('resolveStableNodeBinary', () => {
 
   it('falls back to PATH lookup when all absolute candidates fail', () => {
     const fakeExecPath = '/tmp/nonexistent-cellar/node';
-    const realNode = process.execPath;
+    // A REAL executable in a tmpdir, standing in for "the node PATH lookup found"
+    // — deliberately NOT `process.execPath`.
+    //
+    // It must be real because `existsSyncOverride` only stubs `existsSync`: the
+    // resolver's executability check then calls the genuine `statSync` and
+    // `accessSync`, so a purely synthetic path fails regardless of the override.
+    // And it must not be `process.execPath`, because the override hides the three
+    // absolute candidates BY NAME — including `/usr/local/bin/node` — while also
+    // requiring `p === realNode`. On a host whose node IS at one of those paths
+    // (a plain macOS `/usr/local/bin/node` install — most developer machines) the
+    // two clauses contradict each other: everything is hidden, the resolver
+    // correctly returns null, and the test fails. It passed only where node
+    // happens to sit elsewhere, which is why CI never saw it.
+    const tmpBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-node-'));
+    const realNode = path.join(tmpBinDir, 'node');
+    fs.writeFileSync(realNode, '#!/bin/bash\nexit 0\n', { mode: 0o755 });
 
     const resolved = resolveStableNodeBinary({
       execPathOverride: fakeExecPath,
@@ -82,9 +97,17 @@ describe('resolveStableNodeBinary', () => {
       whichOverride: () => realNode,
     });
 
-    expect(resolved).not.toBeNull();
-    expect(resolved!.source).toBe('which');
-    expect(resolved!.path).toBe(realNode);
+    try {
+      expect(resolved).not.toBeNull();
+      expect(resolved!.source).toBe('which');
+      expect(resolved!.path).toBe(realNode);
+    } finally {
+      SafeFsExecutor.safeRmSync(tmpBinDir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/resolveNodeBinary.test.ts:cleanup',
+      });
+    }
   });
 
   it('returns null when no Node is reachable anywhere', () => {

--- a/tests/unit/telegram-reply-recoverable-classification.test.ts
+++ b/tests/unit/telegram-reply-recoverable-classification.test.ts
@@ -123,12 +123,41 @@ interface RunResult {
  * the same loop. Synchronous `execFileSync` would deadlock against
  * curl waiting on the server.
  */
+/**
+ * A genuinely hermetic environment for the spawned script.
+ *
+ * The script resolves its owning agent home from `INSTAR_AGENT_HOME` FIRST, so
+ * running this suite from inside a LIVE instar session made it resolve to the
+ * REAL agent home: it read the real config and wrote into the real outbound
+ * relay queue (`.instar/state/pending-relay.<agent>.sqlite`). Test fixture text
+ * was queued to real Telegram topics, and at least one — "Your weekly check
+ * finished — all clear." — was actually DELIVERED by the drainer on 2026-08-21.
+ * The tests also failed, because `queueRowCount()` looked in the tmp project
+ * while the rows landed elsewhere.
+ *
+ * An earlier version neutralised `INSTAR_PORT` and `INSTAR_AUTH_TOKEN` by name
+ * and was labelled "hermetic vs live-session env" — enumeration is exactly what
+ * failed here, because the harmful variable was not on the list. So: strip EVERY
+ * `INSTAR_*` variable rather than naming the ones we know about, then PIN
+ * `INSTAR_AGENT_HOME` to the tmp project so the resolution is explicit and does
+ * not depend on the child's cwd either.
+ */
+function hermeticEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith('INSTAR_')) continue;
+    env[k] = v;
+  }
+  env.INSTAR_AGENT_HOME = projectDir;
+  return env;
+}
+
 function runScript(topicId: number, message: string): Promise<RunResult> {
   const scriptPath = path.join(projectDir, '.claude', 'scripts', 'telegram-reply.sh');
   return new Promise((resolve) => {
     const child = spawn('bash', [scriptPath, String(topicId), message], {
       cwd: projectDir,
-      env: { ...process.env, INSTAR_PORT: '', INSTAR_AUTH_TOKEN: '' }, // hermetic vs live-session env
+      env: hermeticEnv(),
     });
     let stdout = '';
     let stderr = '';

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -16,6 +16,48 @@ delete process.env.GIT_INDEX_FILE;
 delete process.env.GIT_OBJECT_DIRECTORY;
 delete process.env.GIT_COMMON_DIR;
 
+// Strip INSTAR_* environment inherited from a LIVE agent session — the same
+// failure class as the git vars above, with a different variable family.
+//
+// A test that spawns a shipped script (the Telegram/Slack relay scripts, the
+// hooks, the CLI) and passes `{ ...process.env }` hands the child the ambient
+// `INSTAR_AGENT_HOME`, `INSTAR_AUTH_TOKEN`, `INSTAR_PORT` and friends. Those
+// scripts resolve their owning agent from exactly those variables and PREFER
+// them over cwd — so when the suite is run from inside a live agent session the
+// child silently abandons the test's tmp project and operates on the REAL one.
+//
+// This is not hypothetical, and it ran for three days before anyone noticed.
+// Between 2026-08-19 and 2026-08-21 the relay tests wrote 21 fixture rows into
+// the LIVE outbound relay queue, and the drainer delivered 15 of them to a real
+// Telegram topic — nine copies of "Your weekly check finished — all clear." and
+// six of "hello world", each landing as if the agent had sent it. ("All clear"
+// asserts a check ran and passed; none had.) A second topic took six copies of
+// "hello from test", five of which exhausted their retries and raised
+// delivery-failure escalations. The tests ALSO failed, because they looked for
+// their rows in the tmp project — but note the asymmetry: the failure is the
+// visible half. A leak like this mutates live state just as happily under a test
+// that still passes, which is why the fix belongs here rather than in the tests
+// that happened to go red.
+//
+// Two tests had already tried to defend against this by clearing INSTAR_PORT and
+// INSTAR_AUTH_TOKEN by name, each labelled "hermetic vs live-session env".
+// Enumerating the dangerous variables is what failed: the harmful one was simply
+// not on the list. So the default here is STRIP, with an explicit allowlist for
+// the few variables that steer the test RUNNER itself rather than the code under
+// test. A test that needs one of these sets it itself, after this file runs.
+const INSTAR_ENV_ALLOWLIST = new Set([
+  // Host test-runner concurrency bound — the documented kill switch and its cap.
+  // Read in globalSetup (which runs before this file), allowlisted so that stays
+  // true no matter where the read moves to.
+  'INSTAR_HOST_TEST_SEMAPHORE',
+  'INSTAR_HOST_TEST_MAX',
+]);
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('INSTAR_') && !INSTAR_ENV_ALLOWLIST.has(key)) {
+    delete process.env[key];
+  }
+}
+
 // Pre-set git identity env vars so SafeGitExecutor's identity lookup
 // doesn't fall through to `git config --global user.name/email` reads via
 // execFileSync. Tests that mock execFileSync would otherwise have their


### PR DESCRIPTION
## ELI16 — the test suite was reaching into the real agent and actually sent messages

Tests are supposed to run in a sandbox. These ones handed the whole environment to a script they launched, and that script uses an environment variable to work out which agent it belongs to. Run the suite from inside a live agent session and the script quietly picked the *real* agent instead of the throwaway one.

That is not a hypothetical. Over three days the tests put 21 fake rows into the live outbound message queue, and the sender delivered 15 of them to a real Telegram topic — nine copies of "Your weekly check finished — all clear." among them. The user received test fixtures as if the agent had written them.

The fix strips the environment by default in the shared test setup, with a short allowlist for variables that steer the test runner itself. Two earlier attempts had tried to block dangerous variables one by one, by name; the one that caused this was not on either list, which is the argument for stripping by default rather than enumerating.

Two other tests are fixed in the same change. Both asked a question whose answer depended on the machine rather than the code — green on a bare CI runner, red on a real workstation with certain tools installed.

## What this fixes

The relay tests spawned the shipped `telegram-reply.sh` with `{ ...process.env }`. That script resolves its owning agent from `INSTAR_AGENT_HOME` **before** falling back to cwd, so running the suite from inside a live agent session made the child abandon its tmp project and operate on the real one.

**This was not theoretical.** Between 2026-08-19 and 2026-08-21 the tests wrote **21 fixture rows into the live outbound relay queue**, and the drainer **delivered 15 of them to a real Telegram topic** — nine copies of `"Your weekly check finished — all clear."` and six of `"hello world"`, each landing as if the agent had sent it. A second topic took six copies of `"hello from test"`, five of which exhausted their retries and raised delivery-failure escalations.

The queue file is named after the agent id, and two fixtures declare theirs as the dev agent's real name — so the rows collided with the live queue rather than landing harmlessly beside it. (Tracked separately: ACT-103, rename those fixtures.)

## Why the fix is in the shared setup

Two tests had already tried to defend against this by clearing `INSTAR_PORT` and `INSTAR_AUTH_TOKEN` **by name**, each labelled *"hermetic vs live-session env"*. Enumerating the dangerous variables is precisely what failed: the harmful one was not on the list.

So the strip goes in `tests/vitest-setup.ts`, covers every spawn site (current and future), and defaults to **strip-everything** with a short explicit allowlist for variables that steer the test *runner* rather than the code under test. This mirrors the `GIT_*` strip already in that file — added after tests committed into the real repo. Same failure class, different family.

**Note the asymmetry that let this survive:** the tests *also* failed, because they looked for their rows in the tmp project. The failure is the visible half. A leak like this mutates live state just as happily under a test that still passes — which is why the fix belongs here rather than in the tests that happened to go red.

## Two host-dependent tests, same shape

Both had a verdict that depends on the machine rather than the code — green on a bare CI runner, red on any real workstation:

- **`frameworkSessionLaunch`** asserted a fixed argv while the builder probes the host `codex` binary via `--help`. On a host with codex >= 0.133 the builder appends `--dangerously-bypass-hook-trust` and the exact-array comparison fails. Switched to the `fakeCodexBinary` helper its sibling tests already use.
- **`resolveNodeBinary`** hid the three absolute candidates by name — including `/usr/local/bin/node` — then required `p === process.execPath` to be reachable. On any host whose node *is* at one of those paths the two clauses contradict each other. It now builds a real executable in a tmpdir, which is necessary because `existsSync` is the only stubbed call: `statSync` and `accessSync` run for real.

## Verification

- Full unit suite: **42,597 passing, 0 failures.**
- Verified **behaviourally**, not just by assertion: a full run with this change adds **zero** rows to the live queue, where the same run previously added them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
