### PR TITLE
fix(mesh): preserve startup without resolver

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-27T16-13-09-306Z-mesh-resolver-startup-fallback.json
+++ b/.instar/instar-dev-decisions/2026-08-27T16-13-09-306Z-mesh-resolver-startup-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-27T16:13:09.306Z",
+  "slug": "mesh-resolver-startup-fallback",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 3,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/resolveMeshPeerUrl.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-27T16-14-00-780Z-mesh-resolver-startup-fallback.json
+++ b/.instar/instar-dev-decisions/2026-08-27T16-14-00-780Z-mesh-resolver-startup-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-27T16:14:00.780Z",
+  "slug": "mesh-resolver-startup-fallback",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 3,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/resolveMeshPeerUrl.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-27T16-18-02-971Z-mesh-resolver-startup-fallback.json
+++ b/.instar/instar-dev-decisions/2026-08-27T16-18-02-971Z-mesh-resolver-startup-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-27T16:18:02.971Z",
+  "slug": "mesh-resolver-startup-fallback",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -22641,6 +22641,8 @@ export async function startServer(options: StartOptions): Promise<void> {
           const peerUrl = (machineId: string): string | null => {
             const entry = meshIdMgr.getActiveMachines().find((m) => m.machineId === machineId)?.entry;
             if (!entry) return null;
+            // Mesh initialization is best-effort; the shared funnel preserves
+            // legacy reachability when it degraded before resolver assignment.
             return resolveMeshPeerUrl(meshResolver, machineId, entry.endpoints, entry.lastKnownUrl);
           };
           _meshSelfId = meshSelfId;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -160,6 +160,7 @@ import { isSlackSessionKey, reconstructSlackMessage } from '../core/SlackForward
 import { formatForwardedTopicContext } from '../core/ForwardedTopicContext.js';
 import { resolveAdvertisedMeshUrl, advertiseSelfMeshUrl, detectTailscaleIp, pickPrimaryLanIp, computeSelfMeshEndpoints, advertiseSelfMeshEndpoints, resolveMeshBindHost } from '../core/MeshUrlAdvertiser.js';
 import { PeerEndpointResolver } from '../core/PeerEndpointResolver.js';
+import { resolveMeshPeerUrl } from '../core/resolveMeshPeerUrl.js';
 import { RelayRefusedError, isRelayRefusal, relayOutbound } from '../core/TelegramRelay.js';
 import { GitSyncManager } from '../core/GitSync.js';
 import { RegistrySyncDebouncer } from '../core/RegistrySyncDebouncer.js';
@@ -22640,7 +22641,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           const peerUrl = (machineId: string): string | null => {
             const entry = meshIdMgr.getActiveMachines().find((m) => m.machineId === machineId)?.entry;
             if (!entry) return null;
-            return meshResolver.resolve(machineId, entry.endpoints, entry.lastKnownUrl)[0]?.url ?? null;
+            return resolveMeshPeerUrl(meshResolver, machineId, entry.endpoints, entry.lastKnownUrl);
           };
           _meshSelfId = meshSelfId;
           // U4.4 — the offer transport (HOLDER side) + the post-hand-back delivery

--- a/src/core/resolveMeshPeerUrl.ts
+++ b/src/core/resolveMeshPeerUrl.ts
@@ -1,0 +1,17 @@
+import type { MeshEndpoint } from './types.js';
+import type { PeerEndpointResolver } from './PeerEndpointResolver.js';
+
+/**
+ * Resolve a peer URL without making optional mesh initialization a server-start
+ * prerequisite. The resolver is assigned inside the best-effort lease/mesh
+ * bootstrap; if that bootstrap degrades before assignment, legacy registry URLs
+ * must continue to keep the rest of the server alive.
+ */
+export function resolveMeshPeerUrl(
+  resolver: PeerEndpointResolver | undefined,
+  machineId: string,
+  endpoints: MeshEndpoint[] | undefined,
+  lastKnownUrl: string | undefined,
+): string | null {
+  return resolver?.resolve(machineId, endpoints, lastKnownUrl)[0]?.url ?? lastKnownUrl ?? null;
+}

--- a/src/core/resolveMeshPeerUrl.ts
+++ b/src/core/resolveMeshPeerUrl.ts
@@ -13,5 +13,6 @@ export function resolveMeshPeerUrl(
   endpoints: MeshEndpoint[] | undefined,
   lastKnownUrl: string | undefined,
 ): string | null {
-  return resolver?.resolve(machineId, endpoints, lastKnownUrl)[0]?.url ?? lastKnownUrl ?? null;
+  if (!resolver) return lastKnownUrl ?? null;
+  return resolver.resolve(machineId, endpoints, lastKnownUrl)[0]?.url ?? null;
 }

--- a/tests/e2e/mesh-resolver-startup-lifecycle.test.ts
+++ b/tests/e2e/mesh-resolver-startup-lifecycle.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('mesh resolver startup lifecycle', () => {
+  it('routes the production session-pool closure through the undefined-safe resolver funnel', () => {
+    const server = readFileSync(resolve(process.cwd(), 'src/commands/server.ts'), 'utf8');
+    const start = server.indexOf('const peerUrl = (machineId: string): string | null =>');
+    expect(start).toBeGreaterThan(0);
+    const closure = server.slice(start, start + 500);
+    expect(closure).toContain('resolveMeshPeerUrl(meshResolver, machineId, entry.endpoints, entry.lastKnownUrl)');
+    expect(closure).not.toContain('meshResolver.resolve(');
+  });
+});

--- a/tests/integration/resolve-mesh-peer-url.test.ts
+++ b/tests/integration/resolve-mesh-peer-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { PeerEndpointResolver } from '../../src/core/PeerEndpointResolver.js';
+import { resolveMeshPeerUrl } from '../../src/core/resolveMeshPeerUrl.js';
+
+describe('mesh peer URL integration', () => {
+  it('uses a live resolver when mesh initialized and preserves legacy reachability when it did not', () => {
+    const resolver = new PeerEndpointResolver({
+      config: {
+        enabled: true,
+        hedgeDelayMs: 10,
+        priorityTailscale: 10,
+        priorityLan: 20,
+        priorityCloudflare: 30,
+        tailscaleEnabled: true,
+        lanSubnetGate: false,
+        unhealthyAfterFailures: 3,
+        endpointEvictionMs: 60_000,
+        maxProbeBackoffMs: 60_000,
+        requestTimeoutMs: 5_000,
+      },
+      ownCidrs: () => [],
+    });
+    const endpoints = [{ kind: 'tailscale' as const, url: 'http://100.64.1.2:4042', priority: 10, observedAt: new Date().toISOString() }];
+
+    expect(resolveMeshPeerUrl(resolver, 'm-peer', endpoints, 'http://legacy-peer')).toBe('http://100.64.1.2:4042');
+    expect(resolveMeshPeerUrl(undefined, 'm-peer', endpoints, 'http://legacy-peer')).toBe('http://legacy-peer');
+  });
+});

--- a/tests/integration/resolve-mesh-peer-url.test.ts
+++ b/tests/integration/resolve-mesh-peer-url.test.ts
@@ -24,5 +24,8 @@ describe('mesh peer URL integration', () => {
 
     expect(resolveMeshPeerUrl(resolver, 'm-peer', endpoints, 'http://legacy-peer')).toBe('http://100.64.1.2:4042');
     expect(resolveMeshPeerUrl(undefined, 'm-peer', endpoints, 'http://legacy-peer')).toBe('http://legacy-peer');
+
+    const rejectingResolver = { resolve: () => [] } as unknown as PeerEndpointResolver;
+    expect(resolveMeshPeerUrl(rejectingResolver, 'm-peer', endpoints, 'http://legacy-peer')).toBeNull();
   });
 });

--- a/tests/unit/mesh-url-advertisement-wiring.test.ts
+++ b/tests/unit/mesh-url-advertisement-wiring.test.ts
@@ -45,7 +45,7 @@ describe('mesh URL advertisement wiring', () => {
     const peerUrlIdx = server.indexOf('const peerUrl = (machineId: string): string | null =>');
     expect(peerUrlIdx).toBeGreaterThan(0);
     const block = server.slice(peerUrlIdx, peerUrlIdx + 500);
-    expect(block).toContain('meshResolver.resolve(machineId, entry.endpoints, entry.lastKnownUrl)');
+    expect(block).toContain('resolveMeshPeerUrl(meshResolver, machineId, entry.endpoints, entry.lastKnownUrl)');
     expect(block).not.toContain('entry.lastKnownUrl ?? null');
   });
 

--- a/tests/unit/resolve-mesh-peer-url.test.ts
+++ b/tests/unit/resolve-mesh-peer-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveMeshPeerUrl } from '../../src/core/resolveMeshPeerUrl.js';
+
+describe('resolveMeshPeerUrl', () => {
+  it('falls back to the legacy registry URL when mesh bootstrap did not produce a resolver', () => {
+    expect(resolveMeshPeerUrl(undefined, 'm-peer', undefined, 'http://peer:4042')).toBe('http://peer:4042');
+  });
+
+  it('returns null when neither mesh nor legacy routing is available', () => {
+    expect(resolveMeshPeerUrl(undefined, 'm-peer', undefined, undefined)).toBeNull();
+  });
+
+  it('prefers the shared resolver when it is available', () => {
+    const resolve = vi.fn(() => [{ url: 'https://mesh-peer', kind: 'tailscale' }]);
+    const resolver = { resolve } as never;
+    expect(resolveMeshPeerUrl(resolver, 'm-peer', [], 'http://legacy-peer')).toBe('https://mesh-peer');
+    expect(resolve).toHaveBeenCalledWith('m-peer', [], 'http://legacy-peer');
+  });
+});

--- a/tests/unit/resolve-mesh-peer-url.test.ts
+++ b/tests/unit/resolve-mesh-peer-url.test.ts
@@ -16,4 +16,9 @@ describe('resolveMeshPeerUrl', () => {
     expect(resolveMeshPeerUrl(resolver, 'm-peer', [], 'http://legacy-peer')).toBe('https://mesh-peer');
     expect(resolve).toHaveBeenCalledWith('m-peer', [], 'http://legacy-peer');
   });
+
+  it('does not bypass an available resolver that rejects every candidate', () => {
+    const resolver = { resolve: vi.fn(() => []) } as never;
+    expect(resolveMeshPeerUrl(resolver, 'm-peer', [], 'http://legacy-peer')).toBeNull();
+  });
 });

--- a/upgrades/eli16/mesh-resolver-startup-fallback.md
+++ b/upgrades/eli16/mesh-resolver-startup-fallback.md
@@ -15,4 +15,5 @@ uses the peer's legacy registry URL, or reports no route if neither source exist
 Optional mesh degradation can no longer become a server-start prerequisite.
 
 Unit, integration, and production-wiring lifecycle tests cover all three paths.
-
+Independent lifecycle review additionally pins that an initialized resolver's
+explicit “no safe route” result is never overridden by the legacy fallback.

--- a/upgrades/eli16/mesh-resolver-startup-fallback.md
+++ b/upgrades/eli16/mesh-resolver-startup-fallback.md
@@ -1,0 +1,18 @@
+# Mesh Resolver Startup Fallback — Plain-English Overview
+
+## The problem
+
+The multi-machine mesh is optional and initializes on a best-effort path. If an
+earlier mesh setup step failed, a later session-pool callback still assumed the
+mesh URL resolver existed. Restarting a configured agent could therefore crash
+the whole server even though its older single-URL peer route was still usable.
+
+## What changes
+
+Peer URL lookup now goes through one small funnel. When the mesh resolver exists,
+the funnel uses its preferred multi-rope endpoint. When it does not, the funnel
+uses the peer's legacy registry URL, or reports no route if neither source exists.
+Optional mesh degradation can no longer become a server-start prerequisite.
+
+Unit, integration, and production-wiring lifecycle tests cover all three paths.
+

--- a/upgrades/eli16/mesh-resolver-startup-fallback.md
+++ b/upgrades/eli16/mesh-resolver-startup-fallback.md
@@ -17,3 +17,4 @@ Optional mesh degradation can no longer become a server-start prerequisite.
 Unit, integration, and production-wiring lifecycle tests cover all three paths.
 Independent lifecycle review additionally pins that an initialized resolver's
 explicit “no safe route” result is never overridden by the legacy fallback.
+The production wiring documents that mesh construction is intentionally best-effort.

--- a/upgrades/next/mesh-resolver-startup-fallback.md
+++ b/upgrades/next/mesh-resolver-startup-fallback.md
@@ -1,0 +1,10 @@
+# Mesh resolver startup fallback
+
+## Summary of New Capabilities
+
+- The server now remains available when optional mesh initialization degrades before its endpoint resolver is constructed.
+
+## Fixed
+
+- Session-pool peer routing falls back to the registry's legacy peer URL instead of crashing startup when the optional mesh resolver is unavailable.
+

--- a/upgrades/next/mesh-resolver-startup-fallback.md
+++ b/upgrades/next/mesh-resolver-startup-fallback.md
@@ -4,7 +4,15 @@
 
 - The server now remains available when optional mesh initialization degrades before its endpoint resolver is constructed.
 
-## Fixed
+## What Changed
 
 - Session-pool peer routing falls back to the registry's legacy peer URL instead of crashing startup when the optional mesh resolver is unavailable.
 
+## What to Tell Your User
+
+Agent servers now keep starting if optional multi-machine mesh setup degrades; peer routing falls back to its existing registry URL.
+
+## Evidence
+
+- Before: restarting Echo with mesh initialization degraded terminated startup with `TypeError: Cannot read properties of undefined (reading 'resolve')` in the production session-pool peer URL closure.
+- After: applying the undefined-safe funnel to the installed build allowed the same configured server to bind and answer `/updates/status`; the permanent source path is pinned at unit, integration, and E2E tiers.

--- a/upgrades/side-effects/mesh-resolver-startup-fallback.md
+++ b/upgrades/side-effects/mesh-resolver-startup-fallback.md
@@ -1,0 +1,23 @@
+# Side-Effects Review — Mesh resolver startup fallback
+
+## Summary
+
+The session-pool peer URL closure now uses an undefined-safe resolution funnel.
+The preferred behavior is unchanged when mesh initialization succeeds. When it
+does not, routing degrades to the pre-mesh registry URL instead of terminating
+the server process.
+
+## Risks and boundaries
+
+- A degraded mesh may temporarily use one legacy route instead of hedged routes.
+- If neither a resolver candidate nor legacy URL exists, lookup still returns
+  no route; it does not invent reachability.
+- The change adds no external writes, credentials, schemas, or user actions.
+- Rollback is a normal patch revert with no state cleanup.
+
+## Evidence
+
+- `tests/unit/resolve-mesh-peer-url.test.ts`
+- `tests/integration/resolve-mesh-peer-url.test.ts`
+- `tests/e2e/mesh-resolver-startup-lifecycle.test.ts`
+

--- a/upgrades/side-effects/mesh-resolver-startup-fallback.md
+++ b/upgrades/side-effects/mesh-resolver-startup-fallback.md
@@ -64,6 +64,7 @@ Pure code hotfix: revert and ship another patch. No persistent state, migration,
 ## Conclusion
 
 The fallback contains an optional-subsystem failure at the correct dependency boundary while keeping successful mesh behavior unchanged. The live before/after restart and all three test tiers support shipping after independent lifecycle review and green CI.
+The production closure now also states its best-effort initialization contract at the call site.
 
 ## Second-pass review (if required)
 

--- a/upgrades/side-effects/mesh-resolver-startup-fallback.md
+++ b/upgrades/side-effects/mesh-resolver-startup-fallback.md
@@ -1,23 +1,83 @@
 # Side-Effects Review — Mesh resolver startup fallback
 
-## Summary
+**Version / slug:** `mesh-resolver-startup-fallback`
+**Date:** `2026-08-27`
+**Author:** `Echo`
+**Second-pass reviewer:** `Lorentz (concurred after revision)`
 
-The session-pool peer URL closure now uses an undefined-safe resolution funnel.
-The preferred behavior is unchanged when mesh initialization succeeds. When it
-does not, routing degrades to the pre-mesh registry URL instead of terminating
-the server process.
+## Summary of the change
 
-## Risks and boundaries
+`src/core/resolveMeshPeerUrl.ts` adds one peer-routing funnel used by the production session-pool closure in `src/commands/server.ts`. It preserves preferred multi-rope resolution when optional mesh initialization succeeds and uses the existing registry URL when initialization degrades before assigning `meshResolver`. The change repairs a live restart crash without changing mesh ordering or inventing reachability.
 
-- A degraded mesh may temporarily use one legacy route instead of hedged routes.
-- If neither a resolver candidate nor legacy URL exists, lookup still returns
-  no route; it does not invent reachability.
-- The change adds no external writes, credentials, schemas, or user actions.
-- Rollback is a normal patch revert with no state cleanup.
+## Decision-point inventory
 
-## Evidence
+- `resolveMeshPeerUrl()` — add — mechanical selection between an available resolver result and the already-authoritative legacy registry URL.
+- Session-pool `peerUrl` closure — modify — delegates URL selection to the undefined-safe funnel.
 
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. A peer with neither an initialized resolver candidate nor a legacy URL remains unreachable exactly as before.
+
+## 2. Under-block
+
+The fallback does not repair the earlier mesh initialization failure; it contains its blast radius so the server starts and legacy routing remains usable. Other call sites that independently dereference optional mesh state would require their own funnel, but focused search found this production closure as the crashing independent consumer.
+
+## 3. Level-of-abstraction fit
+
+The helper sits at the peer-URL resolution boundary, below session routing and above the resolver implementation. It reuses `PeerEndpointResolver` and the existing legacy registry URL rather than duplicating endpoint validation or transport policy.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+This is deterministic availability plumbing. It does not interpret intent, filter messages, or make a judgment call; it preserves a previously supported route when an optional dependency is absent.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The choices are fully enumerable: use the initialized resolver's first candidate, else the persisted legacy URL, else no route.
+
+## 5. Interactions
+
+- **Shadowing:** when the resolver exists, its result is authoritative—including an empty result. The legacy fallback runs only when resolver construction never completed.
+- **Double-fire:** the helper performs no I/O and triggers no action.
+- **Races:** it reads only values already captured by the calling closure; no mutable state is added.
+- **Feedback loops:** it records nothing and cannot feed back into mesh health.
+
+## 6. External surfaces
+
+Agents whose optional mesh bootstrap degrades now retain server availability and legacy peer routing. No message shape, API, credential, database, ledger, or operator action changes. Timing remains owned by the existing startup and resolver paths.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated behavior:** every machine executes the same local resolution funnel against its own live resolver and replicated machine-registry entry. A degraded machine may temporarily use the peer's single legacy URL while a healthy machine uses multiple ropes; that difference reflects machine-local transport health rather than divergent authority. The change emits no notices, holds no durable state, and generates no new URLs.
+
+## 8. Rollback cost
+
+Pure code hotfix: revert and ship another patch. No persistent state, migration, or agent repair is required. Rollback would reintroduce the startup crash on the demonstrated degraded-mesh state.
+
+## Conclusion
+
+The fallback contains an optional-subsystem failure at the correct dependency boundary while keeping successful mesh behavior unchanged. The live before/after restart and all three test tiers support shipping after independent lifecycle review and green CI.
+
+## Second-pass review (if required)
+
+**Reviewer:** Lorentz
+**Independent read of the artifact:** concur after revision. The first pass found that a nullish chain also fell back when an initialized resolver deliberately returned no safe candidates. The helper now branches only on resolver absence, and unit/integration tests pin the empty-result boundary.
+
+## Evidence pointers
+
+- Live before: Echo restart terminated at `meshResolver.resolve` with an undefined resolver.
+- Live after: the same installed build with the funnel guard bound port 4042 and answered `/updates/status`.
 - `tests/unit/resolve-mesh-peer-url.test.ts`
 - `tests/integration/resolve-mesh-peer-url.test.ts`
 - `tests/e2e/mesh-resolver-startup-lifecycle.test.ts`
 
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller change — not applicable.


### PR DESCRIPTION
## Summary
- keep server startup alive when optional mesh initialization exits before constructing its endpoint resolver
- preserve legacy registry URL routing as the degradation path
- add unit, integration, and E2E production-wiring regression coverage

## ELI16 — What happened
The mesh setup is optional, but one later callback treated its URL resolver as mandatory. If an earlier mesh step degraded, restarting the server crashed while reading that missing resolver. Peer lookup now uses the mesh resolver when available and otherwise falls back to the existing registry URL.

## Verification
- 10 focused tests green across unit, integration, and E2E
- TypeScript build green
- live Echo server recovered with the same guard applied to the installed build

Follow-up hotfix discovered while deploying #1983.