### PR TITLE
fix(credentials): a Google account backing two subscriptions is not a missing login

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-26T17-24-00-246Z-credential-identity-dual-subscription-email.json
+++ b/.instar/instar-dev-decisions/2026-08-26T17-24-00-246Z-credential-identity-dual-subscription-email.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-08-26T17:24:00.246Z",
+  "slug": "credential-identity-dual-subscription-email",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 140,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/CredentialLocationLedger.ts",
+      "src/core/InUseAccountResolver.ts"
+    ],
+    "addedLines": 120,
+    "deletedLines": 20
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/credential-identity-dual-subscription-email.eli16.md
+++ b/docs/specs/credential-identity-dual-subscription-email.eli16.md
@@ -1,0 +1,97 @@
+# Why two working accounts kept saying "sign in again" — plain English
+
+## What the operator saw
+
+Four machines, eight subscription accounts. Every time he looked, a handful of them
+were showing "this account needs signing in again" on the dashboard. Each one costs
+about fifteen taps to clear: click sign in, pick the Google account, close the tab
+that cancels the flow, click sign in again, authorize, copy the code, paste it,
+submit. Doing that on repeat, forever, is what prompted "this is getting exhausting."
+
+## What was actually happening
+
+Two of the six Claude accounts on this machine had been flagged "needs owner
+sign-in" since Monday morning. I checked them directly. Both logins were **present,
+valid, unexpired, with working refresh tokens, on Max subscriptions**. When I asked
+the system's own identity check about them, both answered instantly and correctly.
+
+They did not need signing in. They never did.
+
+## The bug
+
+To work out which account a stored login belongs to, the system asks Anthropic
+"whose login is this?", gets an email back, and then looks that email up in the list
+of subscription accounts. It insists on finding **exactly one** match — sensibly, because
+this answer is used to decide whether to physically move credentials between folders,
+and guessing there would be genuinely dangerous.
+
+But the lookup searched the *whole* account list — Claude accounts and Codex accounts
+together.
+
+The operator uses the same Google account for both kinds of subscription. One Gmail
+address backs a Claude subscription *and* a Codex subscription. So the lookup found
+two rows, concluded the answer was ambiguous, and gave up. Giving up is reported as
+"identity unavailable," and further down the chain "identity unavailable" is written
+into the account record as the words **missing local login**.
+
+The correlation is exact and it is the whole story: six Claude accounts on this
+machine, and the only two ever flagged are precisely the two whose Google account
+also backs a Codex subscription. The other four have unique emails and have never
+been flagged once.
+
+## Why it could never fix itself
+
+The code that would *clear* the flag once a login is healthy performs the same lookup.
+It gets the same "can't tell" answer, and it is deliberately written to never change a
+recorded state on an uncertain reading — which is the right instinct, and here it meant
+the flag latched permanently. Signing in again did not help, because signing in was
+never the problem. That is why it had been stuck since 3:29am on Monday.
+
+There was a second, quieter symptom: an account carrying this flag is excluded from the
+pool the agent draws capacity from. So two paid Max subscriptions sat unused for a day
+and a half on a machine that was reporting them broken.
+
+## The fix
+
+Scope the lookup to Claude accounts when the question came from Anthropic's Claude
+endpoint. An email issued by Anthropic's Claude service cannot possibly denote a Codex
+account, so a Codex row was never a legitimate candidate and should never have been in
+the comparison.
+
+The rule that fixes this was already written down, one file over. A sibling function
+that answers the very similar question "which account is this session running on" has
+scoped itself to Claude accounts since the day it was written, with a comment saying
+exactly why. The credential resolver simply never inherited it — it re-implemented the
+lookup from scratch and left the scope out.
+
+So rather than paste the rule into a second place and leave two copies to drift apart
+again, the change lifts it into one shared, documented function that both callers use.
+That is the actual repair: not the missing filter, but the fact that the filter had two
+homes and only one of them knew about it.
+
+## What deliberately did NOT change
+
+Real ambiguity still fails closed. If two *Claude* accounts genuinely shared an email,
+the resolver still refuses to guess, exactly as before — because this answer authorizes
+moving credential files between folders, and a wrong guess there could put the wrong
+login in the wrong place. Only the false ambiguity is gone.
+
+An oracle that cannot answer at all — network down, no token, a rejected token — is
+still treated as unavailable and still quarantines the slot. Nothing about that path
+moved. The change makes a *correct* answer reachable; it does not make an *uncertain*
+one acceptable.
+
+## What this does not fix
+
+It does not tell anyone how often sign-ins genuinely go stale. Nothing has ever
+recorded a sign-in, so the real rate is still unknown, and this fix removes one
+manufactured source of churn without measuring what remains. That measurement is a
+separate piece of work, and it matters that it comes before any attempt to automate the
+sign-in flow: a robot built to re-sign accounts on this signal would have spent its life
+re-signing two accounts that were fine.
+
+## How to check it worked
+
+The two accounts should clear their flag on the next identity pass and return to the
+usable pool without anybody signing in to anything. If they clear without a single tap,
+that is the proof — the login was there the whole time.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13696,13 +13696,21 @@ export async function startServer(options: StartOptions): Promise<void> {
     });
     // Compose the host identity resolver: REAL oracle (slot blob → email) → pool (email → accountId).
     const { CredentialIdentityOracle: CredSwapOracle } = await import('../core/CredentialIdentityOracle.js');
+    const { resolveClaudeSlotAccountId } = await import('../core/InUseAccountResolver.js');
     const credSwapOracle = new CredSwapOracle();
     const credResolveIdentity: import('../core/CredentialSwapExecutor.js').ResolveSlotIdentity = async (slot: string) => {
-      const r = await credSwapOracle.resolveSlotTenant(slot);
-      if (r.unavailable || !r.email) return { unavailable: true, reason: r.reason ?? 'oracle unavailable' };
-      const matches = subscriptionPool.list().filter((a) => a.email && a.email === r.email);
-      if (matches.length !== 1) return { unavailable: true, reason: `ambiguous/unknown email (${matches.length} pool matches)` };
-      return { accountId: matches[0].id };
+      // The oracle probed Anthropic's OAuth profile endpoint, so its email denotes a CLAUDE
+      // login and nothing else. The pool mapping lives in `resolveClaudeSlotAccountId` — one
+      // shared, tested definition — because this lookup previously searched the WHOLE pool:
+      // an operator who backs a Claude subscription AND a Codex subscription with the same
+      // Google account has two rows carrying one email, and the unscoped lookup read that as
+      // a genuine 2-way collision -> `unavailable` -> `missing-local-login`, asking the
+      // operator to re-authenticate a login that was present, unexpired and valid. Verified
+      // 2026-08-26: both of this machine's flagged accounts were exactly the dual-subscription
+      // pair, and both resolved cleanly through the oracle. A collision WITHIN claude-code is
+      // still genuine ambiguity and still fails closed — this resolver gates credential MOVES,
+      // so it must never guess which of two homes a blob belongs to.
+      return resolveClaudeSlotAccountId(subscriptionPool.list(), await credSwapOracle.resolveSlotTenant(slot));
     };
     let quotaPollerRef: import('../core/QuotaPoller.js').QuotaPoller | null = null;
     const credentialSwapExecutor = new CredentialSwapExecutor({

--- a/src/core/CredentialLocationLedger.ts
+++ b/src/core/CredentialLocationLedger.ts
@@ -28,6 +28,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { emailEquals } from './InUseAccountResolver.js';
 
 /** The on-disk schema version this module writes. Bumped only on a breaking shape change. */
 export const CREDENTIAL_LEDGER_SCHEMA_VERSION = 1;
@@ -463,7 +464,7 @@ export class CredentialLocationLedger {
         continue;
       }
 
-      const matches = claudeAccounts.filter((a) => a.email && a.email === result.email);
+      const matches = claudeAccounts.filter((a) => emailEquals(a.email, result.email));
       if (matches.length === 1) {
         this.store.assignments.push({
           slot,
@@ -554,7 +555,7 @@ export class CredentialLocationLedger {
         continue;
       }
 
-      const matches = claudeAccounts.filter((a) => a.email && a.email === result.email);
+      const matches = claudeAccounts.filter((a) => emailEquals(a.email, result.email));
       if (matches.length === 1) {
         const matchId = matches[0].id;
         if (!existing.quarantined && existing.accountId === matchId) {

--- a/src/core/InUseAccountResolver.ts
+++ b/src/core/InUseAccountResolver.ts
@@ -99,26 +99,117 @@ export function defaultAuthStatusProbe(): Promise<string | null> {
   });
 }
 
+/** Structural minimum an account must expose to be matched by email. */
+export interface EmailMatchableAccount {
+  id: string;
+  email?: string;
+  framework?: string;
+}
+
+/**
+ * Pure: normalized email equality (trimmed, case-insensitive).
+ *
+ * An identity oracle returns whatever casing the provider stored; a pool row holds
+ * whatever casing the operator typed at enrollment. Comparing them with raw `===`
+ * makes the answer depend on that accident, and the failure is silent and total —
+ * a non-match is reported as "identity unavailable", which downstream reads as a
+ * missing login. Every email comparison against an oracle answer goes through here.
+ */
+export function emailEquals(a: string | null | undefined, b: string | null | undefined): boolean {
+  if (!a || !b) return false;
+  const left = a.trim().toLowerCase();
+  const right = b.trim().toLowerCase();
+  return left.length > 0 && left === right;
+}
+
+/**
+ * Pure: EVERY pool account an Anthropic-issued email can legitimately denote.
+ *
+ * The Anthropic identity oracle probes Anthropic's OAuth profile endpoint, so the
+ * email it returns is an assertion about a CLAUDE login and says nothing about any
+ * other provider. Scoping the candidate set to claude-code accounts is therefore part
+ * of reading the oracle correctly, not an optimization: an operator who backs a Claude
+ * subscription AND a Codex subscription with the same Google account has two pool rows
+ * carrying one email, and an unscoped lookup sees a 2-way collision that does not exist
+ * at the provider.
+ *
+ * The scope is `framework === 'claude-code'` and DELIBERATELY NOT `provider === 'anthropic'`
+ * as well. `SubscriptionPool` validates `provider` and `framework` independently, with no
+ * cross-check, so `{ provider: 'openai', framework: 'claude-code' }` is an admissible row —
+ * and `buildCredentialRepairPlan` selects the accounts it plans over on `framework` ALONE.
+ * A candidate predicate NARROWER than the account-selection predicate one layer up would
+ * put such a row in the plan while making it unmatchable, manufacturing exactly the false
+ * `missing-local-login` this function exists to delete. The candidate set must equal the
+ * selection set; that invariant, not tidiness, fixes the scope.
+ *
+ * This is the shared definition because the rule previously lived only inside
+ * `matchAccountByEmail`, and the credential identity resolver in `commands/server.ts`
+ * re-implemented the lookup without it — so a dual-subscription account resolved as
+ * `ambiguous/unknown email (2 pool matches)` -> `unavailable` -> `missing-local-login`,
+ * telling the operator to re-authenticate a login that was present and valid. Callers with
+ * different collision policies share this candidate set rather than each restating the scope.
+ *
+ * NOT yet converged: `CredentialLocationLedger` keeps its own scope predicate, which also
+ * admits a framework-LESS legacy row. Widening this one to match would make such a row a
+ * candidate without putting it in the repair plan's account set — reintroducing the
+ * collision in a new shape. The two now share `emailEquals`; their scopes still differ, and
+ * that is stated rather than papered over.
+ */
+export function claudeAccountsMatchingEmail<T extends EmailMatchableAccount>(
+  accounts: readonly T[],
+  email: string | null | undefined,
+): T[] {
+  if (!email) return [];
+  return accounts.filter((a) => a.framework === 'claude-code' && emailEquals(a.email, email));
+}
+
+/** What an identity oracle can say about a slot, before the pool is consulted. */
+export type SlotOracleAnswer = { email?: string; unavailable?: boolean; reason?: string };
+/** What the credential identity resolver answers. */
+export type SlotIdentityResolution = { accountId: string } | { unavailable: true; reason: string };
+
+/**
+ * Pure: the POOL-MAPPING half of `credResolveIdentity` (`src/commands/server.ts`).
+ *
+ * Extracted so the mapping can be tested against the real code path rather than against a
+ * copy of it. A prior version of this fix was tested only through a hand-copied closure in
+ * the test file, and a reviewer demonstrated that reverting the production callsite left
+ * every test green — the suite pinned the helper and not the defect. This function is that
+ * callsite.
+ *
+ * Collision policy: STRICT. This answer authorizes credential MOVES between config homes
+ * (`CredentialSwapExecutor`), so anything other than exactly one candidate fails closed. A
+ * genuine collision between two claude-code accounts sharing an email is still refused.
+ */
+export function resolveClaudeSlotAccountId<T extends EmailMatchableAccount>(
+  accounts: readonly T[],
+  oracle: SlotOracleAnswer,
+): SlotIdentityResolution {
+  if (oracle.unavailable || !oracle.email) {
+    return { unavailable: true, reason: oracle.reason ?? 'oracle unavailable' };
+  }
+  const matches = claudeAccountsMatchingEmail(accounts, oracle.email);
+  if (matches.length !== 1) {
+    return { unavailable: true, reason: `ambiguous/unknown email (${matches.length} claude-code pool matches)` };
+  }
+  return { accountId: matches[0].id };
+}
+
 /**
  * Pure: match the active account email to a pool account (case-insensitive).
- * Only anthropic/claude-code accounts are considered — the active Claude login
- * cannot be a codex/gemini account. Returns the account id or null.
+ * Only claude-code accounts are considered — the active Claude login cannot be a
+ * codex/gemini account. Returns the account id or null.
+ *
+ * Collision policy: first match wins. This resolver only LABELS which account a live
+ * session is using, so a wrong label self-corrects at the next probe; it authorizes no
+ * write. Callers that gate a credential MUTATION must use `resolveClaudeSlotAccountId`,
+ * which fails closed on a collision.
  */
 export function matchAccountByEmail(
   accounts: SubscriptionAccount[],
   email: string | null,
 ): string | null {
-  if (!email) return null;
-  const target = email.trim().toLowerCase();
-  if (!target) return null;
-  const hit = accounts.find(
-    (a) =>
-      a.provider === 'anthropic' &&
-      a.framework === 'claude-code' &&
-      typeof a.email === 'string' &&
-      a.email.trim().toLowerCase() === target,
-  );
-  return hit ? hit.id : null;
+  return claudeAccountsMatchingEmail(accounts, email)[0]?.id ?? null;
 }
 
 export class InUseAccountResolver {

--- a/tests/unit/credential-identity-dual-subscription-email.test.ts
+++ b/tests/unit/credential-identity-dual-subscription-email.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression: an operator whose SINGLE Google account backs BOTH a Claude
+ * subscription and a Codex subscription was told, permanently, that the Claude
+ * login was missing.
+ *
+ * Observed 2026-08-26 on a 4-machine / 8-account pool: the only two accounts
+ * flagged `owner-relogin-required` / `missing-local-login` were exactly the two
+ * claude-code accounts whose email is also carried by a codex-cli account. Both
+ * credentials were present, unexpired and resolved cleanly through the identity
+ * oracle. The reverse email -> accountId lookup in `credResolveIdentity` searched
+ * the WHOLE pool, saw 2 matches, refused to disambiguate, and the refusal was
+ * rendered downstream as a missing login. It could never self-clear, because the
+ * path that would clear the flag calls the same lookup.
+ *
+ * These tests exercise `resolveClaudeSlotAccountId` — the function `server.ts`
+ * ACTUALLY calls. An earlier version of this suite tested a hand-copied closure
+ * declared in the test file, and a reviewer proved that reverting the production
+ * callsite left all of it green: the suite pinned the helper and not the defect.
+ * Nothing here may be a copy of the code under test.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  claudeAccountsMatchingEmail,
+  emailEquals,
+  matchAccountByEmail,
+  resolveClaudeSlotAccountId,
+} from '../../src/core/InUseAccountResolver.js';
+import { planCredentialIdentityRepair } from '../../src/core/CredentialIdentityRepairPlan.js';
+import type { SubscriptionAccount } from '../../src/core/types.js';
+
+const acct = (over: Partial<SubscriptionAccount>): SubscriptionAccount =>
+  ({
+    id: 'x',
+    provider: 'anthropic',
+    framework: 'claude-code',
+    email: 'x@example.com',
+    configHome: '/slots/x',
+    status: 'active',
+    ...over,
+  }) as SubscriptionAccount;
+
+/** The live shape that produced the incident: one Google account, two subscriptions. */
+const dualSubscriptionPool: SubscriptionAccount[] = [
+  acct({ id: 'justin-gmail', email: 'headley.justin@gmail.com', configHome: '/slots/justin-gmail' }),
+  acct({
+    id: 'codex-justin-gmail',
+    provider: 'openai',
+    framework: 'codex-cli',
+    email: 'headley.justin@gmail.com',
+    configHome: '/slots/codex',
+  }),
+  acct({ id: 'adriana', email: 'adriana@gmail.com', configHome: '/slots/adriana' }),
+];
+
+describe('emailEquals', () => {
+  it('ignores case and surrounding whitespace', () => {
+    expect(emailEquals('  HEADLEY.Justin@Gmail.com ', 'headley.justin@gmail.com')).toBe(true);
+  });
+
+  it('never matches an absent or blank email against anything', () => {
+    expect(emailEquals(null, 'a@b.c')).toBe(false);
+    expect(emailEquals('a@b.c', undefined)).toBe(false);
+    expect(emailEquals('   ', '   ')).toBe(false);
+    expect(emailEquals('', '')).toBe(false);
+  });
+});
+
+describe('claudeAccountsMatchingEmail', () => {
+  it('returns exactly one candidate when a Codex subscription shares the Claude account email', () => {
+    expect(claudeAccountsMatchingEmail(dualSubscriptionPool, 'headley.justin@gmail.com').map((a) => a.id))
+      .toEqual(['justin-gmail']);
+  });
+
+  it('still reports a GENUINE collision between two claude-code accounts', () => {
+    const pool = [
+      ...dualSubscriptionPool,
+      acct({ id: 'justin-gmail-second', email: 'headley.justin@gmail.com', configHome: '/slots/second' }),
+    ];
+    expect(claudeAccountsMatchingEmail(pool, 'headley.justin@gmail.com')).toHaveLength(2);
+  });
+
+  it('scopes on framework alone, so a claude-code row with an off-provider value stays matchable', () => {
+    // SubscriptionPool validates provider and framework independently, so this row is
+    // admissible — and `buildCredentialRepairPlan` selects accounts on framework ALONE.
+    // A candidate predicate narrower than that selection set would put this row in the
+    // plan while making it unmatchable, manufacturing the exact false alarm being fixed.
+    const pool = [acct({ id: 'odd', provider: 'openai' as SubscriptionAccount['provider'], email: 'odd@example.com' })];
+    expect(claudeAccountsMatchingEmail(pool, 'odd@example.com').map((a) => a.id)).toEqual(['odd']);
+  });
+
+  it('returns no candidates for an absent, blank or unknown email', () => {
+    expect(claudeAccountsMatchingEmail(dualSubscriptionPool, null)).toEqual([]);
+    expect(claudeAccountsMatchingEmail(dualSubscriptionPool, '   ')).toEqual([]);
+    expect(claudeAccountsMatchingEmail(dualSubscriptionPool, 'nobody@example.com')).toEqual([]);
+  });
+
+  it('keeps matchAccountByEmail behaviour on the shared definition', () => {
+    expect(matchAccountByEmail(dualSubscriptionPool, 'headley.justin@gmail.com')).toBe('justin-gmail');
+    expect(matchAccountByEmail(dualSubscriptionPool, 'nobody@example.com')).toBeNull();
+    expect(matchAccountByEmail(dualSubscriptionPool, null)).toBeNull();
+  });
+});
+
+describe('resolveClaudeSlotAccountId (the function server.ts calls)', () => {
+  it('resolves a dual-subscription account instead of calling it ambiguous', () => {
+    expect(resolveClaudeSlotAccountId(dualSubscriptionPool, { email: 'headley.justin@gmail.com' }))
+      .toEqual({ accountId: 'justin-gmail' });
+  });
+
+  it('resolves regardless of the casing the provider happens to return', () => {
+    expect(resolveClaudeSlotAccountId(dualSubscriptionPool, { email: 'Headley.Justin@Gmail.COM' }))
+      .toEqual({ accountId: 'justin-gmail' });
+  });
+
+  it('fails CLOSED on a genuine two-claude-account collision — it gates credential moves', () => {
+    const pool = [
+      ...dualSubscriptionPool,
+      acct({ id: 'justin-gmail-second', email: 'headley.justin@gmail.com', configHome: '/slots/second' }),
+    ];
+    const r = resolveClaudeSlotAccountId(pool, { email: 'headley.justin@gmail.com' });
+    expect(r).toEqual({ unavailable: true, reason: 'ambiguous/unknown email (2 claude-code pool matches)' });
+  });
+
+  it('passes an unavailable oracle straight through with its reason intact', () => {
+    expect(resolveClaudeSlotAccountId(dualSubscriptionPool, { unavailable: true, reason: 'no access token in slot credential store' }))
+      .toEqual({ unavailable: true, reason: 'no access token in slot credential store' });
+  });
+
+  it('treats an oracle answer with no email as unavailable, never as a match', () => {
+    expect(resolveClaudeSlotAccountId(dualSubscriptionPool, {}))
+      .toEqual({ unavailable: true, reason: 'oracle unavailable' });
+  });
+
+  it('reports an unknown email as unavailable rather than guessing', () => {
+    expect(resolveClaudeSlotAccountId(dualSubscriptionPool, { email: 'stranger@example.com' }))
+      .toEqual({ unavailable: true, reason: 'ambiguous/unknown email (0 claude-code pool matches)' });
+  });
+});
+
+/**
+ * The composed behaviour: `credResolveIdentity` -> `buildCredentialRepairPlan` ->
+ * `planCredentialIdentityRepair`. This is the chain that produced the operator-visible
+ * `owner-relogin-required`, and both halves here are the real exported functions.
+ */
+describe('resolveClaudeSlotAccountId -> planCredentialIdentityRepair', () => {
+  const oracleEmailForSlot: Record<string, string> = {
+    '/slots/justin-gmail': 'headley.justin@gmail.com',
+    '/slots/adriana': 'adriana@gmail.com',
+  };
+
+  /** Mirrors buildCredentialRepairPlan's account selection: framework ALONE. */
+  const claudeAccounts = dualSubscriptionPool
+    .filter((a) => a.framework === 'claude-code')
+    .map((a) => ({ id: a.id, configHome: a.configHome }));
+
+  const planFor = (oracle: (slot: string) => { email?: string; unavailable?: boolean; reason?: string }) =>
+    planCredentialIdentityRepair(
+      claudeAccounts,
+      claudeAccounts.map((a) => {
+        const identity = resolveClaudeSlotAccountId(dualSubscriptionPool, oracle(a.configHome));
+        return { slot: a.configHome, accountId: 'unavailable' in identity ? null : identity.accountId };
+      }),
+    );
+
+  it('demands no owner re-login when every slot resolves', () => {
+    const plan = planFor((slot) => ({ email: oracleEmailForSlot[slot] }));
+    expect(plan.ownerReloginAccountIds).toEqual([]);
+    expect(plan.quarantineSlots).toEqual([]);
+    expect(plan.moves).toEqual([]);
+    expect(plan.complete).toBe(true);
+  });
+
+  it('still quarantines and demands re-login when the oracle genuinely cannot answer', () => {
+    const plan = planFor((slot) =>
+      slot === '/slots/adriana'
+        ? { unavailable: true, reason: 'no access token in slot credential store' }
+        : { email: oracleEmailForSlot[slot] },
+    );
+    expect(plan.quarantineSlots).toEqual(['/slots/adriana']);
+    expect(plan.ownerReloginAccountIds).toEqual(['adriana']);
+    expect(plan.complete).toBe(false);
+  });
+});
+
+/**
+ * Wiring, asserted against the source text.
+ *
+ * The logic tests above pin `resolveClaudeSlotAccountId`; they do NOT pin that `server.ts`
+ * still CALLS it. A reviewer demonstrated the gap: reverting `src/commands/server.ts` alone
+ * to the inline whole-pool filter leaves all of them green. That re-inlining is exactly how
+ * this bug was born — the rule existed in a sibling module and the callsite re-implemented
+ * the lookup without it — so the wiring is the part most worth a structural guard.
+ *
+ * `credResolveIdentity` is a local `const` inside `startServer`, not an injected dependency,
+ * so there is nothing to reach at runtime. A source assertion is the honest instrument
+ * available: cheap, and it fails for the right reason.
+ */
+describe('credResolveIdentity wiring (source assertion)', () => {
+  const serverSrc = readFileSync(
+    new URL('../../src/commands/server.ts', import.meta.url),
+    'utf8',
+  );
+
+  it('routes slot identity through the shared resolver', () => {
+    expect(serverSrc).toContain('resolveClaudeSlotAccountId(subscriptionPool.list()');
+  });
+
+  it('does not re-implement the email lookup inline over the whole pool', () => {
+    // The defect shape: filtering pool accounts by email without the framework scope.
+    // Matched over the filter callback's whole body, not up to the first ')' — the
+    // predicate's own parameter list contains one, which a lazier pattern stops at.
+    const inlineEmailFilter = /subscriptionPool\.list\(\)\s*\.filter\([\s\S]{0,200}?\.email\b/;
+    expect(serverSrc).not.toMatch(inlineEmailFilter);
+  });
+});

--- a/tests/unit/in-use-account-resolver.test.ts
+++ b/tests/unit/in-use-account-resolver.test.ts
@@ -32,7 +32,7 @@ const ACCOUNTS: SubscriptionAccount[] = [
 ];
 
 describe('matchAccountByEmail', () => {
-  it('matches case-insensitively and only anthropic/claude-code', () => {
+  it('matches case-insensitively and only claude-code', () => {
     expect(matchAccountByEmail(ACCOUNTS, 'HEADLEY.JUSTIN@GMAIL.COM')).toBe('gmail');
     expect(matchAccountByEmail(ACCOUNTS, 'justin@sagemindai.io')).toBe('sagemind');
   });

--- a/upgrades/next/credential-identity-dual-subscription-email.md
+++ b/upgrades/next/credential-identity-dual-subscription-email.md
@@ -1,0 +1,102 @@
+---
+change_type: fix
+---
+
+## What Changed
+
+If one Google account backs **both** a Claude subscription and a Codex subscription, instar reported
+that account's Claude login as **missing** — permanently, on a machine where the login was present,
+unexpired and working.
+
+The chain: `CredentialIdentityOracle` asks Anthropic's OAuth profile endpoint who a stored login
+belongs to and gets an email back. `credResolveIdentity` then mapped that email to a pool account by
+filtering **the entire pool** and insisting on exactly one match. Two subscriptions sharing one Gmail
+address are two pool rows carrying one email, so the lookup saw a 2-way collision that does not exist
+at the provider, returned `unavailable`, and `planCredentialIdentityRepair` swept the account into
+`ownerReloginAccountIds` — which `server.ts` stamps as `actualAccountId: 'missing-local-login'`,
+`repairState: 'owner-relogin-required'`.
+
+It could not self-clear. The only path that clears the flag — `QuotaPoller.reconcileIdentity` —
+calls the same resolver, gets the same `unavailable`, and correctly refuses to mutate state on an
+uncertain reading. So the flag latched, and re-signing in did not help, because the login was never
+the problem.
+
+An Anthropic-issued email is an assertion about a **Claude** login; a codex-cli row was never a
+legitimate candidate. The lookup is now scoped to anthropic/claude-code accounts.
+
+That rule already existed one module over — `matchAccountByEmail` in `InUseAccountResolver` has
+scoped itself to Claude accounts since it was written, with a comment saying exactly why. The
+credential resolver re-implemented the lookup and never inherited it. Rather than paste the filter
+into a second place and leave two copies to drift apart again, the pool-mapping half of
+`credResolveIdentity` is lifted into one exported, tested function `resolveClaudeSlotAccountId`
+that `server.ts` calls, over a shared candidate helper and a shared normalized email comparison.
+
+`matchAccountByEmail` keeps its first-match policy; the credential resolver keeps its strict
+fail-closed policy, because it gates credential **moves** and must never guess which home a blob
+belongs to. A genuine collision between two *Claude* accounts still refuses to resolve.
+
+The scope is `framework === 'claude-code'` and deliberately does **not** also require
+`provider === 'anthropic'`: `SubscriptionPool` validates the two fields independently, and
+`buildCredentialRepairPlan` selects the accounts it plans over on framework alone — so a candidate
+predicate narrower than that selection set would manufacture the very false alarm being deleted.
+The candidate set must equal the selection set.
+
+Two adjacent latent defects were closed on the way: `CredentialLocationLedger`'s two email
+comparisons used raw `===` with no trim or case-fold, so a differently-cased provider email would
+have reproduced the same contradiction in the opposite direction; both now share the normalized
+comparison.
+
+## Evidence
+
+Measured on a live 4-machine / 8-account pool, 2026-08-26:
+
+- Exactly 2 of 8 accounts carried `owner-relogin-required` / `missing-local-login`, both stamped
+  `2026-08-25T03:29:54Z` and unchanged for ~37h.
+- Those 2 are exactly the 2 claude-code accounts whose email is also carried by a codex-cli account.
+  The other 4 claude-code accounts have unique emails and carried no drift. 2/2, no false members.
+- `readClaudeOauthAsyncDetailed` on both flagged slots: access token present, refresh token present,
+  `expiresAt` in the future, Max subscription, full scopes. The credentials were never missing.
+- `CredentialIdentityOracle.resolveSlotTenant` on both: resolved, correct email. The oracle half was
+  never failing — only the pool mapping after it.
+- The two surfaces were visibly contradicting each other, which is what made this findable:
+  `.instar/credential-locations.json` reported both slots `quarantined: false` with a recent
+  `lastVerifiedAt`, because `CredentialLocationLedger` already filters to claude-code accounts and
+  therefore never had the bug. The pool said missing; the ledger said verified.
+- Replaying `buildCredentialRepairPlan`'s exact composition against the live pool reproduced
+  `ownerReloginAccountIds: ['justin-gmail','sagemind-justin']`; the same replay through the scoped
+  lookup produced `[]`, `complete: true`.
+
+15 unit tests, all against the exported function `server.ts` actually calls. The dual-subscription
+case resolving to one candidate; a genuine two-Claude collision still failing closed; provider-case
+normalization; the off-provider claude-code row staying matchable; absent/blank/unknown email; an
+unavailable oracle passed through with its reason intact; `matchAccountByEmail` behaviour preserved;
+and the composed `resolveClaudeSlotAccountId` → `planCredentialIdentityRepair` chain asserted in
+both directions.
+
+Test adequacy was verified by mutation, not asserted. An earlier version of this change tested a
+hand-copied closure inside the test file; reverting the production callsite left all of it green —
+a guard that certified itself. That is fixed structurally by exporting the real callsite, and
+reintroducing the pre-fix predicate now fails 7 of the 15 tests.
+
+## What to Tell Your User
+
+If you use the same Google account for a Claude subscription and a Codex subscription, instar has
+been telling you those accounts need signing in again when they did not — and re-signing in would
+not have made it stop, because the flag could not clear itself.
+
+After this update the affected accounts clear on their own at the next identity poll, with no taps
+from you. They also return to the pool the agent draws capacity from: an account carrying that flag
+is excluded from selection, so a paid subscription flagged this way was sitting unused.
+
+This does not change anything for an account whose email is unique to one subscription, and it does
+not make instar guess: if two *Claude* accounts genuinely shared an email, it still refuses to
+resolve and still asks you.
+
+Honest limit: this removes one manufactured source of "sign in again" churn. It does not tell you how
+often sign-ins genuinely go stale, because nothing has ever recorded a sign-in — that measurement is
+separate work, and it belongs before any attempt to automate the sign-in flow.
+
+## Summary of New Capabilities
+
+None. This is a correctness fix to an existing detector — no new route, no new state, no new config
+key, no new agent-facing surface.

--- a/upgrades/side-effects/credential-identity-dual-subscription-email.md
+++ b/upgrades/side-effects/credential-identity-dual-subscription-email.md
@@ -1,0 +1,220 @@
+# Side-effects review — credential identity resolver: dual-subscription email
+
+**Change:** the pool-mapping half of `credResolveIdentity` (`src/commands/server.ts`) was
+extracted into an exported pure function `resolveClaudeSlotAccountId`
+(`src/core/InUseAccountResolver.ts`) and scoped to claude-code accounts, over a shared
+candidate helper `claudeAccountsMatchingEmail` and a shared normalized comparison
+`emailEquals`. `matchAccountByEmail` was refactored onto the same definition;
+`CredentialLocationLedger`'s two email comparisons were routed through `emailEquals`.
+
+**Second-pass review: CONCERN, resolved, then CONCUR on re-review.** The reviewer raised three
+concerns and empirically DISPROVED the first version's test claim by reverting the production
+callsite and watching all 9 tests still pass. All three were folded in; on re-review the
+reviewer concurred and found two further overstatements in this artifact, which are corrected
+in place below. Every correction is marked ✎ rather than silently rewritten, because a claim I
+checked and withdrew has to stay distinguishable from one I never made.
+
+**Tier:** 1 (single-callsite correctness fix + a pure helper extraction; no new capability,
+no new surface, no new state, no config).
+
+## Evidence (measured, not inferred) — 2026-08-26, Mac Studio
+
+- Live pool: 8 accounts. Exactly 2 carried `identityDrift.repairState =
+  'owner-relogin-required'` / `actualAccountId = 'missing-local-login'`, both stamped
+  `2026-08-25T03:29:54Z`.
+- Those 2 (`sagemind-justin`, `justin-gmail`) are exactly the 2 claude-code accounts whose
+  email is also carried by a codex-cli account. The other 4 claude-code accounts have unique
+  emails and carried no drift. 2/2 correlation, 0 false members.
+- `readClaudeOauthAsyncDetailed` on both flagged slots: `ok`, access token present, refresh
+  token present, `expiresAt` in the future, Max subscription, full scopes. The credentials
+  were never missing.
+- `CredentialIdentityOracle.resolveSlotTenant` on both flagged slots: RESOLVED, correct email.
+  The oracle half was never failing.
+- Replaying `buildCredentialRepairPlan`'s exact composition against the live pool reproduced
+  `ownerReloginAccountIds: ['justin-gmail','sagemind-justin']`; the same replay with the
+  framework-scoped lookup produced `[]` with `complete: true`.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+✎ **Corrected after second-pass review.** The first draft of this section claimed a narrowed
+candidate set "can never turn a previously-resolving slot into an ambiguous one". That is
+false — 1 match narrowing to 0 is also `!== 1`, and 0 fails closed exactly like 2 does.
+
+The concrete case the reviewer found: `SubscriptionPool` validates `provider` and `framework`
+against their unions INDEPENDENTLY, with no cross-check, so `{ provider: 'openai', framework:
+'claude-code' }` is an admissible row rather than "malformed by construction". And it is not a
+safe failure: `buildCredentialRepairPlan` selects the accounts it plans over on `framework`
+ALONE, so such a row would enter the plan, resolve to `null`, and receive
+`owner-relogin-required` plus a beacon commitment plus eviction from `isLocallyExecutable` —
+manufacturing precisely the false alarm this change exists to delete.
+
+Resolved by making the candidate predicate EQUAL the account-selection predicate: the scope is
+`framework === 'claude-code'` and deliberately does NOT also require `provider === 'anthropic'`.
+A candidate predicate narrower than the selection set one layer up is the bug, not a
+tightening. That invariant is stated in the helper's docstring and pinned by a unit test.
+
+With that, over-block is nil: the candidate set is exactly the account set, so no slot that
+resolved before can fail to resolve now.
+
+## 2. Under-block — what failure modes does this still miss?
+
+Deliberately unchanged and still present:
+- An oracle that cannot answer (no token, network failure, 401/403/429/5xx, unparseable) is
+  still a flat `unavailable` with the reason string discarded one line later by
+  `buildCredentialRepairPlan` (`accountId: 'unavailable' in identity ? null : …`). So
+  "credential absent" and "credential present but rejected" still collapse into one
+  indistinguishable `missing-local-login`. That is a real defect — it is the reason the
+  expiring-vs-disappearing question is currently unanswerable — but it is a DIFFERENT defect
+  with a different fix, and it is the subject of the in-review
+  `docs/specs/subscription-signin-ledger.md` (round-1 findings ADV-1, ADV-5, LES-1, LES-8 all
+  name it). Fixing it here would be an unscoped second change riding a one-line correctness
+  fix. <!-- tracked: CMT-167 -->
+- A genuine two-Claude-accounts-one-email collision still fails closed. Intended.
+- Non-claude-code frameworks still have no drift raise or clear path at all
+  (`buildCredentialRepairPlan` and `QuotaPoller.reconcileIdentity` are both claude-code-only).
+  Unchanged by this fix and out of its scope. <!-- tracked: CMT-167 -->
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and the change improves it. The scoping rule is a property of *what the oracle's
+answer means*, so it belongs beside the oracle's consumers, not inside the pool or the planner.
+It already existed at that layer in `matchAccountByEmail`; the fix removes the second,
+scope-less re-implementation rather than adding a third.
+
+✎ **Corrected after second-pass review.** The first draft claimed the remaining two definitions
+"disagree only on whether a framework-less row counts". They also disagreed on `provider` and —
+more seriously — on email NORMALIZATION: `CredentialLocationLedger:466/557` compared with raw
+`===`, no trim, no case-fold. A provider returning a differently-cased email would have
+reproduced the same pool-vs-ledger contradiction in the opposite direction, silently.
+
+Both ledger sites now use the shared `emailEquals`. What is honestly NOT converged is the SCOPE
+predicate: the ledger's `isClaudeCodeAccount` additionally admits a framework-LESS legacy row.
+Widening the shared helper to match would make such a row a candidate without putting it in the
+repair plan's account set — reintroducing the collision in a new shape. So the scopes still
+differ by that one case, deliberately, and the helper's docstring says so rather than claiming a
+convergence that did not happen. <!-- tracked: CMT-167 -->
+
+## 4. Signal vs authority compliance (`docs/signal-vs-authority.md`)
+
+The resolver is a DETECTOR. It adds no blocking authority; it makes an existing detector
+correct. The fix strictly *reduces* the authority previously exercised, because a
+manufactured `unavailable` was being rendered downstream as an authoritative
+`repairState: 'owner-relogin-required'` — a detector's uncertainty presented as a verified
+state. The fail-closed rule on genuine ambiguity is retained precisely because this detector
+DOES feed a mutation authority (`CredentialSwapExecutor` moves credential blobs between
+homes), and a guess there is irreversible.
+
+This is also a clean instance of the P20 failure the constitution names: the SYMBOL was
+`matches.length !== 1`; the STATE claimed was "no local login exists"; the corroboration
+(the credential blob is readable and the oracle resolves) was available at zero cost and
+never consulted; and the unmeasurable case was rendered as the alarming value rather than
+as `unknown`.
+
+## 5. Interactions
+
+- `CredentialSwapExecutor` — consumes `resolveIdentity` for pre-flight identity checks. It now
+  gets a resolution where it previously got `unavailable`, so a swap that was refused with
+  `precondition-failed` can now proceed. That path is dev-gated AND `dryRun: true` on this
+  agent and dark on the fleet, so no live credential write changes today.
+- `QuotaPoller.reconcileIdentity` — the sole falling-edge writer. It returns early on
+  `unavailable` ("uncertainty never mutates truth"), which is exactly why the flag latched.
+  With the fix it resolves, `identity.accountId === expected.id`, and it clears
+  `identityDrifted` and calls `onIdentityRestored`. **Expected live effect: the two latched
+  accounts self-clear on the next poll with no operator action.** ✎ Independently verified by
+  the second-pass reviewer against `pollAll`, `accountForReads` and the in-memory
+  `identityCache` (emptied by the restart that ships the fix): no path skips a drifted account,
+  and nothing else must happen first.
+- `SubscriptionPool.isLocallyExecutable` excludes `identityDrifted` accounts, so those two Max
+  accounts re-enter the capacity pool. That is a capacity *increase* on a machine that was
+  under-using paid subscriptions; it cannot exhaust anything that was not already available.
+- `MissingLoginSessionDetector` raises a HIGH attention item on this predicate. Fewer false
+  raises; it is signal-only and mutates nothing.
+- `CredentialLocationLedger.auditIdentities` already scoped by framework, so it never had the
+  dual-subscription bug — which is why the pool and the ledger were visibly contradicting each
+  other (pool: missing since Monday; ledger: verified an hour ago). That contradiction resolves.
+  ✎ Its two email comparisons now also share `emailEquals`, closing a separate latent
+  case-sensitivity divergence the second-pass review found. **This is a real behaviour change
+  on one input shape, not none** — the first draft of this artifact said otherwise and was
+  wrong. Two claude-code rows whose emails differ only in CASE are not rejected at `add()`
+  (there is no email-uniqueness constraint), and case-folding turns them from one exact match
+  into an ambiguous pair, which quarantines the slot rather than resolving it. That is the
+  fail-closed direction, both surfaces now agree on it, and two accounts sharing an email
+  modulo case genuinely IS ambiguous — so it is accepted, but it is stated. The opposite
+  direction (previously matched, now does not) is reachable only for two whitespace-only
+  emails, which `normalizeSubscriptionEmail` rejects at `add()`.
+- ✎ `onIdentityRestored` (server.ts) does more than clear the flag: it DELIVERS the
+  `credential-identity-relogin:<id>` commitment and marks the attention item done. So the
+  self-clear leaves no orphan beacon nagging the operator about a resolved condition.
+- No double-fire, no shadowing, no race introduced: the helper is pure and synchronous.
+
+## 6. External surfaces
+
+`GET /subscription-pool` will stop reporting `identityDrift` for dual-subscription accounts —
+visible in the dashboard Subscriptions grid and to any operator or peer reading pool state.
+That is the intended user-visible effect and it is a correction, not a new surface. No route
+added, no schema field added or removed, no config key, no message text, no agent-installed
+file. The `reason` string on a genuine ambiguity now reads `(N claude-code pool matches)`
+instead of `(N pool matches)` — strictly more accurate, and it appears only in audit rows.
+
+Timing/runtime dependence: none introduced. The helper is deterministic over its inputs.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+`machine-local` by construction, and correctly so — `machine-local-justification:
+physical-credential-locality`. The resolver reads a credential blob that physically lives in
+one `configHome` on one disk (a Claude OAuth login cannot be relocated between machines; that
+is why each machine mints its own). The subscription-pool ROWS it matches against already
+replicate as credential-free metadata, and this change reads that metadata without altering
+what replicates. No notice, no durable state, no generated URL — so no one-voice gating, no
+topic-transfer strand, no machine-boundary link concern.
+
+Each of the operator's four machines runs its own resolver over its own slots and will fix
+itself independently as it updates; there is no cross-machine ordering dependency.
+
+## 8. Rollback cost
+
+Near zero. Two files, no state written, no migration, no data shape change. Revert the commit
+and the previous behaviour returns exactly. Nothing persisted during the fixed window needs
+repairing: `identityDrifted: false` is the same state a successful owner re-login would have
+produced, and `CredentialLocationLedger` assignments were already being written correctly by
+the path that never had the bug. No hot-fix release coupling, no agent state repair.
+
+## Known adjacent issues NOT fixed here (named so they are not mistaken for absent)
+
+- The discarded oracle `reason` (see §2) — the cause-class evidence exists and is thrown away
+  at `buildCredentialRepairPlan`. <!-- tracked: CMT-167 -->
+- `buildCredentialRepairPlan` uses `framework === 'claude-code'` while
+  `CredentialLocationLedger.isClaudeCodeAccount` treats an ABSENT framework as claude-code, so
+  a framework-less row is in one subsystem's account set and not the other's. Pre-existing,
+  unchanged, and not reachable by any live row (all 8 pool rows carry a framework).
+  <!-- tracked: CMT-167 -->
+
+
+## ✎ Test adequacy (added after second-pass review)
+
+The first version of this change was tested through a hand-copied closure declared inside the
+test file. The reviewer reverted `src/commands/server.ts` to `origin/main`, left the helper
+fixed, re-ran the suite, and got 9/9 green — the tests pinned the helper's semantics and the
+production defect could have been reintroduced silently. That is a worse failure than no test,
+because it certifies a guard that is not there.
+
+Resolved structurally rather than by adding assertions: the mapping half of `credResolveIdentity`
+is now an exported function (`resolveClaudeSlotAccountId`) that `server.ts` actually calls, and
+the tests import it. Nothing in the test file is a copy of the code under test.
+
+Verified by mutation rather than asserted, and stated precisely because the obvious summary
+would overclaim. Two different things can be broken, and they need two different guards:
+
+- **The LOGIC.** Reintroducing the pre-fix predicate inside `claudeAccountsMatchingEmail`
+  (whole-pool filter, raw `===`) fails **7 of 17** tests, including both composed
+  `resolveClaudeSlotAccountId -> planCredentialIdentityRepair` cases.
+- **The WIRING.** Reverting `src/commands/server.ts` ALONE — re-inlining the lookup at the
+  callsite while leaving the helper correct — left every logic test green. ✎ The reviewer
+  demonstrated this, and it matters more than it sounds: re-implementing the lookup at the
+  callsite is *precisely how this bug was born*, since the correct rule already existed in a
+  sibling module. `credResolveIdentity` is a local `const` inside `startServer`, not an injected
+  dependency, so there is nothing to reach at runtime; two source assertions are the honest
+  instrument available. Both fail on a callsite-only revert, verified the same way.
+
+The distinction is recorded rather than smoothed over: "7 of 17 fail" would have implied the
+callsite was covered when it was not.


### PR DESCRIPTION
## ELI16 — two working logins were reported missing because one Google account backs two subscriptions

If you use the same Google account for a Claude subscription *and* a Codex subscription, instar has
been telling you that Claude account needs signing in again — on a machine where the login was
present, unexpired and working — and re-signing in did not make it stop.

To work out which account a stored login belongs to, instar asks Anthropic "whose login is this?",
gets an email back, and looks that email up in the list of subscription accounts. It insists on
finding **exactly one** match, which is the right instinct: that answer decides whether credential
files get physically moved between folders, and guessing there would be dangerous.

But the lookup searched the *whole* account list — Claude accounts and Codex accounts together. One
Gmail address backing two subscriptions is two rows carrying one email, so the lookup found two,
concluded the answer was ambiguous, and gave up. "Gave up" is recorded further down the chain as the
words **missing local login**.

It could never fix itself, because the code that would clear the flag runs the same lookup and gets
the same "can't tell". So the flag latched, and the account was excluded from the pool instar draws
capacity from — a paid Max subscription sitting unused.

The fix scopes the lookup to Claude accounts when the question came from Anthropic's Claude service.
An email issued by that service cannot possibly mean a Codex account, so a Codex row was never a
legitimate candidate. The rule already existed one file over and this callsite had simply never
inherited it, so rather than paste it into a second place, it now lives in one shared function both
callers use. A genuine collision between two *Claude* accounts still refuses to resolve.

Affected accounts clear on their own at the next identity poll, with no taps from you.

An operator whose single Google account backs **both** a Claude subscription and a Codex subscription was told, permanently, that the Claude login was missing — on a machine where it was present, unexpired and working.

## What was wrong

`credResolveIdentity` asked Anthropic's OAuth profile endpoint who a stored login belonged to, then mapped that email to a pool account by filtering **the entire pool** and demanding exactly one match. Two subscriptions sharing one Gmail address are two pool rows carrying one email, so the lookup saw a collision that does not exist at the provider, returned `unavailable`, and `planCredentialIdentityRepair` swept the account into `ownerReloginAccountIds` — stamped downstream as `missing-local-login` / `owner-relogin-required`.

It could not self-clear. The only path that clears the flag, `QuotaPoller.reconcileIdentity`, calls the same lookup, gets the same uncertain answer, and correctly refuses to mutate state on it. So the flag latched, re-signing in did not help, and the account was excluded from `isLocallyExecutable` — a paid Max subscription sitting unused — the entire time.

## Evidence

Measured on a live 4-machine / 8-account pool, 2026-08-26:

| check | result |
|---|---|
| accounts flagged `owner-relogin-required` | exactly 2 of 8, both stamped `2026-08-25T03:29:54Z`, unchanged ~37h |
| are those the dual-subscription accounts? | yes — 2/2, and the other 4 claude-code accounts have unique emails and were never flagged |
| `readClaudeOauthAsyncDetailed` on both slots | access token present, refresh token present, `expiresAt` in the future, Max, full scopes |
| `CredentialIdentityOracle.resolveSlotTenant` on both | resolved, correct email — the oracle half never failed |
| replay of `buildCredentialRepairPlan` against the live pool | `ownerReloginAccountIds: ['justin-gmail','sagemind-justin']` |
| same replay through the scoped lookup | `[]`, `complete: true` |

A visible corroborating contradiction: `.instar/credential-locations.json` reported both slots `quarantined: false` with a recent `lastVerifiedAt`, because `CredentialLocationLedger` already filters to claude-code accounts and therefore never had this bug. The pool said missing; the ledger said verified.

## The fix

An Anthropic-issued email denotes a Claude login, so a codex-cli row was never a legitimate candidate. The pool-mapping half of the resolver is now an exported function `resolveClaudeSlotAccountId`, scoped to claude-code accounts, over a shared candidate helper and a shared normalized comparison.

The scope deliberately does **not** also require `provider === 'anthropic'`. `SubscriptionPool` validates the two fields independently and `buildCredentialRepairPlan` selects on framework alone, so a candidate predicate narrower than that selection set would manufacture the same false alarm for a different row shape. **The candidate set must equal the selection set** — that invariant, not tidiness, is what fixes the scope, and it is pinned by a test.

A genuine collision between two claude-code accounts still fails closed: this answer authorizes credential moves between config homes.

Also closed a latent sibling defect: `CredentialLocationLedger`'s two email comparisons used raw `===` with no trim or case-fold, so a differently-cased provider email would have reproduced the same contradiction from the other direction. Both now share `emailEquals`. That is a real behaviour change in one shape — two claude-code rows differing only in case now resolve as ambiguous rather than matching one — which is the fail-closed direction and is stated in the artifact rather than glossed.

## Tests, and how their adequacy was checked

17 unit tests against the exported function `server.ts` actually calls. Adequacy was verified by mutation, **separately for logic and wiring**, because the obvious summary would overclaim:

- **Logic** — reintroducing the pre-fix predicate fails **7 of 17**.
- **Wiring** — reverting the callsite alone left every logic test green. That re-inlining is precisely how this bug was born, so two source assertions pin it; both fail on a callsite-only revert.

## Review

Second-pass review returned **CONCERN** — it disproved the first version's test claim by reverting the callsite — then **CONCUR** after all three concerns were resolved. It also caught two overstatements in the side-effects artifact, both corrected in place and marked rather than silently rewritten.

## Causal autopsy

`origin: latent`. The correct scoping rule already existed in `matchAccountByEmail` with a comment explaining why; `credResolveIdentity` re-implemented the lookup from scratch and never inherited it. The defect only became reachable when a second subscription was enrolled under an email already used by a Claude account, which is why it surfaced now rather than at write time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

