### PR TITLE
fix(mesh): a shorter advertisement no longer discards a working rope

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-29T19-47-36-789Z-mesh-endpoint-degradation-retention.json
+++ b/.instar/instar-dev-decisions/2026-08-29T19-47-36-789Z-mesh-endpoint-degradation-retention.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-29T19:47:36.789Z",
+  "slug": "mesh-endpoint-degradation-retention",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 78,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/PeerEndpointRecorder.ts"
+    ],
+    "addedLines": 75,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/mesh-endpoint-degradation-retention.eli16.md
+++ b/docs/specs/mesh-endpoint-degradation-retention.eli16.md
@@ -1,0 +1,87 @@
+---
+title: Don't throw away a route that's working
+slug: mesh-endpoint-degradation-retention
+audience: decider
+---
+
+# Don't throw away a route that's working
+
+## The one-sentence version
+
+When one of your machines tells the others "here's how to reach me," and its list is
+*shorter* than last time, the other machines currently believe the new short list
+completely — even when they can see, right that second, that one of the dropped routes
+is carrying traffic. This change makes them keep a route they can see working.
+
+## What already exists
+
+Your machines can each be reached several different ways — over Tailscale, over the
+local network, or through the Cloudflare tunnel. Each of these is called a "rope."
+Every machine periodically announces which ropes it has, and the others write that
+list down.
+
+There is already a guard here, and it's a good one: if a machine announces *nothing*,
+the others keep what they had. The reasoning was that silence must never erase
+knowledge — an older or briefly-confused machine shouldn't be able to wipe out the
+routes to itself.
+
+## What was missing
+
+That guard only covers the case of announcing *nothing*. It says nothing about
+announcing *less*. If a machine previously announced two ropes and now announces one,
+the single-rope list replaces the two-rope list outright, and the missing rope is
+forgotten.
+
+That sounds harmless until you meet a machine that genuinely cannot see its own best
+address.
+
+On 2026-08-29 exactly that happened. One machine (a Windows box) runs its agent inside
+WSL — a small Linux environment nested inside Windows. Tailscale runs on the Windows
+side, outside that nested environment. So from where the agent sits, the Tailscale
+address does not exist. It can only see one virtual network address, and that address
+is unreachable from anywhere except that same Windows machine.
+
+So the machine announced its one useless address. The others obediently replaced the
+good Tailscale route — the one that had been carrying every message all day — with the
+useless one. The mesh then had no working way to reach that machine, and the machine
+had no way to correct the record, because it cannot see the address it needs to give.
+
+## What changes
+
+One rule is added: **a route the machine can currently see working is not discarded
+just because an announcement forgot to mention it.**
+
+Concretely, when a machine's new announcement omits a rope that the receiving machine's
+own health record says is alive right now, that rope is kept alongside the new list.
+
+Three things it deliberately does *not* do:
+
+- If the announcement *does* mention a rope, the announcement wins — a machine that
+  genuinely moved to a new address still updates cleanly.
+- If the omitted rope is recorded as dead, it is dropped exactly as before. A route
+  that is genuinely retired does not haunt the registry forever.
+- If there is no health record at all for that rope — it has never been dialled — it is
+  dropped too. No record is not the same as proof; only positive evidence retains.
+
+## The safeguard, in plain terms
+
+The decision is made only on *evidence this machine gathered itself*: its own record of
+whether that rope has been working. It never takes the peer's word for it, and it can
+never invent a route that was not already known. If the health record can't be read for
+any reason, the change does nothing and the old behaviour applies. So the worst case is
+"behaves exactly as it did before," and the best case is "stops discarding the only
+working route to a machine."
+
+It also cannot cause a stale route to be *used* blindly: the part of the system that
+actually chooses which rope to dial already tests ropes and pushes dead ones to the
+back. Keeping a record of a rope is not the same as trusting it.
+
+## What you need to decide
+
+Nothing, really — this is a straightforward correction to a guard that only covered
+half its case. The judgement call worth knowing about is the one above: retention
+requires positive evidence of life, rather than keeping every route forever. That
+choice keeps the registry honest at the cost of not helping a machine whose good route
+has *also* gone quiet at the moment it announces a shorter list. That case is covered
+by the separate, larger piece of work on letting a boxed-in machine be told its own
+reachable address.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5382,6 +5382,17 @@ export async function startServer(options: StartOptions): Promise<void> {
           getPeerEndpoints: (id) => idMgr.getMachineEndpoints(id),
           updateMachineEndpoints: (id, eps) => idMgr.updateMachineEndpoints(id, eps),
           meshTransportEnabled: meshEnabled,
+          // Invariant 2b evidence source — this machine's OWN rope-health record. A kind
+          // the peer stopped advertising is retained only while we can see it working.
+          isEndpointAlive: (id, kind) => {
+            try {
+              const row = meshResolver.snapshot().find((r) => r.peer === id && r.kind === kind);
+              return row ? !row.dead : undefined;
+            } catch {
+              // @silent-fallback-ok: no snapshot ⇒ no evidence ⇒ replace semantics.
+              return undefined;
+            }
+          },
           logger: (m) => console.log(pc.dim(m)),
         });
         leaseTransport = new HttpLeaseTransport({

--- a/src/core/PeerEndpointRecorder.ts
+++ b/src/core/PeerEndpointRecorder.ts
@@ -14,6 +14,16 @@
  *   1. meshTransport gate — a no-op when `multiMachine.meshTransport` is off.
  *   2. Absence is a no-op, NEVER a wipe — undefined/null/`[]`/fully-invalid leaves the
  *      peer's prior ropes intact (a silent or un-upgraded sender must not erase them).
+ *   2b. Degradation does not discard a PROVEN rope — a non-empty advertisement that
+ *      OMITS a kind whose local health record says it is currently alive RETAINS that
+ *      kind instead of replacing it away. Invariant 2 guarded the empty case only, so a
+ *      peer that can no longer SEE its own best address (an agent inside a NAT'd VM —
+ *      the 2026-08-29 WSL machine, whose only visible NIC was an unreachable virtual
+ *      one) replaced a demonstrably-working tailscale rope with a dead-on-arrival lan
+ *      one, and the mesh lost its only route to that machine. Evidence beats assertion:
+ *      a rope carrying traffic is not dropped because an announcement forgot it. A rope
+ *      the health record calls dead (or has never dialed) is still dropped, so a
+ *      genuinely-retired endpoint does not linger forever.
  *   3. Synchronous per-kind validation BEFORE storage (defense-in-depth, not authority).
  *   4. Idempotent — skip the write (and its `lastSeen` bump + registry-dirty mark) when
  *      the normalized set is unchanged, preventing ~720 no-op rewrites/day on a stable
@@ -32,6 +42,13 @@ export interface PeerEndpointRecorderDeps {
   updateMachineEndpoints: (machineId: string, endpoints: MeshEndpoint[]) => void;
   /** Live read: false ⇒ recording is a strict no-op (the lease handling is unchanged). */
   meshTransportEnabled: () => boolean;
+  /**
+   * Invariant 2b evidence source: is (peer, kind) CURRENTLY alive in this machine's own
+   * rope-health record? Only a `true` retains an omitted kind — `false` (dead) and
+   * `undefined` (never dialed, no evidence) both fall through to replace semantics.
+   * Optional so a caller that wires no health source keeps the pre-2b behaviour exactly.
+   */
+  isEndpointAlive?: (machineId: string, kind: MeshEndpoint['kind']) => boolean | undefined;
   logger?: (msg: string) => void;
 }
 
@@ -63,9 +80,10 @@ export class PeerEndpointRecorder {
     if (validated.length === 0) return false; // empty/fully-invalid → no-op, never a wipe
     try {
       const current = this.d.getPeerEndpoints(peerMachineId);
-      if (meshEndpointsEqual(current, validated)) return false; // idempotent — skip the write
-      this.d.updateMachineEndpoints(peerMachineId, validated);
-      this.log(`recorded ${validated.length} endpoint(s) for ${peerMachineId} [${validated.map((e) => e.kind).join(',')}]`);
+      const next = this.retainProvenOmitted(peerMachineId, current, validated);
+      if (meshEndpointsEqual(current, next)) return false; // idempotent — skip the write
+      this.d.updateMachineEndpoints(peerMachineId, next);
+      this.log(`recorded ${next.length} endpoint(s) for ${peerMachineId} [${next.map((e) => e.kind).join(',')}]`);
       return true;
     } catch (err) {
       // @silent-fallback-ok: recording is best-effort enrichment. An unknown-machine write
@@ -75,4 +93,47 @@ export class PeerEndpointRecorder {
       return false;
     }
   }
+
+  /**
+   * Invariant 2b — merge an omitted-but-PROVEN kind back into the advertised set.
+   *
+   * `advertised` wins for every kind it names (a peer re-advertising a kind with a NEW
+   * url is still an upgrade, and must land). A kind present in `current` but absent from
+   * `advertised` is retained ONLY when `isEndpointAlive` positively says it is alive; a
+   * dead rope, an unknown rope, and a caller with no health source all fall through to
+   * plain replace semantics.
+   *
+   * Pure over its inputs (no I/O, no throw) so the retain decision is unit-testable
+   * without a registry or a resolver.
+   */
+  private retainProvenOmitted(
+    peerMachineId: string,
+    current: MeshEndpoint[] | undefined,
+    advertised: MeshEndpoint[],
+  ): MeshEndpoint[] {
+    const alive = this.d.isEndpointAlive;
+    if (!alive || !current || current.length === 0) return advertised;
+    const advertisedKinds = new Set(advertised.map((e) => e.kind));
+    const retained: MeshEndpoint[] = [];
+    for (const ep of current) {
+      if (advertisedKinds.has(ep.kind)) continue;
+      let verdict: boolean | undefined;
+      try {
+        verdict = alive(peerMachineId, ep.kind);
+      } catch {
+        // @silent-fallback-ok: an unreadable health source is NO evidence, which is the
+        // same as "never dialed" — fall through to replace. Never retains on an error.
+        verdict = undefined;
+      }
+      if (verdict === true) retained.push(ep);
+    }
+    if (retained.length > 0) {
+      this.log(
+        `retained ${retained.length} proven endpoint(s) for ${peerMachineId} omitted by its advertisement `
+        + `[${retained.map((e) => e.kind).join(',')}] — health says alive`,
+      );
+    }
+    return [...advertised, ...retained];
+  }
+
 }

--- a/tests/integration/mesh-endpoint-propagation.test.ts
+++ b/tests/integration/mesh-endpoint-propagation.test.ts
@@ -38,6 +38,8 @@ describe('mesh-endpoint-http-propagation receiver (integration)', () => {
   let callerId: string;
   let callerSigning: { publicKey: string; privateKey: string };
   let meshOn: boolean;
+  /** Invariant 2b evidence the app-under-test reads — `${machineId}:${kind}` ⇒ alive? */
+  let aliveEvidence: Record<string, boolean>;
 
   function buildApp(): express.Express {
     const aSigning = generateSigningKeyPair();
@@ -51,6 +53,7 @@ describe('mesh-endpoint-http-propagation receiver (integration)', () => {
       getPeerEndpoints: (id) => identityManager.getMachineEndpoints(id),
       updateMachineEndpoints: (id, eps) => identityManager.updateMachineEndpoints(id, eps),
       meshTransportEnabled: () => meshOn,
+      isEndpointAlive: (id, kind) => aliveEvidence[`${id}:${kind}`],
     });
 
     const routes = createMachineRoutes({
@@ -75,6 +78,7 @@ describe('mesh-endpoint-http-propagation receiver (integration)', () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-prop-'));
     identityManager = new MachineIdentityManager(tmpDir);
     meshOn = true;
+    aliveEvidence = {};
 
     const aSigning = generateSigningKeyPair();
     receiverId = generateMachineId();
@@ -111,6 +115,36 @@ describe('mesh-endpoint-http-propagation receiver (integration)', () => {
 
   afterEach(() => {
     SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/mesh-endpoint-propagation.test.ts:afterEach' });
+  });
+
+  it('a DEGRADED advertisement over the real route keeps a rope this machine sees working', async () => {
+    // The 2026-08-29 regression, end-to-end: the peer previously advertised tailscale+lan;
+    // its agent then lost sight of its own tailscale address (an agent inside a NAT'd VM)
+    // and re-advertised lan ALONE — while this machine's rope health still showed the
+    // tailscale rope carrying traffic. It must not be replaced away.
+    identityManager.updateMachineEndpoints(callerId, [PEER_TS, PEER_LAN]);
+    aliveEvidence[`${callerId}:tailscale`] = true;
+    const app = buildApp();
+    const lease = { holder: callerId, epoch: 11, acquiredAt: 'x', expiresAt: 'y', nonce: 5 };
+    const body = { lease, reqNonce: newReqNonce(), endpoints: [PEER_LAN] };
+    const headers = signRequest(callerId, callerSigning.privateKey, body, 0);
+    expect((await request(app).post('/api/lease').set(headers).send(body)).status).toBe(200);
+
+    const stored = identityManager.getMachineEndpoints(callerId) ?? [];
+    expect(stored.map((e) => e.kind).sort()).toEqual(['lan', 'tailscale']);
+    expect(stored.find((e) => e.kind === 'tailscale')).toEqual(PEER_TS);
+  });
+
+  it('a DEGRADED advertisement DOES drop a rope this machine sees as dead', async () => {
+    identityManager.updateMachineEndpoints(callerId, [PEER_TS, PEER_LAN]);
+    aliveEvidence[`${callerId}:tailscale`] = false;
+    const app = buildApp();
+    const lease = { holder: callerId, epoch: 11, acquiredAt: 'x', expiresAt: 'y', nonce: 5 };
+    const body = { lease, reqNonce: newReqNonce(), endpoints: [PEER_LAN] };
+    const headers = signRequest(callerId, callerSigning.privateKey, body, 0);
+    expect((await request(app).post('/api/lease').set(headers).send(body)).status).toBe(200);
+
+    expect((identityManager.getMachineEndpoints(callerId) ?? []).map((e) => e.kind)).toEqual(['lan']);
   });
 
   it('POST /api/lease records the authenticated sender\'s endpoints for that peer', async () => {

--- a/tests/unit/PeerEndpointRecorder.test.ts
+++ b/tests/unit/PeerEndpointRecorder.test.ts
@@ -15,7 +15,13 @@ const TS: MeshEndpoint = { kind: 'tailscale', url: 'http://100.64.0.9:4042' };
 const LAN: MeshEndpoint = { kind: 'lan', url: 'http://192.168.87.60:4042' };
 const CF: MeshEndpoint = { kind: 'cloudflare', url: 'https://peer.dawn-tunnel.dev' };
 
-function mkRecorder(opts: { meshOn?: boolean; known?: Record<string, MeshEndpoint[]> } = {}) {
+function mkRecorder(opts: {
+  meshOn?: boolean;
+  known?: Record<string, MeshEndpoint[]>;
+  /** Invariant 2b evidence: `${machineId}:${kind}` ⇒ alive?  Absent key ⇒ no evidence. */
+  alive?: Record<string, boolean>;
+  aliveThrows?: boolean;
+} = {}) {
   const store: Record<string, MeshEndpoint[]> = { ...(opts.known ?? {}) };
   let writes = 0;
   const rec = new PeerEndpointRecorder({
@@ -29,6 +35,14 @@ function mkRecorder(opts: { meshOn?: boolean; known?: Record<string, MeshEndpoin
       writes += 1;
     },
     meshTransportEnabled: () => opts.meshOn ?? true,
+    ...(opts.alive || opts.aliveThrows
+      ? {
+        isEndpointAlive: (id: string, kind: MeshEndpoint['kind']) => {
+          if (opts.aliveThrows) throw new Error('snapshot unavailable');
+          return opts.alive?.[`${id}:${kind}`];
+        },
+      }
+      : {}),
   });
   return { rec, store, getWrites: () => writes };
 }
@@ -109,5 +123,87 @@ describe('forged-advert-set-from-non-owner-rejected (U4.2 R-r2-5b — the per-en
     // A's entry is byte-identical — B cannot shrink A's advert set to a rope
     // it controls and manufacture "unreachable on every transport".
     expect(store['m_A']).toEqual([TS, LAN]);
+  });
+});
+
+
+/**
+ * Invariant 2b — a NON-EMPTY advertisement that omits a PROVEN kind must not discard it.
+ *
+ * Regression origin (2026-08-29): a peer whose agent runs inside a NAT'd VM could only
+ * see an unreachable virtual NIC, so it advertised `[lan]` alone. The recorder replaced
+ * `[tailscale, lan]` with `[lan]` and the mesh lost its only working route to that
+ * machine — while the tailscale rope was carrying live traffic at that very moment.
+ * Invariant 2 guarded the EMPTY advertisement; nothing guarded the degraded one.
+ */
+describe('PeerEndpointRecorder.record — invariant 2b (omitted-but-proven retention)', () => {
+  it('retains an omitted kind the health record says is ALIVE (the regression case)', () => {
+    // The merged set equals what is already stored, so invariant 4 correctly skips the
+    // write — the POINT is that tailscale survives the degraded advertisement.
+    const { rec, store } = mkRecorder({
+      known: { peer: [TS, LAN] },
+      alive: { 'peer:tailscale': true },
+    });
+    expect(rec.record('peer', [LAN])).toBe(false);
+    expect(store.peer.map((e) => e.kind).sort()).toEqual(['lan', 'tailscale']);
+    expect(store.peer.find((e) => e.kind === 'tailscale')).toEqual(TS);
+  });
+
+  it('retains the proven kind AND writes when the advertised kind actually changed', () => {
+    const movedLan: MeshEndpoint = { kind: 'lan', url: 'http://192.168.87.99:4042' };
+    const { rec, store } = mkRecorder({
+      known: { peer: [TS, LAN] },
+      alive: { 'peer:tailscale': true },
+    });
+    expect(rec.record('peer', [movedLan])).toBe(true);
+    expect(store.peer.map((e) => e.kind).sort()).toEqual(['lan', 'tailscale']);
+    expect(store.peer.find((e) => e.kind === 'lan')).toEqual(movedLan);
+    expect(store.peer.find((e) => e.kind === 'tailscale')).toEqual(TS);
+  });
+
+  it('DROPS an omitted kind the health record says is DEAD (a retired rope does not linger)', () => {
+    const { rec, store } = mkRecorder({
+      known: { peer: [TS, LAN] },
+      alive: { 'peer:tailscale': false },
+    });
+    expect(rec.record('peer', [LAN])).toBe(true);
+    expect(store.peer.map((e) => e.kind)).toEqual(['lan']);
+  });
+
+  it('DROPS an omitted kind with NO health evidence (never dialed ⇒ not proven)', () => {
+    const { rec, store } = mkRecorder({ known: { peer: [TS, LAN] }, alive: {} });
+    expect(rec.record('peer', [LAN])).toBe(true);
+    expect(store.peer.map((e) => e.kind)).toEqual(['lan']);
+  });
+
+  it('a health source that THROWS retains nothing (error ⇒ no evidence, never a retain)', () => {
+    const { rec, store } = mkRecorder({ known: { peer: [TS, LAN] }, aliveThrows: true });
+    expect(rec.record('peer', [LAN])).toBe(true);
+    expect(store.peer.map((e) => e.kind)).toEqual(['lan']);
+  });
+
+  it('an advertisement RE-advertising a kind with a new url still wins (upgrade lands)', () => {
+    const moved: MeshEndpoint = { kind: 'tailscale', url: 'http://100.64.0.77:4042' };
+    const { rec, store } = mkRecorder({
+      known: { peer: [TS] },
+      alive: { 'peer:tailscale': true },
+    });
+    expect(rec.record('peer', [moved])).toBe(true);
+    expect(store.peer).toEqual([moved]);
+  });
+
+  it('stays idempotent — a re-advertisement that merges to the SAME set skips the write', () => {
+    const { rec, getWrites } = mkRecorder({
+      known: { peer: [LAN, TS] },
+      alive: { 'peer:tailscale': true },
+    });
+    expect(rec.record('peer', [LAN])).toBe(false);
+    expect(getWrites()).toBe(0);
+  });
+
+  it('with NO health dep wired, behaviour is byte-identical to plain replace', () => {
+    const { rec, store } = mkRecorder({ known: { peer: [TS, LAN] } });
+    expect(rec.record('peer', [LAN])).toBe(true);
+    expect(store.peer.map((e) => e.kind)).toEqual(['lan']);
   });
 });

--- a/upgrades/next/mesh-endpoint-degradation-retention.md
+++ b/upgrades/next/mesh-endpoint-degradation-retention.md
@@ -1,0 +1,40 @@
+## What Changed
+
+`PeerEndpointRecorder` gained invariant 2b: a non-empty peer advertisement that OMITS a
+rope kind no longer discards that kind when this machine's own rope-health record shows
+it currently alive. Retention requires positive evidence — a dead rope, a never-dialled
+rope, and an unreadable health source all keep the previous replace semantics, and an
+advertised kind always wins for its own kind. Wired from `meshResolver.snapshot()` in
+`server.ts`.
+
+Found live on 2026-08-29: a peer whose agent runs inside WSL can only see an unreachable
+virtual NIC, so it advertised `[lan]` alone, and the mesh discarded the working tailscale
+rope that was carrying its traffic at that moment.
+
+## What to Tell Your User
+
+If one of your machines runs its agent inside a nested environment (WSL, a container, a
+VM), it may not be able to see the address the other machines actually reach it on. When
+it announced the only address it *could* see, your other machines used to believe it and
+throw away the route that was working — leaving that machine unreachable with no way for
+it to correct the record.
+
+Now a route your machine can see carrying traffic is kept even when an announcement
+forgets to mention it. A route that has genuinely gone dead is still dropped, so nothing
+lingers forever.
+
+## Summary of New Capabilities
+
+- A peer's shorter address list can no longer delete a route this machine can see working.
+- Retention is evidence-based: only a rope the local health record reports alive is kept;
+  dead and never-dialled ropes are dropped exactly as before.
+- Fully reversible — with no health source wired the behaviour is byte-identical to the
+  previous replace semantics.
+
+## Evidence
+
+- Unit: `tests/unit/PeerEndpointRecorder.test.ts` (+8 cases), verified red-then-green
+  against pre-2b behaviour.
+- Integration: `tests/integration/mesh-endpoint-propagation.test.ts` (+2 cases) driving
+  the real `/api/lease` route with a real registry.
+- Side-effects review: `upgrades/side-effects/mesh-endpoint-degradation-retention.md`.

--- a/upgrades/side-effects/mesh-endpoint-degradation-retention.md
+++ b/upgrades/side-effects/mesh-endpoint-degradation-retention.md
@@ -1,0 +1,106 @@
+# Side-effects review — mesh endpoint degradation retention (invariant 2b)
+
+**Change:** `PeerEndpointRecorder.record()` no longer lets a non-empty but DEGRADED peer
+advertisement discard a rope this machine's own health record currently shows alive.
+Wired in `server.ts` from `meshResolver.snapshot()`.
+
+**Origin (live incident, 2026-08-29, topic 62395):** a peer whose agent runs inside WSL
+can only see an unreachable virtual NIC (`eth0 172.22.96.135`); Tailscale lives on the
+Windows host, outside that VM. It advertised `[lan]` alone; the recorder replaced
+`[tailscale, lan]`, and the mesh lost its only working route to that machine — while the
+tailscale rope was verifiably carrying traffic at that moment (peer answered
+`/health` 200 and a signed mesh probe returned the typed `not-router` refusal).
+
+## 1. Over-block — what legitimate input does this now reject?
+
+None: the change never rejects an advertisement. Every advertised kind is still recorded
+verbatim and still wins for its own kind (covered by the "re-advertising a kind with a new
+url still wins" and "advertised kind actually changed" tests). The only behavioural delta
+is ADDITIVE retention of an omitted kind.
+
+The nearest thing to an over-block is over-RETENTION: keeping a rope the peer meant to
+retire. Bounded three ways — retention requires a positive `alive === true`; `false` and
+`undefined` (never dialled) both drop; and the resolver remains the dial-time authority,
+so a retained rope that stops working is marked dead and then dropped on the next
+degraded advertisement.
+
+## 2. Under-block — what does this still miss?
+
+It does NOT help when the proven rope is ALSO not currently alive in the health record at
+the moment the degraded advertisement lands (a machine that reboots into WSL-only
+visibility while its tailscale rope happens to be marked dead). That case needs the
+peer to be able to advertise an address it cannot locally see, which is the separate
+NAT'd-machine work — tracked, not deferred silently:
+<!-- tracked: CMT-211 -->
+
+It also does not fix the root cause for that machine: a WSL-hosted agent still cannot
+discover its own reachable address. This change stops the DATA LOSS, not the blindness.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. `PeerEndpointRecorder` is the documented single chokepoint for "I just
+learned a peer's ropes" and already owns invariants 1–5, including the sibling
+absence-is-never-a-wipe rule. Invariant 2b is the same class of protection (an
+advertisement must not destroy knowledge) and belongs beside it, not in the two
+callsites. Nothing lower (the validator) knows current state; nothing higher (the routes)
+should own merge policy.
+
+## 4. Signal vs authority compliance
+
+Compliant. The recorder produces/persists a SIGNAL (the known endpoint set); it holds no
+blocking authority. `PeerEndpointResolver` remains the dial-time authority and already
+deprioritises-but-probes dead ropes, so a retained-but-stale endpoint cannot block or
+misroute anything — it can only be tried last. The new dep is a read-only evidence
+source; an exception from it is caught and degrades to the previous behaviour.
+
+## 5. Interactions
+
+- **Invariant 4 (idempotency):** preserved and explicitly tested — when the merged set
+  equals what is stored (the common steady-state case), the write is still skipped, so
+  this does not reintroduce the ~720 no-op rewrites/day the idempotency guard removed.
+- **Invariant 2 (absence):** untouched; the empty/invalid path returns before the merge.
+- **Invariant 5 (advisory):** untouched; only the peer's own entry is written.
+- **`MeshEndpointValidator` cap:** the merge appends retained entries AFTER validation of
+  the advertised set. A peer at the kind cap cannot exceed it, because retention only
+  adds kinds the advertisement did NOT name and there are three kinds total.
+- **No double-fire / no race added:** the merge is pure and synchronous inside the
+  existing single write path.
+
+## 6. External surfaces
+
+No route, config key, schema, or user-visible surface changes. `GET /health →
+multiMachine.syncStatus` and `GET /pool` may now show a peer retaining a rope kind they
+would previously have lost — which is the intended correction. Timing dependence is
+limited to reading a live snapshot, and the failure mode of that read is explicitly
+"no evidence ⇒ previous behaviour".
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** The retention decision is made from the RECEIVING machine's
+own rope-health record and written only into its own registry copy. This is deliberate
+and load-bearing: rope health is inherently per-observer (machine A's tailscale rope to C
+can be alive while B's is dead), so replicating the decision would let one machine's view
+overwrite another's ground truth. Each machine independently reaches the correct answer
+from its own evidence. No replication path is added and none is wanted. A single-machine
+agent has no peers and is a strict no-op.
+
+## 8. Rollback cost
+
+Trivial and total. Remove the `isEndpointAlive` dep from the `server.ts` construction and
+the recorder falls back — by an explicitly-tested path ("with NO health dep wired,
+behaviour is byte-identical to plain replace") — to the exact pre-change semantics. No
+data migration: the registry format is unchanged, and a retained endpoint is an ordinary
+entry the next advertisement can overwrite. No agent state repair.
+
+## Tests
+
+- Unit (`tests/unit/PeerEndpointRecorder.test.ts`, +8): retain-on-alive, drop-on-dead,
+  drop-on-no-evidence, drop-on-throw, advertised-kind-upgrade-wins, idempotent-merge,
+  no-dep-is-identical. Verified RED against pre-2b behaviour (3 failures for the right
+  reason: the retention cases) and GREEN after.
+- Integration (`tests/integration/mesh-endpoint-propagation.test.ts`, +2): the real
+  `/api/lease` route with a real registry — a degraded advertisement keeps a live rope,
+  and still drops a dead one.
+- E2E: not applicable — no new API route or feature-liveness surface; the change is a
+  merge rule inside an existing chokepoint already covered end-to-end by the integration
+  route test.


### PR DESCRIPTION
## ELI16 — Don't throw away a route that's working

Your machines can each be reached several ways — over Tailscale, over the local network, or through the Cloudflare tunnel. Each way is a "rope." Every machine periodically announces which ropes it has, and the others write the list down.

There was already a good guard here: if a machine announces *nothing*, the others keep what they had. Silence must never erase knowledge.

But that guard only covered announcing *nothing*. It said nothing about announcing *less*. A machine that used to announce two ropes and now announces one had its single-rope list swallow the two-rope list whole, and the missing rope was forgotten.

That seems harmless until you meet a machine that genuinely cannot see its own best address. One machine here runs its agent inside WSL — a small Linux environment nested inside Windows. Tailscale runs on the Windows side, outside that nested box. So from where the agent sits, the Tailscale address simply does not exist; it can only see one virtual address that nothing outside that machine can reach.

It announced its one useless address. The others dutifully replaced the good Tailscale route — the one carrying every message all day — with the useless one. The mesh then had no working way to reach it, and it had no way to fix the record, because the fix requires naming an address it cannot see.

This adds one rule: **a route the machine can currently see working is not discarded just because an announcement forgot to mention it.**

Three things it deliberately does not do. If the announcement *does* mention a rope, the announcement wins, so a machine that genuinely moved still updates cleanly. If the forgotten rope is recorded as dead, it is dropped as before, so retired routes don't haunt the registry. And if there's no health record at all for it, it's dropped too — never having tried a route is not the same as proof it works.

The decision uses only evidence this machine gathered itself, never the peer's word, and it can never invent a route that wasn't already known. If the health record can't be read, the change does nothing at all. Worst case it behaves exactly as before; best case it stops discarding the only working route to one of your machines.

---

## The bug

`PeerEndpointRecorder` has an invariant that an advertisement must never erase what we know about a peer's routes — but it only ever guarded the **empty** advertisement. A **non-empty but shorter** one replaced the stored set outright.

Found live on 2026-08-29 (topic 62395). A peer whose agent runs inside **WSL** can see exactly one network address — `eth0 172.22.96.135`, the virtual NIC WSL invents, unreachable from anywhere but that Windows host. Tailscale runs on the Windows side, *outside* that VM, so the agent cannot see (and can therefore never advertise) the address every other machine actually reaches it on.

It advertised `[lan]` alone. The recorder replaced `[tailscale, lan]`. The mesh lost its only working route to that machine — while the tailscale rope was carrying its traffic at that very moment (peer answered `/health` 200 in <80ms and a signed mesh probe returned the typed `not-router` refusal).

The machine had no way to correct the record, because the correction requires naming an address it cannot see.

## The fix — invariant 2b

An omitted kind is retained **only** when this machine's own rope-health record says that rope is currently alive. Evidence beats assertion.

Deliberately narrow:
- an **advertised** kind always wins for its own kind (a genuine address change still lands);
- a rope recorded **dead** is dropped exactly as before (a retired endpoint doesn't linger);
- a rope **never dialled** is dropped too — absence of a record is not proof of life;
- an **unreadable** health source retains nothing and degrades to the previous behaviour.

Ordering is unaffected: the resolver sorts by priority and health rather than array order, caps by priority before ordering, and `meshEndpointsEqual` is order-independent — so idempotency (invariant 4) still skips the steady-state write.

## Posture

Machine-local by design. Rope health is inherently per-observer — machine A's rope to C can be alive while B's is dead — so each machine reaches its own answer from its own evidence. No replication path added, and none wanted. Single-machine agents are a strict no-op.

Signal, not authority: `PeerEndpointResolver` remains the dial-time authority and already deprioritises-but-probes dead ropes, so a retained-but-stale entry can only ever be tried last.

## Tests

- **Unit** (+8): retain-on-alive, drop-on-dead, drop-on-no-evidence, drop-on-throw, advertised-kind-upgrade-wins, idempotent-merge, and an explicit "no health dep wired ⇒ byte-identical to plain replace". Verified **red against pre-2b behaviour** (the 3 retention cases fail for the right reason) and green after.
- **Integration** (+2): the real `/api/lease` route with a real registry — a degraded advertisement keeps a live rope, and still drops a dead one.

## Scope

This stops the **data loss**. It does not fix the underlying blindness — a NAT'd/VM-hosted agent still cannot discover its own reachable address, and there is no way to tell it one. That is tracked separately (CMT-211) and is the larger design change.

## Rollback

Remove the `isEndpointAlive` dep from the `server.ts` construction; the recorder falls back to exact pre-change semantics by an explicitly-tested path. Registry format unchanged, no migration, no state repair.

Side-effects review: `upgrades/side-effects/mesh-endpoint-degradation-retention.md`
ELI16: `docs/specs/mesh-endpoint-degradation-retention.eli16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o9kgd1afVCgzEnqJaqmsi