### PR TITLE
fix(tests): an aliveness test was asserting a fact about the calendar

### DIFF
--- a/tests/e2e/benchmark-divergence-alive.test.ts
+++ b/tests/e2e/benchmark-divergence-alive.test.ts
@@ -89,8 +89,21 @@ describe('Benchmark-Divergence E2E lifecycle (feature is alive)', () => {
     // pin was `present:false` while no baseline existed; the first capture ships
     // inside the package and is found via the installed-package fallback, so a
     // real install now reports a live mirror rather than an honest absence).
-    expect(res.body.mirror).toMatchObject({ present: true, stale: false });
+    expect(res.body.mirror).toMatchObject({ present: true });
     expect(res.body.mirror.capturedAt).toBeTruthy();
+    // 2026-08-24: `stale: false` USED to be asserted here and it was a time bomb.
+    // The shipped baseline's `capturedAt` is 2026-07-24T01:20Z and the default
+    // threshold is 30 days, so this line passed for thirty days and then turned red
+    // at 2026-08-24T01:20Z on EVERY branch at once, main included, with no commit
+    // involved. An aliveness test asserted a fact about the calendar.
+    //
+    // What this test legitimately owns is that the envelope is WIRED: the mirror
+    // resolves on the production init path, carries a capture time, and reports a
+    // staleness verdict CONSISTENT with the age it computed. Whether that verdict is
+    // currently false is a question about release cadence, and it is pinned on an
+    // injected clock in tests/unit/BenchmarkDivergenceAnalyzer.test.ts instead.
+    expect(typeof res.body.mirror.staleDays).toBe('number');
+    expect(res.body.mirror.stale).toBe(res.body.mirror.staleDays > 30);
     expect(Array.isArray(res.body.findings)).toBe(true);
     expect(res.body.summary.unanalyzedLoss).toEqual({ byMachine: {} });
   });

--- a/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
+++ b/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
@@ -224,6 +224,29 @@ describe('the pass — verdicts over the pool-merged window', () => {
     expect(a.mirrorStatus()).toMatchObject({ present: false, stale: true });
   });
 
+  it('a PRESENT mirror goes stale strictly past the threshold — both sides of the boundary, on an injected clock', () => {
+    // 2026-08-24: the e2e aliveness test asserted `stale: false` against the
+    // SHIPPED baseline, so it passed for 30 days and then turned red at a wall-clock
+    // instant with no commit involved — `capturedAt` 2026-07-24T01:20Z crossed day 31
+    // at 2026-08-24T01:20Z and every branch went red at once, main included.
+    //
+    // Staleness of a shipped artifact is a fact about the CALENDAR, not about the
+    // wiring, so it does not belong in an aliveness assertion. It belongs here,
+    // where the clock is an input. Both sides are pinned: a fix that made nothing
+    // ever stale would satisfy a one-sided test and destroy the signal.
+    const capturedAt = '2026-07-08T00:00:00.000Z';
+    writeMatchingMirror({ capturedAt });
+    const day = 86_400_000;
+
+    nowMs = Date.parse(capturedAt) + 30 * day;
+    expect(analyzer().mirrorStatus()).toMatchObject({ present: true, staleDays: 30, stale: false });
+
+    nowMs = Date.parse(capturedAt) + 31 * day;
+    expect(analyzer().mirrorStatus()).toMatchObject({ present: true, staleDays: 31, stale: true });
+
+    nowMs = T0;
+  });
+
   it('drifted benched hash ⇒ precondition-failed / prompt-drifted (a benchmark bug, never a model verdict)', async () => {
     writeMatchingMirror({ hashOverride: 'b'.repeat(64) });
     seedDecisions('2026-07-05', 30, { right: 5, wrong: 25 }); // would be divergent-worse — suppressed

--- a/upgrades/mirror-staleness-is-not-an-aliveness-fact.eli16.md
+++ b/upgrades/mirror-staleness-is-not-an-aliveness-fact.eli16.md
@@ -1,0 +1,35 @@
+# A test that turned red at a specific minute, on every branch, with nobody touching anything — Plain-English Overview
+
+## The problem in one breath
+
+One end-to-end test checked that a reference file shipped inside instar was "not stale". That file was captured on 24 July, and the rule is that it goes stale after thirty days. So at **01:20 UTC today** — thirty-one days later — the test started failing everywhere at once. No commit caused it. The clock did.
+
+## Why that is worse than an ordinary failure
+
+Nothing in the code changed, so nothing in the code looks guilty. Every branch went red simultaneously, including the main one, which makes it read like an infrastructure outage rather than a test making a claim it had no business making.
+
+And it blocked everything: nothing could merge, because merges wait on a green build.
+
+## What the test was actually entitled to check
+
+That the feature is **wired up** — that the reference file is found when the server really boots, that it carries a capture date, and that the "is it stale?" answer it reports agrees with the age it worked out.
+
+What it was **not** entitled to check is whether that file happens to be under thirty days old on the day the test runs. That is a fact about how often we ship a fresh capture, not about whether the code works.
+
+## What changes
+
+The end-to-end test now checks the wiring and the internal consistency of the answer. The staleness rule itself moved to a test where the clock is a dial we set: at exactly thirty days it must report *not stale*, and at thirty-one it must report *stale*.
+
+Both sides are pinned deliberately. A "fix" that made nothing ever stale would have satisfied a one-sided test while quietly deleting the warning the feature exists to give.
+
+## The safeguard
+
+Checked against deliberately broken code: with the staleness rule removed, the new test fails. So it is a test, not a decoration.
+
+## One thing worth knowing separately
+
+The shipped reference capture really is more than thirty days old now. That means a fresh install will correctly report it as stale — which is the feature working, not breaking. Whether to ship a newer capture is a release-cadence decision, and it is deliberately not made here: silently refreshing the date would have hidden the same information this change exists to preserve.
+
+## What you actually need to decide
+
+Nothing about the test. Separately, and not urgently: whether the shipped reference capture should be refreshed on a cadence so installs do not inherit a stale one.

--- a/upgrades/next/mirror-staleness-is-not-an-aliveness-fact.md
+++ b/upgrades/next/mirror-staleness-is-not-an-aliveness-fact.md
@@ -1,0 +1,25 @@
+---
+change_type: fix
+---
+
+<!-- internal-only -->
+
+## What Changed
+
+`tests/e2e/benchmark-divergence-alive.test.ts` no longer asserts `mirror.stale === false`. It asserts the wiring facts it owns — the mirror resolves on the production init path, carries a `capturedAt`, and reports a `stale` verdict CONSISTENT with the `staleDays` it computed — and leaves the threshold itself to a unit test with an injected clock.
+
+`tests/unit/BenchmarkDivergenceAnalyzer.test.ts` gains that test: with a PRESENT mirror, `capturedAt + 30d` ⇒ `stale: false`, `capturedAt + 31d` ⇒ `stale: true`.
+
+No runtime behaviour changes — tests only.
+
+## Evidence
+
+The shipped baseline `src/data/benchmarkPredictions.json` carries `capturedAt: 2026-07-24T01:20:00.000Z`; `mirrorStalenessMaxDays` defaults to 30. The assertion therefore passed for thirty days and turned RED at 2026-08-24T01:20Z on every branch simultaneously — main included — with no commit involved. Confirmed by running the e2e against `origin/main` at `9f83c19ca`: 1 failed, 4 passed, `expected { present: true, …(3) } to match object { present: true, stale: false }`. It blocked every merge, since `safe-merge` refuses on any red check.
+
+Both sides of the boundary are pinned deliberately: a change that made nothing ever stale would satisfy a one-sided test while deleting the signal. Negative control — with `staleDays > mirrorStalenessMaxDays` removed from `mirrorStatus()`, the new test fails (1 of 26); restored, 26/26. E2E 5/5.
+
+## Known Limits
+
+The shipped baseline IS now stale by the default threshold, so a fresh install correctly reports `stale: true`. That is the feature working and it is deliberately NOT papered over here — refreshing `capturedAt` to make a test green would fabricate a capture that never happened. Whether to ship a newer capture on a cadence is a release decision, named rather than taken.
+
+This fixes the one assertion found. No sweep was run for other tests whose verdict depends on wall-clock aging of a committed artifact, and none is claimed.

--- a/upgrades/side-effects/mirror-staleness-is-not-an-aliveness-fact.md
+++ b/upgrades/side-effects/mirror-staleness-is-not-an-aliveness-fact.md
@@ -1,0 +1,78 @@
+# Side-Effects Review — an aliveness test stops asserting a fact about the calendar
+
+**Slug:** `mirror-staleness-is-not-an-aliveness-fact`
+**Date:** 2026-08-24
+**Risk floor:** 1 (tests only; no runtime file touched)
+
+## Summary of the change
+
+An e2e aliveness test asserted `mirror.stale === false` against a baseline shipped inside the package. The baseline's `capturedAt` is 2026-07-24T01:20Z and the staleness threshold defaults to 30 days, so the assertion turned red at 2026-08-24T01:20Z on every branch at once, main included, with no commit involved. The e2e now asserts the wiring (present, `capturedAt` set, `stale` consistent with `staleDays`); the threshold moves to a unit test with an injected clock, pinned on both sides.
+
+## Decision-point inventory
+
+None. No runtime decision changes; `mirrorStatus()` is untouched.
+
+## 1. Over-block
+
+None. The e2e can no longer fail for a reason unrelated to the code under test — which is the point, and is a REDUCTION in false red, not in coverage: the staleness rule is now checked more strictly than before (two points, controlled clock) rather than incidentally.
+
+## 2. Under-block
+
+Named honestly: the e2e no longer notices if the SHIPPED baseline ages out. That was never something it could report usefully — it could only say "red today, green yesterday, same code" — but the information is real and now has no automated home. It is recorded under Known Limits in the release fragment rather than silently dropped.
+
+## 3. Level-of-abstraction fit
+
+This is the whole finding. An aliveness test answers "is the feature wired on the production boot path?". Whether a shipped artifact is under thirty days old is a fact about release cadence and belongs where the clock is an input. Putting it in the e2e put a calendar dependency in a layer that cannot control the calendar.
+
+## 4. Signal vs authority compliance
+
+Not applicable — tests only, no runtime authority.
+
+## 4b. Judgment-point check
+
+None.
+
+## 5. Interactions
+
+- **`safe-merge`** refuses on any red check, so this single assertion blocked EVERY merge from 01:20Z. Two open PRs (#1967, and anything opened later) were stuck behind it. That is why the fix is worth doing now rather than filing.
+- **`mirrorStatus()`** is unchanged, so the `precondition-failed / stale-mirror` verdict path and the unit tests around it keep their existing behaviour.
+
+## 6. External surfaces
+
+None.
+
+## 6b. Operator-surface quality
+
+Improves it indirectly: the operator stops seeing a repo-wide red that no commit explains.
+
+## 7. Multi-machine posture
+
+`unified` — tests only, no per-machine state.
+
+## 8. Rollback cost
+
+Revert two test files. Reverting restores a build that goes red on a timer, so it should not be reverted quietly.
+
+## Conclusion
+
+Ship.
+
+## Phase-5 second pass
+
+**Not required, and not run** — no block/allow decision, no session lifecycle, no gate/sentinel/guard/watchdog, no runtime file touched. Stated explicitly so the section below is not mistaken for an independent reviewer's concurrence.
+
+## The finding that outlives the fix
+
+This is the second time today the same shape has appeared, in two unrelated subsystems: a correctness claim resting on wall-clock timing. This morning it was a thread id whose uniqueness came only from the millisecond (fixed in #1971). Tonight it is a test whose verdict came only from the date. Both fail without a commit, both look like flake, and both get *more* likely with time or speed rather than less.
+
+The tempting cheap fix here was to bump `capturedAt` in the shipped baseline. That would have made the suite green in one line and fabricated a capture that never happened — turning a true signal ("the shipped baseline is old") into a false one. Worth naming because it was the obvious move and it was wrong.
+
+## Evidence pointers
+
+- `origin/main` at `9f83c19ca`, e2e run locally: 1 failed / 4 passed, `expected { present: true, …(3) } to match object { present: true, stale: false }`. Main was red on the clock, not on a change.
+- `src/data/benchmarkPredictions.json` → `capturedAt: 2026-07-24T01:20:00.000Z`; age 31 days; `mirrorStalenessMaxDays` default 30 (`BenchmarkDivergenceAnalyzer.ts:110`).
+- Negative control: with the threshold comparison removed from `mirrorStatus()`, the new unit test fails (1/26). Restored: 26/26. E2E 5/5.
+
+## Class-Closure Declaration (display-only mirror)
+
+The class is "a test whose verdict depends on wall-clock aging of a committed artifact." Closed for this one assertion. NOT closed generally — no sweep was run for other date-sensitive assertions, and the sibling class named above (correctness resting on wall-clock timing, in runtime code as well as tests) is not swept for either. Named, not claimed.


### PR DESCRIPTION
## ELI16 — a test that turned red at a specific minute, on every branch, with nobody touching anything

At **01:20 UTC today** the build went red on every branch at once — main included — with no commit involved.

`tests/e2e/benchmark-divergence-alive.test.ts` asserted:

```js
expect(res.body.mirror).toMatchObject({ present: true, stale: false });
```

The mirror is the baseline shipped inside the package, `src/data/benchmarkPredictions.json`, with `capturedAt: 2026-07-24T01:20:00.000Z`. `mirrorStalenessMaxDays` defaults to **30**. So the assertion passed for thirty days and was guaranteed to fail on day thirty-one, at a specific minute.

Because `safe-merge` refuses on any red check, one date blocked every merge in the repository.

**Confirmed, not inferred:** running that e2e against `origin/main` at `9f83c19ca` fails 1 of 5 with exactly that assertion.

## The fix

An aliveness test owns *"is the feature wired on the production boot path?"*. Whether a shipped artifact is under thirty days old is a fact about **release cadence**, and it belongs where the clock is an input.

The e2e now asserts the mirror resolves, carries a `capturedAt`, and reports a `stale` verdict **consistent with the `staleDays` it computed**. The threshold moves to `tests/unit/BenchmarkDivergenceAnalyzer.test.ts` on an injected clock, pinned on **both** sides:

- `capturedAt + 30d` → `stale: false`
- `capturedAt + 31d` → `stale: true`

Both sides deliberately: a change that made nothing ever stale would satisfy a one-sided test while deleting the signal.

## What I did NOT do, deliberately

Bump `capturedAt` in the shipped baseline. That goes green in one line and **fabricates a capture that never happened**, converting a true signal — the shipped baseline really is old, so a fresh install correctly reports `stale: true` — into a false one. The real age is recorded under Known Limits instead.

Whether to ship a newer capture on a cadence is a release decision. Named, not taken.

## Evidence

Negative control: with `staleDays > mirrorStalenessMaxDays` removed from `mirrorStatus()`, the new unit test fails (1 of 26). Restored: 26/26. E2E 5/5. No runtime file is touched.

## Class closure

Closed for this one assertion: *a test whose verdict depends on wall-clock aging of a committed artifact.* **Not** closed generally — no sweep was run for other date-sensitive assertions.

Worth noting it is the second instance today of the same shape in unrelated subsystems: #1971 was a thread id whose uniqueness came only from the millisecond. Both fail without a commit, both read as flake, and both get more likely with time or speed rather than less.

Tier 1. Side-effects review: `upgrades/side-effects/mirror-staleness-is-not-an-aliveness-fact.md`.