### PR TITLE
fix(mesh): a peer refusing signed messages is awake, not "offline — expected"

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-29T21-10-31-075Z-rope-auth-reject-alive.json
+++ b/.instar/instar-dev-decisions/2026-08-29T21-10-31-075Z-rope-auth-reject-alive.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-29T21:10:31.075Z",
+  "slug": "rope-auth-reject-alive",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 129,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/RopeRecoveryProber.ts",
+      "src/monitoring/RopeHealthMonitor.ts"
+    ],
+    "addedLines": 126,
+    "deletedLines": 3
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "U4.5's peer-offline classification keys on registry-online + heartbeat — both signals an auth fault suppresses (a peer that cannot authenticate stops reporting in), so the fault's own symptoms read as the benign explanation. Latent since U4.5 shipped; surfaced by the first real key rotation (2026-08-27 lost identity files) which produced the exact all-down + no-heartbeat + actively-refusing shape for two days."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/rope-auth-reject-alive.eli16.md
+++ b/docs/specs/rope-auth-reject-alive.eli16.md
@@ -1,0 +1,69 @@
+---
+title: A machine that says "no" is not asleep
+slug: rope-auth-reject-alive
+audience: decider
+---
+
+# A machine that says "no" is not asleep
+
+## The one-sentence version
+
+When one of your machines actively refuses another's messages because of a key mix-up,
+the health monitor used to file it as "that machine is offline — expected", and stay
+quiet; now it recognises the refusal as proof the machine is awake, says so loudly, and
+names the likely cause.
+
+## What happened
+
+On the 27th, the Studio's identity files went missing and its signing key had to be
+regenerated. The other machines still remembered the old key, so every message the Studio
+sent them came back "rejected — invalid signature". Nearly eleven thousand rejections per
+connection over two days. Messages *to* the Studio still worked, so the mesh ran one-way,
+and no alarm distinguished this from an ordinary sleeping machine.
+
+## Why the monitor got it wrong — the circular part
+
+The monitor's rule for "offline — expected, no alarm needed" checks two things: has the
+machine stopped reporting itself in? and has its heartbeat stopped?
+
+Both had stopped. But both had stopped *because of the key problem* — a machine that
+can't authenticate to its peers can't report in or heartbeat to them. The monitor was
+reading the fault's own symptoms as the innocent explanation for the fault. A
+classification that consumes the evidence the failure destroys can never fire.
+
+## The insight that fixes it
+
+There was one signal the fault could not destroy: the rejections themselves. The
+recovery prober was still sending test messages, and the Studio's peers were still
+*answering* them — "no, invalid signature." A machine that answers "no" has dialled,
+verified, and refused. It is provably awake. That answer is stronger evidence than any
+missing heartbeat.
+
+## What changes
+
+The prober now remembers, per machine, when it last saw a signature-layer refusal. The
+health monitor checks that evidence *first*, before either "offline — expected" rule.
+Fresh refusals reclassify the machine as **awake but refusing** — a distinct state with
+its own loud alert (one per episode, not a stream) whose text names the likely cause: a
+key or identity mismatch, mesh probably running one-way, stored identity needs repair.
+The daily digest says the same instead of "offline — expected."
+
+## The safeguards
+
+- **Evidence must be fresh** — within 45 minutes. One stale refusal from a long-fixed
+  episode can't keep reviving the alarm.
+- **Only real refusals count.** A connection that simply failed (network down) records
+  nothing; only a typed "invalid signature"-class answer does. So a genuinely sleeping
+  machine can never trip this.
+- **One alert per episode**, with the same delivery honesty as the partition alert: if
+  delivering it fails, it retries next evaluation rather than being lost.
+- **If the evidence source can't be read, nothing is claimed** — the machine classifies
+  by the ordinary rules, exactly as today.
+- It raises an alert; it blocks, restarts, and repairs nothing. Signal only.
+
+## What you need to decide
+
+Nothing. This closes the "detect loudly" half of the machine-self-assertion plan you
+already approved — it's the piece that makes a key mix-up visible in minutes instead of
+days. The automatic *repair* (the machine re-announcing its new key with proof) is the
+separate piece being built under that spec.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -25473,6 +25473,11 @@ export async function startServer(options: StartOptions): Promise<void> {
                 return [];
               }
             },
+            // Alive-but-rejecting evidence: the recovery prober's freshest
+            // auth-layer refusal for this peer. A peer answering probes with a
+            // typed auth refusal is provably awake and must never classify as
+            // 'peer-offline — expected' (2026-08-29 signature-mismatch incident).
+            readAuthRejectAtMs: (id) => _ropeProber?.lastAuthRejectAtMs(id) ?? null,
             raiseAttention: (item) =>
               telegram?.createAttentionItem({
                 id: item.id,

--- a/src/core/RopeRecoveryProber.ts
+++ b/src/core/RopeRecoveryProber.ts
@@ -123,6 +123,16 @@ interface RopeKeyState {
   lastClosedProbeFailures: number;
   /** Previous tick's dead flag (the rope-recovered breadcrumb keys on dead→clear). */
   prevDead: boolean;
+  /**
+   * Last time a probe to this rope was refused at the AUTH layer
+   * (`auth-rejected:*` — signature-invalid / unknown-sender / wrong-recipient).
+   * An auth refusal is POSITIVE liveness evidence: the peer's server dialed,
+   * answered, verified, and said no. RopeHealthMonitor consumes this to keep a
+   * provably-alive peer from classifying as 'peer-offline — expected' (the
+   * 2026-08-29 two-day one-way-mesh signature-mismatch incident, where the
+   * stopped heartbeat that justified 'expected' was itself CAUSED by the fault).
+   */
+  lastAuthRejectAt: number;
 }
 
 /** One row of the /health `ropeHealth` surface (spec §3). */
@@ -177,7 +187,7 @@ export class RopeRecoveryProber {
       const target = targetByKey.get(k);
       if (!target) continue; // not currently dialable (evicted/undiscovered) — nothing to pin
 
-      const st = this.ropes.get(k) ?? { episode: null, lastClosedAt: 0, lastClosedProbeFailures: 0, prevDead: false };
+      const st = this.ropes.get(k) ?? { episode: null, lastClosedAt: 0, lastClosedProbeFailures: 0, prevDead: false, lastAuthRejectAt: 0 };
       this.ropes.set(k, st);
 
       // ── The rope-recovered breadcrumb keys on the DEAD FLAG clearing (R-r2-3). ──
@@ -312,6 +322,9 @@ export class RopeRecoveryProber {
       }
     } else {
       this.d.recordMetric?.('probe-failure');
+      if (typeof res.detail === 'string' && res.detail.startsWith('auth-rejected')) {
+        st.lastAuthRejectAt = this.now();
+      }
       ep.probeFailures += 1;
       ep.unreclaimedSuccesses = 0;
       if (this.cfg.dryRun) {
@@ -410,4 +423,19 @@ export class RopeRecoveryProber {
   episodeOpen(peer: string, kind: string): boolean {
     return !!this.ropes.get(this.key(peer, kind))?.episode;
   }
+
+  /**
+   * Freshest auth-layer refusal observed across this peer's ropes (epoch-ms),
+   * or null when none recorded. Read seam for RopeHealthMonitor's
+   * alive-but-rejecting classification; scheduling-state only, never persisted.
+   */
+  lastAuthRejectAtMs(peer: string): number | null {
+    let best = 0;
+    for (const [k, st] of this.ropes) {
+      if (!k.startsWith(`${peer} `)) continue;
+      if (st.lastAuthRejectAt > best) best = st.lastAuthRejectAt;
+    }
+    return best > 0 ? best : null;
+  }
+
 }

--- a/src/monitoring/RopeHealthMonitor.ts
+++ b/src/monitoring/RopeHealthMonitor.ts
@@ -55,7 +55,7 @@ import {
   soonestKeyExpiry,
 } from '../core/tailscaleStatusParser.js';
 
-export type RopeHealthCondition = 'ok' | 'degraded' | 'peer-offline' | 'urgent' | 'unknown';
+export type RopeHealthCondition = 'ok' | 'degraded' | 'peer-offline' | 'auth-rejected' | 'urgent' | 'unknown';
 
 export interface RopeHealthPeerInfo {
   machineId: string;
@@ -70,7 +70,9 @@ export type RopeHealthMetricEvent =
   | 'transition-ok'
   | 'transition-degraded'
   | 'transition-peer-offline'
+  | 'transition-auth-rejected'
   | 'transition-urgent'
+  | 'auth-rejected-episode'
   | 'urgent-episode'
   | 'suppressed-by-sleep-gate'
   | 'suppressed-by-split-brain'
@@ -94,6 +96,15 @@ export interface RopeHealthMonitorDeps {
   raiseAttention: (item: { id: string; title: string; body: string }) => unknown;
   /** Episode-registry check: a split-brain item already open for this peer wins. */
   splitBrainItemOpen?: (peerMachineId: string) => boolean;
+  /**
+   * Freshest auth-layer probe refusal for this peer (epoch-ms), or null — from
+   * RopeRecoveryProber. An auth refusal is POSITIVE liveness evidence (the
+   * peer's server answered and said no), so an all-down peer with fresh
+   * evidence classifies 'auth-rejected' (loud), never 'peer-offline — expected'
+   * (the 2026-08-29 signature-mismatch incident: the stopped heartbeat that
+   * justified 'expected' was itself caused by the fault it excused).
+   */
+  readAuthRejectAtMs?: (machineId: string) => number | null;
   /**
    * Bounded exec seam for `tailscale status --json` (R-r2-3). Resolves to the
    * raw stdout, or null when the CLI is absent/timed out (the expiry tier is
@@ -124,6 +135,12 @@ export interface RopeHealthMonitorConfig {
   clearSustainMs: number;
   /** Tailscale key expiry warning horizon. Default 14. */
   keyExpiryWarnDays: number;
+  /** The alive-but-rejecting tier master. Default true — near-zero false-positive
+   *  evidence (a signed probe answered with a typed auth refusal). */
+  authRejectAlertEnabled: boolean;
+  /** How fresh auth-reject evidence must be to classify (default 45 min ≈ 3× the
+   *  probe floor, so a single stale refusal from a past episode cannot linger). */
+  authRejectFreshnessMs: number;
   /** The monitor's OWN evaluation loop cadence. Default 30000. */
   evaluateIntervalMs: number;
   /** Key-expiry exec cadence. Default 3600000 (hourly). */
@@ -153,6 +170,8 @@ export const ROPE_HEALTH_DEFAULTS: RopeHealthMonitorConfig = {
   urgentDebounceMs: 60_000,
   clearSustainMs: 600_000,
   keyExpiryWarnDays: 14,
+  authRejectAlertEnabled: true,
+  authRejectFreshnessMs: 45 * 60_000,
   evaluateIntervalMs: 30_000,
   keyExpiryCheckIntervalMs: 3_600_000,
   wakeGraceMaxMs: 300_000,
@@ -206,6 +225,8 @@ interface PeerRuntimeState {
   episodeKey: string | null;
   /** When the ONE urgent item for this episode was raised (lastAlertAt). */
   urgentRaisedAt: number | null;
+  /** When the ONE auth-rejected item for this episode was raised. */
+  authRejectRaisedAt: number | null;
   /** Urgent detected but attention delivery failed — retried next evaluation. */
   detectedNotNotified: boolean;
   /** Continuous-health start while an episode is still open (clear-sustain). */
@@ -439,6 +460,26 @@ export class RopeHealthMonitor {
         st.postOnsetBeatObservedAt = nowMs;
       }
 
+      // ── Alive-but-rejecting (checked FIRST — evidence beats absence). ──
+      // A fresh auth-layer probe refusal is POSITIVE proof the peer's server is
+      // up: it dialed, answered, verified the envelope, and refused. Such a peer
+      // must never fall into either 'peer-offline — expected' branch below —
+      // both key on signals (registry-online, heartbeat) that the auth fault
+      // itself suppresses (the peer's inbound writes to us stop when it cannot
+      // authenticate, so the very symptom excused the outage for two days on
+      // 2026-08-29). Evidence freshness is bounded so one stale refusal from a
+      // long-closed episode cannot keep reviving the classification.
+      const authRejectAt = this.safeAuthRejectAt(peer.machineId);
+      const authFresh = authRejectAt !== null && nowMs - authRejectAt <= this.cfg.authRejectFreshnessMs;
+      if (authFresh) {
+        st.condition = 'auth-rejected';
+        this.recordTransition(prev, st.condition);
+        if (this.cfg.authRejectAlertEnabled && st.authRejectRaisedAt === null) {
+          this.raiseAuthRejected(peer, st, nowMs);
+        }
+        continue;
+      }
+
       if (!peer.registryOnline) {
         // WS4.2 'offline since <t>' — expected. Never urgent.
         st.condition = 'peer-offline';
@@ -507,6 +548,7 @@ export class RopeHealthMonitor {
       st.consecutiveObservations = 0;
       st.episodeKey = null;
       st.urgentRaisedAt = null;
+      st.authRejectRaisedAt = null;
       st.detectedNotNotified = false;
       st.postOnsetBeatObservedAt = null;
       st.healthySince = null;
@@ -519,6 +561,48 @@ export class RopeHealthMonitor {
     if (nowMs - this.ownWakeAt > this.cfg.wakeGraceMaxMs) return false; // bounded (P1-A7)
     // Suppress only while some rope has NOT been re-observed post-wake.
     return peerRows.some((r) => Math.max(r.lastOkAt, r.lastFailAt) <= this.ownWakeAt!);
+  }
+
+  /** Read the prober's auth-reject evidence, fail-silent to null (⇒ no claim). */
+  private safeAuthRejectAt(machineId: string): number | null {
+    try {
+      return this.d.readAuthRejectAtMs?.(machineId) ?? null;
+    } catch {
+      // @silent-fallback-ok: unreadable evidence is NO evidence — the peer then
+      // classifies by the ordinary offline/urgent rules, never a crash.
+      return null;
+    }
+  }
+
+  private raiseAuthRejected(peer: RopeHealthPeerInfo, st: PeerRuntimeState, nowMs: number): void {
+    const sinceMin = st.allDownSince ? Math.round((nowMs - st.allDownSince) / 60_000) : 0;
+    // Content scrub: nickname + relative time ONLY (no key material, no ids).
+    const item = {
+      id: `rope-health-auth-rejected:${st.episodeKey ?? peer.machineId}`,
+      title: `${peer.nickname} is refusing this machine's signed messages`,
+      body:
+        `Every mesh rope to ${peer.nickname} is down (~${sinceMin} min), but it is provably AWAKE: ` +
+        `it answers probes and refuses them at the signature layer. This is a key/identity mismatch ` +
+        `(e.g. a rotated machine key the peer never learned), not a sleeping machine — the mesh is ` +
+        `likely running one-way until the stored identity is repaired. ` +
+        `Episode ${st.episodeKey ?? 'n/a'}; this is the ONE alert for this episode.`,
+    };
+    try {
+      const r = this.d.raiseAttention(item);
+      if (r && typeof (r as Promise<unknown>).then === 'function') {
+        void (r as Promise<unknown>).then(
+          () => { st.authRejectRaisedAt = this.now(); this.metric('auth-rejected-episode'); this.scheduleWrite(); },
+          () => { /* delivery failed — retried next evaluation (authRejectRaisedAt stays null) */ },
+        );
+      } else {
+        st.authRejectRaisedAt = this.now();
+        this.metric('auth-rejected-episode');
+        this.scheduleWrite();
+      }
+    } catch {
+      // Detected-but-silent must not be silent forever: authRejectRaisedAt stays
+      // null so the next evaluation retries the raise.
+    }
   }
 
   private raiseUrgent(peer: RopeHealthPeerInfo, st: PeerRuntimeState, nowMs: number): void {
@@ -705,6 +789,9 @@ export class RopeHealthMonitor {
       if (st.condition === 'urgent') {
         const min = st.allDownSince ? Math.round((nowMs - st.allDownSince) / 60_000) : 0;
         sentences.push(`ALL mesh ropes to ${p.nickname} are down (~${min} min) while its heartbeat still advances — alive but unreachable.`);
+      } else if (st.condition === 'auth-rejected') {
+        const min = st.allDownSince ? Math.round((nowMs - st.allDownSince) / 60_000) : 0;
+        sentences.push(`${p.nickname} is AWAKE but refusing this machine's signed messages (~${min} min) — a key/identity mismatch, not a sleeping machine.`);
       } else if (st.condition === 'peer-offline') {
         const min = st.allDownSince ? Math.round((nowMs - st.allDownSince) / 60_000) : 0;
         sentences.push(`${p.nickname} is offline (~${min} min) — expected (its heartbeat stopped).`);
@@ -811,6 +898,7 @@ export class RopeHealthMonitor {
           consecutiveObservations: st.consecutiveObservations,
           episodeKey: st.episodeKey,
           urgentRaisedAt: st.urgentRaisedAt,
+          authRejectRaisedAt: st.authRejectRaisedAt,
           detectedNotNotified: st.detectedNotNotified,
         };
       }
@@ -843,6 +931,7 @@ export class RopeHealthMonitor {
           consecutiveObservations: 0,
           episodeKey: typeof p.episodeKey === 'string' ? p.episodeKey : null,
           urgentRaisedAt: typeof p.urgentRaisedAt === 'number' ? p.urgentRaisedAt : null,
+          authRejectRaisedAt: typeof p.authRejectRaisedAt === 'number' ? p.authRejectRaisedAt : null,
           detectedNotNotified: p.detectedNotNotified === true,
         });
       }
@@ -860,6 +949,7 @@ function freshPeerState(): PeerRuntimeState {
     consecutiveObservations: 0,
     episodeKey: null,
     urgentRaisedAt: null,
+    authRejectRaisedAt: null,
     detectedNotNotified: false,
     healthySince: null,
     postOnsetBeatObservedAt: null,
@@ -867,5 +957,5 @@ function freshPeerState(): PeerRuntimeState {
 }
 
 function isCondition(v: unknown): v is RopeHealthCondition {
-  return v === 'ok' || v === 'degraded' || v === 'peer-offline' || v === 'urgent' || v === 'unknown';
+  return v === 'ok' || v === 'degraded' || v === 'peer-offline' || v === 'auth-rejected' || v === 'urgent' || v === 'unknown';
 }

--- a/tests/unit/RopeHealthMonitor.test.ts
+++ b/tests/unit/RopeHealthMonitor.test.ts
@@ -76,6 +76,8 @@ interface Harness {
   setRegistryOnline: (id: string, online: boolean) => void;
   setSplitBrain: (open: boolean) => void;
   failRaise: { on: boolean };
+  setAuthRejectAt: (id: string, atMs: number | null) => void;
+  authThrows: { on: boolean };
 }
 
 function mkMonitor(over: Partial<Parameters<typeof RopeHealthMonitor.prototype.evaluate>> & {
@@ -91,6 +93,8 @@ function mkMonitor(over: Partial<Parameters<typeof RopeHealthMonitor.prototype.e
   const stateFile = over.stateFile ?? path.join(tmp(), 'state', 'rope-health.json');
   let splitBrain = false;
   const failRaise = { on: false };
+  const authRejects = new Map<string, number | null>();
+  const authThrows = { on: false };
   const deps: RopeHealthMonitorDeps = {
     snapshot: () => rows.map((r) => ({ ...r })),
     selfMachineId: 'm_self',
@@ -110,6 +114,10 @@ function mkMonitor(over: Partial<Parameters<typeof RopeHealthMonitor.prototype.e
       return undefined;
     },
     splitBrainItemOpen: () => splitBrain,
+    readAuthRejectAtMs: (id) => {
+      if (authThrows.on) throw new Error('prober unreadable');
+      return authRejects.get(id) ?? null;
+    },
     stateFilePath: stateFile,
     recordMetric: (e) => metrics.push(e),
     now: () => nowMs,
@@ -133,6 +141,8 @@ function mkMonitor(over: Partial<Parameters<typeof RopeHealthMonitor.prototype.e
     setRegistryOnline: (id, o) => online.set(id, o),
     setSplitBrain: (open) => { splitBrain = open; },
     failRaise,
+    setAuthRejectAt: (id, atMs) => authRejects.set(id, atMs),
+    authThrows,
   };
 }
 
@@ -592,5 +602,104 @@ describe('RopeHealthMonitor — key-expiry tier (R-r2-3) + content scrub + diges
     expect(digest).toContain('the mini'); // nickname, never a URL/IP
     expect(digest).toContain('tailscale');
     expect((digest.match(/\./g) ?? []).length).toBeLessThanOrEqual(4);
+  });
+});
+
+
+/**
+ * Alive-but-rejecting (2026-08-29 signature-mismatch incident): a peer whose
+ * probes come back with a typed AUTH refusal is provably awake — its server
+ * dialed, answered, verified the envelope, and said no. It must never classify
+ * as 'peer-offline — expected', because BOTH signals that branch keys on (the
+ * registry-online flag and the heartbeat) are suppressed by the very fault:
+ * a peer that cannot authenticate to us stops being able to report in. That
+ * circularity kept a two-day one-way mesh outage silent.
+ */
+describe('RopeHealthMonitor — alive-but-rejecting (auth-reject evidence beats absence)', () => {
+  it('the regression: all-down + stopped heartbeat + registry-offline + fresh auth evidence ⇒ auth-rejected and ONE loud item, never peer-offline', () => {
+    const h = mkMonitor();
+    h.rows.push(row('m_peer', 'tailscale', true), row('m_peer', 'lan', true));
+    h.setRegistryOnline('m_peer', false);   // the fault suppressed its reporting
+    h.setHeartbeat('m_peer', null);          // and its heartbeat
+    h.setAuthRejectAt('m_peer', h.now());    // but probes are actively REFUSED
+    settleAllDown(h);
+    const view = h.monitor.status().peers.find((p) => p.machineId === 'm_peer')!;
+    expect(view.condition).toBe('auth-rejected');
+    expect(h.raised.length).toBe(1);
+    expect(h.raised[0].id).toMatch(/^rope-health-auth-rejected:/);
+    expect(h.raised[0].title).toContain('the mini');
+    expect(h.raised[0].body).toContain('AWAKE');
+    // escalate-once per episode: further evaluations do not re-raise
+    h.setNow(h.now() + MIN);
+    h.monitor.evaluate();
+    expect(h.raised.length).toBe(1);
+    // digest names it distinctly, not as an expected sleep
+    const digest = h.monitor.composeDigest()!;
+    expect(digest).toContain('refusing');
+    expect(digest).not.toContain('expected');
+  });
+
+  it('STALE auth evidence does not classify — falls through to the ordinary offline rule', () => {
+    const h = mkMonitor();
+    h.rows.push(row('m_peer', 'tailscale', true));
+    h.setRegistryOnline('m_peer', false);
+    h.setHeartbeat('m_peer', null);
+    h.setAuthRejectAt('m_peer', h.now() - 46 * MIN); // past the 45-min freshness bound
+    settleAllDown(h);
+    expect(h.monitor.status().peers.find((p) => p.machineId === 'm_peer')!.condition).toBe('peer-offline');
+    expect(h.raised.length).toBe(0);
+  });
+
+  it('a THROWING evidence source is NO evidence (never a crash, never a claim)', () => {
+    const h = mkMonitor();
+    h.rows.push(row('m_peer', 'tailscale', true));
+    h.setRegistryOnline('m_peer', false);
+    h.setHeartbeat('m_peer', null);
+    h.authThrows.on = true;
+    settleAllDown(h);
+    expect(h.monitor.status().peers.find((p) => p.machineId === 'm_peer')!.condition).toBe('peer-offline');
+  });
+
+  it('authRejectAlertEnabled:false still CLASSIFIES honestly but raises nothing', () => {
+    const h = mkMonitor({ cfg: { authRejectAlertEnabled: false } });
+    h.rows.push(row('m_peer', 'tailscale', true));
+    h.setAuthRejectAt('m_peer', h.now());
+    settleAllDown(h);
+    expect(h.monitor.status().peers.find((p) => p.machineId === 'm_peer')!.condition).toBe('auth-rejected');
+    expect(h.raised.length).toBe(0);
+  });
+
+  it('a failed raise retries on the next evaluation (detected-but-silent is impossible)', () => {
+    const h = mkMonitor();
+    h.rows.push(row('m_peer', 'tailscale', true));
+    h.setAuthRejectAt('m_peer', h.now());
+    h.failRaise.on = true;
+    settleAllDown(h);
+    expect(h.raised.length).toBe(0);
+    h.failRaise.on = false;
+    h.setNow(h.now() + MIN);
+    h.setAuthRejectAt('m_peer', h.now()); // evidence stays fresh
+    h.monitor.evaluate();
+    expect(h.raised.length).toBe(1);
+  });
+
+  it('recovery clears the per-episode raise latch (a NEW episode can alert again)', () => {
+    const h = mkMonitor();
+    h.rows.push(row('m_peer', 'tailscale', true));
+    h.setAuthRejectAt('m_peer', h.now());
+    settleAllDown(h);
+    expect(h.raised.length).toBe(1);
+    // rope heals + evidence goes stale → sustained clear
+    h.rows.length = 0;
+    h.rows.push(row('m_peer', 'tailscale', false));
+    h.setAuthRejectAt('m_peer', null);
+    for (let i = 0; i < 12; i++) { h.monitor.evaluate(); h.setNow(h.now() + 2 * MIN); }
+    expect(h.monitor.status().peers.find((p) => p.machineId === 'm_peer')!.condition).toBe('ok');
+    // a fresh episode with fresh evidence raises ONE new item
+    h.rows.length = 0;
+    h.rows.push(row('m_peer', 'tailscale', true));
+    h.setAuthRejectAt('m_peer', h.now());
+    settleAllDown(h);
+    expect(h.raised.length).toBe(2);
   });
 });

--- a/tests/unit/RopeRecoveryProber.test.ts
+++ b/tests/unit/RopeRecoveryProber.test.ts
@@ -421,3 +421,37 @@ describe('RopeRecoveryProber — escalation bodies name machines by NICKNAME (20
     expect(esc.body).toContain(`peer ${PEER}`); // honest fallback
   });
 });
+
+describe('RopeRecoveryProber — auth-reject liveness evidence (2026-08-29 signature-mismatch incident)', () => {
+  it('records the freshest auth-layer refusal per peer; transport failures record nothing', async () => {
+    const h = boot();
+    killRope(h);
+    expect(h.prober.lastAuthRejectAtMs(PEER)).toBeNull();
+
+    // a transport failure is NOT liveness evidence
+    h.setProbeResult({ typedSuccess: false, detail: 'dial-failed: fetch failed' });
+    await h.run(20_000);
+    expect(h.prober.lastAuthRejectAtMs(PEER)).toBeNull();
+
+    // a typed auth refusal IS — the peer's server answered and said no
+    h.setProbeResult({ typedSuccess: false, detail: 'auth-rejected:signature-invalid' });
+    await h.run(60_000);
+    const first = h.prober.lastAuthRejectAtMs(PEER);
+    expect(first).not.toBeNull();
+
+    // freshest wins as more refusals arrive
+    await h.run(120_000);
+    expect(h.prober.lastAuthRejectAtMs(PEER)!).toBeGreaterThan(first!);
+
+    // scoped per peer
+    expect(h.prober.lastAuthRejectAtMs('m_other')).toBeNull();
+  });
+
+  it('a typed SUCCESS never records auth evidence', async () => {
+    const h = boot();
+    killRope(h);
+    h.setProbeResult({ typedSuccess: true, detail: 'refused-not-router:not-router' });
+    await h.run(60_000);
+    expect(h.prober.lastAuthRejectAtMs(PEER)).toBeNull();
+  });
+});

--- a/upgrades/next/rope-auth-reject-alive.md
+++ b/upgrades/next/rope-auth-reject-alive.md
@@ -1,0 +1,36 @@
+## What Changed
+
+`RopeRecoveryProber` records the freshest typed auth-layer probe refusal per peer
+(`lastAuthRejectAtMs`); `RopeHealthMonitor` checks that evidence BEFORE both
+'peer-offline — expected' branches. An all-down peer with a refusal fresher than 45
+minutes classifies as the new `auth-rejected` condition — one actionable attention item
+per episode (default on, `monitoring.ropeHealth.authRejectAlertEnabled`) and a distinct
+digest sentence naming the likely key/identity mismatch. Stale, absent, or unreadable
+evidence falls through to the ordinary offline rules unchanged.
+
+## What to Tell Your User
+
+If one of your machines rotates its identity key and the others never learn about it,
+they start refusing all its messages — and until now the health monitor filed that as
+"offline — expected" because the machine's heartbeat had stopped. The heartbeat had
+stopped *because* of the key problem, so a real two-day outage stayed silent.
+
+A machine that actively answers "no, invalid signature" is provably awake. The monitor
+now treats that refusal as the proof it is, tells you loudly within minutes, and names
+the likely cause — instead of assuming the machine is asleep.
+
+## Summary of New Capabilities
+
+- A peer refusing signed messages is classified "awake but refusing" — a loud, distinct
+  state — never "offline — expected".
+- One alert per episode, delivery-honest (a failed delivery retries), content-scrubbed.
+- Only typed signature-layer refusals count; network failures and sleeping machines
+  structurally cannot trip it.
+- Fully reversible: disable the alert by config, or unwire the evidence source for
+  byte-identical old behaviour.
+
+## Evidence
+
+- Unit: `tests/unit/RopeRecoveryProber.test.ts` (+2), `tests/unit/RopeHealthMonitor.test.ts` (+6),
+  verified red-then-green against pre-fix behaviour.
+- Side-effects review: `upgrades/side-effects/rope-auth-reject-alive.md`.

--- a/upgrades/side-effects/rope-auth-reject-alive.md
+++ b/upgrades/side-effects/rope-auth-reject-alive.md
@@ -1,0 +1,105 @@
+# Side-effects review — alive-but-rejecting classification (auth-reject evidence)
+
+**Change:** `RopeRecoveryProber` records the freshest typed auth-layer probe refusal per
+(peer, kind) and exposes `lastAuthRejectAtMs(peer)`. `RopeHealthMonitor` consumes it via a
+new optional dep checked BEFORE both 'peer-offline — expected' branches: an all-down peer
+with refusal evidence fresher than `authRejectFreshnessMs` (45 min) classifies as the new
+condition `auth-rejected`, raising ONE actionable item per episode
+(`authRejectAlertEnabled`, default true) and a distinct digest sentence.
+
+**Origin (live, 2026-08-27→29, topic 62395):** the Studio's regenerated signing key left
+peers refusing every outbound RPC (`401 auth-rejected:signature-invalid`, ~10,968
+consecutive per rope). The monitor classified all three peers 'peer-offline — expected
+(its heartbeat stopped)' — but the heartbeat and registry-online flag had stopped
+*because* of the auth fault. The classification consumed its own symptom as the benign
+explanation, and a two-day one-way mesh outage raised nothing.
+
+## 1. Over-block — what legitimate input does this now reject?
+
+Nothing is blocked — the change is a classification + one additional alert class. The
+over-fire risk: an alert during a benign transient. Bounded by the evidence bar — only a
+TYPED auth-layer refusal records (the peer's dispatcher answered and refused); transport
+failures, timeouts, and untyped bodies record nothing, so a sleeping machine structurally
+cannot trip it. A single refusal during a healthy period does not alert either: the
+classification only applies inside the ALL-DOWN branch, so at least one rope must already
+be dead-classified.
+
+## 2. Under-block — what does this still miss?
+
+- Evidence only exists where the recovery prober runs (dev-gated live; dark-on-fleet
+  installs record nothing and keep today's exact behaviour — honest, not silent: the
+  classification simply never fires there).
+- The 45-min freshness bound means a wedged prober (not probing at all) yields no
+  evidence and the peer falls back to 'peer-offline'. Failing toward the old behaviour is
+  the chosen direction.
+- Detection, not repair: the mesh stays one-way until the identity is fixed (the
+  automatic re-announce is the machine-self-assertion spec's build).
+
+## 3. Level-of-abstraction fit
+
+The prober owns probe verdicts, so the evidence lives there (scheduling-state only, never
+persisted — same as its other episode state). The monitor owns peer classification, so
+the rule lives there. The wiring site connects the two existing components; no new
+component, no parallel check.
+
+## 4. Signal vs authority compliance
+
+Compliant. Both components are signal-producers: the new path raises an attention item
+and a digest sentence; it blocks nothing, restarts nothing, repairs nothing, and cannot
+suppress any other alert (it runs BEFORE the offline branches and only ever upgrades
+loudness, never downgrades — an auth-rejected peer would otherwise have been the QUIET
+classification).
+
+## 5. Interactions
+
+- **Urgent tier:** unaffected in behaviour — a peer with fresh auth evidence classifies
+  `auth-rejected` and skips the urgent path for that evaluation; without evidence the
+  urgent rules run unchanged. The two alerts cannot double-fire for the same evaluation.
+- **Sleep gate / split-brain suppressors:** not consulted for this class, deliberately —
+  they exist to avoid false "partition" alarms on wake, and a typed refusal is immune to
+  that false-positive mode (a sleeping machine answers nothing).
+- **Escalate-once:** per-episode latch (`authRejectRaisedAt`), persisted like
+  `urgentRaisedAt`, cleared by the same sustained-clear reset; delivery-failure retry
+  mirrors the urgent path's detected-not-notified honesty.
+- **State file:** one additive field; old state files load (missing field → null).
+- **`RopeHealthCondition` union:** gains `'auth-rejected'`. Grep confirmed consumers are
+  in-file (digest, transitions, isCondition) — the HTTP route serves the string through.
+
+## 6. External surfaces
+
+`GET /mesh/rope-health` may now show `condition: "auth-rejected"` and a new digest
+sentence; the attention queue gains one new item class (episode-deduped). Alert text is
+content-scrubbed by construction: nickname + relative time only — no key material, no
+machine ids in prose, no addresses.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** "Peer X refuses MY signatures" is inherently a per-observer
+fact (X may refuse this machine while accepting another whose stored identity is current).
+Each machine classifies from its own probe evidence; no replication path is wanted —
+replicating the verdict would let one machine's key problem misreport another's healthy
+relationship. Single-machine agents have no peers and are a strict no-op.
+
+## 8. Rollback cost
+
+Trivial. `authRejectAlertEnabled: false` silences the alert while keeping the honest
+classification; removing the `readAuthRejectAtMs` dep from the server wiring restores
+byte-identical pre-change classification (explicitly tested: a null/throwing evidence
+source falls through to the ordinary rules). The persisted field is additive and ignored
+by old code. No migration.
+
+## Second-pass note
+
+Signal-only monitoring change (no block/allow authority anywhere in the path); Tier 1
+with the no-dep-equals-old-behaviour test standing in for the reviewer's main concern.
+
+## Tests
+
+- Prober (+2): typed auth refusal records freshest-per-peer; transport failures and typed
+  successes record nothing; per-peer scoping.
+- Monitor (+6): the full regression (all-down + stopped heartbeat + registry-offline +
+  fresh evidence ⇒ `auth-rejected`, ONE item, digest sentence, never 'expected'); stale
+  evidence falls through; throwing source is no evidence; alert-disabled still classifies;
+  failed raise retries; recovery clears the latch and a new episode alerts once more.
+- Verified RED against pre-fix behaviour (the 4 positive cases fail for the right reason)
+  and green after. 55 unit + 7 integration in the touched suites, all green.


### PR DESCRIPTION
## ELI16 — A machine that says "no" is not asleep

On the 27th, the Studio's identity files went missing and its signing key had to be regenerated. The other machines still remembered the old key, so every message the Studio sent came back "rejected — invalid signature". Nearly eleven thousand rejections per connection over two days. Messages *to* the Studio still worked, so the mesh ran one-way — and no alarm distinguished this from an ordinary sleeping machine.

The monitor's rule for "offline — expected, no alarm needed" checks two things: has the machine stopped reporting itself in? and has its heartbeat stopped? Both had stopped. But both had stopped *because of the key problem* — a machine that can't authenticate to its peers can't report in or heartbeat to them. The monitor was reading the fault's own symptoms as the innocent explanation for the fault. A classification that consumes the evidence the failure destroys can never fire.

One signal the fault could not destroy: the rejections themselves. The recovery prober was still sending test messages, and the peers were still *answering* — "no, invalid signature." A machine that answers "no" has dialled, verified, and refused. It is provably awake.

The prober now remembers, per machine, when it last saw a signature-layer refusal. The health monitor checks that evidence *first*. Fresh refusals reclassify the machine as **awake but refusing** — one loud alert per episode naming the likely cause (a key or identity mismatch; mesh probably one-way; stored identity needs repair), and the daily digest says the same instead of "offline — expected."

Safeguards: evidence must be fresher than 45 minutes (one stale refusal can't revive the alarm); only typed signature-layer refusals count, so a genuinely sleeping machine structurally cannot trip it; delivery is retry-honest; an unreadable evidence source claims nothing and the old rules apply. Signal only — it blocks, restarts, and repairs nothing.

---

## The mechanism

- `RopeRecoveryProber`: failure verdicts whose detail is `auth-rejected:*` stamp `lastAuthRejectAt` on the rope's state; `lastAuthRejectAtMs(peer)` exposes the freshest per peer. Scheduling-state only, never persisted — same class as its other episode state.
- `RopeHealthMonitor`: new optional dep `readAuthRejectAtMs`, consulted at the TOP of the all-down branch — before the registry-online and heartbeat rules, both of which the auth fault suppresses. Fresh evidence ⇒ new condition `auth-rejected`, escalate-once per episode (`authRejectRaisedAt`, persisted + reloaded like `urgentRaisedAt`), delivery-failure retry mirrors the urgent tier, digest sentence added, `authRejectAlertEnabled` (default true) silences the raise but keeps the honest classification.
- Wiring: `readAuthRejectAtMs: (id) => _ropeProber?.lastAuthRejectAtMs(id) ?? null`.

Deliberately NOT consulted for this class: the sleep gate and split-brain suppressors — they exist to damp false partition alarms on wake, and a typed refusal is immune to that false-positive mode (a sleeping machine answers nothing).

## Why this can't cry wolf

The evidence bar is a typed refusal from the peer's real dispatcher (the same parser contract the recovery probe uses — any-2xx never counts). Transport failures, timeouts, captive portals, and unparseable bodies record nothing. The classification also only applies inside the ALL-DOWN branch, so a healthy mesh can never surface it.

## Scope

Detection, not repair — the mesh stays one-way until the stored identity is fixed. The automatic proof-of-possession re-announce is the machine-self-assertion spec's build (decided 2026-08-29: fully automatic, per operator directive). On installs where the recovery prober is dark, no evidence exists and behaviour is byte-identical to today.

## Tests

- Prober (+2): auth refusals record freshest-per-peer; transport failures and typed successes record nothing; per-peer scoping.
- Monitor (+6): the full regression shape (all-down + stopped heartbeat + registry-offline + fresh evidence ⇒ `auth-rejected`, ONE item, digest sentence, never "expected"); stale evidence falls through; throwing source claims nothing; alert-disabled still classifies honestly; failed raise retries; recovery clears the latch and a new episode alerts once.
- Verified **red against pre-fix behaviour** (the 4 positive cases fail for the right reason), green after. 55 unit + 7 integration green in the touched suites.

## Rollback

`monitoring.ropeHealth.authRejectAlertEnabled: false` silences the alert; unwiring the one dep restores byte-identical classification (explicitly tested). Persisted field is additive; old state files load unchanged.

Side-effects review: `upgrades/side-effects/rope-auth-reject-alive.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o9kgd1afVCgzEnqJaqmsi