### PR TITLE
fix(sessions): a session that exits on its own now leaves a trace (reason + reap-log row + last pane tail)

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-22T23-51-10-086Z-session-self-exit-leaves-a-trace.json
+++ b/.instar/instar-dev-decisions/2026-08-22T23-51-10-086Z-session-self-exit-leaves-a-trace.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-22T23:51:10.086Z",
+  "slug": "session-self-exit-leaves-a-trace",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 201,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/SessionManager.ts",
+      "src/monitoring/ReapLog.ts"
+    ],
+    "addedLines": 197,
+    "deletedLines": 4
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The monitor's tmux-vanished branch predates endedReason (added later for terminateSession/killSession) and the reap-log; it was never retrofitted, so a process that ended on its own was the one session-end path that wrote no reason and no log row. Dormant until the 2026-08-22 codex interactive death class made self-exits the thing that needed debugging from records."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-23T00-23-39-460Z-session-self-exit-leaves-a-trace.json
+++ b/.instar/instar-dev-decisions/2026-08-23T00-23-39-460Z-session-self-exit-leaves-a-trace.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-23T00:23:39.460Z",
+  "slug": "session-self-exit-leaves-a-trace",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 201,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/SessionManager.ts",
+      "src/monitoring/ReapLog.ts"
+    ],
+    "addedLines": 197,
+    "deletedLines": 4
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The monitor's tmux-vanished branch predates endedReason (added later for terminateSession/killSession) and the reap-log; it was never retrofitted, so a process that ended on its own was the one session-end path that wrote no reason and no log row. Dormant until the 2026-08-22 codex interactive death class made self-exits the thing that needed debugging from records."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-23T00-24-02-434Z-session-self-exit-leaves-a-trace.json
+++ b/.instar/instar-dev-decisions/2026-08-23T00-24-02-434Z-session-self-exit-leaves-a-trace.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-23T00:24:02.434Z",
+  "slug": "session-self-exit-leaves-a-trace",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 201,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/SessionManager.ts",
+      "src/monitoring/ReapLog.ts"
+    ],
+    "addedLines": 197,
+    "deletedLines": 4
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The monitor's tmux-vanished branch predates endedReason (added later for terminateSession/killSession) and the reap-log; it was never retrofitted, so a process that ended on its own was the one session-end path that wrote no reason and no log row. Dormant until the 2026-08-22 codex interactive death class made self-exits the thing that needed debugging from records."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-23T00-25-01-427Z-session-self-exit-leaves-a-trace.json
+++ b/.instar/instar-dev-decisions/2026-08-23T00-25-01-427Z-session-self-exit-leaves-a-trace.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-23T00:25:01.427Z",
+  "slug": "session-self-exit-leaves-a-trace",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 201,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/SessionManager.ts",
+      "src/monitoring/ReapLog.ts"
+    ],
+    "addedLines": 197,
+    "deletedLines": 4
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The monitor's tmux-vanished branch predates endedReason (added later for terminateSession/killSession) and the reap-log; it was never retrofitted, so a process that ended on its own was the one session-end path that wrote no reason and no log row. Dormant until the 2026-08-22 codex interactive death class made self-exits the thing that needed debugging from records."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/session-self-exit-leaves-a-trace.eli16.md
+++ b/docs/eli16/session-self-exit-leaves-a-trace.eli16.md
@@ -1,0 +1,66 @@
+# A session that dies on its own now leaves a trace — in plain English
+
+## What was missing
+
+Earlier today every interactive codex session died about 18 seconds after it
+started. When we went to the records to find out why, there was nothing there.
+Each death was filed as a perfectly normal completion — status "completed",
+reason blank — and the log that records every session shutoff had no row for
+it at all. The cause had to be rediscovered by hand: spawn a session, sit and
+watch the terminal, see what it printed before it vanished.
+
+That is a defect in its own right. Instar promises that a session can never
+disappear without a trace. It had a gap: the promise covered every way INSTAR
+ends a session (reapers, kills, restarts) but not a session whose own process
+simply stopped. Those are exactly the ones you most need evidence for, because
+nobody asked for them to end.
+
+## What changed
+
+Three things, all on the path that notices a session's terminal is gone.
+
+**1. The record says why.** The session record now carries a reason —
+"process exited" — and, when it died young, "process exited during startup".
+That phrase alone would have turned today's mystery into a one-line search.
+
+**2. It lands in the shutoff log like everything else.** The same log that
+records every reaper kill and every refused kill now gets a row of a new kind,
+"exited", with the session's name, its framework, and how many seconds it had
+been alive. The existing "why did my session vanish?" surface (`GET
+/sessions/reap-log`) shows it without any change on the reading side.
+
+**3. It carries the evidence the dead terminal would have taken with it.**
+This is the part that was genuinely missing. By the time instar notices the
+pane is gone, there is nothing left to capture. So during a session's first
+two minutes — the window where silent deaths cluster — the monitor keeps the
+last dozen lines it saw. When the session vanishes, those lines go into the
+row. For today's bug that row would have read, verbatim: "Update available!
+… 1. Update now … Press enter to continue". Case closed from the records.
+
+## What it deliberately is not
+
+- **Not a new alarm.** Nothing pings you. It is a record, read when you ask.
+- **Not a change to how sessions end.** Every listener that fired before
+  still fires; this adds a reason and a row, it removes nothing.
+- **Not a raw terminal dump in a log.** Those lines pass through the same
+  credential scrubber the dashboard's live terminal view already uses, and
+  they are capped at a dozen lines. The scrubbing happens inside the log
+  writer itself, so no caller can bypass it. The row also records how many
+  redactions were applied, so a reader knows the tail was touched.
+- **Not unbounded.** Only young sessions are sampled, samples live in memory
+  only, they are dropped the moment a session is no longer running, and the
+  stored tail is clamped on write and re-clamped on read.
+
+## How we know it works
+
+Each of the three pieces has a test that was made to fail by putting the bug
+back: remove the reason stamp and the reason test fails; make the log reader
+forget the new row kind and the round-trip test fails (it would silently
+relabel a self-exit as a kill). A scrubbing test proves an API key and a
+bearer token in the sampled lines do not reach the log. A clamping test
+proves a 400-line dump is cut to the last dozen lines.
+
+## What you would notice
+
+Nothing, until a session dies on its own — and then, instead of a blank, you
+get a reason, an uptime, and the last thing it printed.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10401,6 +10401,31 @@ export async function startServer(options: StartOptions): Promise<void> {
       }));
     }
 
+    // A session whose process ended on its own (no reaper/operator/kill) lands in
+    // the SAME reap-log as every other session end — `type:'exited'` with uptime
+    // and the last startup-window pane tail. Before this, a self-exit was a
+    // reason-less `completed` record and NO row here (2026-08-22 codex class).
+    sessionManager.on('sessionExited', (e: {
+      session: import('../core/types.js').Session;
+      reason: string;
+      uptimeSeconds?: number;
+      lastTail?: string;
+    }) => {
+      try {
+        reapLog.recordExited({
+          session: e.session.name,
+          tmuxSession: e.session.tmuxSession,
+          reason: e.reason,
+          ...(e.session.framework ? { framework: e.session.framework } : {}),
+          ...(e.uptimeSeconds !== undefined ? { uptimeSeconds: e.uptimeSeconds } : {}),
+          ...(e.session.launchLane ? { launchLane: e.session.launchLane } : {}),
+          ...(e.lastTail ? { lastTail: e.lastTail } : {}),
+        });
+      } catch (err) {
+        // @silent-fallback-ok — an audit write must never disturb the monitor loop.
+        console.warn('[reap-log] recordExited failed (non-fatal):', err);
+      }
+    });
     sessionManager.on('sessionReaped', (e: { session: import('../core/types.js').Session; reason: string; disposition?: 'terminal' | 'recovery-bounce'; origin?: 'operator' | 'autonomous'; authorityScope?: 'lease-holder' | 'local-age-limit' | 'local-post-transfer-closeout' | 'operator'; midWork?: boolean; workEvidence?: string[]; via?: string }) => {
       // ── F7: schedule a post-grace reachability verify for the affected topic. Both a
       //    terminal kill AND a recovery-bounce schedule one (a recovery whose respawn

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -308,6 +308,13 @@ export function deriveTargetKey(sessionId: string): DerivedTarget {
 }
 
 /** Absolute maximum session duration (4 hours) — safety net for sessions without explicit timeout */
+/** Sessions younger than this get their pane tail sampled each monitor tick
+ *  so a self-exit during startup leaves evidence (see `startupTails`). */
+const STARTUP_TAIL_WINDOW_MS = 120_000;
+/** Lines captured per startup-tail sample — enough to show a menu/banner/error,
+ *  small enough to be a negligible per-tick cost. */
+const STARTUP_TAIL_LINES = 15;
+
 const DEFAULT_MAX_DURATION_MINUTES = 240;
 
 /** Age-gate transcript-activity window (ms). A session whose framework transcript
@@ -752,6 +759,22 @@ export class SessionManager extends EventEmitter {
   private worktreeManager: import('./WorktreeManager.js').WorktreeManager | null = null;
   private buildContextStore: SessionBuildContextStore | null = null;
   private pendingInjects!: PendingInjectStore;
+  /**
+   * Last pane tail the monitor saw for a session still in its STARTUP window.
+   *
+   * A session whose process ends on its own takes its terminal with it — by the
+   * time the monitor notices the pane is gone there is nothing left to capture.
+   * 2026-08-22: interactive codex sessions died ~18s after spawn and every death
+   * was a `completed`/reason-null record with no evidence; the cause had to be
+   * re-derived by hand-spawning one and watching. So the monitor samples a small
+   * tail for sessions younger than `STARTUP_TAIL_WINDOW_MS` (where silent deaths
+   * cluster — a session that survives startup is not the silent-death class),
+   * and the vanish path hands the last sample to the reap-log `exited` row.
+   * Bounded: the window caps how many sessions are sampled per tick, entries are
+   * evicted every tick for sessions no longer running, and the stored tail is a
+   * dozen lines. Memory-only; never written anywhere except the redacted row.
+   */
+  private readonly startupTails = new Map<string, { tail: string; at: number }>();
 
   /** Per-session shim directory root (one subdir per session). Used for K9 mandatory shim. */
   private shimRoot: string | null = null;
@@ -2012,13 +2035,34 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // entries for ended sessions + per-entry TTL). The resolver's sweep is internally
       // guarded (it never throws into the monitor loop), so no outer guard is needed.
       this.permissionPromptResolver?.sweep(new Set(running.map(s => s.tmuxSession)));
+      // Evict startup-tail samples for sessions that are no longer running
+      // (bounded map — same hygiene as the resolver sweep above).
+      if (this.startupTails.size > 0) {
+        const live = new Set(running.map(s => s.tmuxSession));
+        for (const key of this.startupTails.keys()) {
+          if (!live.has(key)) this.startupTails.delete(key);
+        }
+      }
       for (const session of running) {
         // Grace period: don't check sessions that started less than 15 seconds ago.
         // Claude Code takes several seconds to start — the process might not be
         // visible in tmux yet when the monitor runs its first check.
+        let ageMs: number | undefined;
         if (session.startedAt) {
-          const ageMs = Date.now() - new Date(session.startedAt).getTime();
+          ageMs = Date.now() - new Date(session.startedAt).getTime();
           if (ageMs < 15_000) continue;
+        }
+
+        // Startup-window evidence sample (see `startupTails`). Taken BEFORE the
+        // liveness probe: if the pane is already gone the capture is empty and
+        // the previous sample is kept — which is exactly the evidence we want.
+        if (ageMs !== undefined && ageMs < STARTUP_TAIL_WINDOW_MS) {
+          try {
+            const tail = await this.captureOutputMaybeAsync(session.tmuxSession, STARTUP_TAIL_LINES);
+            if (tail && tail.trim().length > 0) {
+              this.startupTails.set(session.tmuxSession, { tail, at: Date.now() });
+            }
+          } catch { /* @silent-fallback-ok — evidence sampling must never affect the tick */ }
         }
 
         const alive = await this.isSessionAliveAsync(session.tmuxSession);
@@ -2047,9 +2091,36 @@ rm()  { "${shimRunner}" rm  "$@"; }
               injectedAt: pendingInjection.injectedAt,
             });
           }
+          // The process ended ON ITS OWN — no reaper, no operator, no kill path
+          // owns this transition. Stamp WHY so the record is not a reason-less
+          // `completed` (2026-08-22: the codex interactive death class was
+          // invisible in the records precisely because this branch wrote
+          // nothing), and hand the last startup-window tail sample to the
+          // reap-log `exited` row via `sessionExited`. `sessionComplete` still
+          // fires for every existing listener — this ADDS a record, it changes
+          // no existing semantics.
+          const uptimeSeconds = fresh.startedAt
+            ? Math.max(0, Math.round((Date.now() - new Date(fresh.startedAt).getTime()) / 1000))
+            : undefined;
+          const duringStartup = uptimeSeconds !== undefined && uptimeSeconds * 1000 < STARTUP_TAIL_WINDOW_MS;
+          const lastSample = this.startupTails.get(session.tmuxSession);
+          this.startupTails.delete(session.tmuxSession);
           fresh.status = 'completed';
           fresh.endedAt = new Date().toISOString();
+          fresh.endedReason = duringStartup ? 'process-exited-during-startup' : 'process-exited';
           this.state.saveSession(fresh);
+          console.warn(
+            `[SessionManager] Session "${fresh.name}" (${fresh.framework ?? 'unknown framework'}) exited on its own` +
+            `${uptimeSeconds !== undefined ? ` after ${uptimeSeconds}s` : ''} — not killed by instar.` +
+            `${duringStartup ? ' Died DURING STARTUP.' : ''}` +
+            `${lastSample ? ` Last pane tail sampled ${Math.round((Date.now() - lastSample.at) / 1000)}s before detection (recorded in reap-log).` : ' No startup tail sample was available.'}`,
+          );
+          this.emit('sessionExited', {
+            session: fresh,
+            reason: fresh.endedReason,
+            uptimeSeconds,
+            lastTail: lastSample?.tail,
+          });
           this.emit('sessionComplete', fresh);
           continue;
         }

--- a/src/monitoring/ReapLog.ts
+++ b/src/monitoring/ReapLog.ts
@@ -15,6 +15,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { redactForLiveTail } from '../core/liveTailRedaction.js';
 
 /**
  * Read only the last `maxBytes` of a file and return its non-empty lines,
@@ -89,8 +90,13 @@ const NOTIFY_OUTCOMES: ReadonlySet<string> = new Set([
 export interface ReapLogEntry {
   ts: string;
   /** 'reaped' = a kill happened; 'skipped' = a terminate was refused/no-op;
-   *  'notify' = a reap-notice delivery outcome record (reap-notify spec R1.3). */
-  type: 'reaped' | 'skipped' | 'notify';
+   *  'notify' = a reap-notice delivery outcome record (reap-notify spec R1.3);
+   *  'exited' = the session's process ENDED ON ITS OWN — nobody in instar asked
+   *  for it (2026-08-22: the codex interactive death class). Before this type a
+   *  self-exit was recorded as a plain `status:'completed'` with no reason and
+   *  NO reap-log row, so "why did my session vanish?" was unanswerable from the
+   *  records — which is itself a defect when the exit is the bug. */
+  type: 'reaped' | 'skipped' | 'notify' | 'exited';
   session: string;
   tmuxSession: string;
   /** The reason the killer requested (e.g. 'idle-zombie', 'age-limit'). */
@@ -135,6 +141,19 @@ export interface ReapLogEntry {
   topicId?: number;
   /** Notify entries: the outcome this record asserts. */
   outcome?: ReapNotifyOutcome;
+  /** Exited entries: how long the session had been up when its process ended. */
+  uptimeSeconds?: number;
+  /** Exited entries: the framework the session was launched on, when known. */
+  framework?: string;
+  /** Exited entries: the last pane tail instar SAW before the process ended —
+   *  REDACTED through the live-tail credential scrubber and clamped (see
+   *  `recordExited`). Present only when the monitor had sampled the pane (it
+   *  samples the startup window, where silent deaths cluster). This is the
+   *  evidence a vanished session otherwise takes with it. */
+  lastTail?: string;
+  /** Exited entries: how many credential redactions the scrubber applied to
+   *  `lastTail` (so a reader knows the tail was touched, and how much). */
+  lastTailRedactions?: number;
 }
 
 export interface ReapLogPage {
@@ -236,6 +255,56 @@ export class ReapLog {
    * once at terminal state. Append-only; consumers take the latest record
    * per noticeId as the current state.
    */
+  /**
+   * A session's process ended ON ITS OWN — no reaper, no operator, no kill.
+   *
+   * 2026-08-22: every interactive codex session died ~18s after spawn and each
+   * death was recorded as `status:'completed'`, reason null, no reap-log row.
+   * The charter that found the cause named this as a defect in its own right:
+   * "nobody can debug this from the records alone." This row is the fix for
+   * THAT — the exit lands in the same log every other session end lands in,
+   * with its uptime and the last pane tail the monitor saw.
+   *
+   * `lastTail` is the one field here that carries pane CONTENT. It goes through
+   * the SAME credential redactor the dashboard live-tail uses (the existing
+   * chokepoint for exporting pane text — not a second, divergent scrubber) and
+   * is clamped to a handful of lines, INSIDE this method, so no caller can write
+   * an unscrubbed or unbounded tail into a world-readable log.
+   */
+  recordExited(e: {
+    session: string;
+    tmuxSession: string;
+    /** e.g. 'process-exited' / 'process-exited-during-startup'. */
+    reason: string;
+    framework?: string;
+    uptimeSeconds?: number;
+    launchLane?: 'headless' | 'rerouted-interactive';
+    /** Raw last-seen pane tail; redacted + clamped here, never stored raw. */
+    lastTail?: string;
+  }): void {
+    let tail: { text: string; redactedCount: number } | undefined;
+    if (typeof e.lastTail === 'string' && e.lastTail.trim().length > 0) {
+      tail = clampTail(redactForLiveTail(e.lastTail));
+    }
+    this.append({
+      ts: new Date().toISOString(),
+      type: 'exited',
+      session: e.session,
+      tmuxSession: e.tmuxSession,
+      reason: e.reason,
+      disposition: 'terminal',
+      machine: this.machineId?.(),
+      ...(e.framework ? { framework: e.framework } : {}),
+      ...(typeof e.uptimeSeconds === 'number' && Number.isFinite(e.uptimeSeconds)
+        ? { uptimeSeconds: Math.max(0, Math.round(e.uptimeSeconds)) }
+        : {}),
+      ...(e.launchLane ? { launchLane: e.launchLane } : {}),
+      ...(tail ? { lastTail: tail.text, lastTailRedactions: tail.redactedCount } : {}),
+    });
+    // The session is gone — same skip-state hygiene as a reap.
+    this.forgetSkip(e.session);
+  }
+
   recordNotify(e: {
     noticeId: string;
     topicId: number | null;
@@ -401,7 +470,10 @@ export class ReapLog {
     // but 'notify' and 'skipped' pass through (reap-notify spec R1.3: the new
     // type MUST survive normalization or notify records vanish on read).
     const type =
-      entry.type === 'skipped' ? 'skipped' : entry.type === 'notify' ? 'notify' : 'reaped';
+      entry.type === 'skipped' ? 'skipped'
+        : entry.type === 'notify' ? 'notify'
+          : entry.type === 'exited' ? 'exited'
+            : 'reaped';
     const skipped = typeof entry.skipped === 'string' ? entry.skipped : undefined;
     const outcome =
       typeof entry.outcome === 'string' && NOTIFY_OUTCOMES.has(entry.outcome)
@@ -452,6 +524,31 @@ export class ReapLog {
       ...(typeof entry.noticeId === 'string' ? { noticeId: entry.noticeId } : {}),
       ...(typeof entry.topicId === 'number' ? { topicId: entry.topicId } : {}),
       ...(outcome ? { outcome } : {}),
+      ...(typeof entry.uptimeSeconds === 'number' && Number.isFinite(entry.uptimeSeconds)
+        ? { uptimeSeconds: entry.uptimeSeconds }
+        : {}),
+      ...(typeof entry.framework === 'string' ? { framework: entry.framework } : {}),
+      // Re-clamp on read too: a row written by a future/foreign writer can never
+      // hand an unbounded blob to a consumer of this log.
+      ...(typeof entry.lastTail === 'string'
+        ? { lastTail: entry.lastTail.slice(0, LAST_TAIL_MAX_CHARS) }
+        : {}),
+      ...(typeof entry.lastTailRedactions === 'number' && Number.isFinite(entry.lastTailRedactions)
+        ? { lastTailRedactions: entry.lastTailRedactions }
+        : {}),
     };
   }
+}
+
+/** Clamp on the last-seen tail stored in an 'exited' row: last N non-empty
+ *  lines, then a hard character cap. Bounded Accumulation — a pane dump can
+ *  never inflate this log the way the 2026-07-03 skip flood did. */
+const LAST_TAIL_MAX_LINES = 12;
+const LAST_TAIL_MAX_CHARS = 1500;
+
+function clampTail(r: { text: string; redactedCount: number }): { text: string; redactedCount: number } {
+  const lines = r.text.split('\n').filter((l) => l.trim().length > 0);
+  const kept = lines.slice(-LAST_TAIL_MAX_LINES).join('\n');
+  const text = kept.length > LAST_TAIL_MAX_CHARS ? kept.slice(-LAST_TAIL_MAX_CHARS) : kept;
+  return { text, redactedCount: r.redactedCount };
 }

--- a/tests/unit/reap-log.test.ts
+++ b/tests/unit/reap-log.test.ts
@@ -307,3 +307,88 @@ describe('ReapLog — bounded read + rotation (can never be slurped/grow unbound
     expect(log.read()).toEqual([]);
   });
 });
+
+describe("ReapLog.recordExited — a session that ended on its own leaves a trace", () => {
+  let dir: string;
+  let log: ReapLog;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reap-log-exited-'));
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    log = new ReapLog(path.join(dir, 'state'), () => 'm_test');
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips type 'exited' + uptime + framework + tail — the normalizer must not coerce it to 'reaped'", () => {
+    // 2026-08-22: every interactive codex death was a reason-less `completed`
+    // record and NO reap-log row. This row is what makes the death debuggable
+    // from the records. The read-side whitelist previously coerced every
+    // unknown type to 'reaped' — a row that survives append but comes back as
+    // a 'reaped' row would mis-attribute a self-exit to a kill.
+    log.recordExited({
+      session: 'Observer 2',
+      tmuxSession: 'echo-observer-2',
+      reason: 'process-exited-during-startup',
+      framework: 'codex-cli',
+      uptimeSeconds: 18.66,
+      lastTail: [
+        '  Update available! 0.147.0 -> 0.149.0',
+        '› 1. Update now (runs `npm install -g @openai/codex`)',
+        '  2. Skip',
+        '  Press enter to continue',
+      ].join('\n'),
+    });
+    const [row] = log.read();
+    expect(row.type).toBe('exited');
+    expect(row.disposition).toBe('terminal');
+    expect(row.reason).toBe('process-exited-during-startup');
+    expect(row.framework).toBe('codex-cli');
+    expect(row.uptimeSeconds).toBe(19); // rounded, finite
+    expect(row.machine).toBe('m_test');
+    expect(row.lastTail).toContain('Update now');
+    expect(row.lastTailRedactions).toBe(0);
+  });
+
+  it('REDACTS credential-shaped material in the tail through the live-tail scrubber, and records that it did', () => {
+    // The tail is pane CONTENT — the one field here that can carry a secret.
+    // It goes through the SAME redactor the dashboard live-tail uses, INSIDE
+    // recordExited, so no caller can write a raw secret into this log.
+    log.recordExited({
+      session: 's',
+      tmuxSession: 't',
+      reason: 'process-exited',
+      lastTail: 'export OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456\nAuthorization: Bearer eyJabcdefghijklmnop.qrstuvwxyz012345.ABCDEFGHIJKLMNOP\n› done',
+    });
+    const [row] = log.read();
+    expect(row.lastTail).not.toContain('sk-abcdefghijklmnopqrstuvwxyz123456');
+    expect(row.lastTail).not.toContain('eyJabcdefghijklmnop');
+    expect(row.lastTail).toContain('› done');
+    expect((row.lastTailRedactions ?? 0)).toBeGreaterThanOrEqual(2);
+  });
+
+  it('CLAMPS the tail — a pane dump can never inflate this log (Bounded Accumulation)', () => {
+    const huge = Array.from({ length: 400 }, (_, i) => `line ${i} ${'x'.repeat(80)}`).join('\n');
+    log.recordExited({ session: 's', tmuxSession: 't', reason: 'process-exited', lastTail: huge });
+    const [row] = log.read();
+    expect(row.lastTail!.length).toBeLessThanOrEqual(1500);
+    expect(row.lastTail!.split('\n').length).toBeLessThanOrEqual(12);
+    // Keeps the END of the pane (where the menu / error / prompt is), not the start.
+    expect(row.lastTail).toContain('line 399');
+  });
+
+  it('omits the tail fields entirely when no sample was available — absence is honest, not an empty string', () => {
+    log.recordExited({ session: 's', tmuxSession: 't', reason: 'process-exited', uptimeSeconds: 3600 });
+    const [row] = log.read();
+    expect(row.lastTail).toBeUndefined();
+    expect(row.lastTailRedactions).toBeUndefined();
+    expect(row.uptimeSeconds).toBe(3600);
+  });
+
+  it("an 'exited' row is distinct from a 'reaped' row in the same log — the reader can tell a self-exit from a kill", () => {
+    log.recordReaped({ session: 'a', tmuxSession: 'a', reason: 'idle-zombie' });
+    log.recordExited({ session: 'b', tmuxSession: 'b', reason: 'process-exited' });
+    const types = log.read().map((r) => r.type);
+    expect(types).toEqual(['reaped', 'exited']);
+  });
+});

--- a/tests/unit/session-manager-is-session-alive-async-tristate.test.ts
+++ b/tests/unit/session-manager-is-session-alive-async-tristate.test.ts
@@ -223,3 +223,96 @@ describe('SessionManager.isSessionAliveAsync — tri-state (§A)', () => {
     off.stopMonitoring();
   });
 });
+
+describe('monitorTick — a session that ended on its own leaves a reason and an evidence event', () => {
+  // 2026-08-22: interactive codex sessions died ~18s after spawn and every
+  // death was `status:'completed'`, reason null, no event anyone could log.
+  // These tests pin the evidence trail the vanish branch now leaves.
+  let dir: string;
+  let state: StateManager;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sm-exited-'));
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    state = new StateManager(path.join(dir, 'state'));
+    manager = makeManager(dir, state, true);
+    opHandlers = {};
+  });
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/session-manager-is-session-alive-async-tristate.test.ts' });
+  });
+
+  function startupSession(id: string, ageMs: number): Session {
+    const s: Session = {
+      id, name: id, status: 'running', tmuxSession: id, framework: 'codex-cli',
+      startedAt: new Date(Date.now() - ageMs).toISOString(), prompt: 'p',
+    } as Session;
+    state.saveSession(s);
+    return s;
+  }
+
+  it("stamps endedReason 'process-exited-during-startup' and emits sessionExited carrying the LAST SAMPLED TAIL when a young session vanishes", async () => {
+    startupSession('codex-young', 20_000); // past the 15s grace, inside the 120s startup window
+    const MENU = '  Update available! 0.147.0 -> 0.149.0\n› 1. Update now\n  2. Skip\n  Press enter to continue';
+    // Tick 1: pane alive, capture returns the menu → sampled.
+    opHandlers = {
+      'has-session': () => ({ ok: '' }),
+      'display-message': () => ({ ok: 'codex||codex' }),
+      'capture-pane': () => ({ ok: MENU }),
+    };
+    const exited: Array<{ session: Session; reason: string; uptimeSeconds?: number; lastTail?: string }> = [];
+    manager.on('sessionExited', (e) => exited.push(e));
+    await maintenanceTicks.get(manager)!();
+    expect(exited).toHaveLength(0);
+    expect(state.getSession('codex-young')!.status).toBe('running');
+
+    // Tick 2: the pane is GONE (the process exited on its own). Capture is
+    // empty — exactly the situation where the prior sample is the only evidence.
+    opHandlers = {
+      'has-session': () => ({ reject: absentErr() }),
+      'capture-pane': () => ({ ok: '' }),
+    };
+    await maintenanceTicks.get(manager)!();
+
+    const rec = state.getSession('codex-young')!;
+    expect(rec.status).toBe('completed');
+    expect(rec.endedReason).toBe('process-exited-during-startup');
+    expect(exited).toHaveLength(1);
+    expect(exited[0].reason).toBe('process-exited-during-startup');
+    expect(exited[0].uptimeSeconds).toBeGreaterThanOrEqual(20);
+    expect(exited[0].lastTail).toContain('Update now'); // the evidence the dead pane took with it
+  });
+
+  it("a vanish past the startup window is 'process-exited' (not during-startup), still emits, and carries no tail sample", async () => {
+    startupSession('old-one', 10 * 60_000);
+    opHandlers = { 'has-session': () => ({ reject: absentErr() }), 'capture-pane': () => ({ ok: '' }) };
+    const exited: Array<{ reason: string; lastTail?: string }> = [];
+    manager.on('sessionExited', (e) => exited.push(e));
+    await maintenanceTicks.get(manager)!();
+    expect(state.getSession('old-one')!.endedReason).toBe('process-exited');
+    expect(exited).toHaveLength(1);
+    expect(exited[0].lastTail).toBeUndefined();
+  });
+
+  it('an INDETERMINATE probe stamps nothing and emits nothing — the slow-tmux guard still holds', async () => {
+    startupSession('slow', 20_000);
+    opHandlers = { 'has-session': () => ({ reject: timeoutErr() }), 'capture-pane': () => ({ ok: 'something' }) };
+    let n = 0;
+    manager.on('sessionExited', () => { n++; });
+    await maintenanceTicks.get(manager)!();
+    expect(state.getSession('slow')!.status).toBe('running');
+    expect(state.getSession('slow')!.endedReason).toBeUndefined();
+    expect(n).toBe(0);
+  });
+
+  it('sessionComplete STILL fires on a vanish — existing listeners are unchanged', async () => {
+    startupSession('compat', 20_000);
+    opHandlers = { 'has-session': () => ({ reject: absentErr() }), 'capture-pane': () => ({ ok: '' }) };
+    let completes = 0;
+    manager.on('sessionComplete', () => { completes++; });
+    await maintenanceTicks.get(manager)!();
+    expect(completes).toBe(1);
+  });
+});

--- a/upgrades/next/session-self-exit-leaves-a-trace.md
+++ b/upgrades/next/session-self-exit-leaves-a-trace.md
@@ -1,0 +1,32 @@
+<!-- bump: patch -->
+
+## What Changed
+
+A session whose process ended ON ITS OWN — no reaper, no operator, no kill — used to be recorded as a plain `status:'completed'` with no reason and NO reap-log row. The 2026-08-22 codex interactive death class was invisible in the records for exactly this reason; the charter that found the cause named it as a defect in its own right ("nobody can debug this from the records alone").
+
+Now, on the monitor's vanish branch:
+
+1. the session record carries `endedReason` — `process-exited`, or `process-exited-during-startup` when it died inside the first two minutes;
+2. a `sessionExited` event is emitted and the server writes a reap-log row of a NEW type, `exited`, with the session's framework and uptime — served by the existing `GET /sessions/reap-log` without any reader change;
+3. that row carries the LAST PANE TAIL the monitor saw. By the time the pane is gone there is nothing to capture, so the monitor now samples a dozen lines for sessions in their startup window (15s–120s, where silent deaths cluster) and the vanish path hands the last sample to the row. For today's bug the row would have read, verbatim, `Update available! … › 1. Update now … Press enter to continue`.
+
+The tail goes through the SAME credential redactor the dashboard live-tail uses, INSIDE the log writer (no caller can write a raw tail), clamped to 12 lines / 1500 chars on write and re-clamped on read, with the redaction count recorded on the row. Samples are memory-only, bounded to young sessions, and evicted every tick for sessions no longer running. `sessionComplete` still fires for every existing listener.
+
+## Evidence
+
+- Tests: `recordExited` round-trips type `exited` + uptime + framework + tail (the read-side whitelist previously coerced any unknown type to `reaped` — a self-exit would have been relabelled a kill); credential-shaped material in the tail is redacted and counted; a 400-line dump is clamped to the last 12 lines; absence of a sample yields absent fields, not empty strings; `exited` and `reaped` rows are distinguishable in one log.
+- Monitor tests: a young session that vanishes gets `process-exited-during-startup` + a `sessionExited` event carrying the tail sampled on the PREVIOUS tick (the pane is empty on the vanish tick — the exact situation the sample exists for); an old session gets `process-exited` with no tail; an INDETERMINATE probe stamps and emits nothing (the slow-tmux guard holds); `sessionComplete` still fires.
+- Negative controls: removing the reason stamp + emit fails the monitor tests; removing `exited` from the read whitelist fails the round-trip tests (rows come back as `reaped`).
+- Neighbouring suites green: session-manager terminate/behavioral/reap-detect/async-monitor, headless-spawn-reroute, reap-log lifecycle (e2e), reap-notify lifecycle (e2e + integration), session-lifecycle-reap-wiring (integration).
+
+## What to Tell Your User
+
+Nothing changes day to day. If a session ever dies on its own again, "where did my session go?" now has an answer in the records: a reason, how long it had been up, and the last few lines it printed — instead of a blank. Those lines are scrubbed for anything that looks like a credential before they are stored.
+
+## Summary of New Capabilities
+
+Self-exited sessions are now debuggable from the records: a reason on the session, an `exited` row in the shutoff log, and the last sampled terminal lines. No new surface to learn — it shows up where session ends already show up.
+
+## Known Limits
+
+A death inside the first 15 seconds, or one that lands between two monitor ticks, may carry no tail sample (the reason and the row are recorded regardless). Sessions past the 120-second startup window carry no tail by design. The sync legacy sweep `reapCompletedSessions()` still marks `completed` without a reason; it is superseded by the monitor loop and left untouched here. <!-- tracked: CMT-1044 -->

--- a/upgrades/side-effects/session-self-exit-leaves-a-trace.md
+++ b/upgrades/side-effects/session-self-exit-leaves-a-trace.md
@@ -1,0 +1,145 @@
+# Side-effects review — a session that exits on its own leaves a trace
+
+**Change:** the monitor's "tmux pane is gone" branch previously wrote
+`status:'completed'` with no reason and emitted nothing a log could catch. It
+now stamps `endedReason` (`process-exited` / `process-exited-during-startup`),
+emits `sessionExited`, and the server records a `type:'exited'` row in the
+reap-log carrying uptime, framework, and a redacted, clamped last-seen pane
+tail sampled during the session's startup window.
+
+**Files:**
+- `src/core/SessionManager.ts` — startup-window tail sampling; `endedReason`
+  stamp + `sessionExited` emit on the vanish branch.
+- `src/monitoring/ReapLog.ts` — `recordExited()`, the `'exited'` type, new
+  optional fields, redaction + clamp at the write chokepoint, re-clamp on read.
+- `src/commands/server.ts` — `sessionExited` → `reapLog.recordExited` wiring.
+
+**Tier:** 1. Risk floor 1 — at the floor. Additive observability; no blocking
+authority, no migration, no config, revert-only rollback.
+
+**Origin:** the 2026-08-22 codex interactive death charter named this
+explicitly: "Every death is recorded as a normal completion with an empty
+reason, and no shutoff record explains it. That means nobody can debug this
+from the records alone, which is itself part of what you should fix."
+
+---
+
+## 1. Over-block — what legitimate input does this now reject?
+
+Nothing is rejected; this path gates nothing. The one behaviour a caller could
+perceive as a "block" is that `recordExited` refuses to store an unscrubbed or
+oversized tail — it scrubs and clamps instead of refusing, so no write is ever
+dropped.
+
+## 2. Under-block — what does this still miss?
+
+- **A death in the first 15 seconds has no tail sample.** The monitor's grace
+  period skips sessions younger than 15s, so sampling starts there and the
+  tick is 5s; a session that exits at ~16s may have 0–1 samples. Today's class
+  (18–23s) gets at least one tick in the window in practice, but it is a
+  window, not a guarantee. The reason stamp and the row itself do not depend
+  on the sample.
+- **A death past the 120s window carries no tail.** Deliberate: the silent-
+  death class clusters at startup, and sampling every live session every tick
+  would double the monitor's per-tick tmux calls for the common long-lived
+  case. The row still records uptime + reason.
+- **Server-restart between sample and vanish loses the sample** (memory-only
+  by design — see §8).
+- **`reapCompletedSessions()` (the sync reaper) still marks `completed`
+  without a reason.** Checked: it is a legacy sweep the monitor loop has
+  superseded; I left it untouched rather than widen a Tier-1 change, and it is
+  named here so it is not mistaken for covered.
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and the alternatives were considered:
+
+- The reason belongs on the **vanish branch of the monitor** because that is
+  the single place instar learns a process ended on its own. Every other end
+  path (`terminateSession`, `killSession`) already stamps `endedReason`; this
+  branch was the one that did not.
+- The row belongs in **ReapLog** because that log already IS "why did a
+  session end" — a parallel "exit log" would fork the question the reap-log
+  answers and break `GET /sessions/reap-log` as the one surface.
+- The redaction belongs **inside `recordExited`**, not in the caller: the
+  reap-log is world-readable and a second caller (future or foreign) must not
+  be able to write raw pane text. `redactForLiveTail` is the existing
+  chokepoint for exporting pane content (dashboard live tail) — reused, not
+  re-invented.
+- Sampling belongs in the **monitor tick**, which already probes every
+  running session; adding a bounded capture there is the cheapest place it can
+  live and needs no new timer.
+
+## 4. Signal vs authority compliance
+
+Pure signal. The change produces a record and an event; it blocks, delays, or
+rewrites nothing. `sessionComplete` still fires for every existing listener
+(asserted by test), so no downstream authority changes. The `sessionExited`
+listener in server.ts is wrapped so an audit-write failure cannot disturb the
+monitor loop.
+
+## 5. Interactions
+
+- **`sessionComplete` listeners:** unchanged; the new event is additive and
+  emitted BEFORE `sessionComplete` so a log row exists by the time any
+  completion-driven cleanup runs.
+- **Resume queue / boot reconciliation:** reads `type:'reaped'` rows only
+  (`server.ts:10016`); an `'exited'` row is ignored by it, which is correct —
+  a self-exit is not a mid-work reap to revive.
+- **Pool-scope reap-log merge:** the peer-page validator checks shape only
+  (entries are objects, page has `truncated`), so `'exited'` rows from a peer
+  on this version pass; a peer on the OLD version that reads a new row
+  normalises its type to `'reaped'` (the legacy coercion). Mixed-version
+  honesty: an old reader mislabels, it does not crash. Stated in §7.
+- **Skip-state dedup:** `recordExited` calls `forgetSkip`, same as
+  `recordReaped`, so a same-named successor logs fresh.
+- **Startup tail sampling vs the readiness probe:** both call `capture-pane`
+  on young sessions; they do not share state and the sample is taken before
+  the liveness probe so a dead pane keeps the previous sample.
+
+## 6. External surfaces
+
+- `GET /sessions/reap-log` now returns a new row kind. Consumers that switch
+  on `type` were checked (§5); none break. The dashboard does not render the
+  reap-log directly.
+- `GET /sessions?include=all` now shows `endedReason` on self-exited records.
+- **The tail is pane content in a log.** This is the one genuinely new
+  exposure and it is bounded: redacted through the live-tail scrubber (API
+  keys, bearer tokens, JWTs, private-key blocks, `secret=`-style assignments),
+  capped at 12 lines / 1500 chars, with the redaction count recorded. It is
+  the same class of data the dashboard already streams off-box through the
+  same scrubber; here it stays in a local log. Stated honestly: the scrubber
+  is pattern-based and cannot catch a secret it has no pattern for.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** The reap-log is per-machine and already read
+pool-wide via the existing `?scope=pool` merge, which this rides unchanged.
+The tail sample is per-process memory on the machine that owns the pane —
+there is nothing to replicate (the pane exists on one disk). Mixed-version
+pool: a peer still on the prior version that reads an `'exited'` row coerces
+its type to `'reaped'` on read (legacy whitelist) — a mislabel, never a
+failure, and it resolves as the pool updates. No user-facing notice is
+emitted, so no one-voice concern; no durable state strands on transfer.
+
+## 8. Rollback cost
+
+`git revert`. No migration, no config, no stored state beyond append-only log
+rows that older readers already tolerate (coerced to `'reaped'`). Partial
+rollback is clean: dropping the sampling leaves reason + row intact; dropping
+the row leaves the reason stamp.
+
+## Framework generality
+
+Framework-general by construction. The vanish branch does not know what
+framework it is looking at — it stamps a reason and forwards `session.framework`
+(whatever was recorded at spawn) into the row. The sampling is a `capture-pane`
+on a tmux target, identical for every framework. Nothing here routes through
+the framework abstraction because nothing here is framework-specific; the
+first beneficiary happens to be codex-cli because that is what died today.
+
+## Phase 5 — second-pass review
+
+Not run: this session carries a standing operator directive against spawning
+subagents. Recorded as `secondPass:false`; causal autopsy supplied in the
+trace as the Tier-1 compensating control.


### PR DESCRIPTION
## ELI16 — a session that dies on its own now leaves a trace

Earlier today every interactive codex session died ~18s after spawn (#1961). When we went to the records to find out why, there was nothing there: each death was filed as a normal completion with a blank reason, and the log that records every session shutoff had no row for it. The cause had to be rediscovered by hand — spawn one, watch the pane, see what it printed before it vanished.

That gap is its own defect. Instar promises a session can never disappear without a trace, but the promise covered every way *instar* ends a session (reapers, kills, restarts) and not a process that simply stopped on its own — exactly the deaths that most need evidence, because nobody asked for them.

Three things change on the path that notices a pane is gone: the session record gets a reason ("process exited", or "…during startup" when it died young); a row of a new kind, `exited`, lands in the same shutoff log every other end lands in, with framework and uptime; and that row carries the last dozen terminal lines instar saw. That last piece is the one that was missing — by the time the pane is gone there is nothing to capture, so the monitor now keeps a small sample during a session's first two minutes. For today's bug the row would have read, verbatim: `Update available! … › 1. Update now … Press enter to continue`.

Those lines pass through the same credential scrubber the dashboard's live terminal uses, inside the log writer so no caller can bypass it, capped at 12 lines, with the redaction count recorded. Samples are memory-only, bounded to young sessions, dropped the moment a session stops running. Nothing pings anyone; every listener that fired before still fires.

## The change

| File | What |
|---|---|
| `src/core/SessionManager.ts` | Startup-window tail sampling (15s–120s, 15 lines, memory-only, evicted per tick); the vanish branch stamps `endedReason` and emits `sessionExited` carrying uptime + last sample. `sessionComplete` still fires. |
| `src/monitoring/ReapLog.ts` | `recordExited()` → `type:'exited'`; new optional `uptimeSeconds` / `framework` / `lastTail` / `lastTailRedactions`; redaction (`redactForLiveTail`) + clamp (12 lines / 1500 chars) at the write chokepoint, re-clamp on read; `'exited'` added to the read whitelist (which previously coerced any unknown type to `'reaped'` — a self-exit would have come back mislabelled as a kill). |
| `src/commands/server.ts` | `sessionExited` → `reapLog.recordExited`, wrapped so an audit-write failure can never touch the monitor loop. |

Origin: the 2026-08-22 codex charter — *"Every death is recorded as a normal completion with an empty reason, and no shutoff record explains it. That means nobody can debug this from the records alone, which is itself part of what you should fix."*

## Evidence

- **Round-trip:** `exited` + uptime + framework + tail survive append → read. Negative control: remove `'exited'` from the read whitelist → rows come back as `'reaped'` and two tests fail.
- **Monitor:** a young session that vanishes gets `process-exited-during-startup` and a `sessionExited` event carrying the tail sampled on the *previous* tick — the pane is empty on the vanish tick, which is exactly why the sample exists. Negative control: remove the stamp + emit → two tests fail. An INDETERMINATE probe stamps/emits nothing (the slow-tmux guard holds). `sessionComplete` still fires.
- **Scrubbing:** an API key and a bearer token in the sampled tail do not reach the log; `lastTailRedactions ≥ 2`.
- **Clamping:** a 400-line dump → last 12 lines, ≤ 1500 chars, keeps the END of the pane.
- Neighbouring suites green: session-manager terminate / behavioral / reap-detect / async-monitor, headless-spawn-reroute, reap-log lifecycle (e2e), reap-notify lifecycle (e2e + integration), session-lifecycle-reap-wiring (integration). Full unit suite: see below.

## Known limits (stated)

A death inside the 15s grace, or between two ticks, may carry no tail (reason + row are recorded regardless). Past the 120s window no tail by design. The legacy sync sweep `reapCompletedSessions()` still marks `completed` without a reason — superseded by the monitor loop, left untouched here and named so it is not mistaken for covered. Mixed-version pool: a peer on the prior version reading an `exited` row coerces it to `reaped` on read — a mislabel, never a failure.

## Process

Tier 1 (risk floor 1 — declared at the floor). Phase 5 reviewer **not** run — standing operator directive against spawning subagents; trace records `secondPass:false`, causal autopsy supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkRuEGLYQR9H9AYSnjWqny
