### PR TITLE
fix(mesh): the key-expiry warning stops crying wolf about non-mesh devices

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-29T20-39-51-889Z-rope-key-expiry-mesh-scope.json
+++ b/.instar/instar-dev-decisions/2026-08-29T20-39-51-889Z-rope-key-expiry-mesh-scope.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-08-29T20:39:51.889Z",
+  "slug": "rope-key-expiry-mesh-scope",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 105,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/tailscaleStatusParser.ts",
+      "src/monitoring/RopeHealthMonitor.ts"
+    ],
+    "addedLines": 100,
+    "deletedLines": 5
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-29T20-40-32-101Z-rope-key-expiry-mesh-scope.json
+++ b/.instar/instar-dev-decisions/2026-08-29T20-40-32-101Z-rope-key-expiry-mesh-scope.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-08-29T20:40:32.101Z",
+  "slug": "rope-key-expiry-mesh-scope",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 105,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/tailscaleStatusParser.ts",
+      "src/monitoring/RopeHealthMonitor.ts"
+    ],
+    "addedLines": 100,
+    "deletedLines": 5
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-29T20-41-15-896Z-rope-key-expiry-mesh-scope.json
+++ b/.instar/instar-dev-decisions/2026-08-29T20-41-15-896Z-rope-key-expiry-mesh-scope.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-29T20:41:15.896Z",
+  "slug": "rope-key-expiry-mesh-scope",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 105,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/tailscaleStatusParser.ts",
+      "src/monitoring/RopeHealthMonitor.ts"
+    ],
+    "addedLines": 100,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "U4.5's key-expiry tier was specified against `tailscale status --json` as a whole and never scoped to mesh-relevant nodes — the tailnet was implicitly assumed to BE the mesh. Latent since U4.5 shipped; it only becomes visible once the operator's tailnet contains a node with a lapsed key that is not a mesh peer, which happened when a device went offline 2026-08-13. The permanent warning was then read as a live finding and relayed to the operator as a real risk on 2026-08-29."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/rope-key-expiry-mesh-scope.eli16.md
+++ b/docs/specs/rope-key-expiry-mesh-scope.eli16.md
@@ -1,0 +1,68 @@
+---
+title: Stop warning about a device that isn't part of the mesh
+slug: rope-key-expiry-mesh-scope
+audience: decider
+---
+
+# Stop warning about a device that isn't part of the mesh
+
+## The one-sentence version
+
+Your machines watch for a Tailscale key that's about to expire and warn you — but they
+were checking *every device on your account*, so one long-dead phone or old laptop with a
+lapsed key made the warning permanent and meaningless.
+
+## What this is about
+
+Your machines reach each other over Tailscale, among other routes. Tailscale gives each
+device a key that expires periodically; when it lapses, that device drops off the network.
+Losing a route that way used to be silent, so a warning was added: if any key is within
+two weeks of expiring, say so in the daily mesh summary.
+
+The check asks Tailscale for the status of everything on your account and picks whichever
+key expires soonest.
+
+## What went wrong
+
+Your Tailscale account holds more than the machines running agents. It holds phones,
+other people's laptops, devices you set up once and forgot. One of them — a node called
+"localhost" — went offline on the 13th and its key lapsed.
+
+Because it was the soonest expiry on the whole account, every single check picked it. The
+mesh summary said "a Tailscale key expires in 0 days — re-authenticate before it drops the
+rope" continuously, for over two weeks, about a device that is not part of the mesh and
+whose expiry cannot affect anything.
+
+Worse, it was actively misleading. On 2026-08-29 I read that warning and told you a real
+route was at risk and that you'd need to log in. That was wrong — every machine you
+actually use had months left. A warning that is always on doesn't just get ignored; it
+gets *believed* at the wrong moment.
+
+## What changes
+
+The check now only looks at devices that actually carry mesh traffic — the ones your
+machines are configured to reach each other on — plus this machine itself.
+
+Everything else about it is unchanged: same two-week horizon, same wording, same daily
+summary.
+
+## The safeguards
+
+Three deliberate choices, all in the direction of never hiding a real warning:
+
+- **This machine always counts.** Its own key lapsing would drop every route it has, so
+  it's included whether or not it appears in the list of peer addresses.
+- **If the list of mesh addresses can't be read, the check falls back to looking at
+  everything** — exactly as it does today. A failure makes it noisier, never quieter.
+- **An empty list also falls back to everything.** Otherwise a momentary blank would
+  narrow the check down to this machine alone and quietly hide a genuine peer warning.
+
+None of your device names, addresses, or account details leave the part of the code that
+reads them — that was already a hard rule here, and it still holds. The addresses are
+passed *in* to do the matching; only a yes/no comes back out.
+
+## What you need to decide
+
+Nothing. This is a scoping correction to an existing warning, it cannot suppress a warning
+about a machine you actually use, and every failure path makes it behave exactly as it
+does today.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -25446,6 +25446,33 @@ export async function startServer(options: StartOptions): Promise<void> {
               const t = Date.parse(r.lastHeartbeatAt);
               return Number.isFinite(t) ? t : null;
             },
+            // Scope the key-expiry tier to tailnet nodes that actually back a mesh rope:
+            // the hostnames of every registered peer's `tailscale` endpoint. Without this
+            // the scan is tailnet-wide and any long-dead device the operator still owns is
+            // the permanent soonest-expiry, so the warning never clears.
+            meshTailscaleAddresses: () => {
+              try {
+                const mgr = coordinator?.managers?.identityManager;
+                if (!mgr) return [];
+                const reg = mgr.loadRegistry();
+                const out: string[] = [];
+                for (const entry of Object.values(reg.machines ?? {}) as Array<{ endpoints?: Array<{ kind?: string; url?: string }> }>) {
+                  for (const ep of entry.endpoints ?? []) {
+                    if (typeof ep?.url !== 'string') continue;
+                    if (ep.kind !== 'tailscale') continue;
+                    try {
+                      const host = new URL(ep.url).hostname;
+                      if (host) out.push(host);
+                    } catch { /* a malformed endpoint url contributes nothing */ }
+                  }
+                }
+                return out;
+              } catch {
+                // @silent-fallback-ok: an unreadable registry ⇒ no scoping this pass,
+                // which is the pre-scoping (tailnet-wide) behaviour, never a crash.
+                return [];
+              }
+            },
             raiseAttention: (item) =>
               telegram?.createAttentionItem({
                 id: item.id,

--- a/src/core/tailscaleStatusParser.ts
+++ b/src/core/tailscaleStatusParser.ts
@@ -21,6 +21,18 @@ export interface TailscaleKeyExpiryEntry {
   role: 'self' | 'peer';
   /** ISO-8601 expiry, or null when the node has no expiring key (e.g. expiry disabled). */
   keyExpiryIso: string | null;
+  /**
+   * Does this tailnet node actually BACK a mesh rope? A tailnet holds every device the
+   * operator owns — phones, other people's laptops, long-dead nodes — and only a handful
+   * back a mesh peer. True when the node's tailnet address is in the caller-supplied mesh
+   * address set, and true for every node when no set is supplied (back-compatible: an
+   * un-scoped caller keeps the previous tailnet-wide behaviour).
+   *
+   * SCRUB DIRECTION: addresses are matched INSIDE this parser and never leave it — the
+   * caller passes addresses IN and gets a BOOLEAN back. The return shape still carries no
+   * identity, so the content-scrub boundary above is preserved, not weakened.
+   */
+  backsMeshRope: boolean;
 }
 
 export interface TailscaleStatusParse {
@@ -35,8 +47,15 @@ export interface TailscaleStatusParse {
  * shape. Tolerant of absent fields (a node without KeyExpiry yields null);
  * a malformed body yields `{ parsed: false, entries: [] }` — the expiry tier
  * is then silently absent for that pass (never an error state, spec R-r2-3).
+ *
+ * `meshAddresses` (optional) is the set of tailnet addresses that back a mesh rope. When
+ * supplied, each entry is flagged `backsMeshRope` accordingly; when omitted every entry is
+ * flagged true and behaviour is unchanged.
  */
-export function parseTailscaleStatus(rawBody: string): TailscaleStatusParse {
+export function parseTailscaleStatus(
+  rawBody: string,
+  meshAddresses?: ReadonlySet<string>,
+): TailscaleStatusParse {
   let body: unknown;
   try {
     body = JSON.parse(rawBody);
@@ -60,12 +79,23 @@ export function parseTailscaleStatus(rawBody: string): TailscaleStatusParse {
     return Number.isFinite(t) ? new Date(t).toISOString() : null;
   };
 
+  /** True when this node holds one of the mesh-backing addresses (or no scoping asked). */
+  const backs = (node: unknown): boolean => {
+    if (!meshAddresses || meshAddresses.size === 0) return true;
+    if (!node || typeof node !== 'object') return false;
+    const ips = (node as { TailscaleIPs?: unknown }).TailscaleIPs;
+    if (!Array.isArray(ips)) return false;
+    return ips.some((ip) => typeof ip === 'string' && meshAddresses.has(ip));
+  };
+
   if (obj.Self && typeof obj.Self === 'object') {
-    entries.push({ role: 'self', keyExpiryIso: expiryOf(obj.Self) });
+    // Self ALWAYS counts: this machine's own key expiring drops every rope it has,
+    // whether or not its address happens to appear in the mesh address set.
+    entries.push({ role: 'self', keyExpiryIso: expiryOf(obj.Self), backsMeshRope: true });
   }
   if (obj.Peer && typeof obj.Peer === 'object') {
     for (const peer of Object.values(obj.Peer as Record<string, unknown>)) {
-      entries.push({ role: 'peer', keyExpiryIso: expiryOf(peer) });
+      entries.push({ role: 'peer', keyExpiryIso: expiryOf(peer), backsMeshRope: backs(peer) });
     }
   }
   return { parsed: true, entries };
@@ -74,13 +104,22 @@ export function parseTailscaleStatus(rawBody: string): TailscaleStatusParse {
 /**
  * The days-until-soonest-expiry summary the monitor's degraded tier consumes.
  * Returns null when no entry carries an expiry.
+ *
+ * `opts.meshScopedOnly` restricts the scan to entries that back a mesh rope (self always
+ * counts). Without it the scan is tailnet-wide, which is how a dead unrelated node warned
+ * forever: an old device whose key expired months ago is the permanent global minimum, so
+ * the warning never clears and stops carrying information (observed 2026-08-29 — a node
+ * offline since 2026-08-13 kept the mesh digest warning while every real mesh machine's
+ * key was months from expiry).
  */
 export function soonestKeyExpiry(
   parse: TailscaleStatusParse,
   nowMs: number,
+  opts?: { meshScopedOnly?: boolean },
 ): { role: 'self' | 'peer'; expiresAtIso: string; inDays: number } | null {
   let best: { role: 'self' | 'peer'; expiresAtIso: string; inDays: number } | null = null;
   for (const e of parse.entries) {
+    if (opts?.meshScopedOnly && !e.backsMeshRope) continue;
     if (!e.keyExpiryIso) continue;
     const t = Date.parse(e.keyExpiryIso);
     if (!Number.isFinite(t)) continue;

--- a/src/monitoring/RopeHealthMonitor.ts
+++ b/src/monitoring/RopeHealthMonitor.ts
@@ -100,6 +100,14 @@ export interface RopeHealthMonitorDeps {
    * then silently absent). Default impl provided; tests inject.
    */
   execTailscaleStatusJson?: () => Promise<string | null>;
+  /**
+   * The tailnet addresses that actually BACK a mesh rope (from the peers' tailscale
+   * endpoints). Supplied ⇒ the key-expiry tier considers only those nodes plus self;
+   * absent ⇒ tailnet-wide, the previous behaviour. A tailnet holds every device the
+   * operator owns, so without this a long-dead unrelated node is the permanent global
+   * minimum expiry and the warning never clears.
+   */
+  meshTailscaleAddresses?: () => string[];
   /** Durable state file (state/rope-health.json). */
   stateFilePath: string;
   recordMetric?: (event: RopeHealthMetricEvent) => void;
@@ -584,14 +592,17 @@ export class RopeHealthMonitor {
           }
           return;
         }
-        const parse = parseTailscaleStatus(raw);
+        const scope = this.safeMeshAddresses();
+        const parse = parseTailscaleStatus(raw, scope);
         if (!parse.parsed) {
           this.keyExpiryAvailable = false;
           this.keyExpirySoonest = null;
           return;
         }
         this.keyExpiryAvailable = true;
-        this.keyExpirySoonest = soonestKeyExpiry(parse, this.now());
+        this.keyExpirySoonest = soonestKeyExpiry(parse, this.now(), {
+          meshScopedOnly: scope !== undefined && scope.size > 0,
+        });
         if (this.keyExpiryWarn()) this.metric('key-expiry-warning');
       })
       .catch((err) => {
@@ -603,6 +614,24 @@ export class RopeHealthMonitor {
       .finally(() => {
         this.keyExpiryInFlight = false;
       });
+  }
+
+  /**
+   * Read the mesh-backing tailnet address set, fail-silent to undefined (⇒ tailnet-wide,
+   * the previous behaviour). Never throws into the expiry tier.
+   */
+  private safeMeshAddresses(): ReadonlySet<string> | undefined {
+    if (!this.d.meshTailscaleAddresses) return undefined;
+    try {
+      const list = this.d.meshTailscaleAddresses();
+      if (!Array.isArray(list) || list.length === 0) return undefined;
+      return new Set(list.filter((a): a is string => typeof a === 'string' && a.length > 0));
+    } catch {
+      // @silent-fallback-ok: an unreadable registry means NO scoping this pass, which is
+      // exactly the pre-scoping behaviour — never a crash, never a silent empty scope
+      // (an empty set would scope the scan down to self alone and hide a real warning).
+      return undefined;
+    }
   }
 
   private keyExpiryWarn(): boolean {

--- a/tests/unit/RopeHealthMonitor.test.ts
+++ b/tests/unit/RopeHealthMonitor.test.ts
@@ -507,6 +507,78 @@ describe('RopeHealthMonitor — key-expiry tier (R-r2-3) + content scrub + diges
     expect(everything).not.toMatch(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/);
   });
 
+  it('key-expiry is scoped to nodes backing a mesh rope — a dead unrelated node stops warning', async () => {
+    // 2026-08-29: a device offline since 2026-08-13 was the tailnet-wide soonest expiry, so
+    // the digest warned permanently while every real mesh machine was months from expiry.
+    const nowMs = Date.parse('2026-08-29T19:00:00Z');
+    const raw = JSON.stringify({
+      BackendState: 'Running',
+      Self: { TailscaleIPs: ['100.124.55.70'], KeyExpiry: '2027-02-15T03:47:45Z' },
+      Peer: {
+        mesh: { TailscaleIPs: ['100.64.165.27'], KeyExpiry: '2026-12-11T18:50:57Z' },
+        dead: { TailscaleIPs: ['100.89.225.62'], KeyExpiry: '2026-08-13T05:48:14Z' },
+      },
+    });
+    const build = (addresses?: () => string[]) => new RopeHealthMonitor(
+      {
+        snapshot: () => [],
+        selfMachineId: 'm_self',
+        listPeers: () => [],
+        readHeartbeatAtMs: () => null,
+        raiseAttention: () => undefined,
+        execTailscaleStatusJson: async () => raw,
+        ...(addresses ? { meshTailscaleAddresses: addresses } : {}),
+        stateFilePath: path.join(tmp(), 'state', 'rope-health.json'),
+        now: () => nowMs,
+      },
+      { keyExpiryCheckIntervalMs: 0, writeDebounceMs: 0 },
+    );
+
+    const scoped = build(() => ['100.64.165.27']);
+    scoped.evaluate();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(scoped.status().keyExpiry.warn).toBe(false);
+    expect(scoped.status().keyExpiry.soonest!.expiresAtIso).toBe('2026-12-11T18:50:57.000Z');
+
+    // Same input, no scope wired ⇒ the previous tailnet-wide behaviour (the dead node wins).
+    const unscoped = build();
+    unscoped.evaluate();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(unscoped.status().keyExpiry.warn).toBe(true);
+    expect(unscoped.status().keyExpiry.soonest!.inDays).toBeLessThan(0);
+  });
+
+  it('a throwing / empty address source falls back to tailnet-wide, never to a silent empty scope', async () => {
+    const nowMs = Date.parse('2026-08-29T19:00:00Z');
+    const raw = JSON.stringify({
+      BackendState: 'Running',
+      Peer: { dead: { TailscaleIPs: ['100.89.225.62'], KeyExpiry: '2026-08-13T05:48:14Z' } },
+    });
+    for (const source of [
+      () => { throw new Error('registry unreadable'); },
+      () => [] as string[],
+    ]) {
+      const monitor = new RopeHealthMonitor(
+        {
+          snapshot: () => [],
+          selfMachineId: 'm_self',
+          listPeers: () => [],
+          readHeartbeatAtMs: () => null,
+          raiseAttention: () => undefined,
+          execTailscaleStatusJson: async () => raw,
+          meshTailscaleAddresses: source as () => string[],
+          stateFilePath: path.join(tmp(), 'state', 'rope-health.json'),
+          now: () => nowMs,
+        },
+        { keyExpiryCheckIntervalMs: 0, writeDebounceMs: 0 },
+      );
+      monitor.evaluate();
+      await new Promise((r) => setTimeout(r, 10));
+      // Degrades to the pre-scoping behaviour — a real expiry is still reported, never hidden.
+      expect(monitor.status().keyExpiry.warn).toBe(true);
+    }
+  });
+
   it('digest: null when everything is ok; ≤3 sentences, machine-NAMED (nickname), when not', () => {
     const h = mkMonitor();
     h.rows.push(row('m_peer', 'tailscale', false));

--- a/tests/unit/tailscaleStatusParser.test.ts
+++ b/tests/unit/tailscaleStatusParser.test.ts
@@ -73,8 +73,8 @@ describe('parseTailscaleStatus (registered parser — captured fixtures)', () =>
     }));
     expect(parse.parsed).toBe(true);
     expect(parse.entries).toEqual([
-      { role: 'self', keyExpiryIso: null },
-      { role: 'peer', keyExpiryIso: null },
+      { role: 'self', keyExpiryIso: null, backsMeshRope: true },
+      { role: 'peer', keyExpiryIso: null, backsMeshRope: true },
     ]);
   });
 });
@@ -92,6 +92,78 @@ describe('soonestKeyExpiry', () => {
   });
 
   it('returns null when nothing carries an expiry', () => {
-    expect(soonestKeyExpiry({ parsed: true, entries: [{ role: 'self', keyExpiryIso: null }] }, 0)).toBeNull();
+    expect(soonestKeyExpiry({ parsed: true, entries: [{ role: 'self', keyExpiryIso: null, backsMeshRope: true }] }, 0)).toBeNull();
+  });
+});
+
+/**
+ * Mesh-scoping (2026-08-29): a tailnet holds every device the operator owns, but only a
+ * handful back a mesh rope. Scanning the whole tailnet for the soonest key expiry made a
+ * long-dead unrelated node the permanent global minimum, so the digest warned forever
+ * while every real mesh machine's key was months from expiry.
+ */
+describe('tailscaleStatusParser — mesh scoping', () => {
+  const MESH_IP = '100.64.165.27';
+  const DEAD_IP = '100.89.225.62';
+  const SELF_IP = '100.124.55.70';
+  const NOW = Date.parse('2026-08-29T19:00:00.000Z');
+
+  const raw = JSON.stringify({
+    BackendState: 'Running',
+    Self: { TailscaleIPs: [SELF_IP], KeyExpiry: '2027-02-15T03:47:45Z' },
+    Peer: {
+      'k:mesh': { TailscaleIPs: [MESH_IP], KeyExpiry: '2026-12-11T18:50:57Z' },
+      'k:dead': { TailscaleIPs: [DEAD_IP], KeyExpiry: '2026-08-13T05:48:14Z' },
+    },
+  });
+
+  it('flags only the nodes that back a mesh rope (self always counts)', () => {
+    const parse = parseTailscaleStatus(raw, new Set([MESH_IP]));
+    expect(parse.parsed).toBe(true);
+    expect(parse.entries.map((e) => [e.role, e.backsMeshRope])).toEqual([
+      ['self', true],
+      ['peer', true],
+      ['peer', false],
+    ]);
+  });
+
+  it('mesh-scoped: the long-dead unrelated node no longer sets the soonest expiry', () => {
+    const parse = parseTailscaleStatus(raw, new Set([MESH_IP]));
+    const soonest = soonestKeyExpiry(parse, NOW, { meshScopedOnly: true });
+    expect(soonest?.expiresAtIso).toBe('2026-12-11T18:50:57.000Z');
+    expect(soonest!.inDays).toBeGreaterThan(90);
+  });
+
+  it('un-scoped: the same input still reports the dead node (the pre-fix behaviour)', () => {
+    const soonest = soonestKeyExpiry(parseTailscaleStatus(raw), NOW);
+    expect(soonest?.expiresAtIso).toBe('2026-08-13T05:48:14.000Z');
+    expect(soonest!.inDays).toBeLessThan(0);
+  });
+
+  it('no address set ⇒ every node backs a rope (back-compatible)', () => {
+    expect(parseTailscaleStatus(raw).entries.every((e) => e.backsMeshRope)).toBe(true);
+    expect(parseTailscaleStatus(raw, new Set()).entries.every((e) => e.backsMeshRope)).toBe(true);
+  });
+
+  it('SELF still warns when scoped, even though its own address is not a mesh peer address', () => {
+    const selfSoon = JSON.stringify({
+      BackendState: 'Running',
+      Self: { TailscaleIPs: [SELF_IP], KeyExpiry: '2026-08-30T00:00:00Z' },
+      Peer: { 'k:mesh': { TailscaleIPs: [MESH_IP], KeyExpiry: '2027-02-15T03:47:45Z' } },
+    });
+    const soonest = soonestKeyExpiry(parseTailscaleStatus(selfSoon, new Set([MESH_IP])), NOW, {
+      meshScopedOnly: true,
+    });
+    expect(soonest?.role).toBe('self');
+  });
+
+  it('a node with no TailscaleIPs array is not treated as mesh-backing', () => {
+    const odd = JSON.stringify({
+      BackendState: 'Running',
+      Peer: { 'k:x': { KeyExpiry: '2026-08-13T05:48:14Z' } },
+    });
+    const parse = parseTailscaleStatus(odd, new Set([MESH_IP]));
+    expect(parse.entries[0].backsMeshRope).toBe(false);
+    expect(soonestKeyExpiry(parse, NOW, { meshScopedOnly: true })).toBeNull();
   });
 });

--- a/upgrades/next/rope-key-expiry-mesh-scope.md
+++ b/upgrades/next/rope-key-expiry-mesh-scope.md
@@ -1,0 +1,34 @@
+## What Changed
+
+The Tailscale key-expiry tier of `RopeHealthMonitor` now scans only tailnet nodes that back
+a mesh rope (plus self), rather than every node on the tailnet. `parseTailscaleStatus`
+takes an optional mesh-address set and flags each entry `backsMeshRope`; `soonestKeyExpiry`
+takes `meshScopedOnly`; `server.ts` supplies the addresses from the registry's `tailscale`
+endpoints. An unreadable or empty address source falls back to the previous tailnet-wide
+scan, so a failure is never quieter.
+
+## What to Tell Your User
+
+Your machines warn you when a Tailscale key is about to expire — but they were checking
+every device on your account, including phones and old laptops that aren't part of the
+mesh. One dead device with a lapsed key made that warning permanent, so it stopped meaning
+anything, and on 2026-08-29 it was read as a live risk and reported as one.
+
+The warning now covers only the devices your machines actually reach each other on. Same
+horizon, same wording — it just stops crying wolf about hardware that can't affect
+anything.
+
+## Summary of New Capabilities
+
+- Key-expiry warnings are scoped to devices that genuinely carry mesh traffic.
+- This machine's own key always counts, since its expiry would drop every route it has.
+- Every failure path (unreadable registry, empty list) falls back to the old tailnet-wide
+  scan — the change can make the check noisier, never quieter.
+- No device names, addresses, or account details leave the parser; addresses go in, a
+  boolean comes out.
+
+## Evidence
+
+- Unit: `tests/unit/tailscaleStatusParser.test.ts` (+6), `tests/unit/RopeHealthMonitor.test.ts` (+2),
+  verified red-then-green against pre-fix behaviour.
+- Side-effects review: `upgrades/side-effects/rope-key-expiry-mesh-scope.md`.

--- a/upgrades/side-effects/rope-key-expiry-mesh-scope.md
+++ b/upgrades/side-effects/rope-key-expiry-mesh-scope.md
@@ -1,0 +1,85 @@
+# Side-effects review — rope key-expiry mesh scoping
+
+**Change:** the Tailscale key-expiry tier of `RopeHealthMonitor` now considers only tailnet
+nodes that back a mesh rope (plus self), instead of every node on the tailnet.
+`parseTailscaleStatus` gained an optional mesh-address set and a per-entry
+`backsMeshRope` flag; `soonestKeyExpiry` gained `opts.meshScopedOnly`; `server.ts` supplies
+the addresses from the registry's `tailscale` endpoints.
+
+**Origin (live, 2026-08-29, topic 62395):** a tailnet node offline since 2026-08-13 with a
+lapsed key was the tailnet-wide soonest expiry, so `GET /mesh/rope-health` reported
+`warn: true, inDays: -16.6` continuously. Every real mesh machine's key was valid into
+Dec 2026 / Feb 2027. The permanent warning was not merely noise — it was read as a live
+finding and relayed to the operator as a real risk requiring their login.
+
+## 1. Over-block — what legitimate input does this now reject?
+
+A genuine expiry on a tailnet node that backs a mesh rope but whose address is NOT in the
+registry's endpoint list — e.g. a peer reachable over tailscale that has only ever
+advertised `lan`/`cloudflare`. That node's expiry would no longer warn.
+
+Bounded by two fallbacks that both fail LOUD: an unreadable address source and an empty
+address set BOTH degrade to the tailnet-wide scan. So the narrowed scope applies only when
+a non-empty mesh address list is genuinely available. Self is unconditionally included.
+
+## 2. Under-block — what does this still miss?
+
+It does not detect a rope dropping for any reason other than key expiry (unchanged), and
+it cannot warn about a mesh machine whose tailscale address this machine has never
+recorded. It also does not change the two-week horizon, so a key that lapses inside one
+check interval is still reported late — pre-existing, untouched.
+
+## 3. Level-of-abstraction fit
+
+Correct. The parser owns the scrubbed shape and is the only place that may see addresses,
+so the matching belongs there; the monitor owns the policy (`meshScopedOnly`); the wiring
+site owns knowledge of the registry. Putting the filter in the monitor would have required
+addresses to escape the parser, breaking that file's stated content-scrub boundary.
+
+## 4. Signal vs authority compliance
+
+Compliant. This is a digest/status signal with no blocking authority — it gates nothing,
+changes no routing, and cannot suppress a rope. It makes an existing signal more accurate.
+
+## 5. Interactions
+
+- The `key-expiry-warning` metric fires strictly less often (that is the fix).
+- `composeDigest()` drops the permanent expiry sentence when scoped — the other digest
+  sentences (per-peer conditions) are untouched.
+- `TailscaleKeyExpiryEntry` gained a field; one existing unit assertion deep-equalled the
+  old shape and was updated. No serialized/persisted format includes this type.
+- No interaction with the U4.3 recovery prober or the resolver — the expiry tier has its
+  own cadence and data source.
+
+## 6. External surfaces
+
+`GET /mesh/rope-health → keyExpiry.soonest` may now name a later expiry (a mesh node)
+where it previously named an earlier one (an unrelated node). No shape change. The
+content-scrub boundary is preserved: addresses flow INTO the parser and only a boolean
+flows out — no identity, address, or account data is added to any output.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** Each machine runs its own `tailscale status` and reads its own
+registry, so each scopes to the peers it knows. This is correct rather than a limitation: a
+tailnet node backing a rope is a per-observer fact, and the digest is composed per machine.
+No replication path added. A single-machine agent supplies an empty address list and
+therefore keeps exactly today's tailnet-wide behaviour.
+
+## 8. Rollback cost
+
+Trivial. Remove the `meshTailscaleAddresses` dep from the `server.ts` construction and the
+monitor reverts to the tailnet-wide scan by an explicitly-tested path. No persisted data,
+no migration, no state repair.
+
+## Tests
+
+- Unit `tests/unit/tailscaleStatusParser.test.ts` (+6): flagging, mesh-scoped soonest,
+  un-scoped soonest (pre-fix behaviour retained), no-set and empty-set back-compat, self
+  always counts, node with no address array is not mesh-backing.
+- Unit `tests/unit/RopeHealthMonitor.test.ts` (+2): the dead-node regression through the
+  monitor (scoped vs un-scoped on identical input), and the throwing/empty source falling
+  back to tailnet-wide rather than to a silent empty scope. Verified RED against pre-fix
+  behaviour and green after.
+- E2E: not applicable — no new route or feature-liveness surface; this narrows an existing
+  status field already covered by the monitor's own suite.


### PR DESCRIPTION
## ELI16 — Stop warning about a device that isn't part of the mesh

Your machines reach each other over Tailscale, among other routes. Tailscale gives each device a key that expires periodically; when it lapses, that device drops off the network. Losing a route that way used to be silent, so a warning was added: if any key is within two weeks of expiring, say so in the daily mesh summary.

The check asked Tailscale for the status of everything on your account and picked whichever key expires soonest.

But your Tailscale account holds more than the machines running agents — phones, other people's laptops, devices set up once and forgotten. One of them went offline on the 13th and its key lapsed. Because it was the soonest expiry on the whole account, every check picked it. The summary said "a Tailscale key expires in 0 days — re-authenticate before it drops the rope" continuously, for over two weeks, about a device that isn't part of the mesh and whose expiry cannot affect anything.

Worse, it was actively misleading. On 2026-08-29 I read that warning and told the operator a real route was at risk and that they'd need to log in. That was wrong — every machine actually in use had months left. A warning that is always on doesn't just get ignored; it gets *believed* at the wrong moment.

The check now only looks at devices that actually carry mesh traffic, plus this machine itself. Same horizon, same wording.

Three safeguards, all in the direction of never hiding a real warning: this machine always counts (its own key lapsing drops every route it has); if the mesh address list can't be read the check falls back to scanning everything; and an empty list also falls back, so a momentary blank can't quietly narrow the check down to this machine alone.

No device names, addresses, or account details leave the part of the code that reads them — that was already a hard rule here and it still holds. Addresses are passed *in* to do the matching; only a yes/no comes back out.

---

## The bug

`soonestKeyExpiry` took the global minimum across every node in `tailscale status --json`. A tailnet is not a mesh — it holds every device the operator owns — so a single long-dead node with a lapsed key is the permanent minimum and the warning never clears.

Observed live (topic 62395): `GET /mesh/rope-health` reporting `warn: true, soonest.inDays: -16.6` continuously, for a node offline since 2026-08-13, while Studio/laptop keys were valid to Feb 2027 and mini/dawnmini to Dec 2026.

The real cost was not noise. The permanent warning was read as a live finding and relayed to the operator as a genuine risk requiring their login — the classic always-on-alarm failure, believed at exactly the wrong moment.

## The fix

- `parseTailscaleStatus(raw, meshAddresses?)` flags each entry `backsMeshRope`.
- `soonestKeyExpiry(parse, now, { meshScopedOnly })` skips non-backing entries.
- `server.ts` supplies the hostnames of every registered peer's `tailscale` endpoint.

**Scrub boundary preserved, not weakened.** Addresses are matched *inside* the parser; only a boolean leaves it. The return shape still carries no identity, which is that file's stated hard rule.

**Both failure paths fail loud.** An unreadable address source and an empty address set each degrade to the tailnet-wide scan. The change can make the check noisier; it cannot make it quieter. An empty set is deliberately *not* treated as "scope to self" — that would silently hide a real peer warning.

Self is unconditionally included: its own expiry drops every rope it has.

## Tests

- `tailscaleStatusParser` (+6): flagging, mesh-scoped soonest, un-scoped soonest (pre-fix behaviour retained), no-set and empty-set back-compat, self-always-counts, node-without-address-array.
- `RopeHealthMonitor` (+2): the dead-node regression end-to-end through the monitor (scoped vs un-scoped on identical input), and throwing/empty sources falling back to tailnet-wide.
- Verified **red against pre-fix behaviour**, green after.

## Posture

Machine-local by design — each machine runs its own `tailscale status` and reads its own registry, and the digest is composed per machine. Single-machine agents supply an empty list and keep today's behaviour exactly.

Signal only: gates nothing, changes no routing, cannot suppress a rope.

## Rollback

Drop the `meshTailscaleAddresses` dep from the `server.ts` construction; the monitor reverts to the tailnet-wide scan by an explicitly-tested path. No persisted data, no migration.

Side-effects review: `upgrades/side-effects/rope-key-expiry-mesh-scope.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o9kgd1afVCgzEnqJaqmsi