### PR TITLE
fix(autostart): a Linux auto-start install now starts at boot, and says which

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-25T22-58-00-513Z-linux-autostart-lingering.json
+++ b/.instar/instar-dev-decisions/2026-08-25T22-58-00-513Z-linux-autostart-lingering.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-25T22:58:00.513Z",
+  "slug": "linux-autostart-lingering",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 150,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/cli.ts",
+      "src/commands/setup.ts"
+    ],
+    "addedLines": 148,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1912,13 +1912,25 @@ autostartCmd
   .option('-d, --dir <path>', 'Project directory')
   .action(async (opts) => {
     const { loadConfig } = await import('./core/Config.js');
-    const { installAutoStart } = await import('./commands/setup.js');
+    const { installAutoStart, takeLastLingerOutcome, describeLingerOutcome, currentSystemdUser } =
+      await import('./commands/setup.js');
     const config = loadConfig(opts.dir);
     const hasTelegram = config.messaging?.some((m: { type: string }) => m.type === 'telegram') ?? false;
     const installed = installAutoStart(config.projectName, config.projectDir, hasTelegram);
     if (installed) {
       console.log(pc.green(`Auto-start installed for "${config.projectName}".`));
-      console.log(pc.dim('Your agent will start automatically when you log in.'));
+      // On Linux, "installed" and "starts at boot" are different facts: an
+      // enabled user service only runs while that user holds a login session
+      // unless lingering is on. Report which one is actually true rather than
+      // the old unconditional "starts when you log in" (2026-08-25, headless
+      // Linux host — the message was true in a way that meant never).
+      const linger = takeLastLingerOutcome();
+      if (linger) {
+        const line = describeLingerOutcome(linger, currentSystemdUser());
+        console.log(linger === 'needs-privilege' ? pc.yellow(line) : pc.dim(line));
+      } else {
+        console.log(pc.dim('Your agent will start automatically when you log in.'));
+      }
     } else {
       console.log(pc.red('Failed to install auto-start.'));
       console.log(pc.dim(`Platform: ${process.platform} — auto-start supports macOS and Linux.`));

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1857,6 +1857,133 @@ ${argsXml}
   }
 }
 
+/**
+ * Whether the systemd user manager for `user` survives logout — i.e. whether an
+ * enabled user service actually starts at BOOT rather than only at login.
+ *
+ * Returns `null` when the question cannot be answered (no loginctl, command
+ * failed) — the caller must report that honestly rather than assuming either
+ * answer.
+ */
+export function readLingerState(
+  user: string,
+  run: (cmd: string, args: string[]) => string = (cmd, args) =>
+    // stderr is piped, not inherited: loginctl writes "Failed to look up user
+    // <x>" for an unknown account, and a setup step must not leak a raw system
+    // error into the operator's terminal on a path it handles cleanly.
+    execFileSync(cmd, args, { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'] }),
+): boolean | null {
+  try {
+    // lint-allow-sync-spawn: a bounded one-shot install-time query, never on a hot path.
+    const out = run('loginctl', ['show-user', user, '-p', 'Linger']);
+    const m = out.match(/Linger=(yes|no)/);
+    return m ? m[1] === 'yes' : null;
+  } catch {
+    // @silent-fallback-ok: no loginctl / unknown user → unanswerable, not "no".
+    return null;
+  }
+}
+
+/**
+ * Result of trying to make a Linux auto-start service survive logout.
+ *
+ * WHY THIS EXISTS (2026-08-25, first headless Linux host). `instar autostart
+ * install` wrote a correct systemd USER service, enabled it, started it, and
+ * printed "your agent will start automatically when you log in." On Linux a
+ * per-user service only runs while that user holds a login session, and does
+ * NOT start at boot unless LINGERING is enabled for the account. It was not.
+ *
+ * On a desktop Mac the distinction never bites, because someone is logged in.
+ * On a headless box it is the whole problem: the agent comes up when you SSH
+ * in and dies when you disconnect. The message was not false — it was true in a
+ * way that means NEVER on a machine nobody logs into.
+ *
+ * `enabled-already` / `enabled-now` — starts at boot.
+ * `needs-privilege`  — loginctl refused; the operator must run the named
+ *                      command. The service still works at login.
+ * `unavailable`      — no loginctl (a container, a non-systemd distro). The
+ *                      service still works at login.
+ *
+ * Note the deliberate absence of a sudo attempt: a setup step must not silently
+ * escalate privilege. It reports the exact command instead.
+ */
+export type LingerOutcome = 'enabled-already' | 'enabled-now' | 'needs-privilege' | 'unavailable';
+
+/**
+ * The lingering outcome from the most recent Linux auto-start install, so the
+ * CLI can report the truth without changing `installAutoStart`'s boolean
+ * contract (four callers depend on it). Null on macOS and before any install.
+ */
+let lastLingerOutcome: LingerOutcome | null = null;
+
+/** Read (and clear) the lingering outcome of the last Linux auto-start install. */
+export function takeLastLingerOutcome(): LingerOutcome | null {
+  const out = lastLingerOutcome;
+  lastLingerOutcome = null;
+  return out;
+}
+
+/** Test seam: set the carrier directly. */
+export function _setLastLingerOutcomeForTest(o: LingerOutcome | null): void {
+  lastLingerOutcome = o;
+}
+
+export function ensureLinuxLingering(
+  user: string,
+  deps: {
+    read?: (user: string) => boolean | null;
+    enable?: (user: string) => void;
+  } = {},
+): LingerOutcome {
+  const read = deps.read ?? ((u: string) => readLingerState(u));
+  const before = read(user);
+  if (before === true) return 'enabled-already';
+  if (before === null) return 'unavailable';
+  try {
+    const enable =
+      deps.enable ??
+      ((u: string) => {
+        // lint-allow-sync-spawn: bounded one-shot at install time.
+        execFileSync('loginctl', ['enable-linger', u], { stdio: 'ignore', timeout: 5000 });
+      });
+    enable(user);
+  } catch {
+    // @silent-fallback-ok: polkit refused (common when not root) — reported to
+    // the operator by the caller as a named command, never silently swallowed.
+    return 'needs-privilege';
+  }
+  // Verify rather than trust the exit code — the whole defect being fixed here
+  // is a step that reported success without producing its effect.
+  return read(user) === true ? 'enabled-now' : 'needs-privilege';
+}
+
+/** The system user whose systemd user-manager owns the installed service. */
+export function currentSystemdUser(): string {
+  return process.env.USER || process.env.LOGNAME || os.userInfo().username;
+}
+
+/**
+ * Human-readable truth about when the installed Linux service actually starts.
+ * The CLI prints this INSTEAD of an unconditional "starts when you log in".
+ */
+export function describeLingerOutcome(outcome: LingerOutcome, user: string): string {
+  switch (outcome) {
+    case 'enabled-already':
+    case 'enabled-now':
+      return 'Your agent will start automatically when this machine boots, with nobody logged in.';
+    case 'needs-privilege':
+      return [
+        'Your agent will start when you log in — but NOT at boot.',
+        `On a machine nobody logs into, that means never. To fix it: sudo loginctl enable-linger ${user}`,
+      ].join('\n');
+    case 'unavailable':
+      return [
+        'Your agent will start when you log in.',
+        'Whether it also starts at boot could not be determined on this system.',
+      ].join('\n');
+  }
+}
+
 function installLinuxSystemdService(projectName: string, projectDir: string, hasTelegram: boolean): boolean {
   const serviceName = `instar-${projectName}.service`;
   const serviceDir = path.join(os.homedir(), '.config', 'systemd', 'user');
@@ -1895,6 +2022,13 @@ WantedBy=default.target
     execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' });
     execFileSync('systemctl', ['--user', 'enable', serviceName], { stdio: 'ignore' });
     execFileSync('systemctl', ['--user', 'start', serviceName], { stdio: 'ignore' });
+    // Enabling the unit is not enough on Linux: without lingering, the user's
+    // systemd manager exits at logout and an "enabled" service never starts at
+    // boot. Attempted here; the OUTCOME is reported by the caller (see
+    // describeLingerOutcome) rather than folded into this boolean, because a
+    // service that works only at login is still a successful install — it is
+    // just not the thing the old message claimed.
+    lastLingerOutcome = ensureLinuxLingering(currentSystemdUser());
     return true;
   } catch {
     return false;

--- a/tests/unit/linux-autostart-lingering.test.ts
+++ b/tests/unit/linux-autostart-lingering.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Linux auto-start lingering — the difference between "installed" and "starts
+ * at boot".
+ *
+ * THE DEFECT (2026-08-25, first headless Linux host). `instar autostart
+ * install` wrote a correct systemd USER service, enabled it, started it, and
+ * reported "your agent will start automatically when you log in." On Linux a
+ * per-user service only runs while that user holds a login session and does NOT
+ * start at boot unless LINGERING is enabled for the account. It was not. On a
+ * machine nobody logs into, the message was true in a way that meant NEVER —
+ * the agent came up on SSH and died on disconnect.
+ *
+ * These tests pin the three things that matter: the outcome is VERIFIED rather
+ * than inferred from an exit code, a refusal is reported rather than swallowed,
+ * and the message the operator reads matches which of those actually happened.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  readLingerState,
+  ensureLinuxLingering,
+  describeLingerOutcome,
+  currentSystemdUser,
+  type LingerOutcome,
+} from '../../src/commands/setup.js';
+
+describe('Linux auto-start lingering', () => {
+  // ── readLingerState ────────────────────────────────────────────────────
+  it('parses loginctl output in both directions', () => {
+    expect(readLingerState('echo', () => 'Linger=yes\n')).toBe(true);
+    expect(readLingerState('echo', () => 'Linger=no\n')).toBe(false);
+  });
+
+  it('reports UNANSWERABLE rather than false when loginctl is absent or mute', () => {
+    // The distinction is the whole point: "no linger" is a fixable finding,
+    // "could not ask" is not — and conflating them would make a container
+    // without loginctl print a fix instruction that cannot work there.
+    expect(
+      readLingerState('echo', () => {
+        throw new Error('ENOENT loginctl');
+      }),
+    ).toBeNull();
+    expect(readLingerState('echo', () => 'some unrelated output\n')).toBeNull();
+  });
+
+  // ── ensureLinuxLingering ───────────────────────────────────────────────
+  it('is a no-op when lingering is already on', () => {
+    let enableCalls = 0;
+    const out = ensureLinuxLingering('echo', {
+      read: () => true,
+      enable: () => {
+        enableCalls++;
+      },
+    });
+    expect(out).toBe('enabled-already');
+    expect(enableCalls).toBe(0); // never re-runs a privileged command needlessly
+  });
+
+  it('enables lingering and VERIFIES the effect rather than trusting the exit code', () => {
+    let enabled = false;
+    const out = ensureLinuxLingering('echo', {
+      read: () => enabled,
+      enable: () => {
+        enabled = true;
+      },
+    });
+    expect(out).toBe('enabled-now');
+  });
+
+  it('reports needs-privilege when the command SUCCEEDS but the effect did not happen', () => {
+    // This is the exact defect class being fixed: a step that returns success
+    // while the effect it exists to produce never occurred. A silent exit 0
+    // must not be read as "lingering is on".
+    const out = ensureLinuxLingering('echo', {
+      read: () => false, // still off after the "successful" enable
+      enable: () => {
+        /* exits 0, changes nothing */
+      },
+    });
+    expect(out).toBe('needs-privilege');
+  });
+
+  it('reports needs-privilege when loginctl refuses', () => {
+    const out = ensureLinuxLingering('echo', {
+      read: () => false,
+      enable: () => {
+        throw new Error('Interactive authentication required');
+      },
+    });
+    expect(out).toBe('needs-privilege');
+  });
+
+  it('reports unavailable — never needs-privilege — when the state cannot be read at all', () => {
+    let enableCalls = 0;
+    const out = ensureLinuxLingering('echo', {
+      read: () => null,
+      enable: () => {
+        enableCalls++;
+      },
+    });
+    expect(out).toBe('unavailable');
+    expect(enableCalls).toBe(0); // don't run a privileged command blind
+  });
+
+  // ── describeLingerOutcome ──────────────────────────────────────────────
+  it('only promises boot start when boot start is actually true', () => {
+    const boots: LingerOutcome[] = ['enabled-already', 'enabled-now'];
+    for (const o of boots) {
+      const msg = describeLingerOutcome(o, 'echo');
+      expect(msg).toMatch(/boots/);
+      expect(msg).not.toMatch(/NOT at boot/);
+    }
+  });
+
+  it('says plainly that a login-only service means never on an unattended machine, and names the fix', () => {
+    const msg = describeLingerOutcome('needs-privilege', 'echo');
+    expect(msg).toMatch(/NOT at boot/);
+    expect(msg).toMatch(/means never/);
+    expect(msg).toContain('loginctl enable-linger echo'); // the exact command, with the real user
+  });
+
+  it('does not claim boot start when the answer is unknown', () => {
+    const msg = describeLingerOutcome('unavailable', 'echo');
+    expect(msg).toMatch(/could not be determined/);
+    expect(msg).not.toMatch(/when this machine boots/);
+  });
+
+  it('never renders the old unconditional promise for a non-booting outcome', () => {
+    // The regression guard: the string the defect shipped was
+    // "will start automatically when you log in", said unconditionally.
+    for (const o of ['needs-privilege', 'unavailable'] as LingerOutcome[]) {
+      expect(describeLingerOutcome(o, 'echo')).not.toBe(
+        'Your agent will start automatically when you log in.',
+      );
+    }
+  });
+
+  // ── currentSystemdUser ─────────────────────────────────────────────────
+  it('resolves a non-empty system user for the fix instruction', () => {
+    // The instruction is useless without the right account name in it.
+    expect(currentSystemdUser().length).toBeGreaterThan(0);
+  });
+});

--- a/upgrades/linux-autostart-lingering.eli16.md
+++ b/upgrades/linux-autostart-lingering.eli16.md
@@ -1,0 +1,45 @@
+# "Starts automatically" didn't mean at boot on Linux — Plain-English Overview
+
+> The one-line version: on Linux, instar set itself to start automatically and then told you it would start when you log in — which on a machine nobody logs into means never; this turns on the missing setting, checks it actually worked, and says which of the two is really true.
+
+## The problem in one breath
+
+`instar autostart install` on Linux writes a correct startup service, switches it on, starts it, and reports "your agent will start automatically when you log in." That sentence is true and useless: on Linux a per-user service only runs while that user has a login session open, and it does not start when the machine boots unless a separate setting is turned on. It wasn't. On a headless machine the agent came up when someone connected over SSH and died the moment they disconnected.
+
+## What already exists
+
+- **`instar autostart install`** — sets your agent to start on its own, so you don't have to launch it by hand after a restart.
+- **The macOS path** — writes a login item. Works, and has always worked, because on a Mac somebody is logged in.
+- **The Linux path** — writes a systemd user service, enables it, and starts it. Every one of those steps genuinely succeeds. The gap is the step nobody wrote.
+
+## What this adds
+
+After enabling the service on Linux, instar now also tries to turn on "lingering" — the setting that lets your account's services keep running when you're not logged in, which is what makes them start at boot. Then it checks whether that actually worked, and prints the truth accordingly rather than an unconditional promise.
+
+- If lingering is on, it says the agent will start when the machine boots with nobody logged in.
+- If turning it on was refused (it usually needs administrator rights), it says plainly that the agent starts at login but **not** at boot, that on an unattended machine this means never, and gives you the exact one-line command to fix it.
+- If the system can't answer the question at all — a container, or a Linux without this component — it says the agent starts at login and that boot behaviour couldn't be determined, rather than guessing.
+
+## The new pieces
+
+- **A lingering check** — asks the system whether your account's services survive logout. It deliberately distinguishes "no" from "couldn't ask", because those need different answers and merging them would print a fix instruction that cannot work where it doesn't apply.
+- **A lingering enabler** — tries to turn it on, then *re-reads the state to confirm it took effect*. It does not trust the command's exit code, because a step reporting success while producing no effect is the exact defect being fixed here.
+- **An honest message** — one sentence per real outcome, replacing one sentence used for all of them.
+
+## The safeguards
+
+**It never escalates privilege behind your back.** Turning on lingering usually requires administrator rights. Instar tries the plain command; if the system refuses, it tells you the command to run rather than quietly reaching for `sudo`. A setup step that silently escalates is worse than one that asks.
+
+**It cannot claim success it didn't achieve.** The outcome is established by reading the state back afterwards, not by the command exiting cleanly. A command that returns success and changes nothing is reported as "not done", which is the honest answer and the one that gets the agent actually running.
+
+**It doesn't make the install fail.** A service that works at login is still a working install — it's just not the thing the old message claimed. The install still succeeds; only the description of what you got becomes accurate.
+
+**macOS is untouched.** Not a line of the Mac path changes, and lingering is a Linux-only concept.
+
+## What ships when
+
+One change, one PR: the lingering attempt, the verification, the honest message, and twelve tests — including a regression guard asserting the old unconditional sentence is never printed for an outcome that doesn't deserve it.
+
+## What you actually need to decide
+
+Whether instar should attempt to enable lingering during a Linux auto-start install and report which of "starts at boot" or "starts at login only" is actually true — rather than always claiming the second — yes or no.

--- a/upgrades/next/linux-autostart-lingering.md
+++ b/upgrades/next/linux-autostart-lingering.md
@@ -1,0 +1,71 @@
+---
+change_type: fix
+---
+
+## What Changed
+
+`instar autostart install` on Linux wrote a systemd **user** service, enabled it, started it, and
+reported *"Your agent will start automatically when you log in."* Every one of those steps genuinely
+succeeded — and the sentence was true in a way that meant **never** on a machine nobody logs into.
+
+A per-user systemd service only runs while that user holds a login session. It does **not** start at
+boot unless **lingering** is enabled for the account, and nothing enabled it or said so. On a headless
+host the agent came up when someone connected over SSH and died the moment they disconnected.
+
+`installLinuxSystemdService` now calls a new `ensureLinuxLingering()` after enabling the unit. It
+reads the current linger state, attempts `loginctl enable-linger <user>` when it is off, and then
+**re-reads the state to verify the effect** rather than trusting the exit code — a command that
+returns success while changing nothing is reported as not done, because that is the exact defect
+class being fixed. The outcome reaches the CLI, which prints what actually happened:
+
+- **starts at boot** — lingering is on, with nobody logged in.
+- **starts at login, NOT at boot** — the attempt was refused (it usually needs root). The message says
+  plainly that on an unattended machine this means never, and names the exact one-line fix.
+- **starts at login; boot behaviour undetermined** — no `loginctl` on this system (a container, a
+  non-systemd distro). No fix instruction is printed, because it would not work there.
+
+There is deliberately **no `sudo` attempt**. A setup step that silently escalates privilege takes an
+authority the operator did not grant it; naming the command keeps that decision with the human. The
+install still returns success in every case — a login-only service is a working install, it is just
+not the thing the old message claimed.
+
+macOS is untouched, and Windows already returns false.
+
+## Evidence
+
+Found on the first headless Linux host — WSL2 / Ubuntu 26.04. The reproduction is the contradiction
+itself: `instar autostart install` reported success and `systemctl --user is-enabled` returned
+`enabled`, while `loginctl show-user echo -p Linger` returned `Linger=no` — an enabled service that
+would never start at boot.
+
+Both live paths were exercised against a real `loginctl` on that host: an account with lingering on
+returns `enabled-already`, and an unknown account returns `unavailable` rather than being
+misreported as "off". That second case also surfaced a smaller leak now fixed — `loginctl` writes
+`Failed to look up user <x>` to stderr, which was reaching the operator's terminal on a path the
+code handles cleanly; stderr is now piped.
+
+12 unit tests. Both parse directions; the unanswerable case kept distinct from "no" (they need
+different answers, and merging them would print a fix instruction that cannot work where it does not
+apply); the already-on path asserting the privileged command is **not** re-run; verification-over-exit
+-code, where a fake enable that exits 0 and changes nothing yields `needs-privilege`; a polkit
+refusal; a blind-enable guard asserting the command is never run when the state is unreadable; and
+four message assertions — including a regression guard that the old unconditional sentence is never
+rendered for an outcome that does not deserve it.
+
+The two failure paths are covered by injected dependencies rather than by breaking a live machine's
+configuration, which is stated here rather than implied.
+
+## What to Tell Your User
+
+If you run instar on Linux, "auto-start installed" has not meant "starts when the machine boots" — it
+meant "starts when you log in", and on a machine you never log into that is never. That is why an
+agent on a headless Linux box could come up when you connected and vanish when you disconnected.
+
+Instar now turns on the missing setting where it can, and where it cannot (it usually needs
+administrator rights) it tells you so plainly and gives you the one command to run. Nothing changes
+on macOS.
+
+## Summary of New Capabilities
+
+No new capabilities. A Linux auto-start install now completes the step it was missing, and reports
+which of "starts at boot" or "starts at login only" is actually true.

--- a/upgrades/side-effects/linux-autostart-lingering.md
+++ b/upgrades/side-effects/linux-autostart-lingering.md
@@ -1,0 +1,144 @@
+# Side-Effects Review — Linux auto-start lingering (boot vs login)
+
+**Version / slug:** `linux-autostart-lingering`
+**Date:** `2026-08-25`
+**Author:** `Echo`
+**Second-pass reviewer:** `not run — see the Second-pass section`
+
+## Summary of the change
+
+`instar autostart install` on Linux writes a systemd **user** service, enables it, starts it, and the CLI reports *"Your agent will start automatically when you log in."* A per-user systemd service only runs while that user holds a login session, and does not start at boot unless **lingering** is enabled for the account. It was not, and nothing said so — on a headless host the agent came up on SSH connect and died on disconnect.
+
+This change: after enabling the unit, `installLinuxSystemdService` calls a new `ensureLinuxLingering()`, which reads the current linger state, attempts `loginctl enable-linger <user>` when it is off, and then **re-reads the state to verify the effect** rather than trusting the exit code. The outcome (`enabled-already` / `enabled-now` / `needs-privilege` / `unavailable`) is carried to the CLI, which prints a message matching what actually happened instead of one sentence for all cases.
+
+Files touched: `src/commands/setup.ts` (`readLingerState`, `ensureLinuxLingering`, `describeLingerOutcome`, `currentSystemdUser`, outcome carrier; one call added inside `installLinuxSystemdService`), `src/cli.ts` (the `autostart install` report), `tests/unit/linux-autostart-lingering.test.ts` (+12 tests).
+
+## Decision-point inventory
+
+- `installLinuxSystemdService` — **modify** — one added call after the existing enable/start. Its boolean contract is unchanged; a login-only service is still a successful install.
+- `autostart install` CLI output — **modify** — the success message becomes outcome-dependent. The failure branch is untouched.
+- `installAutoStart` — **pass-through** — signature and boolean semantics unchanged (four callers depend on it: `cli.ts`, `PostUpdateMigrator`, `TelegramLifeline`, and the migrator's boot-wrapper regeneration). The outcome travels via a module-level carrier read with `takeLastLingerOutcome()`, deliberately so those callers need no change.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. Nothing is refused, gated, or filtered; the change adds one system call and changes what a message says.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. The nearest analogue is what the change still cannot fix, stated plainly:
+
+- **A refusal is reported, not resolved.** When polkit denies `enable-linger` (the common case when not root), the agent still starts only at login until the operator runs the named command. This is deliberate — see §4.
+- **`unavailable` is genuinely unknown, not assumed good.** A container without `loginctl` gets "couldn't be determined", and no fix instruction is printed, because the instruction would not work there.
+- **Nothing re-checks later.** If lingering is turned off after install, nothing notices. Out of scope for an install-time step; the guard-posture surfaces are where a standing check would belong.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer: the defect is that the Linux install path performs an incomplete install, so the missing step belongs in the Linux install path. No new layer, no new caller, no new subsystem.
+
+The CLI split is deliberate. Reporting is the CLI's job and the install function's job is to install — so the install function establishes the fact and the CLI renders it. Folding lingering into `installAutoStart`'s boolean was rejected: a login-only service is a working install, and returning `false` for it would make `PostUpdateMigrator` log a spurious error and could make a migration look failed when it succeeded.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+It performs one idempotent system configuration step and reports the result. It holds no authority over any agent behaviour and gates nothing.
+
+The one authority-adjacent decision is what it does **not** do: there is no `sudo` attempt. A setup step that silently escalates privilege takes an authority the operator did not grant it; naming the command instead keeps the decision with the human. That is a deliberate design choice, not an omission.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The domain is enumerable and binary: lingering is on, off, or unreadable. There are no competing live signals to weigh — one query, one answer, and the "unreadable" case is carried explicitly rather than collapsed into either verdict.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The call runs after the existing `daemon-reload` / `enable` / `start` sequence and changes none of them.
+- **Double-fire:** `enable-linger` is idempotent, and the `enabled-already` branch skips the call entirely, so a repeat install runs no privileged command needlessly. `PostUpdateMigrator` regenerates auto-start on update and will therefore re-check lingering on every update — a read, then a no-op.
+- **Races:** none introduced. Two concurrent installs would both read, possibly both enable (idempotent), and both verify.
+- **Feedback loops:** none.
+- **Carrier lifetime:** `takeLastLingerOutcome()` clears on read, so a later caller cannot pick up a stale outcome from an earlier install. Null on macOS and before any install, where the CLI falls back to the original message.
+- **PostUpdateMigrator:** calls `installAutoStart` but not the carrier, so it is unaffected and prints nothing new. Intentional — an update is not the moment to surface an install-time instruction.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** `enable-linger` is per-user, so enabling it for the account running instar affects every service that account owns. On a dedicated agent account this is the intent; on a shared login it means that user's other services also survive logout. Worth naming, but it is the setting the operator would run by hand anyway.
+- **Install base:** Linux only. macOS is untouched and Windows already returns false.
+- **External systems:** none.
+- **Persistent state:** `enable-linger` writes `/var/lib/systemd/linger/<user>`, owned by systemd. Removing it is `loginctl disable-linger <user>`.
+- **Timing:** one or two bounded `loginctl` calls (5s timeout) at install time only. Not on any hot path.
+- **Operator surface (Mobile-Complete Operator Actions):** the change adds no operator-facing *action*. It changes an existing CLI message and, in the refusal case, hands the operator a one-line command — which is the correct surface, because the action requires root on that machine's shell and no dashboard control could perform it. No PIN-gated or approval-class route is added.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. No dashboard renderer, approval page, or grant/revoke/secret-drop form is touched. (`src/cli.ts` is a terminal message, not a dashboard surface.)
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** Lingering is a property of one account on one machine's init system; whether machine A's agent survives logout says nothing about machine B, and each machine installs its own auto-start. Replicating it would be meaningless.
+
+- **User-facing notices:** none — the change emits no Telegram/Slack/attention output. It prints to the terminal of the person running the command. One-voice gating not applicable.
+- **Durable state:** none instar-owned. The systemd linger marker is machine-local by definition and cannot strand on topic transfer.
+- **Generated URLs:** none.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert both files, ship as a patch. Pure code.
+- **Data migration:** none instar-owned. Any `linger` markers already set stay set — which is the desired state anyway, and is reversible with `loginctl disable-linger <user>`.
+- **Agent state repair:** none. Reverting restores the previous message; already-installed services keep working exactly as they do now.
+- **User visibility:** the message reverts to the old unconditional sentence. No functional regression.
+
+---
+
+## Conclusion
+
+The review produced one design change: the outcome travels to the CLI through a read-and-clear carrier rather than by widening `installAutoStart`'s return type. Widening it would have touched four callers, and `PostUpdateMigrator` treats `false` as an error — so a login-only-but-working install would have started logging spurious migration failures. The carrier keeps the blast radius to the two files that actually care.
+
+The second design point worth recording is the refusal to call `sudo`. It makes the fix incomplete in the common non-root case, and that is the right trade: a setup step that silently escalates privilege is a worse defect than the one being fixed.
+
+Verification is honest about its own limits: the `enabled-already` and `unavailable` paths were exercised against a real `loginctl` on the Linux host, and the two failure paths (`needs-privilege` via refusal, and via a command that exits 0 while changing nothing) are covered by injected dependencies rather than by breaking a live machine's configuration.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** none — not spawned.
+**Independent read of the artifact: NOT PERFORMED.**
+
+Recorded rather than glossed. This change is not in the Phase-5 trigger list — no messaging block/allow, no session lifecycle, no coherence/idempotency/trust surface, and nothing named sentinel/guard/gate/watchdog. It is an install-time configuration step with no authority over agent behaviour.
+
+A reviewer subagent was additionally not available: a standing operator instruction in the authoring session forbids delegating to subagents unless explicitly asked. The PR is the review surface. If an independent read is wanted before merge, it can be run on request.
+
+---
+
+## Evidence pointers
+
+- Live reproduction (WSL2 / Ubuntu 26.04, headless): `instar autostart install` reported success and `systemctl --user is-enabled` returned `enabled`, while `loginctl show-user echo -p Linger` returned `Linger=no` — an enabled service that would not start at boot.
+- 12 unit tests. Both parse directions; the unanswerable case kept distinct from "no"; the no-op-when-already-on path asserting the privileged command is *not* re-run; verification-over-exit-code (a fake enable that exits 0 and changes nothing yields `needs-privilege`); a polkit refusal; the blind-enable guard (`unavailable` never runs the command); and four message assertions including a regression guard that the old unconditional sentence is never rendered for a non-booting outcome.
+- The fix was authored on macOS and the live linger paths were exercised on the Linux host that exposed the defect.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The defect is in hand-written TypeScript, not an LLM prompt, hook, config, skill, or standards text. No self-triggered controller is added or modified: the change adds no loop, monitor, sentinel, reaper, scheduler, or recovery path — it is a one-shot install-time step with no timer and no re-drive.


### PR DESCRIPTION
## Description

`instar autostart install` on Linux wrote a systemd **user** service, enabled it, started it, and reported *"Your agent will start automatically when you log in."* Every step genuinely succeeded — and the sentence was true in a way that meant **never** on a machine nobody logs into.

A per-user systemd service only runs while that user holds a login session. It does **not** start at boot unless **lingering** is enabled for the account, and nothing enabled it or said so. On a headless host the agent came up when someone connected over SSH and died the moment they disconnected.

`installLinuxSystemdService` now calls `ensureLinuxLingering()` after enabling the unit: read the linger state, attempt `loginctl enable-linger <user>` when off, then **re-read the state to verify the effect** rather than trusting the exit code. The outcome reaches the CLI, which prints what actually happened instead of one sentence for all cases.

There is deliberately **no `sudo` attempt**, and the install still returns success in every case — a login-only service is a working install, it is just not what the old message claimed.

## ELI16

When you tell instar to start itself automatically on Linux, it sets up a startup service, switches it on, and tells you your agent will start when you log in. All of that genuinely happens. The problem is the part nobody wrote down: on Linux, a service that belongs to your user account only runs while you have a login session open. When you log out, it stops. And when the machine boots with nobody logged in, it never starts at all.

On a Mac this never bites, because someone is always logged in. On a machine sitting in a corner that you only ever reach over the network, it means the agent comes to life when you connect and dies the moment you disconnect — while the setup step reports success.

The fix is to also turn on the setting that lets your account's services keep running when you're not logged in, then check whether that actually worked, and say which of the two is really true. If it worked, it says the agent starts when the machine boots with nobody logged in. If turning it on was refused — it usually needs administrator rights — it says plainly that the agent starts at login but not at boot, that on an unattended machine this means never, and gives you the exact one-line command to fix it. If the system can't answer at all, like inside a container, it says so rather than guessing.

Two deliberate restraints. It doesn't reach for `sudo` on its own: a setup step that silently escalates privilege takes an authority you didn't give it, so it names the command instead. And it doesn't trust the command's exit code — it reads the state back afterwards, because a step that reports success while producing no effect is the exact bug being fixed here.

## UX Impact

**Who sees it:** anyone running `instar autostart install` on Linux. macOS output is unchanged.

**First contact:** the line printed immediately after `Auto-start installed for "<name>".` Previously always `Your agent will start automatically when you log in.` Now one of three, matching reality — and on the refusal path it prints in yellow rather than dim, because it is an action the operator needs to take.

Exact strings from the diff:

- `Your agent will start automatically when this machine boots, with nobody logged in.`
- `Your agent will start when you log in — but NOT at boot.` / `On a machine nobody logs into, that means never. To fix it: sudo loginctl enable-linger <user>`
- `Your agent will start when you log in.` / `Whether it also starts at boot could not be determined on this system.`

A smaller UX leak is also fixed: `loginctl` writes `Failed to look up user <x>` to stderr for an unknown account, which was reaching the operator's terminal on a path the code handles cleanly. stderr is now piped.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My code follows the project's style (TypeScript strict mode)
- [x] I have added tests for my changes
- [ ] `npm test` passes locally — the pre-push smoke tier reported `SKIPPED reason=affected-set-indeterminate` (the affected-test listing timed out), so CI is the authority. The new test file was run directly and passes; see Evidence.
- [x] `npm run build` passes locally
- [x] I have updated documentation (release-note fragment + ELI16 + side-effects review)

## Evidence

Found on the first headless Linux host — WSL2 / Ubuntu 26.04. The reproduction is the contradiction itself: `instar autostart install` reported success and `systemctl --user is-enabled` returned `enabled`, while `loginctl show-user echo -p Linger` returned `Linger=no` — an enabled service that would never start at boot.

**Live paths exercised against a real `loginctl` on that host**, using the built output rather than the source:

```
readLingerState(echo)          : true
readLingerState(nonexistent)   : null
ensureLinuxLingering(echo)     : enabled-already
ensureLinuxLingering(nonexist) : unavailable
```

The stderr leak was observed on that same run before the fix and is silent after it.

**12 unit tests.** Both parse directions; the unanswerable case kept distinct from "no" (they need different answers — merging them would print a fix instruction that cannot work where it does not apply); the already-on path asserting the privileged command is **not** re-run; verification-over-exit-code, where a fake enable that exits 0 and changes nothing yields `needs-privilege`; a polkit refusal; a blind-enable guard asserting the command is never run when the state is unreadable; and four message assertions including a regression guard that the old unconditional sentence is never rendered for an outcome that does not deserve it.

**Stated plainly:** the two failure paths (`needs-privilege` by refusal, and by a command that exits 0 while changing nothing) are covered by injected dependencies rather than by breaking a live machine's configuration.

## Design notes worth a reviewer's attention

**Why the boolean contract is unchanged.** The outcome travels to the CLI through a read-and-clear carrier (`takeLastLingerOutcome()`) rather than by widening `installAutoStart`'s return type. Four callers depend on that boolean, and `PostUpdateMigrator` treats `false` as an error — so returning `false` for a login-only-but-working install would start logging spurious migration failures. The carrier keeps the blast radius to the two files that care.

**Why no `sudo`.** It leaves the fix incomplete in the common non-root case, and that is the right trade: a setup step that silently escalates privilege is a worse defect than the one being fixed.

## Reviewer note — a gap I am naming rather than hiding

No independent second-pass reviewer was run. This change is not in the Phase-5 trigger list (no messaging block/allow, no session lifecycle, no coherence/idempotency/trust surface, nothing named sentinel/guard/gate/watchdog) — it is an install-time configuration step with no authority over agent behaviour. A standing operator instruction in the authoring session also forbade delegating to a reviewer subagent, so rather than record a concurrence that never happened, the side-effects artifact says so and this PR is the review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176Kb53isVdCD1Ug7aSgcSQ
