### PR TITLE
fix(autonomy): revive completed Codex turns

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-27T01-48-30-242Z-stall-sentinel-recovery.json
+++ b/.instar/instar-dev-decisions/2026-08-27T01-48-30-242Z-stall-sentinel-recovery.json
@@ -1,0 +1,30 @@
+{
+  "ts": "2026-08-27T01:48:30.242Z",
+  "slug": "stall-sentinel-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 191,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "skills/spec-converge/scripts/cross-model-review.mjs",
+      "src/commands/server.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/monitoring/AutonomousLivenessReconciler.ts",
+      "src/monitoring/AutonomousThroughputFloor.ts",
+      "src/scaffold/templates.ts"
+    ],
+    "addedLines": 182,
+    "deletedLines": 9
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/skills/spec-converge/scripts/cross-model-review.mjs
+++ b/skills/spec-converge/scripts/cross-model-review.mjs
@@ -289,8 +289,16 @@ function resolveReviewerConfigPath(explicitPath) {
     if (parent === dir) break;
     dir = parent;
   }
+  // The legacy package-root fallback is only coherent for callers operating
+  // inside that package tree. Without this boundary, invoking the checkout's
+  // script from an unrelated repo can silently inherit the checkout owner's
+  // agent config, defeating both isolation and the authorship guard above.
+  const cwdRelativeToRoot = path.relative(ROOT, process.cwd());
+  const cwdIsInsideRoot =
+    cwdRelativeToRoot === '' ||
+    (!cwdRelativeToRoot.startsWith(`..${path.sep}`) && cwdRelativeToRoot !== '..' && !path.isAbsolute(cwdRelativeToRoot));
   const legacy = path.join(ROOT, '.instar', 'config.json');
-  if (fs.existsSync(legacy) && acceptCandidate(legacy)) return { path: legacy };
+  if (cwdIsInsideRoot && fs.existsSync(legacy) && acceptCandidate(legacy)) return { path: legacy };
   return { path: null };
 }
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -10115,6 +10115,16 @@ export async function startServer(options: StartOptions): Promise<void> {
                 }
                 return set;
               },
+              idleTopicSnapshot: () => {
+                const idle = new Map<number, string>();
+                for (const s of sessionManager.listRunningSessions()) {
+                  const topicId = resolveTopicForTmux(s.tmuxSession);
+                  if (topicId == null) continue;
+                  const frame = sessionManager.captureOutput(s.tmuxSession, 60);
+                  if (frame && SessionReaper.isPositivelyIdle(s.framework, frame)) idle.set(topicId, s.tmuxSession);
+                }
+                return idle;
+              },
               queuePaused: () => rq.isPaused(),
               topicInResumeQueue: (topicId) =>
                 rq.list().some((e) => e.topicId === topicId && (e.status === 'queued' || e.status === 'starting')),
@@ -10207,6 +10217,15 @@ export async function startServer(options: StartOptions): Promise<void> {
                 // no-op when the flag is OFF / single-machine, and best-effort (a lost
                 // CAS / owned-by-peer race withholds — never undoes the live spawn).
                 _claimOwnershipForAutonomousSpawn?.(topicId);
+              },
+              recoverIdle: async ({ sessionName }) => {
+                if (!_sessionRefresh) return false;
+                const result = await _sessionRefresh.refreshSession({
+                  sessionName,
+                  fresh: true,
+                  reason: 'autonomous-completed-turn-continuation',
+                });
+                return result.ok;
               },
               claimInflight: (topicId) => {
                 if (livenessInflight.has(topicId)) return false; // CAS: someone holds it
@@ -25489,7 +25508,25 @@ export async function startServer(options: StartOptions): Promise<void> {
           return { merged, open, digest: createHash('sha256').update(JSON.stringify({ merged, open })).digest('hex') };
         };
         autonomousThroughputFloor = new AutonomousThroughputFloor({
-          listRuns: () => activeAutonomousJobs(config.stateDir).flatMap(job => { const topicId = Number(job.topic); const startedAt = Date.parse(job.startedAt ?? ''); if (!Number.isSafeInteger(topicId) || topicId <= 0 || !Number.isFinite(startedAt)) return []; const markers = readAutonomousRunMarkers(config.stateDir, topicId); return [{ signalRunId: `topic:${topicId}:${job.startedAt}`, topicId, startedAt, telegramBacked: Boolean(telegram), registeredMachineCount: _listPoolMachines?.().length || 1, midMove: !markers || Boolean(markers.movedTo || markers.moveSuspended) }]; }),
+          listRuns: () => activeAutonomousJobs(config.stateDir).flatMap(job => {
+            const topicId = Number(job.topic);
+            const startedAt = Date.parse(job.startedAt ?? '');
+            if (!Number.isSafeInteger(topicId) || topicId <= 0 || !Number.isFinite(startedAt)) return [];
+            const markers = readAutonomousRunMarkers(config.stateDir, topicId);
+            const ownershipRecord = sessionOwnershipRegistry?.read(String(topicId)) ?? null;
+            const ownership = ownershipRecord?.status === 'active'
+              ? (ownershipRecord.ownerMachineId === _meshSelfId ? 'local-active' as const : 'remote-active' as const)
+              : 'unknown' as const;
+            return [{
+              signalRunId: `topic:${topicId}:${job.startedAt}`,
+              topicId,
+              startedAt,
+              telegramBacked: Boolean(telegram),
+              registeredMachineCount: _listPoolMachines?.().length || 1,
+              ownership,
+              midMove: !markers || Boolean(markers.movedTo || markers.moveSuspended),
+            }];
+          }),
           sweep: async (_run, previous) => { try { const next = await snapshot(previous); return { status: 'ok' as const, snapshot: next, meaningfulDelta: previous ? hasMeaningfulDeliverableDelta(previous, next) : false }; } catch (error) { const msg = error instanceof Error ? error.message : ''; return { status: 'unknown' as const, failure: /invalid-scope/.test(msg) ? 'invalid-scope' as const : /timed out|ETIMEDOUT/.test(msg) ? 'timeout' as const : 'github-read' as const }; } },
           observeOutbound: (run, cursor) => { const rows = telegram?.getTopicHistory(run.topicId, 100) ?? []; const newest = [...rows].reverse().find(row => !row.fromUser); const covered = rows.length < 100 || rows.some(row => Date.parse(row.timestamp) <= run.startedAt || row.timestamp === cursor); return { coverage: covered ? 'proven' as const : 'unknown' as const, newestOutboundAt: newest ? Date.parse(newest.timestamp) : undefined, cursor: rows.at(-1)?.timestamp }; },
           loadState: loadTf,

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -6595,6 +6595,16 @@ setTimeout(() => process.exit(0), 2000);
       patched = true;
       result.upgraded.push('CLAUDE.md: added Autonomous Throughput Floor section');
     }
+    const oldThroughputFloor = 'A pull/audit-only view measures project PR movement and manager outbound silence for active autonomous runs. It never notifies, dispatches, remediates, or creates attention.';
+    if (content.includes(oldThroughputFloor) && !content.includes('stale machine registrations cannot globally disable the floor')) {
+      content = content.replace(
+        oldThroughputFloor,
+        'A pull/audit-only view measures project PR movement and manager outbound silence for active autonomous runs. Eligibility is ownership-aware: in a multi-machine pool, only the durable active topic owner judges the run, so stale machine registrations cannot globally disable the floor. Ineligible rows name the exact failed boundary instead of collapsing everything into scope-or-ownership-ineligible.',
+      );
+      content += `\nThe AutonomousLivenessReconciler also detects an active autonomous run whose live Codex/Claude process is positively at a completed-turn prompt. Because a newline cannot revive a turn that already ended, it uses the canonical SessionRefresh funnel after the normal ownership/lease/debounce/safety gates; failure raises one aggregated attention item. Read \`GET /autonomous/liveness\`; conditions include \`terminal-turn\` and \`turn-revived\`.\n`;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added ownership-aware throughput eligibility and completed-turn revival');
+    }
 
     // Parallel-Hand PR Lease (parallel-hand-pr-lease.md) — Agent Awareness + Migration
     // Parity: an agent that doesn't know this exists will be confused when a `git push`

--- a/src/monitoring/AutonomousLivenessReconciler.ts
+++ b/src/monitoring/AutonomousLivenessReconciler.ts
@@ -43,7 +43,9 @@ export type ReconcileCondition =
   | 'blocked-pressure'
   | 'blocked-not-owner'
   | 'blocked-queue-owns'
-  | 'mid-move';
+  | 'mid-move'
+  | 'terminal-turn'
+  | 'turn-revived';
 
 export interface ReconcilerActiveRun {
   topicId: number;
@@ -83,6 +85,12 @@ export interface AutonomousLivenessReconcilerDeps {
    * the returned set.
    */
   liveTopicSnapshot: () => Set<number>;
+  /**
+   * Active autonomous topics whose live process is positively at a completed
+   * turn prompt. The value is the authoritative tmux session name. Optional so
+   * older/single-shot wiring keeps the dead-process behavior unchanged.
+   */
+  idleTopicSnapshot?: () => Map<number, string>;
   /** Is the resume queue globally paused (e.g. emergency stop)? */
   queuePaused: () => boolean;
   /** Is this topic already queued / in-flight in the resume queue? (criterion 7, queue arm) */
@@ -142,6 +150,8 @@ export interface AutonomousLivenessReconcilerDeps {
    * inputs; tags the new session midWork so a later reaper kill is revived.
    */
   respawn: (input: { topicId: number; resumeUuid: string | null; cwd: string }) => Promise<void>;
+  /** Replace a completed-turn session through the canonical refresh funnel. */
+  recoverIdle?: (input: { topicId: number; sessionName: string }) => Promise<boolean>;
   /**
    * Atomic CAS claim of the in-flight-spawn key for a topic (process-local
    * in-memory map). Returns true if THIS caller now owns the claim, false if
@@ -335,6 +345,7 @@ export class AutonomousLivenessReconciler {
       // Actuation still fails safe below; evidence classification stays honest.
     }
     const liveTopics = liveTopicsEvidence ?? new Set<number>();
+    const idleTopics = this.safe(() => this.deps.idleTopicSnapshot?.() ?? new Map<number, string>(), new Map<number, string>());
     const pressure = this.safe(() => this.deps.pressureTier(), 'critical' as const);
     const queuePaused = this.safeBool(() => this.deps.queuePaused(), false);
 
@@ -416,7 +427,8 @@ export class AutonomousLivenessReconciler {
         continue;
       }
       // Criterion 6: NO live session (own once-per-tick snapshot).
-      if (liveTopics.has(topicId)) {
+      const idleSession = idleTopics.get(topicId);
+      if (liveTopics.has(topicId) && !idleSession) {
         // Stably live → debounce reset. Record live-since for the stable-live rule.
         const obs = this.observed.get(topicId);
         if (obs) {
@@ -500,7 +512,8 @@ export class AutonomousLivenessReconciler {
       // their debounce state persists. dryRun would-respawn is cheap → still log.
       if (actedThisTick && !this.cfg.dryRun) continue;
 
-      const acted = await this.actOn(run, now, pressure);
+      if (idleSession) this.setCondition(topicId, 'terminal-turn', now);
+      const acted = await this.actOn(run, now, pressure, idleSession);
       if (acted) actedThisTick = true;
     }
 
@@ -517,6 +530,7 @@ export class AutonomousLivenessReconciler {
     run: ReconcilerActiveRun,
     now: number,
     pressure: 'normal' | 'moderate' | 'critical',
+    idleSession?: string,
   ): Promise<boolean> {
     const topicId = run.topicId;
 
@@ -618,6 +632,86 @@ export class AutonomousLivenessReconciler {
     if (this.safeBool(() => this.deps.migrationInFlight(), true)) {
       this.deps.audit({ ts: new Date(now).toISOString(), event: 'skipped-migration', topicId });
       return false;
+    }
+
+    // A live process sitting at a positively identified completed-turn prompt
+    // cannot be revived by another newline: the prior Codex turn is already
+    // terminal. Replace it through SessionRefresh, which preserves the topic
+    // binding and uses the same spawn/ownership gates as operator refreshes.
+    if (idleSession) {
+      if (!this.deps.recoverIdle) {
+        this.deps.raiseAggregated('liveness-idle-recovery-unwired', `topic ${topicId} has an active run at a completed turn, but idle recovery is unavailable.`);
+        this.deps.audit({ ts: new Date(now).toISOString(), event: 'idle-recovery-unwired', topicId });
+        return false;
+      }
+      if (this.cfg.dryRun) {
+        this.deps.audit({ ts: new Date(now).toISOString(), event: 'would-recover-idle-turn', topicId, dryRun: true });
+        this.observed.delete(topicId);
+        return true;
+      }
+      if (!this.safeBool(() => this.deps.claimInflight(topicId), false)) return false;
+      try {
+        const currentIdle = this.safe(() => this.deps.idleTopicSnapshot?.().get(topicId), undefined);
+        const currentRun = this.safe(
+          () => this.deps.listActiveRuns().find((candidate) => candidate.topicId === topicId),
+          undefined,
+        );
+        const stoppedNow = this.safeBool(
+          () => this.deps.operatorStoppedSince(topicId, new Date(run.startedAtMs ?? 0).toISOString()),
+          true,
+        );
+        const ownerElsewhereNow = this.safeBool(() => this.deps.topicOwnerElsewhere(topicId), true);
+        const leaseHeldNow = this.safeBool(() => this.deps.holdsLease(), false);
+        const queuedNow = this.safeBool(() => this.deps.topicInResumeQueue(topicId), true);
+        const runEligibleNow =
+          currentRun != null &&
+          currentRun.remainingSeconds > 0 &&
+          !currentRun.paused &&
+          currentRun.movedTo == null &&
+          !currentRun.moveSuspended &&
+          this.isCurrentGeneration(currentRun);
+        if (
+          currentIdle !== idleSession ||
+          stoppedNow ||
+          ownerElsewhereNow ||
+          !leaseHeldNow ||
+          queuedNow ||
+          !runEligibleNow
+        ) {
+          this.deps.audit({
+            ts: new Date(now).toISOString(),
+            event: 'idle-recheck-aborted',
+            topicId,
+            sameIdleSession: currentIdle === idleSession,
+            stopped: stoppedNow,
+            ownerElsewhere: ownerElsewhereNow,
+            leaseHeld: leaseHeldNow,
+            queued: queuedNow,
+            runEligible: runEligibleNow,
+          });
+          this.observed.delete(topicId);
+          return false;
+        }
+        const ok = await this.withTimeout(
+          this.deps.recoverIdle({ topicId, sessionName: idleSession }),
+          this.cfg.respawnTimeoutMs,
+        );
+        if (!ok) throw new Error('canonical-refresh-refused');
+        this.recordRedie(topicId, now);
+        this.respawnTotal += 1;
+        this.setCondition(topicId, 'turn-revived', now);
+        this.deps.audit({ ts: new Date(now).toISOString(), event: 'idle-turn-revived', topicId });
+        if (this.cfg.notifyUser) void this.deps.notifyTopic(topicId, 'My autonomous run had reached a completed turn while work remained, so I started a fresh continuation session.').catch(() => {});
+        this.observed.delete(topicId);
+        return true;
+      } catch (err) {
+        this.recordSpawnFailure(topicId, now);
+        this.deps.audit({ ts: new Date(now).toISOString(), event: 'idle-recovery-failed', topicId, error: this.scrub(err) });
+        this.deps.raiseAggregated('liveness-idle-recovery-failed', `topic ${topicId} remained active after its turn completed, and canonical refresh failed — needs your eyes.`);
+        return true;
+      } finally {
+        this.deps.releaseClaim(topicId);
+      }
     }
 
     // ── Resolve authoritative respawn inputs (NEVER the untrusted state file) ──

--- a/src/monitoring/AutonomousThroughputFloor.ts
+++ b/src/monitoring/AutonomousThroughputFloor.ts
@@ -18,8 +18,21 @@ export interface ThroughputRun {
   startedAt: number;
   telegramBacked: boolean;
   registeredMachineCount: number;
+  /**
+   * Durable ownership verdict for this topic on the evaluating machine. In a
+   * multi-machine pool, only the active owner may judge the run. `unknown` is
+   * accepted only for the legacy/single-machine case.
+   */
+  ownership: 'local-active' | 'remote-active' | 'unknown';
   midMove: boolean;
 }
+
+export type ThroughputIneligibilityReason =
+  | 'invalid-run'
+  | 'not-telegram-backed'
+  | 'ownership-remote'
+  | 'ownership-unproven-multi-machine'
+  | 'ownership-move-in-progress';
 
 export type SweepFailureClass = 'timeout' | 'rate-limited' | 'auth' | 'invalid-scope' | 'git-read' | 'github-read';
 
@@ -130,9 +143,8 @@ export class AutonomousThroughputFloor {
   }
 
   private async evaluate(run: ThroughputRun, now: number): Promise<void> {
-    if (!validRun(run) || !run.telegramBacked || run.registeredMachineCount !== 1 || run.midMove) {
-      return this.record(run, now, 'ineligible', 'scope-or-ownership-ineligible');
-    }
+    const ineligible = ineligibilityReason(run);
+    if (ineligible) return this.record(run, now, 'ineligible', ineligible);
     const loaded = this.deps.loadState(run.signalRunId);
     if (loaded && 'corrupt' in loaded) return this.record(run, now, 'unknown', 'state-corrupt');
     let state = loaded;
@@ -200,4 +212,14 @@ function baseline(run: ThroughputRun, now: number, outbound: OutboundObservation
   return { version: 1, signalRunId: run.signalRunId, lastDeliverableDeltaAt: now, lastManagerOutboundAt: Math.max(run.startedAt, outbound.newestOutboundAt ?? run.startedAt), lastHistoryCursor: outbound.cursor, consecutiveSweepFailures: 0, nextSweepAt: now };
 }
 function validRun(run: ThroughputRun): boolean { return Boolean(run.signalRunId) && Number.isSafeInteger(run.topicId) && run.topicId > 0 && Number.isFinite(run.startedAt) && run.startedAt > 0; }
+export function ineligibilityReason(run: ThroughputRun): ThroughputIneligibilityReason | null {
+  if (!validRun(run)) return 'invalid-run';
+  if (!run.telegramBacked) return 'not-telegram-backed';
+  if (run.midMove) return 'ownership-move-in-progress';
+  if (run.ownership === 'remote-active') return 'ownership-remote';
+  if (run.registeredMachineCount > 1 && run.ownership !== 'local-active') {
+    return 'ownership-unproven-multi-machine';
+  }
+  return null;
+}
 function invalidTime(value: number, now: number): boolean { return !Number.isFinite(value) || value < 0 || value > now + 30_000; }

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -1729,7 +1729,9 @@ A proactive backstop that posts ONE purely-observational liveness line when an a
 
 ## Autonomous Throughput Floor
 
-A pull/audit-only view measures project PR movement and manager outbound silence for active autonomous runs. It never notifies, dispatches, remediates, or creates attention. Read \`GET /autonomous/throughput-floor\` when investigating a quiet run. HOLD still requires an actual open approval gate plus authoritative saturation of every non-gated lane; v1 has no lane authority and cannot grant HOLD. A proactive surface is follow-on work gated on a separately converged SelfHealGate.
+A pull/audit-only view measures project PR movement and manager outbound silence for active autonomous runs. Read \`GET /autonomous/throughput-floor\` when investigating a quiet run. Eligibility is ownership-aware: in a multi-machine pool, only the machine with the durable active topic ownership record judges the run, so stale machine registrations cannot globally disable the floor. Ineligible rows name the exact boundary (invalid run, non-Telegram scope, remote/unproven ownership, or move in progress), never the collapsed \`scope-or-ownership-ineligible\` label. HOLD still requires an actual open approval gate plus authoritative saturation of every non-gated lane; the floor has no lane authority and cannot grant HOLD.
+
+The AutonomousLivenessReconciler also covers a second dead-work shape: an autonomous run can remain active while its Codex/Claude process sits at a positively identified completed-turn prompt. A newline cannot revive a turn that already ended, so after the normal debounce, ownership, lease, stop, pressure, quota, and loop-cap gates, the reconciler replaces that session through the canonical SessionRefresh funnel. A failed refresh raises one aggregated attention item instead of silently nudging forever. Read \`GET /autonomous/liveness\`; conditions include \`terminal-turn\` and \`turn-revived\`.
 `;
 
   if (hasTelegram) {

--- a/tests/e2e/autonomous-liveness-reconciler-lifecycle.test.ts
+++ b/tests/e2e/autonomous-liveness-reconciler-lifecycle.test.ts
@@ -32,24 +32,28 @@ const AUTH = 'test-liveness-e2e';
 interface Knobs {
   runs: ReconcilerActiveRun[];
   liveTopics: Set<number>;
+  idleTopics: Map<number, string>;
   queuedTopics: Set<number>;
   operatorStopped: Set<number>;
   ownerElsewhere: Set<number>;
   leaseHeld: boolean;
   pressure: 'normal' | 'moderate' | 'critical';
   respawned: number[];
+  idleRecovered: number[];
 }
 
 function buildKnobs(): Knobs {
   return {
     runs: [],
     liveTopics: new Set<number>(),
+    idleTopics: new Map<number, string>(),
     queuedTopics: new Set<number>(),
     operatorStopped: new Set<number>(),
     ownerElsewhere: new Set<number>(),
     leaseHeld: true,
     pressure: 'normal',
     respawned: [],
+    idleRecovered: [],
   };
 }
 
@@ -58,6 +62,7 @@ function liveReconciler(k: Knobs, now: { v: number }): AutonomousLivenessReconci
     now: () => now.v,
     listActiveRuns: () => k.runs,
     liveTopicSnapshot: () => k.liveTopics,
+    idleTopicSnapshot: () => k.idleTopics,
     queuePaused: () => false,
     topicInResumeQueue: (t) => k.queuedTopics.has(t),
     operatorStoppedSince: (t) => k.operatorStopped.has(t),
@@ -73,6 +78,11 @@ function liveReconciler(k: Knobs, now: { v: number }): AutonomousLivenessReconci
     resolveCwd: () => '/agent/home/.worktrees/run',
     bindingUnambiguous: () => true,
     respawn: async ({ topicId }) => { k.respawned.push(topicId); },
+    recoverIdle: async ({ topicId }) => {
+      k.idleRecovered.push(topicId);
+      k.idleTopics.delete(topicId);
+      return true;
+    },
     claimInflight: () => true,
     releaseClaim: () => {},
     settleKill: async () => {},
@@ -154,6 +164,17 @@ describe('AutonomousLivenessReconciler lifecycle (e2e)', () => {
     // The route reflects the live respawn total.
     const res = await request(app).get('/autonomous/liveness').set(auth());
     expect(res.body.respawnTotal).toBeGreaterThanOrEqual(1);
+  });
+
+  it('active run at a completed turn → canonical idle recovery after debounce', async () => {
+    const k = buildKnobs(); const t = { v: 2_000_000 };
+    const r = liveReconciler(k, t);
+    k.runs = [run({ topicId: 556 })];
+    k.liveTopics.add(556);
+    k.idleTopics.set(556, 'echo-topic-556');
+    await r.tick(); t.v += 61_000; await r.tick();
+    expect(k.idleRecovered).toEqual([556]);
+    expect(r.status().conditions).toContainEqual(expect.objectContaining({ topicId: 556, state: 'turn-revived' }));
   });
 
   it('operator-stopped → NOT respawned', async () => {

--- a/tests/integration/autonomous-liveness-routes.test.ts
+++ b/tests/integration/autonomous-liveness-routes.test.ts
@@ -72,6 +72,44 @@ function mkTmp(): { tmpDir: string; stateDir: string } {
 }
 
 describe('GET /autonomous/liveness (integration)', () => {
+  it('surfaces completed-turn recovery through the real HTTP status route', async () => {
+    const t = mkTmp();
+    const recovered: number[] = [];
+    const idle = new Map<number, string>([[700, 'echo-topic-700']]);
+    const deps: AutonomousLivenessReconcilerDeps = {
+      now: () => 1_000_000,
+      listActiveRuns: () => [{ topicId: 700, remainingSeconds: 3600, paused: false, movedTo: null, moveSuspended: false, startedAtMs: 900_000 }],
+      liveTopicSnapshot: () => new Set([700]),
+      idleTopicSnapshot: () => idle,
+      queuePaused: () => false, topicInResumeQueue: () => false, operatorStoppedSince: () => false,
+      topicOwnerElsewhere: () => false, holdsLease: () => true, currentGenerationMs: () => null,
+      quotaOk: () => true, sessionCountOk: () => true, migrationInFlight: () => false,
+      pressureTier: () => 'normal', inflightSpawnStatus: () => ({ state: 'none' }),
+      resolveResumeUuid: () => 'uuid', resolveCwd: () => t.tmpDir, bindingUnambiguous: () => true,
+      respawn: async () => {},
+      recoverIdle: async ({ topicId }) => { recovered.push(topicId); idle.delete(topicId); return true; },
+      claimInflight: () => true, releaseClaim: () => {}, settleKill: async () => {}, notifyTopic: async () => {},
+      raiseAggregated: () => {}, audit: () => {},
+    };
+    const reconciler = new AutonomousLivenessReconciler(deps, { enabled: true, dryRun: false, debounceTicks: 1, debounceWindowSec: 0 });
+    const server = new AgentServer({
+      config: baseConfig(t.tmpDir, t.stateDir),
+      sessionManager: { listRunningSessions: () => [], getSession: () => null } as never,
+      state: new StateManager(t.stateDir), autonomousLivenessReconciler: reconciler,
+    });
+    try {
+      await server.start();
+      await reconciler.tick();
+      const res = await request(server.getApp()).get('/autonomous/liveness').set({ Authorization: `Bearer ${AUTH}` });
+      expect(res.status).toBe(200);
+      expect(recovered).toEqual([700]);
+      expect(res.body.conditions).toContainEqual(expect.objectContaining({ topicId: 700, state: 'turn-revived' }));
+    } finally {
+      await server.stop();
+      SafeFsExecutor.safeRmSync(t.tmpDir, { recursive: true, force: true, operation: 'tests/integration/autonomous-liveness-routes.test.ts' });
+    }
+  });
+
   describe('DARK — reconciler not wired', () => {
     let tmpDir: string; let server: AgentServer;
     let app: ReturnType<AgentServer['getApp']>;

--- a/tests/unit/AutonomousLivenessReconciler.test.ts
+++ b/tests/unit/AutonomousLivenessReconciler.test.ts
@@ -40,6 +40,7 @@ interface Harness {
   flags: {
     runs: ReconcilerActiveRun[];
     liveTopics: Set<number>;
+    idleTopics: Map<number, string>;
     queuedTopics: Set<number>;
     queuePaused: boolean;
     ownerElsewhere: Set<number>;
@@ -73,6 +74,7 @@ function build(config: AutonomousLivenessReconcilerConfig = {}): Harness {
   const flags: Harness['flags'] = {
     runs: [makeRun()],
     liveTopics: new Set<number>(),
+    idleTopics: new Map<number, string>(),
     queuedTopics: new Set<number>(),
     queuePaused: false,
     ownerElsewhere: new Set<number>(),
@@ -97,6 +99,7 @@ function build(config: AutonomousLivenessReconcilerConfig = {}): Harness {
     now: () => nowMs.v,
     listActiveRuns: () => flags.runs,
     liveTopicSnapshot: () => flags.liveTopics,
+    idleTopicSnapshot: () => flags.idleTopics,
     queuePaused: () => flags.queuePaused,
     topicInResumeQueue: (t) => flags.queuedTopics.has(t),
     operatorStoppedSince: (t) => {
@@ -117,6 +120,11 @@ function build(config: AutonomousLivenessReconcilerConfig = {}): Harness {
     respawn: async (input) => {
       if (flags.respawnThrows) throw new Error('spawn failed');
       respawned.push(input);
+    },
+    recoverIdle: async ({ topicId }) => {
+      respawned.push({ topicId, resumeUuid: 'idle-refresh', cwd: '' });
+      flags.idleTopics.delete(topicId);
+      return true;
     },
     claimInflight: (t) => {
       if (flags.claimHeld.has(t)) return false;
@@ -163,6 +171,51 @@ async function tickPastDebounce(h: Harness): Promise<void> {
 const topicsRespawned = (h: Harness): number[] => h.respawned.map((r) => r.topicId);
 
 describe('AutonomousLivenessReconciler', () => {
+  it('structurally refreshes an active run whose Codex turn is complete', async () => {
+    const h = build({ debounceTicks: 1, debounceWindowSec: 0 });
+    h.flags.liveTopics.add(100);
+    h.flags.idleTopics.set(100, 'echo-topic-100');
+    await h.reconciler.tick();
+    expect(topicsRespawned(h)).toEqual([100]);
+    expect(h.audit).toContainEqual(expect.objectContaining({ event: 'idle-turn-revived', topicId: 100 }));
+    expect(h.reconciler.status().conditions).toContainEqual(expect.objectContaining({ topicId: 100, state: 'turn-revived' }));
+  });
+
+  it('escalates when canonical completed-turn refresh fails', async () => {
+    const h = build({ debounceTicks: 1, debounceWindowSec: 0 });
+    h.flags.liveTopics.add(100);
+    h.flags.idleTopics.set(100, 'echo-topic-100');
+    const deps = (h.reconciler as unknown as { deps: AutonomousLivenessReconcilerDeps }).deps;
+    deps.recoverIdle = async () => false;
+    await h.reconciler.tick();
+    expect(h.aggregated).toContainEqual(expect.objectContaining({ kind: 'liveness-idle-recovery-failed' }));
+    expect(h.audit).toContainEqual(expect.objectContaining({ event: 'idle-recovery-failed', topicId: 100 }));
+  });
+
+  it('aborts completed-turn refresh when ownership moves after the claim', async () => {
+    const h = build({ debounceTicks: 1, debounceWindowSec: 0 });
+    h.flags.liveTopics.add(100);
+    h.flags.idleTopics.set(100, 'echo-topic-100');
+    const deps = (h.reconciler as unknown as { deps: AutonomousLivenessReconcilerDeps }).deps;
+    deps.claimInflight = (topicId) => {
+      h.flags.claimHeld.add(topicId);
+      h.flags.ownerElsewhere.add(topicId);
+      h.flags.runs = [makeRun({ movedTo: 'machine-b', moveSuspended: true })];
+      return true;
+    };
+
+    await h.reconciler.tick();
+
+    expect(h.respawned).toHaveLength(0);
+    expect(h.audit).toContainEqual(expect.objectContaining({
+      event: 'idle-recheck-aborted',
+      topicId: 100,
+      ownerElsewhere: true,
+      runEligible: false,
+    }));
+    expect(h.flags.claimHeld.has(100)).toBe(false);
+  });
+
   it('detects dead-active runs while paused but leaves live sessions alone', async () => {
     const h = build({ dryRun: true, debounceTicks: 1, debounceWindowSec: 0 });
     h.flags.queuePaused = true;

--- a/tests/unit/AutonomousThroughputFloor.test.ts
+++ b/tests/unit/AutonomousThroughputFloor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import { AutonomousThroughputFloor, deterministicHoldAllowed, hasMeaningfulDeliverableDelta, type DeliverableSnapshot, type ThroughputFloorRunState, type ThroughputRun } from '../../src/monitoring/AutonomousThroughputFloor.js';
+import { AutonomousThroughputFloor, deterministicHoldAllowed, hasMeaningfulDeliverableDelta, ineligibilityReason, type DeliverableSnapshot, type ThroughputFloorRunState, type ThroughputRun } from '../../src/monitoring/AutonomousThroughputFloor.js';
 
-const run: ThroughputRun = { signalRunId: 'topic:1:start', topicId: 1, startedAt: 1_000, telegramBacked: true, registeredMachineCount: 1, midMove: false };
+const run: ThroughputRun = { signalRunId: 'topic:1:start', topicId: 1, startedAt: 1_000, telegramBacked: true, registeredMachineCount: 1, ownership: 'unknown', midMove: false };
 const snap = (head: string, tree = head, descendsPrevious = false): DeliverableSnapshot => ({ merged: [], open: [{ number: 1, headSha: head, treeSha: tree, descendsPrevious }], digest: `${head}:${tree}` });
 
 describe('AutonomousThroughputFloor PULL/AUDIT-only', () => {
@@ -16,6 +16,30 @@ describe('AutonomousThroughputFloor PULL/AUDIT-only', () => {
   it('preserves deterministic HOLD without claiming missing lane truth', () => {
     expect(deterministicHoldAllowed({ openApprovalGate: true, allNonGatedLanesSaturated: true })).toBe(true);
     expect(deterministicHoldAllowed({ openApprovalGate: true, allNonGatedLanesSaturated: false })).toBe(false);
+  });
+
+  it('reports each eligibility boundary with a typed reason', () => {
+    expect(ineligibilityReason({ ...run, signalRunId: '' })).toBe('invalid-run');
+    expect(ineligibilityReason({ ...run, telegramBacked: false })).toBe('not-telegram-backed');
+    expect(ineligibilityReason({ ...run, midMove: true })).toBe('ownership-move-in-progress');
+    expect(ineligibilityReason({ ...run, ownership: 'remote-active' })).toBe('ownership-remote');
+    expect(ineligibilityReason({ ...run, registeredMachineCount: 4 })).toBe('ownership-unproven-multi-machine');
+  });
+
+  it('judges a locally owned run even when stale machine registrations exist', async () => {
+    const audit = vi.fn();
+    const multiMachineRun = { ...run, registeredMachineCount: 4, ownership: 'local-active' as const };
+    const floor = new AutonomousThroughputFloor({
+      listRuns: () => [multiMachineRun],
+      sweep: async () => ({ status: 'ok', snapshot: snap('a'), meaningfulDelta: false }),
+      observeOutbound: () => ({ coverage: 'proven' }),
+      loadState: () => null,
+      saveState: () => {},
+      audit,
+      now: () => 10_000_000,
+    }, { enabled: true });
+    await floor.tick();
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({ decision: 'baseline', reason: 'first-successful-observation' }));
   });
 
   it('audits a dual flatline without any action seam', async () => {

--- a/upgrades/next/stall-sentinel-recovery.md
+++ b/upgrades/next/stall-sentinel-recovery.md
@@ -1,0 +1,42 @@
+# Stall Sentinel Recovery
+
+<!-- bump: patch -->
+
+## What Changed
+
+Autonomous throughput monitoring no longer disables itself merely because the
+machine registry contains stale or additional entries. A Telegram-backed run
+with durable local ownership remains eligible, while remote, moving, unknown,
+invalid, and non-Telegram runs now report distinct typed refusal reasons.
+
+The autonomous liveness reconciler now detects a live session whose Codex turn
+has positively completed and revives it through the canonical fresh-session
+refresh path. The recovery retains the existing debounce, ownership, lease,
+stop, quota, pressure, and concurrency gates. Failed or unwired recovery is
+audited and escalated instead of being hidden behind an ineffective terminal
+nudge.
+
+Cross-model review config resolution also no longer imports the checkout
+owner's agent config when the script is invoked from an unrelated repository.
+The legacy package-root fallback is now confined to callers inside that package
+tree.
+
+## What to Tell Your User
+
+Autonomous runs that are locally owned will no longer be silently excluded by
+stale machine registrations. If a Codex turn finishes while autonomous work is
+still active, instar can structurally start the next turn instead of typing into
+an already-completed terminal and assuming it resumed.
+
+## Summary of New Capabilities
+
+No new operator action is required. Existing agents receive the behavior and
+agent-awareness update through the normal post-update migration path.
+
+## Evidence
+
+Unit, HTTP integration, and production-lifecycle E2E tests cover typed
+eligibility boundaries, durable local ownership in a multi-machine registry,
+completed-turn revival, failed-revival escalation, and the live status route.
+The affected verification gate passes 91/91 tests and the TypeScript build is
+green.

--- a/upgrades/side-effects/stall-sentinel-recovery.md
+++ b/upgrades/side-effects/stall-sentinel-recovery.md
@@ -1,0 +1,121 @@
+# Side-Effects Review — Stall Sentinel Recovery
+
+**Version / slug:** `stall-sentinel-recovery`
+**Date:** `2026-08-26`
+**Author:** `echo`
+**Second-pass reviewer:** `stall_recovery_review`
+
+## Summary of the change
+
+This change repairs two linked autonomous-liveness failures. `AutonomousThroughputFloor` now reports typed eligibility reasons and accepts durable local ownership even when the registry contains other machines. `AutonomousLivenessReconciler` now treats a positively idle live Codex session as a completed turn and uses the canonical fresh `SessionRefresh` path to continue it. Server wiring supplies ownership and idle-session evidence; templates and `PostUpdateMigrator` carry awareness to new and existing agents. A related cross-model-review fallback is confined to its package tree so unrelated repositories cannot inherit this checkout's agent config.
+
+## Decision-point inventory
+
+- `AutonomousThroughputFloor.ineligibilityReason` — modify — separates enumerable validity, channel, ownership, and move-state boundaries.
+- `AutonomousLivenessReconciler.tick` — modify — routes a positively idle live session through the same eligibility and safety floors as an absent session before refresh.
+- `server.ts` liveness wiring — modify — supplies positive-idle evidence and delegates actuation to canonical `SessionRefresh`.
+- `cross-model-review.mjs` config fallback — modify — confines a compatibility fallback to callers inside the package tree.
+
+---
+
+## 1. Over-block
+
+An ownership-unknown run remains refused when more than one machine is registered, even if all other registrations are stale. This is intentional fail-closed behavior: only a durable `local-active` record proves this machine may judge or revive the run. A live session that is not positively idle is not refreshed. A caller outside `ROOT` no longer receives the legacy package-root config; it must use cwd walk-up, `--config`, or `INSTAR_CONFIG_PATH`.
+
+---
+
+## 2. Under-block
+
+Incorrect durable ownership data could still authorize the wrong machine; this change consumes the ownership registry rather than redefining its authority. Prompt classification can miss a future Codex idle-screen shape until `SessionReaper.isPositivelyIdle` learns it. A process can change state between observation and actuation, so the reconciler rechecks the same session under the claim immediately before refresh. Refresh failure is bounded, audited, and escalated rather than retried without limit.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The change reuses the existing ownership registry as authority, `SessionReaper.isPositivelyIdle` as the shared detector, the liveness reconciler as the existing gated recovery controller, and `SessionRefresh` as the canonical lifecycle actuator. It does not add a competing tmux nudge or a parallel session-spawn mechanism.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the positive-idle detector produces a signal consumed by the existing gated liveness authority.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The terminal classifier never actuates directly. The reconciler combines it with durable run validity, Telegram scope, ownership, move state, lease, stop, quota, pressure, concurrency, debounce, failure budget, and an actuation-time recheck. The eligibility reasons are enumerable structural invariants, not semantic message judgments.
+
+---
+
+## 4b. Judgment-point check
+
+No new static heuristic decides among competing live signals. Positive-idle classification is an observation fed into the existing floor-based controller. Durable ownership and run validity are enumerable invariants. The controller retains all existing floors and does not introduce a new priority policy.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** active non-idle sessions still take the existing healthy path. Idle sessions enter recovery only after the same debounce and safety gates used for missing sessions.
+- **Double-fire:** the topic claim plus actuation-time idle/session-name equality check prevents concurrent ticks from refreshing the same observed turn twice.
+- **Races:** a session becoming busy after the snapshot is caught by the second `idleTopicSnapshot` check; ownership and stop state are also re-read before actuation through existing gates.
+- **Feedback loops:** successful refresh makes the old idle session disappear or cease being positively idle. Failures consume the existing bounded failure budget and raise one aggregated escalation.
+- **Config resolution:** explicit and environment config rungs still win; cwd walk-up is unchanged; only unrelated use of the package-root compatibility fallback is removed.
+
+---
+
+## 6. External surfaces
+
+Existing agents gain typed status/audit conditions and can observe a canonical fresh session replacement when an autonomous Codex turn completes. No new operator action, credential, URL, external API, or persistent schema is introduced. Telegram notification uses the existing liveness notification path and existing one-voice ownership gates. Timing depends on the configured reconciler cadence and debounce.
+
+---
+
+## 6b. Operator-surface quality
+
+No dashboard renderer, approval page, grant/revoke form, or other operator surface is changed. Not applicable.
+
+---
+
+## 7. Multi-machine posture
+
+**Machine-local by design, governed by replicated ownership.** Terminal state and tmux sessions are machine-local physical truths. The decision to act is authorized by the durable topic ownership registry and the existing lease/move gates. A remote-owned run is explicitly refused; an unknown owner is accepted only in a genuinely single-machine registry. User-facing notices use the existing owner-gated notification path. The change adds no durable state that can strand on transfer and generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+Rollback is a hot-fix revert and patch release. No schema or user-data migration is required. Existing audit rows remain readable. During rollback propagation, completed turns return to the old non-revivable behavior and typed reasons collapse, but no stored state needs repair.
+
+---
+
+## Conclusion
+
+The recovery is placed at the existing lifecycle-controller layer, consumes shared detectors and authorities, preserves all safety floors, and adds bounded escalation. The isolation fix removes unintended ambient configuration without altering explicit or normal walk-up resolution. The independent review found a multi-machine TOCTOU gap between the initial ownership check and destructive refresh; the implementation now re-reads ownership, lease, move/run eligibility, operator stop, queue custody, and the exact idle session under the claim, with a race regression test. The change is clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `stall_recovery_review`
+**Independent read of the artifact:** Concur with the review
+
+The reviewer found that the first implementation rechecked only the idle session under the process-local claim, leaving ownership transfer able to race with destructive refresh. The code and artifact were corrected to revalidate every lifecycle authority at the actuation instant, and a regression test moves ownership immediately after claim acquisition and proves refresh is refused.
+
+Concurrence: the claimed session, current run generation/state, ownership, lease, operator-stop, and queue custody are now revalidated fail-closed under the claim; the regression demonstrates refresh suppression and claim release, closing the material lifecycle race.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/AutonomousThroughputFloor.test.ts`
+- `tests/unit/AutonomousLivenessReconciler.test.ts`
+- `tests/integration/autonomous-liveness-routes.test.ts`
+- `tests/e2e/autonomous-liveness-reconciler-lifecycle.test.ts`
+- Final affected gate: 91/91 tests; full repository gate: 50,085 tests exercised, all discovered failures repaired and rerun.
+
+---
+
+## Class-Closure Declaration
+
+`defectClass: unbounded-self-action`, `closure: guard`, `guardEvidence: { enforcementType: ratchet, citation: tests/unit/self-action-convergence.test.ts, howCaught: the controller edge is gated by a per-topic claim and actuation-time idle recheck; success settles by replacing the completed session, while failure consumes a bounded retry budget and escalates, so the same idle turn cannot drive an unbounded refresh loop }`.


### PR DESCRIPTION
## ELI16 — autonomous work now survives a completed Codex turn

Imagine an agent still has an active work order, but the Codex conversation doing that work has reached its finished prompt. Pressing Enter does not restart the work: the turn is over. Instar previously treated the terminal as live and could keep nudging it without creating a new turn. At the same time, its throughput monitor could disable itself merely because old machine registrations existed, even when the current machine had durable proof that it owned the topic.

This fix separates those cases clearly. A run with durable local ownership stays eligible even if stale machine records exist. Remote, moving, unknown, invalid, and non-Telegram runs each get an honest reason for refusal. When the liveness controller sees that an active autonomous run is sitting at a positively completed Codex turn, it starts a fresh continuation through the same canonical refresh mechanism used elsewhere instead of typing into a finished terminal.

The refresh is not allowed to race a machine transfer. Immediately before acting, under the claim, Instar rechecks the exact idle session, current run generation and state, topic ownership, lease, operator stop, queue custody, and move state. If any changed, it refuses the refresh. Failures are bounded, audited, and escalated. Existing agents receive the behavior and awareness update through normal migration.

## What Changed

- Typed autonomous-throughput eligibility reasons replace the ambiguous combined refusal.
- Durable local ownership remains eligible in a multi-machine registry.
- Positively completed Codex turns are revived with canonical fresh session refresh.
- Lifecycle authority is revalidated under the claim to prevent ownership-transfer races.
- Cross-model review no longer inherits this checkout owner config from unrelated repositories.

## Evidence

Unit, HTTP integration, and production-lifecycle E2E coverage exercises eligibility boundaries, multi-machine local ownership, completed-turn revival, failed-revival escalation, status wiring, and ownership transfer after claim acquisition. The affected tests and TypeScript build pass. Full repository verification exercised 50,085 tests; every discovered failure was repaired and rerun.