### PR TITLE
fix(control-paths): emergency stop kills and reports truthfully; reply client keeps decision refs intact

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-25T02-51-25-210Z-w26-false-success-repairs.json
+++ b/.instar/instar-dev-decisions/2026-08-25T02-51-25-210Z-w26-false-success-repairs.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-08-25T02:51:25.210Z",
+  "slug": "w26-false-success-repairs",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 7,
+  "loc": 169,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/SessionManager.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/shared/emergencyStopUserMessage.ts",
+      "src/server/routes.ts",
+      "src/templates/scripts/telegram-reply.sh"
+    ],
+    "addedLines": 153,
+    "deletedLines": 16
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-25T02-52-20-511Z-w26-false-success-repairs.json
+++ b/.instar/instar-dev-decisions/2026-08-25T02-52-20-511Z-w26-false-success-repairs.json
@@ -1,0 +1,36 @@
+{
+  "ts": "2026-08-25T02:52:20.511Z",
+  "slug": "w26-false-success-repairs",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 7,
+  "loc": 169,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/SessionManager.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/shared/emergencyStopUserMessage.ts",
+      "src/server/routes.ts",
+      "src/templates/scripts/telegram-reply.sh"
+    ],
+    "addedLines": 153,
+    "deletedLines": 16
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "The kill is a one-shot, operator-driven emergency stop (one inbound stop message -> at most one kill of the named session); this change only makes the reported outcome truthful and adds no retry, loop, or self-triggered controller. The relay-client change is a client-side input validator with no action at all."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-25T02-53-12-007Z-w26-false-success-repairs.json
+++ b/.instar/instar-dev-decisions/2026-08-25T02-53-12-007Z-w26-false-success-repairs.json
@@ -1,0 +1,36 @@
+{
+  "ts": "2026-08-25T02:53:12.007Z",
+  "slug": "w26-false-success-repairs",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 7,
+  "loc": 169,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/SessionManager.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/shared/emergencyStopUserMessage.ts",
+      "src/server/routes.ts",
+      "src/templates/scripts/telegram-reply.sh"
+    ],
+    "addedLines": 153,
+    "deletedLines": 16
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "The kill is a one-shot, operator-driven emergency stop (one inbound stop message -> at most one kill of the named session); this change only makes the reported outcome truthful and adds no retry, loop, or self-triggered controller. The relay-client change is a client-side input validator with no action at all."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/w26-false-success-repairs.eli16.md
+++ b/docs/specs/w26-false-success-repairs.eli16.md
@@ -1,0 +1,83 @@
+# Two stops that did not stop — in plain English
+
+> The one-line version: two places in the system said "done" when nothing had happened — an
+> emergency stop that never killed the session, and an override that was recorded but could not be
+> matched to the decision it answered — and both now either do the thing or say plainly that they
+> did not.
+
+## The problem in one breath
+
+Window 25 checked each repair where a user would notice it, and found that the failures that
+remained all had the same shape: the system reported success while the effect it was reporting
+never happened. Two of those were chosen for this window because they sit on control paths a
+person relies on — stopping a session in an emergency, and teaching the message check what it got
+wrong.
+
+## What already exists
+
+- **The emergency stop.** When you send a stop message, a sentinel recognises it, records that the
+  run is stopped so it cannot come back on its own, and is supposed to kill the running session.
+  The record half of that already worked and was kept.
+- **The tone check and its overrides.** Before one of my messages goes out, a check can hand it
+  back with a reason. I may override it with a reason of my own, and the pairing of my override
+  with the check's decision is what gets graded — right or wrong — so the check improves over time.
+- **The update path.** Scripts installed on an agent's machine are refreshed on update, but only
+  when the installed copy matches a version we know we shipped; an unknown copy is left alone.
+
+## What was actually wrong
+
+**The stop.** The code that kills a session looks it up by its internal id. The stop path handed
+it the session's *terminal window name* instead. The lookup found nothing and returned false —
+quietly. Nobody read that false. The reply to the stop request said "killed", the log said
+"killed session", and the person was told "Session terminated." The session kept running.
+
+**The override.** The documented script that sends my replies scrubbed the decision reference to a
+safe set of characters — and that set did not include the underscore. A real reference contains
+the machine's id, which has an underscore in it. The underscore was stripped, the server could not
+match the override to the decision, and the grade landed as an orphan: recorded, useless.
+
+## What this adds
+
+**The kill resolves the right thing and reports what happened.** There is now one helper that turns
+a terminal-window name into the session id and kills it, returning the true outcome. Both stop
+paths use it, so they cannot drift apart. The reply's "killed" field is that outcome. The log says
+"KILL FAILED — the session was NOT killed" when it fails. And the message a person reads comes from
+one shared place with three honest states: nothing to stop; stopped; or "stop failed — the session
+is still running; your request was recorded; send stop again or close it from the dashboard."
+
+**The reference survives byte-for-byte.** Instead of deleting characters it does not like, the
+reply script now checks the reference against the exact shape the router produces (a prefix, an
+optional machine id, a UUID) and passes it through whole when it matches — or drops it entirely
+when it does not. Hostile input still cannot get through; a real reference is no longer damaged.
+
+**Existing agents get the fix.** The exact version of the reply script that shipped last release
+is registered as a known version, so the update replaces it in place instead of leaving a spare
+copy beside the broken one.
+
+## The safeguards
+
+- **Tests that fail for the right reason.** Each repair has a must-fail arm that was shown red
+  before the fix: passing the window name straight through; answering "killed" for a kill that
+  returned false; telling the person "terminated" when it was not; and stripping an underscore
+  from a reference. Both sides are tested — a kill that works still reports success, and a
+  hostile reference is still rejected.
+- **The record is never traded for the kill.** Every failure arm also asserts that the stop record
+  was still written.
+- **No synthetic history.** The parity test used to reconstruct last release's script from
+  today's, which broke the moment the script changed for any other reason. The tempting fix — paste
+  the new number in — would have registered a version no agent ever ran. Instead the genuine
+  historical script is pinned as a fixture and the test asserts every really-shipped version is
+  registered.
+
+## What this deliberately does not do
+
+It does not retry a failed kill; it tells you. It does not guess at a decision reference that
+does not fit the shape; it drops it and the integration test will notice if the shape ever
+changes. It does not touch a hand-edited reply script on an agent's machine.
+
+## Why it matters
+
+A stop that lies to the operator is worse than a stop that lies to a log: a person acts on it.
+And a grade that cannot be matched to its decision teaches nothing, so the check never gets
+better. Both repairs are small; the invariant they restore is the window's whole point — a
+critical action must not report success unless its effect happened through the documented path.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16411,7 +16411,21 @@ export async function startServer(options: StartOptions): Promise<void> {
             }
           } catch { /* best effort */ }
         }
-        return sessionManager.killSession(sessionName);
+        // W26 lane 1 — the stop that does not stop.
+        // `killSession` takes a session ID and resolves it through the state
+        // store; it was being handed a TMUX NAME, so the lookup missed and it
+        // returned false silently while every caller reported "killed". Resolve
+        // the id via the single shared helper, and make a miss LOUD rather than
+        // a quiet false.
+        const killed = sessionManager.killSessionByTmuxName(sessionName);
+        if (!killed) {
+          console.error(
+            `[sentinel] KILL FAILED for "${sessionName}": no running session with that tmux name, ` +
+            'or the kill returned false. The session was NOT killed — reporting failure ' +
+            'rather than a kill that did not happen.',
+          );
+        }
+        return killed;
       };
       telegram.onSentinelPauseSession = (sessionName: string) => {
         // Save resume UUID so if the session dies during pause, respawn can --resume

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -15876,6 +15876,13 @@ process.stdin.on('end', async () => {
     // mis-reporting version in place with a `.new` beside it, and every
     // existing agent keeps being told its suppressed sends succeeded.
     '4464581188f5c736a62edac5e6a2edecfcfcd365557a18e514b741731bed6e0b',
+    // Suppressed-duplicate honesty version, shipped immediately BEFORE the
+    // decision-ref preservation fix. In this version the relay stripped `_`
+    // from `--tone-decision-ref`, turning production refs like
+    // `d-m_03b30f-...` into unjoinable orphan outcomes. Registering it here is
+    // what lets deployed agents receive the fixed client instead of only
+    // writing a `.new` candidate beside the broken installed copy.
+    '74ee09b4d4d537ddfe032f3192cab08b4f2f956fdb1e1b3ccd94b26dc218fb52',
   ]);
 
   /**

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -3788,6 +3788,34 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Kill the running session whose TMUX NAME is `tmuxSession`, resolving that
+   * name to the session id first.
+   *
+   * W26 lane 1 — the stop that does not stop. `killSession(sessionId)` resolves
+   * its argument through the state store BY ID. The emergency-stop path was
+   * handing it a tmux name, so the lookup missed and it returned `false`
+   * silently while every caller reported "killed". This helper is the one place
+   * that resolution lives, so the two emergency-stop call sites (the
+   * `onSentinelKillSession` wiring and the route's direct fallback) cannot drift
+   * apart, and the resolution is unit-testable in isolation.
+   *
+   * Returns the REAL outcome: `false` when no running session carries that tmux
+   * name (a miss the caller must report as a failed kill, never as success), and
+   * `false` when the underlying kill itself fails. Resolves against the state
+   * record (status `running`) rather than a live tmux probe, so a wedged or
+   * already-dead pane is still resolved and `killSession` — which is defensive
+   * about a pane that is already gone — reconciles the record.
+   */
+  killSessionByTmuxName(tmuxSession: string): boolean {
+    if (!tmuxSession) return false;
+    const session = this.state
+      .listSessions({ status: 'running' })
+      .find((s) => s.tmuxSession === tmuxSession);
+    if (!session) return false;
+    return this.killSession(session.id);
+  }
+
+  /**
    * Check if a tmux session has active (non-baseline) child processes.
    * Returns true if the session is doing real work — running tools, bash commands,
    * subagents, etc. Returns false if only baseline processes (MCP servers, caffeinate)

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -19,6 +19,7 @@ import { NotificationBatcher, NotificationTier } from './NotificationBatcher.js'
 import type { ContentValidationConfig } from './TopicContentValidator.js';
 import { validateTopicContent, getTopicPurpose, classifyContent } from './TopicContentValidator.js';
 import { SHARED_INFRA_FLAGS } from './shared/FeatureFlags.js';
+import { emergencyStopUserMessage } from './shared/emergencyStopUserMessage.js';
 import { MessageLogger, type LogEntry as SharedLogEntry } from './shared/MessageLogger.js';
 import type { MessageProvenance } from './shared/MessageProvenance.js';
 import { SessionChannelRegistry } from './shared/SessionChannelRegistry.js';
@@ -4987,8 +4988,22 @@ export class TelegramAdapter implements MessagingAdapter {
           const sessionName = this.topicToSession.get(numericTopicId);
           if (classification.category === 'emergency-stop' && sessionName) {
             console.log(`[sentinel] Emergency stop for session "${sessionName}" in topic ${numericTopicId}`);
+            // W26 lane 1 — the conversational stop path must not swallow a
+            // failed kill either. Default false: no kill has happened yet, and
+            // an unset outcome must never read as success (a missing kill
+            // handler means nothing was killed).
+            let killed = false;
             if (this.onSentinelKillSession) {
-              this.onSentinelKillSession(sessionName);
+              killed = this.onSentinelKillSession(sessionName) === true;
+            }
+            if (!killed) {
+              // The record below is preserved regardless, but a kill that did
+              // not land is logged as a failure, never as silence that reads
+              // like success.
+              console.error(
+                `[sentinel] KILL FAILED for session "${sessionName}" in topic ${numericTopicId} — ` +
+                'the session was NOT killed. Stop custody and the run record still proceed.',
+              );
             }
             // Durable Inbound Message Queue §3.6: the stop reaches custody —
             // queued rows for this topic settle terminal (operator-stop),
@@ -5007,9 +5022,9 @@ export class TelegramAdapter implements MessagingAdapter {
             if (classification.reason) {
               console.log(`[sentinel] Stop reason: ${classification.reason}`);
             }
-            await this.sendToTopic(numericTopicId,
-              `Session terminated.\n\nSend a new message to start a fresh session.`
-            ).catch(() => {});
+            // The text a PERSON reads is keyed on the kill OUTCOME — it used to
+            // say "Session terminated." for a kill that failed (W26 lane 1).
+            await this.sendToTopic(numericTopicId, emergencyStopUserMessage(sessionName, killed)).catch(() => {});
           } else if (classification.category === 'pause' && sessionName) {
             console.log(`[sentinel] Pause for session "${sessionName}" in topic ${numericTopicId}`);
             if (this.onSentinelPauseSession) {

--- a/src/messaging/shared/emergencyStopUserMessage.ts
+++ b/src/messaging/shared/emergencyStopUserMessage.ts
@@ -1,0 +1,40 @@
+/**
+ * emergencyStopUserMessage — the ONE source of the text a person is shown
+ * after an emergency stop, keyed on what actually HAPPENED.
+ *
+ * W26 lane 1 (addendum). Both emergency-stop paths — the lifeline route
+ * (`POST /internal/telegram-forward` in routes.ts) and the conversational
+ * path (TelegramAdapter.processUpdate) — used to branch this text on whether
+ * a session NAME resolved, not on whether the kill LANDED. So when a kill
+ * failed, the API answered `killed:false` and the log said `KILL FAILED`
+ * (both correct) while the operator was told "Session terminated." A stop
+ * that lies to the operator is worse than a stop that lies to a log: the
+ * person acts on it.
+ *
+ * Three states, three truths. Plain English only — no session names, no
+ * paths, no internal identifiers ever reach this text.
+ */
+export type EmergencyStopOutcome = 'no-session' | 'killed' | 'kill-failed';
+
+export const EMERGENCY_STOP_USER_MESSAGES: Readonly<Record<EmergencyStopOutcome, string>> = Object.freeze({
+  'no-session': 'No active session to stop.',
+  'killed': 'Session terminated.\n\nSend a new message to start a fresh session.',
+  'kill-failed':
+    'Stop failed — the session is still running.\n\n'
+    + 'Your stop request was recorded, but the session itself could not be halted. '
+    + 'Send stop again, or close the session from the dashboard.',
+});
+
+/**
+ * Resolve the outcome from the two facts the stop paths actually hold:
+ * whether a session was bound to the topic, and whether the kill returned
+ * true. An unset/false outcome NEVER reads as success.
+ */
+export function emergencyStopOutcome(sessionName: string | null | undefined, killed: boolean): EmergencyStopOutcome {
+  if (!sessionName) return 'no-session';
+  return killed === true ? 'killed' : 'kill-failed';
+}
+
+export function emergencyStopUserMessage(sessionName: string | null | undefined, killed: boolean): string {
+  return EMERGENCY_STOP_USER_MESSAGES[emergencyStopOutcome(sessionName, killed)];
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7,6 +7,7 @@
 
 import { Router } from 'express';
 import { telegramFetch } from '../messaging/telegram-egress.js';
+import { emergencyStopUserMessage } from '../messaging/shared/emergencyStopUserMessage.js';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { execFileSync } from 'node:child_process';
 import { createHash, timingSafeEqual, randomUUID } from 'node:crypto';
@@ -22548,15 +22549,35 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
             sessionName = ctx.telegram?.getSessionForTopic(Number(topicId)) ?? null;
           }
           if (decision.disposition === 'kill') {
+            // Default false: no kill has happened yet at this point, and an
+            // unset outcome must never read as success.
+            let killOutcome = false;
             if (sessionName) {
+              // W26 lane 1 — report what happened, not what was attempted.
+              // The outcome used to be discarded here and `killed` was derived
+              // from whether a session NAME resolved, so a kill that never
+              // landed still answered killed:true and logged "killed session".
               if (ctx.telegram?.onSentinelKillSession) {
-                ctx.telegram.onSentinelKillSession(sessionName); // saves resume UUID + kills
+                killOutcome = ctx.telegram.onSentinelKillSession(sessionName) === true; // saves resume UUID + kills
               } else {
-                try { ctx.sessionManager?.killSession(sessionName); } catch { /* best-effort */ }
+                try {
+                  // killSession resolves by session ID, so a tmux name must be
+                  // translated first — passing the name straight through is the
+                  // original defect and returns false silently. The shared helper
+                  // owns that resolution and returns the REAL outcome.
+                  killOutcome = ctx.sessionManager?.killSessionByTmuxName(sessionName) === true;
+                } catch { killOutcome = false; }
               }
               // Clear this topic's autonomous job so it doesn't zombie-resume.
               try { stopAutonomousTopic(ctx.config.stateDir, String(topicId), ctx.state.getCoherenceJournal()); } catch { /* best-effort */ }
-              console.log(`[telegram-forward] sentinel emergency-stop: killed session "${sessionName}" for topic ${topicId}`);
+              if (killOutcome) {
+                console.log(`[telegram-forward] sentinel emergency-stop: killed session "${sessionName}" for topic ${topicId}`);
+              } else {
+                console.error(
+                  `[telegram-forward] sentinel emergency-stop: KILL FAILED for session "${sessionName}" ` +
+                  `(topic ${topicId}) — the session was NOT killed. The stop record is still preserved.`,
+                );
+              }
             }
             // Emergency stop reaches the resume queue (reap-notify R2.7): the
             // MessageSentinel stop pauses the queue globally + cancels this
@@ -22570,10 +22591,14 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
             if (decision.reason) {
               console.log(`[telegram-forward] sentinel stop reason: ${decision.reason}`);
             }
-            ctx.telegram?.sendToTopic(Number(topicId), sessionName
-              ? 'Session terminated.\n\nSend a new message to start a fresh session.'
-              : 'No active session to stop.').catch(() => { /* best-effort */ });
-            res.json({ ok: true, sentinel: 'emergency-stop', killed: !!sessionName });
+            // The text a PERSON reads is keyed on the kill OUTCOME, never on
+            // whether a session name resolved — it used to say "Session
+            // terminated." for a kill that failed (W26 lane 1 addendum).
+            ctx.telegram?.sendToTopic(Number(topicId), emergencyStopUserMessage(sessionName, killOutcome))
+              .catch(() => { /* best-effort */ });
+            // `killed` is the OUTCOME of the kill, never merely "a session name
+            // resolved" — the latter reported success for a kill that never ran.
+            res.json({ ok: true, sentinel: 'emergency-stop', killed: killOutcome });
             return;
           }
           // pause

--- a/tests/e2e/autonomous-emergency-stop-preserves-state-lifecycle.test.ts
+++ b/tests/e2e/autonomous-emergency-stop-preserves-state-lifecycle.test.ts
@@ -25,6 +25,8 @@ describe('E2E: autonomous emergency-stop preserves state record', () => {
   let server: Server;
   let baseUrl: string;
   let killed: string[];
+  let killOutcome: boolean;
+  let sent: string[]; // what the PERSON in the topic is told
 
   beforeEach(async () => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-emergency-stop-e2e-'));
@@ -41,6 +43,8 @@ describe('E2E: autonomous emergency-stop preserves state record', () => {
     ProcessIntegrity.reset();
     ProcessIntegrity.initialize('1.2.36', null);
     killed = [];
+    killOutcome = true;
+    sent = [];
 
     const config = {
       projectName: 'emergency-stop-e2e',
@@ -59,7 +63,7 @@ describe('E2E: autonomous emergency-stop preserves state record', () => {
       state,
       sessionManager: {
         listRunningSessions: () => [],
-        killSession: (name: string) => { killed.push(name); return true; },
+        killSession: (name: string) => { killed.push(name); return killOutcome; },
       } as never,
       sentinel: {
         decideInboundDisposition: async () => ({
@@ -71,8 +75,8 @@ describe('E2E: autonomous emergency-stop preserves state record', () => {
       telegram: {
         logInboundMessage: () => {},
         getSessionForTopic: () => SESSION,
-        onSentinelKillSession: (name: string) => { killed.push(name); return true; },
-        sendToTopic: async () => {},
+        onSentinelKillSession: (name: string) => { killed.push(name); return killOutcome; },
+        sendToTopic: async (_topic: number, text: string) => { sent.push(text); },
         onTopicMessage: () => { throw new Error('emergency stop routed to session'); },
       } as never,
       scheduler: null,
@@ -133,5 +137,48 @@ describe('E2E: autonomous emergency-stop preserves state record', () => {
     const content = fs.readFileSync(stateFile, 'utf8');
     expect(content).toMatch(/^active: false$/m);
     expect(content).toContain('release evidence in progress');
+    // The person in the topic is told the truth: it was terminated.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatch(/^Session terminated\./);
+  });
+
+  // Both sides of the decision boundary on the production init path: a kill that
+  // FAILS must report failure (killed:false) — never the original false
+  // killed:true — while the record is still preserved.
+  it('reports killed:false when the kill fails, and STILL leaves the record intact', async () => {
+    killOutcome = false; // the emergency-stop kill does not land
+    const stateFile = path.join(stateDir, 'autonomous', `${TOPIC}.local.md`);
+    const res = await fetch(`${baseUrl}/internal/telegram-forward`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        topicId: TOPIC,
+        text: 'stop everything',
+        fromUserId: 1,
+        fromUsername: 'operator',
+        fromFirstName: 'Operator',
+        messageId: 2,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, sentinel: 'emergency-stop', killed: false });
+    expect(killed).toContain(SESSION); // the kill was attempted against the bound session
+    // The record-preservation half still holds even when the kill fails.
+    expect(fs.existsSync(stateFile)).toBe(true);
+    const content = fs.readFileSync(stateFile, 'utf8');
+    expect(content).toMatch(/^active: false$/m);
+    expect(content).toContain('release evidence in progress');
+    // The message a PERSON reads must not claim termination when the kill
+    // failed: it says the session is still running AND that the stop was
+    // recorded, in plain English with no internal identifiers.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).not.toMatch(/terminated/i);
+    expect(sent[0]).toMatch(/still running/i);
+    expect(sent[0]).toMatch(/recorded/i);
+    expect(sent[0]).not.toContain(SESSION);
   });
 });

--- a/tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts
+++ b/tests/e2e/telegram-reply-suppressed-duplicate-alive.test.ts
@@ -30,16 +30,21 @@ import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const TEMPLATE = path.resolve('src/templates/scripts/telegram-reply.sh');
+const PRE_SUPPRESSION_FIX_FIXTURE = path.resolve(
+  'tests/fixtures/relay-history/telegram-reply-pre-suppression.sh',
+);
 const PRIOR_SHIPPED_SHA =
   '4464581188f5c736a62edac5e6a2edecfcfcd365557a18e514b741731bed6e0b';
 const TOPIC = '29723';
 
-/** The pre-fix shipped script: the current template minus the 7-line branch. */
+/**
+ * The real pre-fix shipped script. Keep this pinned to repository history
+ * rather than deriving it from the current template, because today's template
+ * may contain unrelated later changes that never existed in this deployed
+ * version.
+ */
 function priorShippedContent(): string {
-  const lines = fs.readFileSync(TEMPLATE, 'utf-8').split('\n');
-  const start = lines.findIndex(l => l.includes('get("suppressedDuplicate") is True'));
-  if (start === -1) throw new Error('suppression branch not found in template');
-  return [...lines.slice(0, start), ...lines.slice(start + 7)].join('\n');
+  return fs.readFileSync(PRE_SUPPRESSION_FIX_FIXTURE, 'utf-8');
 }
 
 /**

--- a/tests/e2e/tone-gate-advisory-migration-alive.test.ts
+++ b/tests/e2e/tone-gate-advisory-migration-alive.test.ts
@@ -23,11 +23,13 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { AgentServer } from '../../src/server/AgentServer.js';
 import { StateManager } from '../../src/core/StateManager.js';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
 import type { InstarConfig } from '../../src/core/types.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { resolveToneGateOperatorConfig } from '../../src/core/MessagingToneGate.js';
@@ -61,6 +63,60 @@ function createStubTelegram() {
       return { ok: true };
     },
   };
+}
+
+function runInstalledReplyScript(opts: {
+  scriptPath: string;
+  agentHome: string;
+  decisionRef: string;
+}): Promise<{ status: number | null; body: any; stdout: string; stderr: string }> {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tone-advisory-client-e2e-bin-'));
+  const bodyPath = path.join(binDir, 'body.json');
+  const curlStub = path.join(binDir, 'curl');
+  fs.writeFileSync(curlStub, `#!/bin/sh
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = "-d" ]; then
+    printf '%s' "$arg" > '${bodyPath}'
+  fi
+  prev="$arg"
+done
+printf '%s\\n%s\\n' '{"ok":true}' '200'
+`);
+  fs.chmodSync(curlStub, 0o755);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [
+      opts.scriptPath,
+      '--tone-complied', 'B2_FILE_PATH',
+      '--tone-decision-ref', opts.decisionRef,
+      '9005',
+      'The revised answer avoids the raw path.',
+    ], {
+      cwd: opts.agentHome,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        INSTAR_SENDER_CLASS: 'script',
+        INSTAR_AUTH_TOKEN: '',
+        INSTAR_PORT: '',
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', c => { stdout += c.toString(); });
+    child.stderr.on('data', c => { stderr += c.toString(); });
+    child.on('error', reject);
+    child.on('close', status => {
+      const body = JSON.parse(fs.readFileSync(bodyPath, 'utf-8'));
+      SafeFsExecutor.safeRmSync(binDir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/e2e/tone-gate-advisory-migration-alive.test.ts:client-bin',
+      });
+      resolve({ status, body, stdout, stderr });
+    });
+  });
 }
 
 describe('Tone-gate advisory migration E2E lifecycle (feature is alive)', () => {
@@ -212,6 +268,31 @@ describe('Tone-gate advisory migration E2E lifecycle (feature is alive)', () => 
     });
     // Keep the pre-existing credential-wall assertions independent of this send.
     sent.length = 0;
+  });
+
+  it('the production update path installs a reply client that preserves machine-prefixed decisionRefs', async () => {
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ port: 49999, projectName: 'e2e', agentName: 'E2E' }),
+    );
+    const migration = new PostUpdateMigrator({
+      projectDir: tmpDir,
+      stateDir,
+      port: 49999,
+      hasTelegram: true,
+      projectName: 'e2e',
+    }).migrate();
+    expect(migration.errors.filter(e => e.includes('telegram-reply'))).toEqual([]);
+
+    const decisionRef = 'd-m_03b30f-00000000-0000-4000-8000-000000000005';
+    const result = await runInstalledReplyScript({
+      scriptPath: path.join(stateDir, 'scripts', 'telegram-reply.sh'),
+      agentHome: tmpDir,
+      decisionRef,
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.body.metadata.toneAdvisoryDecisionRef).toBe(decisionRef);
   });
 
   it('REJECTS an impostor annotator claiming the rule (self-report cannot be forged by another component)', () => {

--- a/tests/fixtures/relay-history/telegram-reply-pre-suppression.sh
+++ b/tests/fixtures/relay-history/telegram-reply-pre-suppression.sh
@@ -414,11 +414,9 @@ if [ -n "$MESSAGE_KIND" ] || [ -n "$SENDER_CLASS" ] || [ -n "$JOB_SLUG" ] \
   # ── Tone-gate reaction metadata ─────────────────────────────────────────
   # Without these four the migration is inert through the only sanctioned send
   # path: the agent would be told by the 422 to override and have no way to do
-  # it. Rule ids are charset-clamped; decision refs are accepted only in the
-  # router correlation-id shape (`d-<uuid>` / `d-<machine>-<uuid>`, same for
-  # `b-`) so production machine ids like `m_03b30f` survive byte-for-byte
-  # without admitting shell- or JSON-hostile text. The reason is JSON-escaped via
-  # python3 (the only field that can contain arbitrary prose).
+  # it. Values are charset-clamped — a rule id and a correlation id have narrow
+  # alphabets, and the reason is JSON-escaped via python3 (the only field that
+  # can contain arbitrary prose).
   if [ -n "$TONE_ACK" ]; then
     TONE_ACK_CLEAN=$(printf '%s' "$TONE_ACK" | tr -cd 'A-Z0-9_' | cut -c1-64)
     [ -n "$META_PARTS" ] && META_PARTS="${META_PARTS},"
@@ -434,13 +432,7 @@ if [ -n "$MESSAGE_KIND" ] || [ -n "$SENDER_CLASS" ] || [ -n "$JOB_SLUG" ] \
     META_PARTS="${META_PARTS}\"toneAdvisoryComplied\":\"${TONE_COMPLIED_CLEAN}\""
   fi
   if [ -n "$TONE_DECISION_REF" ]; then
-    TONE_REF_CLEAN=$(printf '%s' "$TONE_DECISION_REF" | python3 -c '
-import re, sys
-ref = sys.stdin.read()[:129]
-pat = re.compile(r"^[db]-(?:[A-Za-z0-9_]{1,64}-)?[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$")
-if len(ref) <= 128 and pat.fullmatch(ref):
-    sys.stdout.write(ref)
-' 2>/dev/null || printf '')
+    TONE_REF_CLEAN=$(printf '%s' "$TONE_DECISION_REF" | tr -cd 'a-zA-Z0-9-' | cut -c1-128)
     [ -n "$META_PARTS" ] && META_PARTS="${META_PARTS},"
     META_PARTS="${META_PARTS}\"toneAdvisoryDecisionRef\":\"${TONE_REF_CLEAN}\""
   fi
@@ -527,13 +519,6 @@ HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 
 if [ "$HTTP_CODE" = "200" ]; then
-  if printf '%s' "$BODY" | python3 -c 'import sys,json; raise SystemExit(0 if json.load(sys.stdin).get("suppressedDuplicate") is True else 1)' 2>/dev/null; then
-    SUPPRESSED_DELIVERY_ID=$(printf '%s' "$BODY" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("deliveryId", ""))' 2>/dev/null || echo "")
-    DELIVERY_ID_DETAIL=""
-    [ -n "$SUPPRESSED_DELIVERY_ID" ] && DELIVERY_ID_DETAIL="; delivery id $SUPPRESSED_DELIVERY_ID"
-    echo "NOT SENT — suppressed duplicate for topic $TOPIC_ID${DELIVERY_ID_DETAIL}; an identical message was already delivered to that topic recently"
-    exit 1
-  fi
   echo "Sent $(echo "$MSG" | wc -c | tr -d ' ') chars to topic $TOPIC_ID"
 elif [ "$HTTP_CODE" = "408" ]; then
   # Request timeout on the server side — the outbound path (tone gate + Telegram API)

--- a/tests/integration/telegram-forward-sentinel-intercept.test.ts
+++ b/tests/integration/telegram-forward-sentinel-intercept.test.ts
@@ -43,7 +43,7 @@ function buildContext(
   stateDir: string,
   decideImpl: (msg: string) => Promise<{ disposition: 'kill' | 'pause' | 'route-through'; category: SentinelCategory; reason?: string }>,
   spies: Spies,
-  opts: { withSession: boolean } = { withSession: true },
+  opts: { withSession: boolean; killOutcome?: boolean } = { withSession: true },
 ): RouteContext {
   // Persistent topic→session registry (the resolver's primary source).
   if (opts.withSession) {
@@ -80,7 +80,7 @@ function buildContext(
       onTopicMessage: (m: { content: string }) => { spies.routed.push(m.content); },
       logInboundMessage: () => {},
       getSessionForTopic: (_t: number) => (opts.withSession ? SESSION : null),
-      onSentinelKillSession: (name: string) => { spies.killed.push(name); return true; },
+      onSentinelKillSession: (name: string) => { spies.killed.push(name); return opts.killOutcome ?? true; },
       onSentinelPauseSession: (name: string) => { spies.paused.push(name); },
       sendToTopic: async (_t: number, msg: string) => { spies.sent.push(msg); },
     } as never,
@@ -152,6 +152,51 @@ describe('/internal/telegram-forward — sentinel emergency-stop/pause intercept
     expect(spies.routed).toHaveLength(0);    // message was NOT delivered to the session
     expect(fs.existsSync(stateFile)).toBe(true); // record survives emergency stop
     expect(fs.readFileSync(stateFile, 'utf8')).toMatch(/^active: false$/m);
+    // The thing a person reads: a kill that landed is reported as terminated.
+    expect(spies.sent).toHaveLength(1);
+    expect(spies.sent[0]).toMatch(/^Session terminated\./);
+  });
+
+  // ── MUST-FAIL ARM 2: a false killed:true ────────────────────────────────
+  // The session name resolves (a session IS bound to the topic), but the kill
+  // itself does not land. The response must report the OUTCOME (killed:false),
+  // never merely "a session name resolved" — the latter is the original defect
+  // (`killed: !!sessionName`) that answered killed:true for a kill that never
+  // ran. The record is still preserved regardless.
+  it('disposition kill whose kill FAILS reports killed:false and STILL preserves the record', async () => {
+    fs.mkdirSync(path.join(stateDir, 'autonomous'), { recursive: true });
+    const stateFile = path.join(stateDir, 'autonomous', `${TOPIC}.local.md`);
+    fs.writeFileSync(
+      stateFile,
+      `---\nactive: true\npaused: false\nreport_topic: "${TOPIC}"\nstarted_at: "2026-08-23T00:00:00Z"\n---\n\nlive notes\n`,
+    );
+    const ctx = buildContext(
+      stateDir,
+      async () => ({ disposition: 'kill', category: 'emergency-stop', reason: 'exact match: stop' }),
+      spies,
+      { withSession: true, killOutcome: false }, // the kill does not land
+    );
+    const res = await forward(makeApp(ctx), 'stop everything');
+    expect(res.status).toBe(200);
+    // The arm that would have caught the original defect:
+    expect(res.body).toMatchObject({ ok: true, sentinel: 'emergency-stop', killed: false });
+    expect(spies.killed).toContain(SESSION);   // the kill was ATTEMPTED against the bound session
+    expect(spies.routed).toHaveLength(0);       // the message was NOT delivered to the session
+    // The half that already worked must keep working — the record is preserved
+    // and stamped inactive even though the kill failed.
+    expect(fs.existsSync(stateFile)).toBe(true);
+    expect(fs.readFileSync(stateFile, 'utf8')).toMatch(/^active: false$/m);
+    // The message the PERSON receives must not claim termination. The JSON
+    // above is read by machines; this line is read by someone who will act on
+    // it. It used to branch on `sessionName` (a name resolved) rather than on
+    // the kill outcome, so a failed kill still told the operator
+    // "Session terminated." — the exact defect this lane exists to remove.
+    expect(spies.sent).toHaveLength(1);
+    const userMessage = spies.sent[0];
+    expect(userMessage).not.toMatch(/terminated/i);
+    expect(userMessage).toMatch(/still running/i);   // plainly: it did NOT stop
+    expect(userMessage).toMatch(/recorded/i);        // ...and the stop record was preserved
+    expect(userMessage).not.toContain(SESSION);      // plain English — no internal identifiers
   });
 
   it('disposition pause → pauses the session and does NOT route (deterministic pause)', async () => {
@@ -204,6 +249,10 @@ describe('/internal/telegram-forward — sentinel emergency-stop/pause intercept
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ ok: true, sentinel: 'emergency-stop', killed: false });
     expect(spies.routed).toHaveLength(0);
+    expect(spies.killed).toHaveLength(0); // nothing to kill, so nothing was attempted
+    // Third state of the user-facing text: no session to stop (not "terminated",
+    // not "still running").
+    expect(spies.sent).toEqual(['No active session to stop.']);
   });
 });
 

--- a/tests/integration/telegram-reply-advisory-migration.test.ts
+++ b/tests/integration/telegram-reply-advisory-migration.test.ts
@@ -21,17 +21,21 @@
 
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import express from 'express';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { AddressInfo } from 'node:net';
 import { createRoutes } from '../../src/server/routes.js';
 import { MessagingToneGate } from '../../src/core/MessagingToneGate.js';
+import { FeatureMetricsLedger } from '../../src/monitoring/FeatureMetricsLedger.js';
 import {
   DecisionQualityRecorderImpl,
   installDecisionQualityRecorder,
 } from '../../src/core/DecisionQualityRecorderImpl.js';
 import type { IntelligenceProvider } from '../../src/core/types.js';
+import { DP_MESSAGING_TONE_GATE } from '../../src/data/provenanceCoverage.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 /**
  * The advisory disposition is CONDITIONAL on the reaction being recordable
@@ -39,9 +43,13 @@ import type { IntelligenceProvider } from '../../src/core/types.js';
  * gate keeps its authority and returns a plain block. So an advisory test must
  * install a live recorder — and the un-installed case is itself worth asserting.
  */
+let ledger: FeatureMetricsLedger | null = null;
+const tmpDirs: string[] = [];
 function installLiveRecorder(): void {
+  ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
   installDecisionQualityRecorder(
     new DecisionQualityRecorderImpl({
+      ledger,
       config: {
         developmentAgent: true,
         provenance: { uniformSeam: { enabled: true, dryRun: false } },
@@ -113,6 +121,36 @@ function buildApp(opts: {
   return app;
 }
 
+function runReplyScript(opts: {
+  port: number;
+  args: string[];
+}): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'telegram-reply-client-int-'));
+  tmpDirs.push(dir);
+  fs.mkdirSync(path.join(dir, '.instar'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.instar', 'config.json'),
+    JSON.stringify({ port: opts.port, projectName: 'client-int' }),
+  );
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [path.resolve('src/templates/scripts/telegram-reply.sh'), ...opts.args], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        INSTAR_SENDER_CLASS: 'script',
+        INSTAR_AUTH_TOKEN: '',
+        INSTAR_PORT: '',
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
 /** The founding complaint: a message whose only sin is naming a directory. */
 const PATH_MESSAGE =
   'I put the convergence report in docs/audits/tone-gate-grading.md — it lists every scenario and the verdicts.';
@@ -127,7 +165,19 @@ const B2_VERDICT = {
 describe('advisory migration through POST /telegram/reply', () => {
   let server: TestServer;
   beforeEach(() => { installLiveRecorder(); });
-  afterEach(async () => { await server?.close(); installDecisionQualityRecorder(null); });
+  afterEach(async () => {
+    await server?.close();
+    installDecisionQualityRecorder(null);
+    ledger?.close();
+    ledger = null;
+    for (const dir of tmpDirs.splice(0)) {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/integration/telegram-reply-advisory-migration.test.ts',
+      });
+    }
+  });
 
   async function reply(topicId: number, text: string, metadata?: Record<string, unknown>) {
     const res = await fetch(`${server.url}/telegram/reply/${topicId}`, {
@@ -358,6 +408,48 @@ describe('advisory migration through POST /telegram/reply', () => {
     });
     expect(res.status).toBe(200);
     expect(sent).toHaveLength(1);
+  });
+
+  it('the documented reply client preserves a machine-prefixed decisionRef and settles the outcome', async () => {
+    const sent: Array<{ topicId: number; text: string }> = [];
+    const gate = new MessagingToneGate(
+      makeProvider({ pass: true, rule: '', issue: '', suggestion: '' }),
+      { advisoryMigration: true },
+    );
+    server = await listen(buildApp({ toneGate: gate, sent }));
+    const port = Number(new URL(server.url).port);
+    const correlationId = 'd-m_03b30f-00000000-0000-4000-8000-000000000111';
+    expect(ledger).not.toBeNull();
+    ledger!.recordDecision({
+      correlationId,
+      decisionPoint: DP_MESSAGING_TONE_GATE,
+      feature: 'messaging-tone-gate',
+      verdictClass: 'advisory',
+      mintedBy: 'router',
+      volumeClass: 'all',
+      contentClass: 'identity-only',
+      ts: Date.now() - 100,
+    });
+
+    const result = await runReplyScript({
+      port,
+      args: [
+        '--tone-complied', 'B2_FILE_PATH',
+        '--tone-decision-ref', correlationId,
+        '204',
+        'The revised answer avoids the raw path.',
+      ],
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(sent).toHaveLength(1);
+    await new Promise((resolve) => setImmediate(resolve));
+    const point = ledger!.decisionQualityRollupDaily({ decisionPoint: DP_MESSAGING_TONE_GATE })[0];
+    expect(point).toMatchObject({
+      right: 1,
+      wrong: 0,
+      orphanOutcomes: 0,
+    });
   });
 });
 

--- a/tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts
+++ b/tests/integration/telegram-reply-suppressed-duplicate-migration.test.ts
@@ -24,36 +24,33 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
 
 const TEMPLATE = path.resolve('src/templates/scripts/telegram-reply.sh');
+const PRE_SUPPRESSION_FIX_FIXTURE = path.resolve(
+  'tests/fixtures/relay-history/telegram-reply-pre-suppression.sh',
+);
 
 /**
- * The SHA this PR registers — the version shipped immediately BEFORE the fix.
- * Every agent in the field is running this exact content.
+ * The SHA registered by the suppressed-duplicate honesty fix — the version
+ * shipped immediately BEFORE that fix.
  */
 const PRIOR_SHIPPED_SHA =
   '4464581188f5c736a62edac5e6a2edecfcfcd365557a18e514b741731bed6e0b';
 
+/**
+ * The SHA registered by the decision-ref preservation fix — the version shipped
+ * immediately BEFORE that fix.
+ */
+const DECISION_REF_CORRUPT_SHIPPED_SHA =
+  '74ee09b4d4d537ddfe032f3192cab08b4f2f956fdb1e1b3ccd94b26dc218fb52';
+
 const SUPPRESSION_MARKER = 'suppressedDuplicate';
 
 /**
- * Reconstruct the pre-fix shipped script by removing the seven-line
- * suppression branch from the current template.
- *
- * Deriving it (rather than pasting a 42KB literal) is deliberate: the
- * reconstruction is only valid if it hashes to the SHA actually registered in
- * the migrator, which the first test asserts. That single assertion is what
- * proves the registered constant is genuinely "current template minus this
- * fix" — a typo'd or stale hash there would silently strand every deployed
- * agent on a `.new` candidate, which is exactly the failure this PR fixes.
+ * Read the actual pre-fix shipped script from a pinned fixture. This must not
+ * be reconstructed from today's template: later unrelated template changes
+ * would create a synthetic version that never shipped.
  */
 function priorShippedContent(): string {
-  const lines = fs.readFileSync(TEMPLATE, 'utf-8').split('\n');
-  const start = lines.findIndex(l => l.includes(`get("${SUPPRESSION_MARKER}") is True`));
-  if (start === -1) throw new Error('suppression branch not found in template');
-  const removed = lines.slice(start, start + 7);
-  if (removed[6].trim() !== 'fi') {
-    throw new Error(`expected the 7-line branch to close with "fi", got: ${removed[6]}`);
-  }
-  return [...lines.slice(0, start), ...lines.slice(start + 7)].join('\n');
+  return fs.readFileSync(PRE_SUPPRESSION_FIX_FIXTURE, 'utf-8');
 }
 
 function sha256(text: string): string {
@@ -106,11 +103,12 @@ describe('suppressed-duplicate honesty — post-update migration', () => {
     });
   });
 
-  it('registers the EXACT sha of the shipped pre-fix template', () => {
-    // If this fails, the migrator's registered hash does not describe any real
-    // deployed script, and the migration reaches nobody.
+  it('registers the EXACT deployed relay shas this migration must reach', () => {
+    // If either membership check fails, a real deployed stock script is treated
+    // as unknown/user-modified and the update path only writes a `.new` file.
     expect(sha256(priorShippedContent())).toBe(PRIOR_SHIPPED_SHA);
     expect(PostUpdateMigrator.TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS.has(PRIOR_SHIPPED_SHA)).toBe(true);
+    expect(PostUpdateMigrator.TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS.has(DECISION_REF_CORRUPT_SHIPPED_SHA)).toBe(true);
   });
 
   it('the pre-fix script genuinely lacks the fix (the "before" state is real)', () => {

--- a/tests/unit/PostUpdateMigrator-neutralRelayPath.test.ts
+++ b/tests/unit/PostUpdateMigrator-neutralRelayPath.test.ts
@@ -89,4 +89,10 @@ describe('PostUpdateMigrator — framework-neutral telegram-reply mirror (Gap 4)
     expect(fs.existsSync(neutralPath)).toBe(false);
     expect(fs.existsSync(claudePath)).toBe(false);
   });
+
+  it('recognizes the last shipped decision-ref-corrupt relay for in-place upgrade', () => {
+    expect(PostUpdateMigrator.TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS.has(
+      '74ee09b4d4d537ddfe032f3192cab08b4f2f956fdb1e1b3ccd94b26dc218fb52',
+    )).toBe(true);
+  });
 });

--- a/tests/unit/emergency-stop-user-message.test.ts
+++ b/tests/unit/emergency-stop-user-message.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit: the text a PERSON is shown after an emergency stop tells the truth in
+ * all three states — no session, stopped, and tried-to-stop-but-could-not.
+ *
+ * W26 lane 1 addendum. Both stop paths used to branch this text on whether a
+ * session NAME resolved, so a failed kill still told the operator
+ * "Session terminated." while the API said killed:false. The helper is the one
+ * source both paths read; the adapter test below drives the conversational
+ * path end-to-end through processUpdate and reads what was sent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  emergencyStopOutcome,
+  emergencyStopUserMessage,
+  EMERGENCY_STOP_USER_MESSAGES,
+} from '../../src/messaging/shared/emergencyStopUserMessage.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const SESSION = 'echo-topic-4242-worker';
+
+describe('emergencyStopUserMessage — three states, three truths', () => {
+  it('no session bound → "No active session to stop." regardless of the kill flag', () => {
+    expect(emergencyStopOutcome(null, false)).toBe('no-session');
+    expect(emergencyStopOutcome(undefined, true)).toBe('no-session');
+    expect(emergencyStopOutcome('', true)).toBe('no-session');
+    expect(emergencyStopUserMessage(null, true)).toBe('No active session to stop.');
+  });
+
+  it('session bound + kill landed → terminated', () => {
+    expect(emergencyStopOutcome(SESSION, true)).toBe('killed');
+    expect(emergencyStopUserMessage(SESSION, true)).toMatch(/^Session terminated\./);
+  });
+
+  it('session bound + kill did NOT land → says still running AND that the stop was recorded, never "terminated"', () => {
+    expect(emergencyStopOutcome(SESSION, false)).toBe('kill-failed');
+    const msg = emergencyStopUserMessage(SESSION, false);
+    expect(msg).not.toMatch(/terminated/i);
+    expect(msg).toMatch(/still running/i);
+    expect(msg).toMatch(/recorded/i);
+  });
+
+  it('an unset/non-boolean outcome never reads as success', () => {
+    // A truthy-but-not-true value (e.g. a stray object or 1) is NOT a kill.
+    expect(emergencyStopOutcome(SESSION, 1 as unknown as boolean)).toBe('kill-failed');
+    expect(emergencyStopOutcome(SESSION, undefined as unknown as boolean)).toBe('kill-failed');
+  });
+
+  it('every message is plain English — no session names, paths, or identifiers', () => {
+    for (const msg of Object.values(EMERGENCY_STOP_USER_MESSAGES)) {
+      expect(msg).not.toContain(SESSION);
+      expect(msg).not.toMatch(/\.instar|\/Users\/|tmux|\.local\.md|topic \d+/i);
+    }
+  });
+});
+
+describe('TelegramAdapter conversational emergency-stop — the user is told the truth', () => {
+  let tmpDir: string;
+  let adapter: TelegramAdapter;
+  let sent: string[];
+
+  function textUpdate(topic: number, text: string) {
+    return {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        message_thread_id: topic,
+        date: Math.floor(Date.now() / 1000),
+        text,
+        from: { id: 4242, first_name: 'Op', username: 'op' },
+        chat: { id: -1001, type: 'supergroup' },
+      },
+    };
+  }
+
+  function writeAutonomousJob(topic: number): string {
+    const dir = path.join(tmpDir, 'autonomous');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `${topic}.local.md`);
+    fs.writeFileSync(
+      file,
+      `---\nactive: true\npaused: false\nreport_topic: "${topic}"\nstarted_at: "2026-08-24T00:00:00.000Z"\n---\n\nlive notes\n`,
+    );
+    return file;
+  }
+
+  async function stop(topic: number, killOutcome: boolean): Promise<void> {
+    (adapter as unknown as { topicToSession: Map<number, string> }).topicToSession.set(topic, SESSION);
+    adapter.onSentinelKillSession = () => killOutcome;
+    adapter.onSentinelIntercept = async () => ({
+      category: 'emergency-stop' as const,
+      action: { type: 'kill' },
+      reason: 'stop everything',
+    });
+    await (adapter as unknown as { processUpdate: (u: unknown) => Promise<void> }).processUpdate(
+      textUpdate(topic, 'stop everything'),
+    );
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-stop-user-msg-'));
+    sent = [];
+    // Tokenless adapter: no polling — but processUpdate runs. Capture what the
+    // person in the topic would have been sent.
+    adapter = new TelegramAdapter({ token: '' } as never, tmpDir);
+    adapter.sendToTopic = async (_topic: number, text: string) => { sent.push(text); };
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'emergency-stop-user-message:cleanup' });
+  });
+
+  it('kill landed → the person is told "Session terminated."', async () => {
+    const topic = 4242;
+    const file = writeAutonomousJob(topic);
+    await stop(topic, true);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatch(/^Session terminated\./);
+    expect(fs.readFileSync(file, 'utf8')).toMatch(/^active: false$/m); // record preserved
+  });
+
+  it('kill FAILED → the person is told the session is still running and the stop was recorded — never "terminated"', async () => {
+    const topic = 4243;
+    const file = writeAutonomousJob(topic);
+    await stop(topic, false);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).not.toMatch(/terminated/i);
+    expect(sent[0]).toMatch(/still running/i);
+    expect(sent[0]).toMatch(/recorded/i);
+    expect(sent[0]).not.toContain(SESSION);
+    // The half that already worked keeps working alongside the failure.
+    expect(fs.existsSync(file)).toBe(true);
+    expect(fs.readFileSync(file, 'utf8')).toMatch(/^active: false$/m);
+  });
+});

--- a/tests/unit/session-manager-kill-by-tmux-name.test.ts
+++ b/tests/unit/session-manager-kill-by-tmux-name.test.ts
@@ -1,0 +1,130 @@
+/**
+ * W26 lane 1 — the stop that does not stop (UNIT tier).
+ *
+ * `SessionManager.killSession(sessionId)` resolves its argument through the
+ * state store BY ID. The emergency-stop path handed it a TMUX NAME, so the
+ * lookup missed and it returned `false` silently while every caller reported
+ * "killed". `killSessionByTmuxName` is the single shared resolution helper both
+ * emergency-stop call sites now use; this tier tests the resolution and the
+ * outcome plumbing in isolation.
+ *
+ * MUST-FAIL ARM 1 (tmux-name-vs-session-id resolution): the helper must resolve
+ * the tmux name to the session ID and call killSession with the ID, not the
+ * name. The `toHaveBeenCalledWith(<id>)` + killed-record assertions go red the
+ * moment the resolution is reverted to passing the name straight through.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+// Mock child_process so no real tmux is required — kill-session is a no-op.
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockReturnValue(''),
+  execFile: vi.fn(),
+  execSync: vi.fn().mockReturnValue(''),
+  exec: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig, Session } from '../../src/core/types.js';
+
+const RUNNING_ID = 'sess-1-uuid';
+const RUNNING_TMUX = 'echo-worker-1';
+
+function runningSession(): Session {
+  return {
+    id: RUNNING_ID,
+    name: 'echo-worker',
+    status: 'running',
+    tmuxSession: RUNNING_TMUX,
+    startedAt: '2026-08-24T00:00:00.000Z',
+  };
+}
+
+describe('SessionManager.killSessionByTmuxName — tmux-name → session-id resolution', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let state: StateManager;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kill-by-tmux-'));
+    stateDir = path.join(tmpDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    state = new StateManager(stateDir);
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: tmpDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: ['Session complete'],
+      framework: 'claude-code',
+    };
+    manager = new SessionManager(config, state);
+  });
+
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'session-manager-kill-by-tmux-name:cleanup' });
+  });
+
+  // ── MUST-FAIL ARM 1 ──────────────────────────────────────────────────────
+  it('resolves the tmux name to the session ID and calls killSession WITH THE ID (not the name)', () => {
+    state.saveSession(runningSession());
+    const killSpy = vi.spyOn(manager, 'killSession');
+
+    const result = manager.killSessionByTmuxName(RUNNING_TMUX);
+
+    expect(result).toBe(true);
+    // The exact defect: passing the tmux NAME straight through. The kill must be
+    // dispatched by the resolved session ID.
+    expect(killSpy).toHaveBeenCalledWith(RUNNING_ID);
+    expect(killSpy).not.toHaveBeenCalledWith(RUNNING_TMUX);
+    // And the record is actually marked killed (a name passed straight through
+    // would have missed getSession() and left it 'running').
+    expect(state.getSession(RUNNING_ID)!.status).toBe('killed');
+  });
+
+  it('a tmux name with no running session returns false (a miss is a failed kill, never silent success)', () => {
+    // No session saved for this name.
+    state.saveSession({ ...runningSession(), id: 'other', tmuxSession: 'some-other-worker' });
+    const killSpy = vi.spyOn(manager, 'killSession');
+
+    const result = manager.killSessionByTmuxName(RUNNING_TMUX);
+
+    expect(result).toBe(false);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it('only resolves RUNNING records — a killed/completed record with that tmux name is not re-killed', () => {
+    state.saveSession({ ...runningSession(), status: 'killed' });
+    const killSpy = vi.spyOn(manager, 'killSession');
+
+    expect(manager.killSessionByTmuxName(RUNNING_TMUX)).toBe(false);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  // ── Outcome plumbing: a resolved name whose kill FAILS returns false ──────
+  it('propagates a false outcome — when the underlying kill returns false, the helper returns false', () => {
+    state.saveSession(runningSession());
+    // The name resolves, but the kill itself does not land.
+    const killSpy = vi.spyOn(manager, 'killSession').mockReturnValue(false);
+
+    const result = manager.killSessionByTmuxName(RUNNING_TMUX);
+
+    expect(killSpy).toHaveBeenCalledWith(RUNNING_ID); // resolution happened
+    expect(result).toBe(false);                        // ...but the outcome is not swallowed into success
+  });
+
+  it('an empty tmux name returns false without touching killSession', () => {
+    const killSpy = vi.spyOn(manager, 'killSession');
+    expect(manager.killSessionByTmuxName('')).toBe(false);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/telegram-reply-bounded-outcome.test.ts
+++ b/tests/unit/telegram-reply-bounded-outcome.test.ts
@@ -15,15 +15,25 @@ afterEach(() => {
   }
 });
 
-function runWithFailingCurl(): Promise<{ status: number | null; stdout: string; stderr: string; curlArgs: string }> {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'telegram-bounded-outcome-'));
+function makeScriptHarness(prefix: string): { dir: string; binDir: string; instarDir: string; argsPath: string; bodyPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tmpDirs.push(dir);
   const binDir = path.join(dir, 'bin');
   const instarDir = path.join(dir, '.instar');
   fs.mkdirSync(binDir);
   fs.mkdirSync(instarDir);
   fs.writeFileSync(path.join(instarDir, 'config.json'), JSON.stringify({ port: 49999, projectName: 'test-agent' }));
-  const argsPath = path.join(dir, 'curl-args.txt');
+  return {
+    dir,
+    binDir,
+    instarDir,
+    argsPath: path.join(dir, 'curl-args.txt'),
+    bodyPath: path.join(dir, 'curl-body.json'),
+  };
+}
+
+function runWithFailingCurl(): Promise<{ status: number | null; stdout: string; stderr: string; curlArgs: string }> {
+  const { dir, binDir, argsPath } = makeScriptHarness('telegram-bounded-outcome-');
   const curlStub = path.join(binDir, 'curl');
   fs.writeFileSync(curlStub, `#!/bin/sh\nprintf '%s\\n' "$@" > '${argsPath}'\nexit 28\n`);
   fs.chmodSync(curlStub, 0o755);
@@ -53,6 +63,40 @@ function runWithFailingCurl(): Promise<{ status: number | null; stdout: string; 
   });
 }
 
+function runAndCaptureBody(args: string[]): Promise<{ status: number | null; body: any }> {
+  const { dir, binDir, bodyPath } = makeScriptHarness('telegram-decision-ref-');
+  const curlStub = path.join(binDir, 'curl');
+  fs.writeFileSync(curlStub, `#!/bin/sh
+prev=''
+for arg in "$@"; do
+  if [ "$prev" = "-d" ]; then
+    printf '%s' "$arg" > '${bodyPath}'
+  fi
+  prev="$arg"
+done
+printf '%s\\n%s\\n' '{"ok":true}' '200'
+`);
+  fs.chmodSync(curlStub, 0o755);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [SCRIPT, ...args], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        INSTAR_SENDER_CLASS: 'script',
+        INSTAR_PORT: '',
+        INSTAR_AUTH_TOKEN: '',
+      },
+    });
+    child.on('error', reject);
+    child.on('close', (status) => resolve({
+      status,
+      body: JSON.parse(fs.readFileSync(bodyPath, 'utf8')),
+    }));
+  });
+}
+
 describe('telegram-reply.sh bounded final outcome', () => {
   it('keeps the client window just beyond the server outbound budget', () => {
     const source = fs.readFileSync(SCRIPT, 'utf8');
@@ -70,5 +114,30 @@ describe('telegram-reply.sh bounded final outcome', () => {
     expect(result.stderr).toMatch(/AMBIGUOUS: Telegram relay transport ended/);
     expect(result.stderr).toMatch(/Do NOT retry blindly/);
     expect(result.stderr).toMatch(/Delivery id:/);
+  });
+
+  it('preserves an underscore-bearing tone decision ref byte-for-byte in the documented client body', async () => {
+    const ref = 'd-m_03b30f-00000000-0000-4000-8000-000000000000';
+    const result = await runAndCaptureBody([
+      '--tone-complied', 'B2_FILE_PATH',
+      '--tone-decision-ref', ref,
+      '458',
+      'I revised the message.',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.body.metadata.toneAdvisoryDecisionRef).toBe(ref);
+  });
+
+  it('does not pass shell-hostile tone decision refs through the documented client body', async () => {
+    const result = await runAndCaptureBody([
+      '--tone-complied', 'B2_FILE_PATH',
+      '--tone-decision-ref', 'd-m_03b30f-00000000-0000-4000-8000-000000000000";$(touch bad)',
+      '458',
+      'I revised the message.',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.body.metadata.toneAdvisoryDecisionRef).toBe('');
   });
 });

--- a/upgrades/next/w26-false-success-repairs.md
+++ b/upgrades/next/w26-false-success-repairs.md
@@ -1,0 +1,117 @@
+---
+change_type: fix
+---
+
+## What Changed
+
+Two control paths reported success where the effect never happened. Both are repaired at the
+consumer, with must-fail tests that go red if the false report returns.
+
+**1. An emergency stop now stops, and says so truthfully.** The stop path — both the lifeline route
+(`POST /internal/telegram-forward` with an emergency-stop message) and the conversational path in
+`TelegramAdapter` — handed a *tmux name* to `SessionManager.killSession`, which resolves its argument
+by *session id*. The lookup missed, the kill returned `false` silently, and every consumer reported
+"killed": the route answered `killed: !!sessionName` (derived from a name having resolved, not from a
+kill having happened), the log printed `killed session` unconditionally, and the person was told
+"Session terminated."
+
+Now `SessionManager.killSessionByTmuxName` is the one place the name→id resolution lives, so the two
+stop paths cannot drift apart, and it returns the real outcome. The route's `killed` field IS that
+outcome. The log prints `KILL FAILED … the session was NOT killed` when the kill does not land. The
+text a person reads comes from one shared module, `emergencyStopUserMessage`, keyed on the outcome in
+all three states: no session to stop, stopped, and *tried to stop and could not* (which says the
+session is still running and that the stop request was still recorded). The run record
+(`active:false`, `stopped_at`) is preserved in every state — that half already worked and is asserted
+alongside each failure arm.
+
+**2. A tone-gate override sent through the documented reply client keeps its decision reference
+byte-for-byte.** `telegram-reply.sh --tone-decision-ref` clamped the reference with
+`tr -cd 'a-zA-Z0-9-'`. The allowed set had no underscore, so a real reference such as
+`d-m_03b30f-<uuid>` lost its `_`, the server could not join the override to its decision, and the
+outcome landed as an orphan — a grade that tunes nothing. The client now accepts a reference only in
+the router's correlation-id shape (`d-<uuid>` or `d-<machine-id>-<uuid>`, likewise `b-`), validated by
+a full-match pattern, so production machine ids survive intact while shell- and JSON-hostile input is
+still rejected (an invalid reference is dropped to empty, never partially passed through).
+
+Migration parity: the previously shipped relay script's sha
+(`74ee09b4d4d537ddfe032f3192cab08b4f2f956fdb1e1b3ccd94b26dc218fb52`, the v1.3.1199 version) is
+registered in `PostUpdateMigrator`'s known-shipped set, so deployed agents receive the fixed client in
+place rather than a `.new` candidate beside the broken installed copy. The migration test no longer
+reconstructs the historical script from the current template (a derivation that broke on any
+unrelated template change and would have registered a version that never shipped); it reads a pinned
+fixture, `tests/fixtures/relay-history/telegram-reply-pre-suppression.sh`, whose sha is exactly the
+genuine historical version, and asserts the registered set covers every really-deployed version.
+
+## Evidence
+
+Lane 1 must-fail arms, each shown red for the right reason before the fix, across all three tiers:
+(a) a tmux name passed straight through to `killSession` fails; (b) a session name that resolves but
+whose kill returns `false` must answer `killed: false` — the arm that would have caught the original
+defect; (c) when the kill fails, the message the person receives must not claim termination. Both
+sides of the boundary are covered: a kill that succeeds reports success and sends "Session
+terminated."; a kill that fails reports failure in the JSON, the log, and the human text, with the run
+record still preserved. Unit: `session-manager-kill-by-tmux-name`, `emergency-stop-user-message`.
+Integration: `telegram-forward-sentinel-intercept`. E2E: `autonomous-emergency-stop-preserves-state-lifecycle`.
+
+Lane 2 must-fail arm: a reference containing an underscore altered on its way through the client fails
+(red under the old character class, with the stripped underscore as the reason). The other side: hostile
+input (shell metacharacters, quotes, JSON breakouts, over-length) does not survive. Unit:
+`telegram-reply-bounded-outcome`. Integration: `telegram-reply-advisory-migration` (the documented client
+path through to a recorded, *settled* outcome — not an orphan). E2E: `tone-gate-advisory-migration-alive`.
+Migration parity: `telegram-reply-suppressed-duplicate-migration`, `telegram-reply-suppressed-duplicate-alive`,
+`PostUpdateMigrator-neutralRelayPath` assert both really-deployed shas are registered.
+
+Full suite on a clean worktree off v1.3.1199 carrying exactly these files, nothing else running:
+Test Files 3170 passed, 4 skipped; Tests 49,988 passed, 29 skipped, 3 todo; runner `EXIT=0`
+(`.instar/w26/deploy-evidence/candidate-v2-full-suite.log`; per-file shas in `candidate-v2-file-shas.txt`).
+
+A first candidate failed 9 tests in the migration-parity files — not because the fix was wrong, but
+because the test derived the historical script from the current template. It was NOT made green by
+pasting the new derived hash over the constant: that hash was a version no agent in the field ever ran,
+and registering it would have been this release's own defect committed by a test. The fixture pin above
+is the repair.
+
+## Known Limits
+
+The stop repair reports a failed kill; it does not retry it. The person is told the session is still
+running and pointed at sending stop again or closing it from the dashboard. Whether a kill can fail for
+reasons other than a name miss (a wedged pane that survives the kill sequence) is the watchdog's
+territory, unchanged here.
+
+The decision-reference shape is now strict by design: a reference that is not `d-…`/`b-…` plus an
+optional machine id plus a UUID is dropped, not passed through. If the router ever changes its
+correlation-id format, the client must change with it or overrides go unrecorded again — the
+integration test asserts the joined, settled outcome, so that drift fails a test rather than
+silently orphaning.
+
+Existing agents receive the relay fix only if their installed script matches a registered shipped
+version; a hand-edited copy is left alone with a `.new` candidate beside it, as before.
+
+## What to Tell Your User
+
+When you tell me to stop a session in an emergency, I now actually stop it — and if for some reason I
+could not, I say so instead of telling you it was terminated. Before, there was a wiring mistake where
+the stop request looked up the session by the wrong kind of name, quietly found nothing, and then every
+report — the reply you saw, the log, the status — said "killed" anyway. Your stop request was always
+recorded, so a stopped run never came back on its own, but the session itself kept running while you
+were told it had ended. Now you get one of three honest answers: there was nothing to stop, it was
+stopped, or I tried and it is still running, so please send stop again or close it from the dashboard.
+
+Separately, when one of my outgoing messages gets held back by the tone check and I decide to override
+it with a reason, that decision is now properly recorded against the check that raised it. A small
+character-handling mistake had been mangling the reference that ties the two together, so my overrides
+were being logged as unmatched noise instead of graded feedback. That feedback is what tunes the check
+over time, so this quietly makes the check smarter from here on. If your agent was set up before this
+release, it picks up the corrected version automatically on update.
+
+## Summary of New Capabilities
+
+- Emergency stops resolve the session correctly, kill it, and report the real outcome in the API
+  response, the server log, and the message a person reads — including an explicit "stop failed, still
+  running" state; the stop record is preserved in every case.
+- A shared kill-by-tmux-name helper and a shared stop-message module, so the two stop paths cannot
+  drift apart again.
+- Tone-gate overrides sent through the documented reply client preserve the decision reference
+  byte-for-byte and settle as graded outcomes instead of orphans; hostile input is still rejected.
+- Deployed agents receive the corrected relay client in place via a registered shipped-version sha;
+  the parity test reads a pinned historical fixture instead of deriving one.

--- a/upgrades/side-effects/w26-false-success-repairs.md
+++ b/upgrades/side-effects/w26-false-success-repairs.md
@@ -1,0 +1,103 @@
+# Side-effects review — two false-success control paths (W26 lanes 1 and 2)
+
+**Slug:** `w26-false-success-repairs`
+**Window:** 26, exit-test items 3 and 3b
+**Files:** `src/commands/server.ts`, `src/core/SessionManager.ts`, `src/server/routes.ts`,
+`src/messaging/TelegramAdapter.ts`, `src/messaging/shared/emergencyStopUserMessage.ts` (new),
+`src/templates/scripts/telegram-reply.sh`, `src/core/PostUpdateMigrator.ts`, plus unit /
+integration / e2e tests and the pinned fixture `tests/fixtures/relay-history/telegram-reply-pre-suppression.sh`.
+
+## What changed
+
+**Lane 1 — the stop that does not stop.** `killSession(sessionId)` resolves by id; the two
+emergency-stop paths handed it a tmux name, so it returned `false` silently while the route answered
+`killed: !!sessionName`, the log printed "killed session" unconditionally, and the person was told
+"Session terminated." Now `SessionManager.killSessionByTmuxName` owns the name→id resolution and
+returns the real outcome; `onSentinelKillSession` and the route's direct fallback both use it; the
+route's `killed` field, both log paths, and the shared `emergencyStopUserMessage` text are keyed on
+that outcome (three states: no-session / killed / kill-failed). The run-record preservation
+(`stopAutonomousTopic`) is untouched and asserted alongside every failure arm.
+
+**Lane 2 — the reply client corrupts decision references.** `telegram-reply.sh` clamped
+`--tone-decision-ref` with `tr -cd 'a-zA-Z0-9-'`, stripping the `_` in machine-prefixed refs
+(`d-m_03b30f-<uuid>`) so the override landed as an orphan outcome. The clamp is replaced by a
+full-match shape check (`^[db]-(?:[A-Za-z0-9_]{1,64}-)?<uuid>$`, ≤128 chars) that passes a valid
+ref through byte-for-byte and drops anything else to empty. Migration parity: the v1.3.1199 script
+sha `74ee09b4…c218fb52` is added to `PostUpdateMigrator`'s known-shipped set; the parity test reads
+a pinned historical fixture instead of deriving one from the current template.
+
+## Phase 1 — principle check (signal vs authority)
+
+Lane 1 removes a *false* signal; it adds no new authority. The kill already had authority (an
+operator's emergency stop). What changes is that the reported outcome is now the real outcome. The
+resolver is a total, deterministic lookup (running sessions whose `tmuxSession` equals the name) —
+nothing heuristic holds blocking power. Failure direction: a miss reports failure, never success.
+
+Lane 2's shape check is a deterministic validator over an explicit format. It rejects rather than
+repairs: an unrecognised reference is dropped, so the client never forwards a *partially* sanitised
+value the server would mis-join. No new authority; the server-side grading is unchanged.
+
+## Phase 4 — the eight questions
+
+**1. Over-block.** Lane 2: a decision reference not in the router's shape is now dropped where it
+was previously forwarded mangled. Nothing legitimate is lost — a mangled ref was already an orphan —
+but if the router's correlation-id format ever changes, overrides silently stop joining. Mitigation:
+the integration test asserts a *settled* grade through the documented client, so a format drift
+fails a test. Lane 1 over-blocks nothing.
+
+**2. Under-block.** Lane 1 reports a failed kill but does not retry it, and does not distinguish
+"no running session with that name" from "kill sequence failed" in the JSON (`killed:false` for
+both; the log line does distinguish). A wedged pane that survives the kill sequence is the session
+watchdog's territory, unchanged. Lane 2 still trusts python3 to be present for the shape check
+(already true: the same script uses python3 for JSON-escaping the reason); if python3 is missing the
+ref drops to empty — the safe side, and the same behaviour the script already has for the reason.
+
+**3. Level of abstraction.** Lane 1: resolution belongs in `SessionManager`, the only layer that
+knows both the state records and the kill sequence; putting it at each call site is what let the
+two paths drift. The user text belongs in one shared module, because the previous defect survived
+in exactly the one consumer (the human message) that was fixed separately. Lane 2: the client is the
+right place — the server ingress was already proven correct via the raw route in W25.
+
+**4. Signal vs authority compliance.** Yes — see Phase 1.
+
+**5. Interactions.** Stop custody / resume-queue pause / `stopAutonomousTopic` run in the same order
+as before, regardless of kill outcome. `onSentinelKillSession` returning `false` where it used to
+return a discarded value is consumed only by the two stop paths. The migration set addition is
+additive: an installed script matching the new sha is now replaced in place; any other installed
+content behaves exactly as before. The `.new`-candidate path is untouched. The suppressed-duplicate
+honesty branch in the script is unchanged.
+
+**6. External surfaces.** The `POST /internal/telegram-forward` emergency-stop response `killed`
+field now carries the real outcome (previously always `true` when a name resolved). The Telegram
+text a person receives gains a third state. `telegram-reply.sh` emits `toneAdvisoryDecisionRef`
+intact for valid refs, empty otherwise. No new routes, no wire-format change.
+
+**7. Multi-machine posture.** Machine-local by nature: a kill acts on the machine holding the
+session; the relay script is installed per machine and migrated per machine. Nothing replicates.
+A stop forwarded to the owning machine is judged there — the reported outcome is that machine's.
+
+**8. Rollback cost.** Low. Reverting the source files restores the previous behaviour with no data
+migration. Reverting `PostUpdateMigrator` after agents have been migrated leaves them on the fixed
+script (harmless — it is a strict improvement). The fixture file is inert.
+
+## Evidence
+
+Must-fail arms shown red-then-green, all three tiers, both lanes (listed in the release fragment).
+Full suite on a clean worktree carrying exactly these files: Test Files 3170 passed / 4 skipped;
+Tests 49,988 passed; `EXIT=0` — `.instar/w26/deploy-evidence/candidate-v2-full-suite.log`, per-file
+shas in `candidate-v2-file-shas.txt`, independently recomputed by Observer 2 (02:45Z).
+
+## Live proofs still owed (post-deploy, by the charter)
+
+Lane 1: a throwaway autonomous run on a demo topic, stopped through the real route; the process
+gone within 60 s; route JSON, log, and human text agreeing. Lane 2: one advisory round-trip through
+the documented client with a machine-prefixed ref, then a settled grade on the meter with
+`orphanOutcomes` unchanged. Both recorded under `.instar/w26/deploy-evidence/`.
+
+## Class-Closure Declaration
+
+- **defectClass:** `unbounded-self-action` — **closure: n/a** (negative declaration). The kill is a
+  one-shot, operator-driven emergency stop: one inbound stop message produces at most one kill of
+  the named session. This change only makes the reported outcome truthful; it adds no retry, no
+  loop, and no self-triggered controller. The relay-client change is a client-side input validator
+  with no action at all.


### PR DESCRIPTION
## What this is

Window 26 lanes 1 and 2 — two control paths that reported success where the effect never happened.

**Lane 1 — an emergency stop now stops, and says so truthfully.** Both emergency-stop paths handed a tmux NAME to `killSession` (which resolves by session ID), so the kill missed silently while the route answered `killed:true`, the log printed "killed session", and the person was told "Session terminated." `SessionManager.killSessionByTmuxName` now owns the resolution and returns the real outcome; the route's `killed` field, both log paths, and the shared `emergencyStopUserMessage` text are keyed on that outcome (no-session / killed / kill-failed). The run record is preserved in every state.

**Lane 2 — the documented reply client keeps decision references byte-for-byte.** `telegram-reply.sh` clamped `--tone-decision-ref` with `tr -cd 'a-zA-Z0-9-'`, stripping the `_` in machine-prefixed refs (`d-m_03b30f-<uuid>`) so overrides landed as orphan outcomes. Replaced by a full-match shape check that passes a valid ref through intact and drops anything else. The v1.3.1199 script sha is registered as known-shipped so deployed agents receive the fix in place; the parity test reads a pinned historical fixture instead of deriving one from the current template.

## Evidence

- Must-fail arms across unit / integration / e2e for both lanes, each shown red for the right reason before the fix; both sides of each boundary covered (a kill that works still reports success; hostile refs are still rejected).
- Full suite on a clean worktree off v1.3.1199 carrying exactly these files, nothing else running: Test Files 3170 passed / 4 skipped; Tests 49,988 passed; runner `EXIT=0`.
- All 18 candidate file hashes independently recomputed and verified by Observer 2 (candidate-green sign-off, 2026-08-25T02:45:51Z).
- Ship-gate docs: `upgrades/next/w26-false-success-repairs.md` (fragment), `upgrades/side-effects/w26-false-success-repairs.md`, `docs/specs/w26-false-success-repairs.eli16.md`.

## ELI16 — what this is, in plain English

Two places in the system said "done" when nothing had happened. First: when you told me to stop a session in an emergency, the code looked the session up by the wrong kind of name, quietly found nothing, and then every report — the reply you saw, the log, the status — said it was killed anyway while it kept running. Now the lookup uses the right name, and you get one of three honest answers: nothing to stop, stopped, or "I tried and it is still running — send stop again or close it from the dashboard." Your stop request is always recorded either way. Second: when one of my messages gets held back by the tone check and I override it with a reason, that decision is supposed to be graded so the check gets smarter. A character-handling mistake was mangling the reference that ties my override to the check's decision, so the grades landed as unmatched noise. The reference now passes through untouched, and agents set up before this release pick up the corrected script automatically on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CA8NdxTFEzHLj4z23kzV7Z
