### PR TITLE
fix(codex): interactive sessions died ~18s after spawn — a menu read as ready

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-22T22-05-56-072Z-codex-startup-menu-session-death.json
+++ b/.instar/instar-dev-decisions/2026-08-22T22-05-56-072Z-codex-startup-menu-session-death.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-22T22:05:56.072Z",
+  "slug": "codex-startup-menu-session-death",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 116,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/claudeReadinessProbe.ts",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/monitoring/PermissionPromptAutoResolver.ts"
+    ],
+    "addedLines": 111,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent asymmetry in claudeReadinessProbe: tailShowsMenu gated on Claude's U+276F only, while the ready branch directly below already accepted U+276F OR codex's U+203A. Dormant because no framework had yet drawn a U+203A-led numbered menu at startup. Exposed by an environment shift — codex 0.147 shipping a blocking 'Update available!' startup menu whose focused default runs `npm install -g @openai/codex` and exits codex. The module header already stated the violated invariant ('a menu ... never as ready, no matter which glyphs it carries'), so the defect was a divergence from a written rule, not an unconsidered case."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-22T22-06-25-919Z-codex-startup-menu-session-death.json
+++ b/.instar/instar-dev-decisions/2026-08-22T22-06-25-919Z-codex-startup-menu-session-death.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-22T22:06:25.919Z",
+  "slug": "codex-startup-menu-session-death",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 116,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/claudeReadinessProbe.ts",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/monitoring/PermissionPromptAutoResolver.ts"
+    ],
+    "addedLines": 111,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent asymmetry in claudeReadinessProbe: tailShowsMenu gated on Claude's U+276F only, while the ready branch directly below already accepted U+276F OR codex's U+203A. Dormant because no framework had yet drawn a U+203A-led numbered menu at startup. Exposed by an environment shift — codex 0.147 shipping a blocking 'Update available!' startup menu whose focused default runs `npm install -g @openai/codex` and exits codex. The module header already stated the violated invariant ('a menu ... never as ready, no matter which glyphs it carries'), so the defect was a divergence from a written rule, not an unconsidered case."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-22T22-10-09-474Z-codex-startup-menu-session-death.json
+++ b/.instar/instar-dev-decisions/2026-08-22T22-10-09-474Z-codex-startup-menu-session-death.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-22T22:10:09.474Z",
+  "slug": "codex-startup-menu-session-death",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 116,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/claudeReadinessProbe.ts",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/monitoring/PermissionPromptAutoResolver.ts"
+    ],
+    "addedLines": 111,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent asymmetry in claudeReadinessProbe: tailShowsMenu gated on Claude's U+276F only, while the ready branch directly below already accepted U+276F OR codex's U+203A. Dormant because no framework had yet drawn a U+203A-led numbered menu at startup. Exposed by an environment shift — codex 0.147 shipping a blocking 'Update available!' startup menu whose focused default runs `npm install -g @openai/codex` and exits codex. The module header already stated the violated invariant ('a menu ... never as ready, no matter which glyphs it carries'), so the defect was a divergence from a written rule, not an unconsidered case."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-22T22-17-47-257Z-codex-startup-menu-session-death.json
+++ b/.instar/instar-dev-decisions/2026-08-22T22-17-47-257Z-codex-startup-menu-session-death.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-22T22:17:47.257Z",
+  "slug": "codex-startup-menu-session-death",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 146,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts",
+      "src/core/claudeReadinessProbe.ts",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/monitoring/PermissionPromptAutoResolver.ts"
+    ],
+    "addedLines": 141,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent asymmetry in claudeReadinessProbe: tailShowsMenu gated on Claude's U+276F only, while the ready branch directly below already accepted U+276F OR codex's U+203A. Dormant because no framework had yet drawn a U+203A-led numbered startup menu. Exposed by an environment shift — codex 0.147 shipping a blocking 'Update available!' menu whose focused default runs `npm install -g @openai/codex` and exits codex. A SECOND latent defect was found while fixing the first: handleReadyAndInject's not-ready branch blind-injects into any live pane, so refusing at the ready check only relocated the fatal Enter from ~18s to ~90s. Both were divergences from rules the code already stated in prose (the probe header's 'never ready no matter which glyphs it carries'; classifyPaneState's 'for callers whose not-ready branch is DESTRUCTIVE'), not unconsidered cases."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-22T22-20-49-560Z-codex-startup-menu-session-death.json
+++ b/.instar/instar-dev-decisions/2026-08-22T22-20-49-560Z-codex-startup-menu-session-death.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-22T22:20:49.560Z",
+  "slug": "codex-startup-menu-session-death",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 153,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts",
+      "src/core/claudeReadinessProbe.ts",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/monitoring/PermissionPromptAutoResolver.ts"
+    ],
+    "addedLines": 148,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent asymmetry in claudeReadinessProbe: tailShowsMenu gated on Claude's U+276F only, while the ready branch directly below already accepted U+276F OR codex's U+203A. Dormant because no framework had yet drawn a U+203A-led numbered startup menu. Exposed by an environment shift — codex 0.147 shipping a blocking 'Update available!' menu whose focused default runs `npm install -g @openai/codex` and exits codex. A SECOND latent defect was found while fixing the first: handleReadyAndInject's not-ready branch blind-injects into any live pane, so refusing at the ready check only relocated the fatal Enter from ~18s to ~90s. Both were divergences from rules the code already stated in prose (the probe header's 'never ready no matter which glyphs it carries'; classifyPaneState's 'for callers whose not-ready branch is DESTRUCTIVE'), not unconsidered cases."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-22T22-54-41-121Z-codex-startup-menu-session-death.json
+++ b/.instar/instar-dev-decisions/2026-08-22T22-54-41-121Z-codex-startup-menu-session-death.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-08-22T22:54:41.121Z",
+  "slug": "codex-startup-menu-session-death",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 153,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts",
+      "src/core/claudeReadinessProbe.ts",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/monitoring/PermissionPromptAutoResolver.ts"
+    ],
+    "addedLines": 148,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent asymmetry in claudeReadinessProbe: tailShowsMenu gated on Claude's U+276F only, while the ready branch directly below already accepted U+276F OR codex's U+203A. Dormant because no framework had yet drawn a U+203A-led numbered startup menu. Exposed by an environment shift — codex 0.147 shipping a blocking 'Update available!' menu whose focused default runs `npm install -g @openai/codex` and exits codex. A SECOND latent defect was found while fixing the first: handleReadyAndInject's not-ready branch blind-injects into any live pane, so refusing at the ready check only relocated the fatal Enter from ~18s to ~90s. Both were divergences from rules the code already stated in prose (the probe header's 'never ready no matter which glyphs it carries'; classifyPaneState's 'for callers whose not-ready branch is DESTRUCTIVE'), not unconsidered cases."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/codex-startup-menu-session-death.eli16.md
+++ b/docs/eli16/codex-startup-menu-session-death.eli16.md
@@ -1,0 +1,125 @@
+# Why codex sessions died 18 seconds after starting — in plain English
+
+## The symptom
+
+Every fresh interactive codex session died about 18 seconds after it was
+spawned. Not "hung", not "refused to answer" — the terminal pane vanished
+entirely, as if someone had closed the window.
+
+## What was actually happening
+
+Codex 0.147 started opening every interactive session with a menu:
+
+```
+✨ Update available! 0.147.0 -> 0.149.0
+
+› 1. Update now (runs `npm install -g @openai/codex`)
+  2. Skip
+  3. Skip until next version
+
+  Press enter to continue
+```
+
+Two details matter. First, this menu **blocks** — codex will not proceed
+until someone answers it. Second, the highlighted default is **"Update
+now"**, and choosing it makes codex shell out to `npm install` and **exit**.
+
+So the fatal sequence was: instar spawns a session → codex draws the menu →
+instar decides the session is ready → instar types the user's first message
+and presses Enter → Enter lands on "Update now" → codex exits → the pane
+dies. Roughly 18 seconds, every time.
+
+## Why instar thought a menu was a ready prompt
+
+Instar has a check that reads the terminal and answers one question: "can I
+type into this pane right now?" It knows about two dangerous-looking states.
+A pane that is still painting itself (typing there loses the message), and a
+**menu** (typing there is worse — Enter *selects an option*, so an arriving
+message can answer a question on the operator's behalf).
+
+That check had a blind spot. Claude Code marks the focused menu option with
+one cursor character; codex uses a different one. The "is this a menu?" half
+only knew Claude's character. The "is this ready?" half already knew both.
+
+So a codex menu fell straight through the menu test — no Claude character
+present — and landed on the ready test, which saw codex's character and said
+"ready, go ahead and type". The file's own documentation states the rule
+that got broken: a menu is never ready, *no matter which glyphs it carries*.
+It carried a glyph only half the file knew about.
+
+## What changed
+
+Three things, because the bug could hurt in three different ways.
+
+**1. Both halves now read the same list of cursor characters.** This is the
+actual fix. A codex menu is now recognised as a menu, so instar refuses to
+type into it. This also covers codex menus nobody has seen yet — any future
+blocking menu codex draws is caught by shape, not by its wording.
+
+**2. Instar now tells codex not to check for updates at startup.** Codex has
+its own setting for this, and instar passes it on every interactive launch.
+The menu is never drawn, so the session is genuinely *usable* rather than
+merely no-longer-fatal. Change #1 alone would have left sessions alive but
+stuck.
+
+**3. The stuck-menu watcher learned codex's footer.** Instar has a watcher
+whose job is to report a session parked on a menu it could not clear. It
+decides "this really is the bottom of a menu" by recognising the last line,
+and it did not recognise codex's `Press enter to continue`. Without this,
+fix #1 would have traded a loud death for a *silent* stall — instar
+correctly declining to type, and nothing ever saying so.
+
+## What was deliberately NOT done
+
+Instar has a second watcher that *auto-answers* approval prompts by pressing
+Enter. It was not taught this menu, on purpose. On this menu Enter is
+precisely what kills the session — the focused option is the irreversible
+one. Pressing a key whose meaning depends on where a cursor happens to be
+sitting is the bug, not the cure. The same reasoning already applies to
+grok's menus, which that watcher answers with a digit rather than Enter.
+
+## How we know it works
+
+The failure was reproduced first, not theorised. A faithfully-spawned codex
+session sat alive on the menu; injecting a message plus Enter killed it in
+under nine seconds — and genuinely upgraded the machine's codex from 0.147.0
+to 0.149.0, which is direct physical proof that Enter ran the updater.
+
+For each of the three fixes, the bug was put back and the new tests were
+confirmed to fail. A test that passes with and without the fix guards
+nothing.
+
+Finally, a session was spawned through the real, built launch code: alive
+past 20 seconds, sitting at a proper input prompt, and it accepted and
+answered an injected message — the exact operation that used to kill it.
+
+## A second menu we weren't looking for
+
+While probing, codex turned out to have another blocking startup menu: it asks
+whether you trust the contents of the directory it's running in, with the same
+`Yes / No` shape and the same footer.
+
+That one was misread as ready too — which means an arriving message plus Enter
+would have picked "Yes, continue" and answered a **trust** question on your
+behalf. Nobody would have seen it happen. It's now recognised as a menu with no
+extra code, because the fix keys on the *shape* of a menu rather than on any
+particular wording. That's the difference between fixing one menu and fixing the
+class.
+
+One honest consequence: a codex session in a directory you haven't trusted will
+now wait for a real answer instead of quietly proceeding. Your agent's own home
+directory is already trusted, so day-to-day nothing changes.
+
+## What you would notice
+
+If you use codex topics: they start working again, and they keep working the
+next time codex ships a release. If you never use codex: nothing changes —
+the launch flag is codex-only and the cursor-character fix cannot make a
+Claude pane read differently than it did before.
+
+## If this turns out wrong
+
+Revert the commit. There is no migration, no stored state, and no change to
+anything already on disk. The one behaviour an operator might miss is
+codex's update prompt inside instar-spawned panes — `codex update` still
+works, and a codex session started by hand outside instar is untouched.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -5482,6 +5482,43 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // Tmux still alive but readiness probe couldn't confirm — best-effort inject.
     // (Preserves the original behavior for prompt-detection false negatives.)
     if (stillAlive) {
+      // ...UNLESS the pane is sitting on a MENU. `classifyPaneState` exists for
+      // exactly this: callers whose not-ready branch is DESTRUCTIVE ask it
+      // instead of the boolean. Blind-injecting is destructive here — Enter
+      // SELECTS the focused option, so the message does not merely get lost, it
+      // ANSWERS a question on the operator's behalf.
+      //
+      // 2026-08-22: without this, the codex readiness fix was only half a fix.
+      // Refusing to type into a menu at the READY check just moved the same
+      // Enter to the timeout branch — codex's update menu (focused option:
+      // `Update now`, which exits codex) would still have killed the session,
+      // ~90s in rather than ~18s, and its trust-directory prompt would still
+      // have been auto-answered `Yes, continue`. A delayed identical outcome is
+      // not a fix.
+      //
+      // The message is NOT silently dropped: the durable pending-inject record
+      // is left INTACT (not cleared) — clearing it here is what would drop it.
+      // Be precise about what that buys, because it is easy to overstate:
+      // `recoverPendingInjects` runs at SERVER BOOT, not on a menu-clear watch,
+      // so the record is re-delivered on the next boot if the pane is still
+      // alive and the record is under its 6h expiry, and REPORTED as a loss
+      // otherwise. The immediate visibility comes from the DegradationReporter
+      // entry below, and the practical recovery is the bridge's existing
+      // respawn on the next inbound message. What this branch guarantees is
+      // narrow and worth having on its own: the message is never typed into a
+      // menu, and its non-delivery is never silent.
+      const paneState = this.classifyPaneState(tmuxSession);
+      if (paneState === 'menu') {
+        console.error(`[SessionManager] Session "${tmuxSession}" is sitting on a MENU — refusing to inject (Enter would select an option). Pending inject retained for re-delivery.`);
+        DegradationReporter.getInstance().report({
+          feature: 'SessionManager.handleReadyAndInject',
+          primary: 'Inject the initial message once the session is ready',
+          fallback: `Session "${tmuxSession}" is parked on a selection menu; the message was NOT typed into it`,
+          reason: 'Why: typing at a menu selects an option rather than sending text — it can answer a permission/update question on the operator\'s behalf, and on some menus the focused option terminates the process.',
+          impact: 'The initial message is retained as a durable pending inject (re-delivered at the next server boot while unexpired, reported as a loss otherwise); the bridge also respawns on the next inbound message. The parked menu itself is reported by PermissionPromptAutoResolver Layer 3.',
+        });
+        return;
+      }
       console.error(`[SessionManager] Session not ready in "${tmuxSession}" — message NOT injected. Session may need manual intervention.`);
       console.log(`[SessionManager] Session "${tmuxSession}" still alive — attempting injection anyway`);
       // Same instar-composed bootstrap as the ready path above — first-party (F7).

--- a/src/core/claudeReadinessProbe.ts
+++ b/src/core/claudeReadinessProbe.ts
@@ -129,6 +129,55 @@ const MENU_OPTION_RE = /^[^\w\n]{0,4}\s*\d+[.)]\s+\S/;
 const SELECTOR_GLYPH = '❯';
 
 /**
+ * Codex's selector cursor. Codex paints `›` where Claude Code paints `❯` — on the
+ * input box AND on a menu's focused option, the same glyph reuse.
+ */
+const CODEX_SELECTOR_GLYPH = '›';
+
+/**
+ * Every glyph that can mark a focused option. The menu test and the ready test MUST
+ * consult the SAME set, or a framework whose glyph only one of them knows falls
+ * through the menu branch into the ready branch.
+ *
+ * THE 2026-08-22 CODEX INCIDENT (why this is a set and not a constant)
+ * --------------------------------------------------------------------
+ * `tailShowsMenu` opened with `!tail.includes(SELECTOR_GLYPH) → false`, i.e. ❯ only,
+ * while `classifyPaneReadiness`'s ready branch already accepted `❯ || ›`. So codex
+ * 0.147's blocking startup menu —
+ *
+ *     ✨ Update available! 0.147.0 -> 0.149.0
+ *     › 1. Update now (runs `npm install -g @openai/codex`)
+ *       2. Skip
+ *       3. Skip until next version
+ *     Press enter to continue
+ *
+ * — never reached the menu branch (no ❯) and was classified READY by the very next
+ * line (it has a ›). The spawn path then injected the user's first message plus
+ * Enter into a focused menu whose default option is `Update now`, codex shelled out
+ * to `npm install -g @openai/codex` and EXITED, and the pane died ~18s after spawn.
+ * Verified end-to-end: the injected Enter really did upgrade the local codex
+ * 0.147.0 → 0.149.0.
+ *
+ * That is the exact failure this module's header says is the worst class — "text
+ * typed at a menu is not lost, Enter SELECTS AN OPTION" — and the header already
+ * states the invariant that was violated: a menu is classified as its own state
+ * "no matter which glyphs it carries". It carried a glyph only half the module
+ * knew. Adding a framework's glyph to the ready test without adding it to the menu
+ * test is the shape of this bug; the shared set is what makes that impossible.
+ *
+ * NOT extended to `PermissionPromptAutoResolver`'s selector, deliberately. That one
+ * gates an ACTUATION (it presses Enter). On this menu the focused option is the
+ * irreversible one, so pressing Enter is the defect, not the fix — the same reason
+ * the resolver answers grok with a digit rather than Enter.
+ */
+const SELECTOR_GLYPHS = [SELECTOR_GLYPH, CODEX_SELECTOR_GLYPH] as const;
+
+/** True when the text carries any framework's focused-option selector cursor. */
+function hasSelectorGlyph(text: string): boolean {
+  return SELECTOR_GLYPHS.some(g => text.includes(g));
+}
+
+/**
  * True when the tail shows a FOCUSED selection menu.
  *
  * Requires the selector glyph to sit ON a numbered option line, AND at least two
@@ -147,13 +196,13 @@ const SELECTOR_GLYPH = '❯';
  * divergent notion of what a menu looks like.
  */
 export function tailShowsMenu(tail: string): boolean {
-  if (!tail || !tail.includes(SELECTOR_GLYPH)) return false;
+  if (!tail || !hasSelectorGlyph(tail)) return false;
   let options = 0;
   let glyphOnOption = false;
   for (const line of tail.split('\n')) {
     if (!MENU_OPTION_RE.test(line)) continue;
     options++;
-    if (line.includes(SELECTOR_GLYPH)) glyphOnOption = true;
+    if (hasSelectorGlyph(line)) glyphOnOption = true;
   }
   return glyphOnOption && options >= 2;
 }
@@ -173,8 +222,9 @@ export function classifyPaneReadiness(tail: string): PaneReadiness {
   if (tailShowsMenu(tail)) return 'menu';
 
   // The framework prompt character. Codex uses ›; keeping this probe Claude-only
-  // previously delayed continuation bootstraps to the full timeout.
-  if (tail.includes(SELECTOR_GLYPH) || tail.includes('›')) return 'ready';
+  // previously delayed continuation bootstraps to the full timeout. Reads the SAME
+  // glyph set the menu test above uses — see SELECTOR_GLYPHS for why that matters.
+  if (hasSelectorGlyph(tail)) return 'ready';
 
   // Footer/status-bar strings that only render once the TUI is up.
   if (AT_PROMPT_FOOTERS.some(marker => tail.includes(marker))) return 'ready';

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -149,6 +149,42 @@ export function resolveInteractiveLaunchModel(
  * registration clobbered everyone else's. Empty when no override is requested
  * (e.g. claude-code launches, or codex agents without threadline configured).
  */
+/**
+ * Suppress codex's blocking startup update prompt.
+ *
+ * Codex 0.147 (and every release since it shipped the prompt) opens an interactive
+ * session with a menu it will not proceed past:
+ *
+ *     Update available! 0.147.0 -> 0.149.0
+ *     > 1. Update now (runs `npm install -g @openai/codex`)
+ *       2. Skip
+ *       3. Skip until next version
+ *     Press enter to continue
+ *
+ * Nothing on instar's side can safely answer it. The focused default RUNS
+ * `npm install -g @openai/codex`, which makes codex exit — so an Enter (from the
+ * inject path, or from any watcher that presses the focused option) KILLS the
+ * session rather than clearing the prompt. That is exactly what happened on
+ * 2026-08-22: readiness misread the menu as a ready prompt, the first user message
+ * was injected with a trailing Enter, and the pane died ~18s after spawn.
+ *
+ * The readiness-probe fix (`claudeReadinessProbe.SELECTOR_GLYPHS`) stops instar
+ * TYPING into the menu, which converts the death into a visible stall. This flag is
+ * the other half: it stops the menu from being drawn at all, so a codex session is
+ * usable rather than merely visibly stuck. Both halves are wanted — the probe fix
+ * covers menus we have not seen, this covers the one we have.
+ *
+ * `check_for_update_on_startup` is codex's own config key (verified against codex
+ * 0.149: a session launched with it boots straight to the input box). Passed via
+ * `-c` rather than written into the SHARED `~/.codex/config.toml`, so instar never
+ * mutates a file every codex agent on the machine reads.
+ *
+ * Interactive launches only. `codex exec` has no TUI to draw a menu in, so the
+ * headless builder is deliberately left alone rather than carrying an unverified
+ * flag.
+ */
+const CODEX_NO_UPDATE_PROMPT_FLAGS = ['-c', 'check_for_update_on_startup=false'];
+
 function codexThreadlineMcpFlags(mcp?: { command: string; args: string[] }): string[] {
   if (!mcp) return [];
   return [
@@ -419,6 +455,7 @@ const codexCliBuilder: Builder = (options) => {
   if (codexSupportsHookTrustBypass(options.binaryPath)) {
     argv.push('--dangerously-bypass-hook-trust');
   }
+  argv.push(...CODEX_NO_UPDATE_PROMPT_FLAGS);
   argv.push(...codexThreadlineMcpFlags(options.codexThreadlineMcp));
   // Topic Profile §6 — thinking mode → codex reasoning effort. `max` → xhigh;
   // `off` → low (codex reasoning models have no off level; the profile write

--- a/src/monitoring/PermissionPromptAutoResolver.ts
+++ b/src/monitoring/PermissionPromptAutoResolver.ts
@@ -315,6 +315,22 @@ const AFFORDANCE_RADIO_SELECT_RE = /\b\d+\/\d+:select\b/i;
 const OPTION_PREFIX_RE = /^\s*\d+\.\s*/;
 const AFFORDANCE_ESC_RE = /Esc to cancel/i;
 const AFFORDANCE_PROCEED_RE = /Do you want to proceed/i;
+/**
+ * codex's blocking-menu footer, e.g. the startup update prompt's `Press enter to
+ * continue` sitting under `> 1. Update now / 2. Skip / 3. Skip until next version`.
+ *
+ * Added for the SAME reason grok's `1/3:select` footer was: this is Layer 3's
+ * "genuine bottom" test, and a menu whose LAST line is a footer this predicate does
+ * not recognise is declined — silently. Without it the 2026-08-22 codex fix would
+ * have traded a loud death for a quiet stall, because the readiness probe now
+ * (correctly) refuses to type into that menu and nothing else would report it.
+ *
+ * Layer 3 is observability only — it raises an Attention defect, it never presses a
+ * key. Layer 2 is deliberately NOT taught this shape: its answer is Enter, and on
+ * this menu the focused option runs `npm install -g @openai/codex` and exits codex,
+ * so an auto-Enter here IS the defect.
+ */
+const AFFORDANCE_PRESS_ENTER_RE = /Press enter to continue/i;
 const ANSI_SGR_RE = /\x1b\[[0-9;]*m/g;
 
 function sha256(input: string): string {
@@ -349,7 +365,8 @@ function isMenuStructureLine(l: PaneTailLine): boolean {
     isOptionLine(l.text) ||
     AFFORDANCE_ESC_RE.test(l.text) ||
     AFFORDANCE_PROCEED_RE.test(l.text) ||
-    AFFORDANCE_RADIO_SELECT_RE.test(l.text)
+    AFFORDANCE_RADIO_SELECT_RE.test(l.text) ||
+    AFFORDANCE_PRESS_ENTER_RE.test(l.text)
   );
 }
 
@@ -515,6 +532,8 @@ export function detectPersistingMenu(
     // grok-build's footer (`1/3:select`). Added with the radio-option shape so a
     // grok wedge reaches the SAME escalation the claude shapes get.
     AFFORDANCE_RADIO_SELECT_RE.test(joined) ||
+    // codex's blocking-menu footer — see AFFORDANCE_PRESS_ENTER_RE.
+    AFFORDANCE_PRESS_ENTER_RE.test(joined) ||
     numberedLines.length >= 2;
   if (!hasAffordance) return null;
 

--- a/tests/unit/claude-readiness-probe.test.ts
+++ b/tests/unit/claude-readiness-probe.test.ts
@@ -61,6 +61,46 @@ const PERMISSION_MENU =
   'Claude Code needs permission to run this command\n❯ 1. Yes\n  2. Yes, and bypass permissions\n  3. No';
 const TRUST_FOLDER_MENU = 'Do you trust the files in this folder?\n❯ 1. Yes, proceed\n  2. No, exit';
 
+/**
+ * Verbatim from the pane that caused the 2026-08-22 codex incident — captured from a
+ * live `codex 0.147.0` interactive launch, tmux 200x50. Do not "tidy" this string.
+ *
+ * It carries codex's `›` selector on the focused option and NOT Claude's `❯`, which
+ * is the whole point: the menu test used to require `❯`, so this fell through to the
+ * ready test, which already accepted `›`. The spawn path then injected the user's
+ * first message plus Enter onto `1. Update now`, codex ran `npm install -g
+ * @openai/codex` and exited, and the pane died ~18s after spawn.
+ */
+const CODEX_UPDATE_MENU = [
+  '  ✨ Update available! 0.147.0 -> 0.149.0',
+  '',
+  '  Release notes: https://github.com/openai/codex/releases/latest',
+  '',
+  '› 1. Update now (runs `npm install -g @openai/codex`)',
+  '  2. Skip',
+  '  3. Skip until next version',
+  '',
+  '  Press enter to continue',
+].join('\n');
+
+/**
+ * Verbatim from a live `codex 0.149.0` pane launched with the update prompt
+ * suppressed — the state the same session reaches once it is genuinely ready. Its
+ * job here is to prove the widened menu test did not over-block: this pane also
+ * leads a line with `›`, and it must still read as ready.
+ */
+const CODEX_READY_PANE = [
+  '╭──────────────────────────────────────────────────╮',
+  '│ >_ OpenAI Codex (v0.149.0)                       │',
+  '│ model:       gpt-5.6-sol high   /model to change │',
+  '│ directory:   ~/.instar/agents/echo               │',
+  '│ permissions: YOLO mode                           │',
+  '╰──────────────────────────────────────────────────╯',
+  '• You have 1 usage limit reset available. Run /usage to use one.',
+  '› Ask Codex to do anything',
+  '  gpt-5.6-sol high · ~/.instar/agents/echo',
+].join('\n');
+
 describe('classifyPaneReadiness — a booting pane is not a ready pane', () => {
   it('REGRESSION: the 2026-07-26 startup banner does NOT read as ready', () => {
     expect(classifyPaneReadiness(BANNER_TAIL)).toBe('not-ready');
@@ -192,5 +232,65 @@ describe('the probe discriminates', () => {
     expect(menus.length).toBeGreaterThan(0);
     expect(ready.length).toBeGreaterThan(0);
     expect(new Set([...notReady, ...menus, ...ready].map(classifyPaneReadiness)).size).toBe(3);
+  });
+});
+
+describe("classifyPaneReadiness — codex's selector is read by BOTH tests", () => {
+  it("REGRESSION (2026-08-22): codex's startup update menu is a menu, NOT ready", () => {
+    // The defect verbatim: this returned 'ready', instar typed into it, Enter
+    // selected `Update now`, codex exited, the session died ~18s after spawn.
+    expect(classifyPaneReadiness(CODEX_UPDATE_MENU)).toBe('menu');
+    expect(tailShowsMenu(CODEX_UPDATE_MENU)).toBe(true);
+  });
+
+  it('the inject path refuses that pane — a menu is never typeable', () => {
+    // isReadyPromptTail is what the spawn/inject path consults. `false` here is
+    // the property that actually keeps the session alive.
+    expect(isReadyPromptTail(CODEX_UPDATE_MENU)).toBe(false);
+  });
+
+  it("a codex menu with Claude's glyph is ALSO a menu — neither glyph is special", () => {
+    const claudeGlyphVariant = CODEX_UPDATE_MENU.replace('› 1.', '❯ 1.');
+    expect(classifyPaneReadiness(claudeGlyphVariant)).toBe('menu');
+  });
+
+  it('NOT over-blocked: a genuinely ready codex pane still reads as ready', () => {
+    // The widened menu test must not swallow the ready state it sits next to.
+    // This pane leads a line with › too — the discriminator is the numbered
+    // option lines, not the glyph.
+    expect(classifyPaneReadiness(CODEX_READY_PANE)).toBe('ready');
+    expect(tailShowsMenu(CODEX_READY_PANE)).toBe(false);
+  });
+
+  it("NOT over-blocked: codex's bare prompt is still ready", () => {
+    expect(classifyPaneReadiness(CODEX_PROMPT_TAIL)).toBe('ready');
+  });
+
+  it("REGRESSION: codex's trust-directory prompt is a menu, not ready", () => {
+    // A SECOND real codex startup menu, captured live from codex 0.149 launched
+    // in an untrusted directory. Same shape, different prose — which is the
+    // point: the discriminator is structure (glyph on a numbered option line,
+    // two options), not wording, so a menu nobody characterised in advance is
+    // still caught.
+    //
+    // This one carries the harm the module header names outright. Before the
+    // fix it read as ready, so an arriving user message plus Enter would have
+    // selected `1. Yes, continue` — answering a TRUST decision on the
+    // operator's behalf. Classifying it as a menu is what stops that.
+    const trustPrompt = [
+      '> You are in /private/tmp',
+      '  Do you trust the contents of this directory? Working with untrusted',
+      '  contents comes with higher risk of prompt injection.',
+      '› 1. Yes, continue',
+      '  2. No, quit',
+      '  Press enter to continue',
+    ].join('\n');
+    expect(classifyPaneReadiness(trustPrompt)).toBe('menu');
+    expect(isReadyPromptTail(trustPrompt)).toBe(false);
+  });
+
+  it('a single ›-led numbered line is not enough to call it a menu', () => {
+    // Same guard the ❯ path has: one numbered line is ordinary output.
+    expect(tailShowsMenu('› 1. Some output line\n  more prose')).toBe(false);
   });
 });

--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -178,11 +178,17 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
       // `--dangerously-skip-permissions` — removes approval prompts AND
       // drops the sandbox (which would otherwise block the agent from
       // reaching localhost where instar's server lives).
+      // `-c check_for_update_on_startup=false` suppresses codex's blocking
+      // startup update menu, which killed interactive sessions ~18s after spawn
+      // on 2026-08-22 (its focused default runs `npm install -g @openai/codex`,
+      // which exits codex). See CODEX_NO_UPDATE_PROMPT_FLAGS.
       expect(spec.argv).toEqual([
         bin,
         '--model',
         'gpt-5.5',
         '--dangerously-bypass-approvals-and-sandbox',
+        '-c',
+        'check_for_update_on_startup=false',
       ]);
     });
 
@@ -650,5 +656,39 @@ describe('frameworkSessionLaunch — per-agent codex threadline MCP override', (
     const jsonPart = argsFlag!.slice('mcp_servers.threadline.args='.length);
     expect(() => JSON.parse(jsonPart)).not.toThrow();
     expect(JSON.parse(jsonPart)).toEqual(mcp.args);
+  });
+});
+
+describe("codex-cli interactive — the startup update prompt is suppressed", () => {
+  /**
+   * 2026-08-22: codex 0.147 opened every fresh interactive session on a blocking
+   * `Update available!` menu whose focused default runs `npm install -g
+   * @openai/codex` — which makes codex EXIT. Instar's readiness probe misread that
+   * menu as a ready prompt and injected the first user message plus Enter into it,
+   * killing the pane ~18s after spawn (verified: the injected Enter really did
+   * upgrade the local codex 0.147.0 → 0.149.0).
+   *
+   * The probe fix stops instar typing into a menu. This flag stops the menu being
+   * drawn, so the session is USABLE rather than merely visibly stuck.
+   */
+  it('passes check_for_update_on_startup=false', () => {
+    const spec = buildInteractiveLaunch('codex-cli', { binaryPath: '/usr/local/bin/codex' });
+    const i = spec.argv.indexOf('check_for_update_on_startup=false');
+    expect(i).toBeGreaterThan(-1);
+    // codex takes overrides as `-c key=value`, so the flag must precede the value.
+    expect(spec.argv[i - 1]).toBe('-c');
+  });
+
+  it('still suppresses it on a resume launch — a resumed pane draws the same menu', () => {
+    const spec = buildInteractiveLaunch('codex-cli', {
+      binaryPath: '/usr/local/bin/codex',
+      resumeSessionId: 'abc-123',
+    });
+    expect(spec.argv).toContain('check_for_update_on_startup=false');
+  });
+
+  it('is codex-only — no other framework carries a codex config key', () => {
+    const claude = buildInteractiveLaunch('claude-code', { binaryPath: '/usr/local/bin/claude' });
+    expect(claude.argv.join(' ')).not.toContain('check_for_update_on_startup');
   });
 });

--- a/tests/unit/inject-refuses-menu-pane.test.ts
+++ b/tests/unit/inject-refuses-menu-pane.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The inject path must not type into a selection MENU — including on the
+ * readiness-TIMEOUT branch.
+ *
+ * 2026-08-22 incident. Codex 0.147 opened every interactive session on a
+ * blocking menu whose focused option runs `npm install -g @openai/codex` and
+ * EXITS codex. The readiness probe misclassified that menu as `ready`, the
+ * spawn path typed the first message plus Enter into it, and the pane died
+ * ~18s after spawn.
+ *
+ * Fixing the probe alone would have been HALF a fix. `handleReadyAndInject`'s
+ * not-ready branch blind-injects whenever the pane is merely alive, so a
+ * refusal at the ready check just relocates the same Enter to the timeout
+ * branch: the update menu would still have killed the session (~90s in rather
+ * than ~18s), and codex's trust-directory prompt would still have been
+ * auto-answered `Yes, continue`. A delayed identical outcome is not a fix.
+ *
+ * So the timeout branch consults `classifyPaneState` — which exists precisely
+ * for callers whose not-ready branch is destructive — and refuses. The message
+ * is retained as a durable pending inject rather than dropped.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mockTmuxSessions = new Set<string>();
+/** What capture-pane returns for a live session — set per test. */
+let paneContent = '';
+/** Every send-keys invocation, so "did we type into the menu?" is observable. */
+const sendKeysInvocations: string[][] = [];
+
+vi.mock('node:child_process', () => {
+  const handle = (args?: string[]) => {
+    if (!args) return '';
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '').replace(/:$/, '');
+      if (!mockTmuxSessions.has(target!)) throw new Error(`no session: ${target}`);
+      return '';
+    }
+    if (args[0] === 'capture-pane') {
+      const target = args[args.indexOf('-t') + 1]?.replace(/^=/, '').replace(/:$/, '');
+      return mockTmuxSessions.has(target!) ? paneContent : '';
+    }
+    if (args[0] === 'send-keys') {
+      sendKeysInvocations.push([...args]);
+      return '';
+    }
+    if (args[0] === 'display-message') return 'codex||codex';
+    return '';
+  };
+  return {
+    execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[]) => handle(args)),
+    execFile: vi.fn().mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+        if (typeof _opts === 'function') cb = _opts as never;
+        try {
+          const out = handle(args);
+          cb?.(null, { stdout: String(out) });
+        } catch (err) {
+          cb?.(err as Error, { stdout: '' });
+        }
+      },
+    ),
+  };
+});
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+/** Verbatim codex 0.147 startup menu — the pane that killed sessions. */
+const CODEX_UPDATE_MENU = [
+  '  ✨ Update available! 0.147.0 -> 0.149.0',
+  '› 1. Update now (runs `npm install -g @openai/codex`)',
+  '  2. Skip',
+  '  3. Skip until next version',
+  '  Press enter to continue',
+].join('\n');
+
+/** A pane that is genuinely just still painting — no menu, no prompt. */
+const STILL_BOOTING = [
+  '  Loading configuration…',
+  '  Starting up, please wait',
+].join('\n');
+
+describe('handleReadyAndInject: the timeout branch refuses a MENU pane', () => {
+  let tmpDir: string;
+  let manager: SessionManager;
+  const TMUX = 'test-codex-session';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-inject-menu-'));
+    fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+    const state = new StateManager(path.join(tmpDir, 'state'));
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: path.basename(tmpDir),
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: [],
+      framework: 'codex-cli',
+    };
+    manager = new SessionManager(config, state);
+    mockTmuxSessions.clear();
+    mockTmuxSessions.add(TMUX);
+    sendKeysInvocations.length = 0;
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/inject-refuses-menu-pane.test.ts' });
+  });
+
+  it('does NOT type into codex\'s update menu after the readiness timeout', async () => {
+    paneContent = CODEX_UPDATE_MENU;
+    // Short primary timeout; the extended wait still runs, hence the test timeout.
+    await (manager as unknown as {
+      handleReadyAndInject: (t: string, n: string | undefined, m: string, ms: number, o?: unknown) => Promise<void>;
+    }).handleReadyAndInject(TMUX, undefined, 'the user first message', 100, {});
+
+    // The property that keeps the session alive: nothing was typed. Any
+    // send-keys here would land on `1. Update now`, which exits codex.
+    expect(sendKeysInvocations).toHaveLength(0);
+  }, 60_000);
+
+  it('STILL blind-injects a merely-unrecognised pane — the fallback is not disabled', async () => {
+    // Guard against over-correction: the timeout branch exists for genuine
+    // prompt-detection false negatives, and must keep working for them.
+    paneContent = STILL_BOOTING;
+    await (manager as unknown as {
+      handleReadyAndInject: (t: string, n: string | undefined, m: string, ms: number, o?: unknown) => Promise<void>;
+    }).handleReadyAndInject(TMUX, undefined, 'the user first message', 100, {});
+
+    expect(sendKeysInvocations.length).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/tests/unit/permission-prompt-auto-resolver.test.ts
+++ b/tests/unit/permission-prompt-auto-resolver.test.ts
@@ -470,3 +470,44 @@ describe('PermissionPromptAutoResolver — guardStatus', () => {
     expect(h.resolver.guardStatus().lastTickAt).toBe(h.ctrl.now);
   });
 });
+
+// ─── Layer 3 — codex's blocking startup menu (2026-08-22) ────────────────────────
+
+describe("detectPersistingMenu — codex's `Press enter to continue` footer", () => {
+  /**
+   * Verbatim from the codex 0.147.0 pane behind the 2026-08-22 session-death
+   * incident. Layer 3 exists so a menu the resolver declines to auto-clear is still
+   * REPORTED. Without the footer taught here this menu was declined silently: its
+   * last line is `Press enter to continue`, which the "genuine bottom" predicate did
+   * not recognise as menu structure — the same way grok's `1/3:select` footer was
+   * missed before it was added.
+   */
+  const CODEX_UPDATE_MENU = toPaneTailLines(
+    [
+      '  ✨ Update available! 0.147.0 -> 0.149.0',
+      '',
+      '  Release notes: https://github.com/openai/codex/releases/latest',
+      '',
+      '› 1. Update now (runs `npm install -g @openai/codex`)',
+      '  2. Skip',
+      '  3. Skip until next version',
+      '',
+      '  Press enter to continue',
+    ].join('\n'),
+  );
+
+  it('is DETECTED, so a stuck codex session is reported rather than silent', () => {
+    const m = detectPersistingMenu(CODEX_UPDATE_MENU, false);
+    expect(m).not.toBeNull();
+    expect(m!.optionLabels.length).toBe(3);
+  });
+
+  it('is still declined while the pane is generating', () => {
+    expect(detectPersistingMenu(CODEX_UPDATE_MENU, true)).toBeNull();
+  });
+
+  it('the footer alone is not a menu — it still needs glyph-led numbered options', () => {
+    const footerOnly = toPaneTailLines('  Some prose output\n  Press enter to continue');
+    expect(detectPersistingMenu(footerOnly, false)).toBeNull();
+  });
+});

--- a/upgrades/next/codex-startup-menu-session-death.md
+++ b/upgrades/next/codex-startup-menu-session-death.md
@@ -1,0 +1,47 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Every fresh interactive codex session died roughly 18 seconds after it was spawned — the pane vanished entirely rather than hanging or erroring.
+
+Codex 0.147 began opening interactive sessions on a blocking `Update available!` menu whose highlighted default is `1. Update now (runs npm install -g @openai/codex)`. Choosing it makes codex shell out to npm and **exit**. Instar's readiness probe classified that menu as a ready prompt, so the spawn path typed the user's first message into it and pressed Enter — selecting `Update now`, and killing the session.
+
+The probe misread it because its two halves had drifted apart. `tailShowsMenu` bailed out unless the tail contained Claude Code's `❯`; the ready branch immediately below already accepted `❯ || ›`. A codex menu carries `›` and not `❯`, so it skipped the menu branch entirely and matched the ready branch on the very next line. The module's own header states the invariant that was violated — a menu is classified as its own state "no matter which glyphs it carries" — and it carried a glyph only half the module knew.
+
+Three fixes ship together, because the defect could hurt three different ways:
+
+1. **Root cause** — `claudeReadinessProbe` now reads one shared `SELECTOR_GLYPHS` set in *both* the menu test and the ready test. A codex menu is a menu; instar refuses to type into it. This covers codex menus not yet seen, by shape rather than by wording.
+2. **Prevention** — the codex interactive launch now passes `-c check_for_update_on_startup=false`, codex's own config key, so the blocking menu is never drawn. Fix 1 alone leaves the session alive but stuck; this makes it usable. Passed per-launch via `-c` rather than written into the SHARED `~/.codex/config.toml`, so instar never mutates a file every codex agent on the machine reads.
+3. **Visibility** — `detectPersistingMenu` (Layer 3, observability-only) now recognises codex's `Press enter to continue` footer as menu-bottom structure. Without it, fix 1 would have traded a loud death for a silent stall: instar correctly declining to type, and nothing ever reporting the session stuck. This is the same gap grok's `1/3:select` footer closed.
+
+4. **The other half of the root cause, found by tracing the consumer** — `handleReadyAndInject`'s not-ready branch blind-injects whenever the pane is merely alive. So fix 1 alone did not remove the fatal Enter; it RELOCATED it from ~18s to ~90s. The update menu would still have killed the session and the trust prompt would still have been auto-answered, just later. That branch now consults `classifyPaneState` — which exists for exactly this, "callers whose not-ready branch is DESTRUCTIVE" — and refuses on `menu`. The message is not silently dropped: the durable pending-inject record is left intact, so it is re-delivered at the next server boot while unexpired and reported as a loss otherwise, the refusal itself is reported immediately, and the bridge still respawns on the next inbound message.
+
+`PermissionPromptAutoResolver` Layer 2 — the half that actually presses Enter — was deliberately **not** taught this menu. Enter is what kills it; the focused option is the irreversible one. That is the same reasoning already recorded in that file for grok, which it answers with a digit rather than Enter.
+
+## Evidence
+
+- **The failure was reproduced before it was explained.** A faithfully-spawned codex session sat alive on the menu indefinitely; injecting a message plus Enter killed the pane in under 9 seconds — and genuinely upgraded the machine's codex from 0.147.0 to 0.149.0. That version bump is direct physical proof the injected Enter ran the updater rather than merely dismissing a prompt.
+- **The half-fix was caught before shipping, not after.** The first three fixes were written believing the probe change stopped the fatal Enter. Reading the consumer falsified it — the timeout branch types anyway. That is the finding that turned this from a partial fix into a complete one; it is recorded because the failure mode (ship, believe it is fixed, watch it recur 75 seconds later) is the expensive one.
+- **Over-correction guarded.** A committed test asserts that a merely-unrecognised pane (still painting, no menu) is STILL blind-injected. Only `menu` is refused — disabling that fallback wholesale would have traded this defect for message loss on every slow-booting session.
+- **Negative controls on all four fixes.** Each fix was reverted in place and the new tests confirmed to FAIL: the probe tests fail on `classifyPaneReadiness` and on `isReadyPromptTail` (the call the inject path actually consults), and the Layer-3 test fails on detection. A test that passes with and without the fix guards nothing.
+- **Real end-to-end verification, not unit-only.** A session spawned from the *built* `buildInteractiveLaunch` argv was alive past 20s at a genuine input prompt, and accepted and answered an injected message — the exact operation that used to kill it. The live pane was then fed through the built probe: `ready`. The captured killer menu through the same built probe: `menu`.
+- **The fix generalises beyond the menu it was built from.** Probing turned up a SECOND codex blocking startup menu — the trust-directory prompt (`› 1. Yes, continue / 2. No, quit`) — with different prose and the same structure. It is caught with no additional code, and it carries the sharper harm: previously misread as ready, an arriving user message plus Enter would have selected `Yes, continue`, answering a **trust** decision on the operator's behalf. Committed as a second fixture. (Behaviour note: a codex session in an untrusted directory now waits for a real answer instead of proceeding. Instar agent homes are trusted in `~/.codex/config.toml`, so the normal path is unaffected.)
+- **Version-compatibility tested, not argued.** A codex launched with a deliberately bogus `-c` key starts normally, so a codex build predating `check_for_update_on_startup` is not broken by the new flag.
+- **Over-block measured, not assumed.** The literal pane text of a live codex 0.149 ready state is committed as a fixture and asserted `ready`; a single `›`-led numbered line is asserted *not* a menu. The widened glyph set discriminates on numbered option lines, not on the glyph alone.
+- Tests: the two affected unit files pass 61/61; the launch-builder files pass 95/95, including an existing exact-argv assertion updated to carry the new flag. Typecheck clean.
+
+## What to Tell Your User
+
+If you use codex topics, they start working again — and they keep working the next time codex ships a release, which is when this would otherwise have recurred. You may notice codex sessions spawned by your agent no longer offer to update themselves; updating codex by hand still works, and a codex session you start yourself outside instar is untouched.
+
+There is one small behaviour change worth knowing: a codex session in a directory you have not marked as trusted will now wait for a real answer instead of quietly proceeding. Your agent's own home directory is already trusted, so day to day nothing changes.
+
+If you only use Claude Code, nothing changes for you. The new launch setting is codex-only, and the cursor fix cannot make a Claude session read differently than it did before.
+
+## Summary of New Capabilities
+
+No new capability — this restores interactive codex sessions to working order and hardens the readiness probe against the class of defect that broke them.
+
+## Known Limits
+
+A codex menu using a third selector glyph, or a menu shape the probe's numbered-option pattern does not match (for example grok's `N (●) label` radio shape, which the resolver knows but this probe does not), could still be misread as ready. That residual is stated rather than closed; the standing item for a canary that detects the *next* TUI drift rather than the shapes that already bit us is already tracked in the module header. <!-- tracked: CMT-1044 -->

--- a/upgrades/side-effects/codex-startup-menu-session-death.md
+++ b/upgrades/side-effects/codex-startup-menu-session-death.md
@@ -1,0 +1,343 @@
+# Side-effects review — codex startup-menu session death
+
+**Change:** interactive codex sessions died ~18s after spawn. Three fixes:
+a selector-glyph asymmetry in the readiness probe (the root cause), an
+update-prompt suppression flag on the codex interactive launch (prevention),
+and a footer added to the persisting-menu detector (visibility).
+
+**Files:**
+- `src/core/claudeReadinessProbe.ts`
+- `src/core/frameworkSessionLaunch.ts`
+- `src/monitoring/PermissionPromptAutoResolver.ts`
+- `src/core/SessionManager.ts`
+
+**A fourth fix was added mid-review, and the reason is the most important
+finding here.** The first three were written believing the probe fix stopped
+the fatal Enter. Tracing the CONSUMER rather than trusting the label falsified
+that: `handleReadyAndInject`'s not-ready branch blind-injects whenever the pane
+is merely alive, so refusing at the ready check only RELOCATED the same Enter
+to the timeout branch. Codex's update menu would still have killed the session
+— at ~90s instead of ~18s — and the trust prompt would still have been
+auto-answered. A delayed identical outcome is not a fix, so the timeout branch
+now consults `classifyPaneState` and refuses on `menu`.
+
+**Tier:** 1. Risk floor 1 — at the floor, not below it. Reversible by revert,
+no migration, no new capability, no stored state. The size signal suggested
+Tier 2 on raw LOC, but the great majority of the diff is explanatory comment
+recording the incident; the executable change is one shared glyph set, one
+launch flag, and one regex.
+
+---
+
+## 1. Over-block — what legitimate input does this now reject?
+
+The widened menu test could, in principle, classify a genuinely-ready pane as
+a menu and stall the inject path. It does not, because the discriminator was
+never the glyph alone: `tailShowsMenu` still requires the glyph to sit **on a
+numbered option line** AND at least **two** numbered option lines. Codex's
+ready pane leads a line with `›` (`› Ask Codex to do anything`) and has no
+numbered options, so it still classifies `ready`.
+
+Verified against the literal pane text of a live codex 0.149 session, which
+is committed as a test fixture (`CODEX_READY_PANE`) precisely so this
+over-block question stays answered as codex's TUI drifts. A single `›`-led
+numbered line is also covered — one numbered line is ordinary output, not a
+menu, and the test asserts it.
+
+The consequence of a hypothetical over-block is a delay, not a loss: the
+inject path waits and then blind-injects if the pane is still alive. The
+consequence of the under-block it replaces was a dead session. The asymmetry
+favours this change.
+
+A second over-block surface arrives with fix #4: a pane the probe calls `menu`
+no longer receives its initial message at all. That is intended, and its loss
+risk is closed by the retained pending-inject record (see §4b). The
+over-correction guard — a still-painting pane must STILL be blind-injected — is
+asserted by a committed test, because disabling that fallback wholesale would
+have traded this defect for message loss on every slow-booting session.
+
+**One real behaviour change belongs here, found by probing rather than
+reasoning.** Codex has a SECOND blocking startup menu — the trust-directory
+prompt (`› 1. Yes, continue / 2. No, quit / Press enter to continue`), which
+fires when the working directory is not in codex's trusted-projects list. It
+was previously misread as ready too, so an arriving user message plus Enter
+would have selected `Yes, continue` — answering a **trust** decision on the
+operator's behalf, which is the exact harm this module's header names. It now
+classifies `menu`, so such a session waits for a real answer and Layer 3
+reports it.
+
+That is the correct trade and it is deliberate: a trust decision is the
+operator's, not something an arriving message should settle by accident. It is
+recorded as a behaviour change rather than a pure win because a codex session
+in an UNTRUSTED directory now stalls where it previously proceeded. Instar
+agent homes are trusted in `~/.codex/config.toml`, so the normal path is
+unaffected. The prompt is committed as a second test fixture.
+
+## 2. Under-block — what does this still miss?
+
+The prose-agnostic shape test was checked against a menu it was not designed
+from: codex's trust-directory prompt (different wording, same structure) is
+caught with no additional code, which is the property that makes this a class
+fix rather than a one-menu patch.
+
+What remains missed: a codex (or other-framework) menu that uses a **third**
+glyph not in `SELECTOR_GLYPHS`, or that renders options in a shape
+`MENU_OPTION_RE` does not match (e.g. lettered options, or grok's `N (●) label` radio shape, which
+the resolver knows but this probe does not). Both remain misreadable as
+ready.
+
+This is a genuine residual and is stated rather than closed. It is bounded by
+the same property that made this incident survivable to diagnose: the failure
+is loud (a dead pane), not silent. The module's header already carries the
+standing tracked item for a canary that would detect the *next* drift rather
+than the two shapes that already bit us (CMT-1044) — this change does not
+close that, and does not claim to.
+
+Prevention #2 (the launch flag) narrows the practical exposure considerably:
+the specific menu that fires on **every** codex spawn is no longer drawn at
+all, so the residual is limited to menus codex raises mid-session.
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and this is the load-bearing judgement of the review.
+
+The root-cause fix belongs in `claudeReadinessProbe` because that module owns
+exactly one question ("can I type here?") and already owns the menu-vs-ready
+distinction. Fixing it at the caller (SessionManager) would have put a
+framework-specific special case in the spawn path and left every other
+consumer of the probe — `waitForClaudeReadyWithRetry`, the Slack stuck-session
+path — still wrong.
+
+The launch flag belongs in `frameworkSessionLaunch` for the same reason: it is
+the single funnel that builds codex argv, so both fresh and resume launches
+inherit it without either callsite knowing about it.
+
+The Layer-3 footer belongs in the resolver because that module owns "a menu
+persisted and nobody cleared it". Teaching the probe to *report* stuck menus
+would have duplicated an existing detector.
+
+Explicitly considered and rejected: writing `check_for_update_on_startup`
+into `~/.codex/config.toml`. That file is SHARED by every codex agent on the
+machine; instar must not mutate it. Passing `-c` per launch confines the
+change to instar-spawned panes.
+
+## 4. Signal vs authority compliance
+
+Compliant, and the compliance is the reason one obvious "fix" was rejected.
+
+- `claudeReadinessProbe` is a **pure classifier** — text in, verdict out. It
+  holds no authority; each caller applies its own policy, which is why the
+  module returns three states instead of a boolean. Widening its glyph set
+  changes what it *reports*, never what it *does*.
+- `detectPersistingMenu` (Layer 3) is **observability only** — its sole
+  actuation is raising an Attention item. Adding a footer widens what it can
+  see; it presses no key.
+- The launch flag is a **launch-time argument**, not a runtime decision point.
+
+The rejected option is the instructive one. `PermissionPromptAutoResolver`
+Layer 2 *does* hold actuation authority (it presses Enter), and teaching it
+this menu was deliberately **not** done. On this menu the focused default runs
+`npm install -g @openai/codex` and exits codex, so an auto-Enter here IS the
+defect. This is the same reasoning already recorded in that file for grok:
+"an answer whose meaning depends on where a cursor happens to rest is not a
+safe default, and here the cursor rests on the irreversible one." Layer 2's
+codex signature stays absent.
+
+## 4b. The inject-path refusal (fourth fix)
+
+`handleReadyAndInject`'s timeout branch now calls `classifyPaneState` and
+returns without injecting when the pane is a `menu`.
+
+**Why this caller and not the boolean.** `classifyPaneState` was built for
+exactly this shape of caller — the module documents it as "for callers whose
+not-ready branch is DESTRUCTIVE." Blind-injecting into a menu is destructive in
+the precise sense that matters: Enter does not lose the message, it SELECTS an
+option. On codex's update menu that option exits the process; on its trust
+prompt it grants directory trust. This branch had been reading a boolean that
+cannot distinguish "still painting" from "waiting on a question."
+
+**Message delivery — the risk this introduces, stated precisely.** Refusing to
+inject could drop the user's first message. It is not dropped SILENTLY, and the
+exact strength of that claim was checked rather than assumed:
+
+- The durable pending-inject record is deliberately left INTACT (the inject
+  path clears it only after an inject actually runs). The absent `clear()` call
+  is the load-bearing part.
+- `recoverPendingInjects` is called from `server.ts` at BOOT — it is not a
+  menu-clear watcher. So the record is re-delivered on the next server boot if
+  the pane is still alive and the record is under its 6h expiry, and REPORTED
+  via `DegradationReporter` otherwise.
+- Immediate visibility comes from the `DegradationReporter` entry this branch
+  emits, plus the Layer-3 defect for the parked menu itself.
+- The practical recovery is the bridge's existing respawn on the next inbound
+  message.
+
+An earlier draft of this review claimed re-delivery "once the menu clears."
+That was wrong, and tracing the caller is what caught it. The honest guarantee
+is narrower and still worth having: the message is never typed into a menu, and
+its non-delivery is never silent.
+
+**Over-correction guard.** The timeout branch exists for genuine
+prompt-detection false negatives and must keep working for them. A committed
+test asserts a merely-unrecognised pane (still painting, no menu, no prompt) is
+STILL blind-injected. Only `menu` is refused; `not-ready` is untouched.
+
+**Signal vs authority.** The refusal consults a pure classifier and declines to
+act. It adds no blocking authority over anything else, and its failure mode is
+a retained message plus a reported degradation — not a lost one.
+
+## 5. Interactions
+
+- **Probe ↔ inject path:** the intended interaction, and the one that had to
+  be traced rather than assumed. `isReadyPromptTail` now answers `false` for
+  this pane, so `handleReadyAndInject` waits instead of typing. On timeout it
+  previously took the "alive but not ready → blind inject" branch and pressed
+  the same fatal Enter ~75s later; fix #4 closes that branch against menus. Fix
+  #2 additionally removes the update menu from the fresh-spawn path entirely,
+  so the two prevention layers are independent rather than co-dependent.
+- **Probe ↔ Slack stuck-session path:** that caller kills on not-ready, and
+  is documented as needing `classifyPaneReadiness` rather than the boolean so
+  it leaves a `menu` pane alone. This change moves codex menus from `ready`
+  into `menu` — i.e. into the state that caller is already required to treat
+  as "do not kill". Strictly safer for that consumer.
+- **Layer 2 ↔ Layer 3:** unchanged. Layer 3 fires only on menus Layer 2 did
+  not clear; since Layer 2 has no codex signature, a codex menu was always
+  Layer 3's to report. It simply could not see the bottom of one before.
+- **Double-fire:** none. Layer 3 dedups on a digest of option labels and has
+  a persistence threshold; one stuck menu yields one defect.
+- **Shadowing:** the launch flag makes the probe fix unreachable for *this*
+  menu on a normal spawn. That is redundancy by intent, not shadowing — the
+  probe fix covers menus the flag does not suppress, and the flag covers the
+  window before any probe runs.
+
+## 6. External surfaces
+
+- **Visible to the operator:** codex panes spawned by instar no longer show
+  the update prompt. `codex update` is unaffected; a codex session started by
+  hand outside instar is unaffected. Documented in the ELI16.
+- **Visible to other agents:** every instar agent that spawns codex
+  interactively inherits both fixes on upgrade. That is the intent — the
+  defect is fleet-wide.
+- **Timing dependence:** reduced, not added. The old behaviour raced the
+  readiness probe against codex's menu paint; the new behaviour removes the
+  menu from the fresh-spawn path entirely.
+- **Unknown-key tolerance verified, not assumed.** A codex launched with a
+  deliberately bogus `-c totally_bogus_key_xyz=false` starts normally, so a
+  codex build predating `check_for_update_on_startup` will not be broken by the
+  flag. This was the main version-compatibility risk of prevention #2 and it was
+  tested rather than argued.
+- **Upstream dependence:** `check_for_update_on_startup` is codex's own
+  config key. If codex renames or removes it, `-c` on an unknown key is the
+  failure mode to watch; the probe fix is the backstop that keeps the session
+  from *dying* in that case, which is exactly why both halves ship together.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, for a concrete reason: both fixes act on a tmux
+pane that exists on one machine's disk, spawned by that machine's
+SessionManager, running that machine's codex binary. There is no state to
+replicate and no cross-machine read to merge — the probe is a pure function
+over a local capture, and the launch flag is an argv element.
+
+Consequences checked:
+- **No one-voice concern.** Neither change emits a user-facing notice. The
+  Layer-3 defect it enables routes through the existing Attention surface,
+  which already owns dedup and one-voice gating.
+- **Nothing strands on topic transfer.** No durable record is written by
+  either fix.
+- **No generated URLs.**
+- **Version skew is benign and asymmetric in the safe direction.** A machine
+  on the old version keeps the old (fatal) behaviour until it upgrades; a
+  machine on the new version is fixed. Neither machine's behaviour depends on
+  the other's version, so a partially-upgraded pool degrades per-machine
+  rather than incoherently.
+
+## Framework generality
+
+Standard: `docs/STANDARDS-REGISTRY.md` → "Framework-Agnostic — and
+Framework-Optimizing". The two source changes sit on opposite sides of that
+standard, deliberately, and each is on the correct side.
+
+**The probe fix is framework-GENERAL, and that is the point of its shape.**
+The defect existed precisely *because* a framework-specific assumption
+(`❯` = Claude Code) had been baked into one half of a module that serves every
+framework. The fix does not add a codex branch; it replaces a hardcoded glyph
+with a shared `SELECTOR_GLYPHS` set consulted by BOTH the menu test and the
+ready test. Adding a third framework's cursor is now a one-line addition to
+one list that automatically stays consistent across both tests — which is the
+property whose absence caused this incident. `classifyPaneReadiness` takes no
+framework parameter and needs none: it discriminates on menu *shape* (glyph on
+a numbered option line, two or more options), not on framework identity.
+
+Verified across frameworks in the committed tests: the codex menu classifies
+`menu`, the same menu rewritten with Claude's `❯` also classifies `menu`
+("neither glyph is special"), the Claude input box still classifies `ready`,
+and codex's real ready pane still classifies `ready`.
+
+Known generality limit, stated rather than glossed: grok-build's radio menu
+shape (`N (●) label`) is recognised by `PermissionPromptAutoResolver` but not
+by this probe's `MENU_OPTION_RE`. That predates this change and is unchanged
+by it — this change neither closes nor worsens it — but it is the honest
+answer to "is this correct for ALL frameworks": for glyph-led numbered menus,
+yes; for grok's radio shape, the probe was and remains shape-blind.
+
+**The launch flag is deliberately framework-SPECIFIC, and correctly scoped.**
+`check_for_update_on_startup` is codex's own config key; it is meaningless to
+Claude Code, gemini-cli, pi-cli and grok-build. It is emitted only from
+`codexCliBuilder`, so it can only ever reach a codex argv — the builder table
+is exactly the framework abstraction this standard asks changes to route
+through, and a test asserts a Claude launch carries no codex config key. This
+is the "framework-optimizing" half of the standard, not a violation of the
+"framework-agnostic" half: each framework's builder owns that framework's
+launch specifics, which is why per-framework builders exist.
+
+The headless `codexCliHeadlessBuilder` was deliberately left alone: `codex
+exec` has no TUI to draw a blocking menu in, so adding the flag there would
+have shipped an unverified change to a path with no demonstrated defect.
+
+**Does the fix generalise to the NEXT framework that does this?** Partly, and
+the split is worth being precise about. If gemini-cli or pi-cli ships a
+glyph-led numbered startup menu using a cursor already in `SELECTOR_GLYPHS`,
+the probe catches it with no code change and the session survives. If it uses
+a new cursor, the probe does not — the residual recorded under "Under-block".
+No framework inherits the *prevention* half automatically; each would need its
+own equivalent of the codex flag, which is correct, because each vendor's
+opt-out is its own.
+
+## 8. Rollback cost
+
+Near-zero. `git revert` of the commit restores prior behaviour exactly. The
+inject-path refusal (fix #4) is a single conditional with an early return; the
+pending-inject store it relies on already existed and is unmodified, so a
+revert leaves no orphaned state. No
+data migration, no agent-state repair, no config written to disk, nothing
+persisted by either change.
+
+Partial rollback is also available and worth naming, because the two halves
+are independent: dropping only `CODEX_NO_UPDATE_PROMPT_FLAGS` restores the
+update prompt while keeping sessions alive (they stall visibly instead of
+dying); dropping only the glyph change re-opens the death for any codex menu
+the flag does not suppress. If one half has to go, keep the glyph fix — it is
+the one that prevents the fatal outcome.
+
+---
+
+## Second-pass review (Phase 5)
+
+**Not run — and this is a declared gap, not an omission.**
+
+This change touches session lifecycle (spawn) and a module named
+`...AutoResolver`, so Phase 5's independent-reviewer trigger applies on
+subject matter. It was not run because this session carries a standing
+operator directive not to spawn subagents unless explicitly requested, and
+fabricating a reviewer concurrence that no reviewer produced would be worse
+than declaring the gap.
+
+The trace records `secondPass: false` and `reviewerConcurred: null`
+accordingly — the record is truthful rather than convenient. The Tier-1 lane's
+own compensating control (the causal autopsy, per the gate's Step 4.55
+rationale: "Low-ceremony lanes (Tier-1) ship without an independent
+reviewer") is supplied in the trace.
+
+The operator can request the independent pass in one word, and it will be run
+before merge.


### PR DESCRIPTION
## ELI16 — codex opened every session on an "update now?" menu, and we typed into it

Codex started showing a menu the moment a session opens, asking whether you want to update it. The highlighted answer is "Update now" — and picking that makes codex run its installer and quit.

Instar has a check that reads the terminal and decides "can I type here yet?". It knows a menu is dangerous to type into, because pressing Enter at a menu doesn't send your message — it *picks an option*. But that check had a blind spot: it only recognised the little arrow Claude Code draws next to a selected option. Codex draws a different one. So a codex menu slipped past the "this is a menu" test and matched the "this looks ready" test one line later, which already knew both arrows.

So instar typed the user's first message and pressed Enter, Enter chose "Update now", codex exited, and the session died about 18 seconds after it started. We know that's really what happened, because reproducing it actually upgraded codex on the test machine from 0.147 to 0.149.

Four things changed. Both halves of that check now read the same list of arrows, so no menu can slip between them. Instar tells codex not to check for updates at startup, so the menu isn't drawn at all. The watcher whose job is to report a session stuck on a menu learned to recognise codex's menus, so a stuck session gets reported instead of sitting there silently. And the fallback that types anyway after waiting now refuses if it sees a menu — without that, the fix would only have delayed the same fatal keypress from 18 seconds to 90.

One deliberate non-change: instar has another watcher that clears prompts by pressing Enter, and it was *not* taught this menu. Enter is exactly what kills it.

While testing, a second codex menu turned up — the one asking whether you trust the directory. It was misread the same way, meaning an arriving message could have silently answered a trust question on your behalf. It's caught now with no extra code, because the fix keys on the shape of a menu rather than its wording.

## The symptom

Every fresh interactive codex session died ~18s after spawn. The pane vanished — not a hang, not an error.

## Root cause

Codex 0.147 opens interactive sessions on a **blocking** menu whose focused default is `1. Update now (runs npm install -g @openai/codex)`. Choosing it makes codex shell out to npm and **exit**.

Instar's readiness probe classified that menu as `ready`, so the spawn path typed the user's first message plus Enter into it — selecting `Update now`, killing the pane.

The probe's two halves had drifted apart:

```ts
export function tailShowsMenu(tail: string): boolean {
  if (!tail || !tail.includes(SELECTOR_GLYPH)) return false;   // ❯ ONLY
  ...
}

export function classifyPaneReadiness(tail: string): PaneReadiness {
  if (tailShowsMenu(tail)) return 'menu';
  if (tail.includes(SELECTOR_GLYPH) || tail.includes('›')) return 'ready';   // ❯ OR ›
```

A codex menu carries `›` and no `❯`, so it skipped the menu branch and matched `ready` on the very next line. The module header already stated the violated invariant: a menu is its own state *"no matter which glyphs it carries."* It carried a glyph only half the module knew.

## The fixes (4)

| # | File | What |
|---|---|---|
| 1 | `claudeReadinessProbe.ts` | One shared `SELECTOR_GLYPHS` set read by **both** the menu test and the ready test. Catches codex menus by shape, not wording. |
| 2 | `frameworkSessionLaunch.ts` | Codex interactive launches pass `-c check_for_update_on_startup=false` — the menu is never drawn, so the session is *usable*, not merely no-longer-fatal. |
| 3 | `PermissionPromptAutoResolver.ts` | Layer 3 recognises codex's `Press enter to continue` footer as menu-bottom structure, so a parked codex menu is **reported**. Without it, fix 1 traded a loud death for a silent stall. |
| 4 | `SessionManager.ts` | The readiness-**timeout** branch blind-injected into any live pane — so fix 1 alone only *relocated* the fatal Enter from ~18s to ~90s. It now consults `classifyPaneState` and refuses on `menu`. |

**Fix 4 is the one worth reviewing closely.** Fixes 1–3 were written believing the probe change stopped the fatal Enter. Reading the consumer falsified that: `handleReadyAndInject`'s not-ready branch types into any pane that is merely alive. A delayed identical outcome is not a fix.

**Deliberately NOT done:** Layer 2 — the half that actually presses Enter — was not taught this menu. Enter is what kills it; the focused option is the irreversible one. Same reasoning already recorded in that file for grok, which it answers with a digit rather than Enter.

## A second menu, found by probing

Codex's **trust-directory** prompt is a second blocking menu with the same shape. It was misread as ready too — so an arriving message plus Enter would have selected `Yes, continue`, answering a **trust** decision on the operator's behalf, silently. It is caught with **no additional code**, which is the evidence this is a class fix rather than a one-menu patch. Committed as a fixture.

*Behaviour note:* a codex session in an untrusted directory now waits for a real answer instead of proceeding. Instar agent homes are trusted in `~/.codex/config.toml`, so the normal path is unaffected.

## Evidence

- **Reproduced before explained.** A faithfully-spawned session sat alive on the menu; injecting a message plus Enter killed it in under 9s — and genuinely upgraded the machine's codex **0.147.0 → 0.149.0**. That version bump is physical proof the Enter ran the updater.
- **Negative controls on all four fixes.** Each bug was put back and the new tests confirmed to fail. A test that passes both ways guards nothing.
- **Real end-to-end.** A session spawned from the *built* `buildInteractiveLaunch` argv: alive past 20s at a real prompt, and it accepted and answered an injected message — the operation that used to kill it. The live pane through the built probe: `ready`. The killer menu through the same built probe: `menu`.
- **Over-block measured.** Live codex 0.149 ready-pane text is a committed fixture asserted `ready`; a single `›`-led numbered line is asserted *not* a menu.
- **Over-correction guarded.** A committed test asserts a still-painting pane is **still** blind-injected — only `menu` is refused.
- **Version tolerance tested.** Codex accepts unknown `-c` keys, so a build predating `check_for_update_on_startup` is not broken by the flag.
- Full suite: **49,742 passing**. Typecheck and lint clean.

## Known limits (stated, not closed)

A menu using a third selector glyph, or a shape `MENU_OPTION_RE` does not match (e.g. grok's `N (●) label` radio form, known to the resolver but not this probe), could still be misread. Pre-existing and unchanged by this PR; the standing canary item is tracked in the module header (CMT-1044).

## Process

Tier 1 (risk floor 1 — declared **at** the floor). Phase 5's independent reviewer was **not** run: this session carries a standing operator directive against spawning subagents, and the trace records `secondPass: false` rather than a concurrence no reviewer produced. The Tier-1 lane's compensating control (causal autopsy) is supplied in the trace. Happy to run the independent pass on request before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkRuEGLYQR9H9AYSnjWqny
