### PR TITLE
spec(mesh): machine self-assertion — CONVERGED, awaiting operator build sign-off

### DIFF
--- a/docs/specs/carriers/machine-self-assertion.json
+++ b/docs/specs/carriers/machine-self-assertion.json
@@ -3,7 +3,7 @@
   "slug": "machine-self-assertion",
   "carriers": {
     "CMT-211": {
-      "status": "pending",
+      "status": "complete",
       "owner": "agent",
       "blockedOn": "none",
       "excerpt": "Carry the machine-self-assertion decision to closure: (1) the operator's accept-or-decline on the PIN-gated key re-announce path, taken with the token/identity boundary-collapse cost stated (spec section 2); (2) classify a rope failing auth-rejected as a PROVABLY-ALIVE peer rather than 'offline - expected', since the heartbeat that grades it stopped because of the very fault; (3) scope the Tailscale key-expiry warning to nodes that actually back a mesh peer endpoint, so a dead unrelated tailnet node stops warning forever; (4) the externally-observed-endpoint path that lets peers record the address they OBSERVED, which is what a NAT'd or VM-hosted agent cannot assert about itself."

--- a/docs/specs/carriers/machine-self-assertion.json
+++ b/docs/specs/carriers/machine-self-assertion.json
@@ -1,0 +1,12 @@
+{
+  "generatedAt": "2026-08-29T20:30:53.867994Z",
+  "slug": "machine-self-assertion",
+  "carriers": {
+    "CMT-211": {
+      "status": "pending",
+      "owner": "agent",
+      "blockedOn": "none",
+      "excerpt": "Carry the machine-self-assertion decision to closure: (1) the operator's accept-or-decline on the PIN-gated key re-announce path, taken with the token/identity boundary-collapse cost stated (spec section 2); (2) classify a rope failing auth-rejected as a PROVABLY-ALIVE peer rather than 'offline - expected', since the heartbeat that grades it stopped because of the very fault; (3) scope the Tailscale key-expiry warning to nodes that actually back a mesh peer endpoint, so a dead unrelated tailnet node stops warning forever; (4) the externally-observed-endpoint path that lets peers record the address they OBSERVED, which is what a NAT'd or VM-hosted agent cannot assert about itself."
+    }
+  }
+}

--- a/docs/specs/machine-self-assertion.eli16.md
+++ b/docs/specs/machine-self-assertion.eli16.md
@@ -83,3 +83,14 @@ change that opens the proper door.
 Nothing new — this is your least-human-effort directive, made survivable: zero taps for
 every legitimate case, one tap reserved for the case where the evidence itself says
 "this could be theft."
+
+## One correction the review forced (worth knowing)
+
+The recovery-key idea only works if the recovery key is stored somewhere that survives the
+very failure it's for. On Macs it is — the system keychain outlives a folder getting deleted.
+On a plain Linux/Windows-WSL machine, the vault's own key lives *in the folder that
+disappeared*, so stashing the recovery key there would vanish right alongside everything else.
+So: machines with a real system keychain get the fully-automatic recovery; machines without
+one honestly say "no auto-recovery here — I'll ask for one tap if the rare double-failure
+ever hits," instead of pretending to be protected. That's safer than a guarantee that
+evaporates exactly when you need it.

--- a/docs/specs/machine-self-assertion.eli16.md
+++ b/docs/specs/machine-self-assertion.eli16.md
@@ -1,0 +1,84 @@
+---
+title: How does a machine prove something about itself that it can't see?
+slug: machine-self-assertion
+audience: decider
+---
+
+# How does a machine prove something about itself that it can't see?
+
+## The one-sentence version
+
+Twice this week a machine needed to tell the others something true about itself — "here's
+my new key", "here's the address that actually reaches me" — and had no way to prove it,
+because the proof was either lost or invisible from where it stands.
+
+## The two things that happened
+
+**The lost key.** The Studio's identity files went missing on the 27th. Its keys were
+regenerated. The other three machines still held the old key, so every message the Studio
+sent them was rejected as forged. Messages *to* the Studio kept working, so the mesh ran
+one-way for two days without anything stopping.
+
+Fixing it meant a human reaching into each machine's filesystem. There is no built-in way
+to do it, and there's a reason: the normal way a machine introduces itself requires a
+pairing code issued by the trusted machine — but here the machine needing to re-introduce
+itself is exactly the one nobody trusts any more.
+
+**The invisible address.** One machine runs its agent inside WSL, a Linux environment
+nested inside Windows. The address everyone actually reaches it on belongs to the Windows
+side, outside that nested box. From where the agent sits, that address does not exist. So
+it announces the only address it can see — one that works from nowhere — and it can never
+announce the right one.
+
+Both are the same problem wearing different clothes: **state a fact about yourself that
+you cannot back up.**
+
+## The tempting fix, and what it costs
+
+The machines already share a password-like token for talking to each other. That token is
+what I used by hand to repair the key. So the obvious move is to let a machine simply
+re-announce itself using that token.
+
+Here's the catch, and it's the whole reason this is a decision rather than a fix.
+
+Right now, if that token leaked, someone could read and change a lot — but they could
+**not** pretend to be one of your machines. Machine identity is protected by keys the
+token has no power over. Two separate locks.
+
+Allowing re-announcement over the token merges those two locks into one. A leaked token
+would then be enough to impersonate a machine, or to redirect one machine's traffic to an
+address of the attacker's choosing.
+
+That may still be worth it. But it should be your call, made knowing that's the trade —
+not something I quietly implement because it was convenient.
+
+## What I'd suggest
+
+**Two of the three pieces don't need that trade at all.**
+
+First, a straightforward bug fix. When a machine is refusing another's messages, it
+currently gets filed as "that machine is probably asleep" — because the heartbeat stopped.
+But the heartbeat stopped *because of the refusal*. It's reading its own symptom as the
+innocent explanation. A machine that actively answers "no, I don't believe you" is
+demonstrably awake, and should be reported as a problem, loudly. This needs no new powers.
+
+Second, for the address problem, there's a nicer answer than letting a machine claim an
+address. The other machines already *know* the working address — they're connecting to it
+successfully every minute. Instead of trusting a claim, let them record what they
+observed. That's first-hand evidence rather than an assertion, and it adds no new risk.
+
+That leaves only the key case genuinely needing your decision. My suggestion there is a
+middle path: the machine can ask to re-announce itself, but it takes one tap from you on
+your dashboard, protected by your PIN. Your PIN is something the token doesn't grant, so a
+leaked token still can't impersonate anything on its own. The cost to you is one tap, and
+only when a key is actually lost — which has happened once in the mesh's lifetime.
+
+## What you actually need to decide
+
+Just this: **is one PIN-protected tap an acceptable price for making a lost key
+self-repairable, given it means your PIN becomes the thing standing between a leaked token
+and a machine impersonation?**
+
+If you'd rather not, the fallback is honest and still much better than what happened: I
+detect the breakage within minutes and tell you loudly, and you or I repair it by hand.
+Nothing silently runs one-way for two days again either way.

--- a/docs/specs/machine-self-assertion.eli16.md
+++ b/docs/specs/machine-self-assertion.eli16.md
@@ -8,77 +8,78 @@ audience: decider
 
 ## The one-sentence version
 
-Twice this week a machine needed to tell the others something true about itself — "here's
-my new key", "here's the address that actually reaches me" — and had no way to prove it,
-because the proof was either lost or invisible from where it stands.
+Twice in one week a machine needed to tell the others something true about itself —
+"here's my new key", "here's the address that actually reaches me" — and had no way to
+prove it; this design lets the mesh accept the truth automatically when the evidence backs
+it, and asks you for one tap only when the evidence can't tell recovery from takeover.
 
 ## The two things that happened
 
 **The lost key.** The Studio's identity files went missing on the 27th. Its keys were
-regenerated. The other three machines still held the old key, so every message the Studio
-sent them was rejected as forged. Messages *to* the Studio kept working, so the mesh ran
-one-way for two days without anything stopping.
+regenerated. The other machines still held the old key, so every message the Studio sent
+was rejected as forged — nearly eleven thousand rejections per connection — and the mesh
+ran one-way for two days. Fixing it took a human writing files onto each machine by hand.
 
-Fixing it meant a human reaching into each machine's filesystem. There is no built-in way
-to do it, and there's a reason: the normal way a machine introduces itself requires a
-pairing code issued by the trusted machine — but here the machine needing to re-introduce
-itself is exactly the one nobody trusts any more.
+**The invisible address.** One machine runs its agent inside WSL, a Linux box nested
+inside Windows. The address everyone reaches it on belongs to the Windows side, which the
+agent literally cannot see. So it announces an address that works from nowhere, and can
+never announce the right one.
 
-**The invisible address.** One machine runs its agent inside WSL, a Linux environment
-nested inside Windows. The address everyone actually reaches it on belongs to the Windows
-side, outside that nested box. From where the agent sits, that address does not exist. So
-it announces the only address it can see — one that works from nowhere — and it can never
-announce the right one.
+## Why "just let it announce itself" was rejected
 
-Both are the same problem wearing different clothes: **state a fact about yourself that
-you cannot back up.**
+Your directive was the least human effort possible, and the first draft said: fully
+automatic — a machine announces its new key, proves it holds that key, done. Eight
+independent reviews (including two non-Anthropic models) all found the same hole: *anyone*
+who just created a key can prove they hold it. That proof filters out nobody. Combined
+with the shared machine password, a fully automatic accept would mean anyone who stole
+that password could become one of your machines — and the only trace would be one
+notification into a queue that provably buried the last critical alert for two days.
 
-## The tempting fix, and what it costs
+## The design that keeps it zero-touch anyway
 
-The machines already share a password-like token for talking to each other. That token is
-what I used by hand to repair the key. So the obvious move is to let a machine simply
-re-announce itself using that token.
+The trick is that a *real* recovery leaves evidence an impostor can't fake, and the mesh
+already holds it:
 
-Here's the catch, and it's the whole reason this is a decision rather than a fix.
+- The recovering machine has a **local rotation record** — a timestamped "my keys were
+  regenerated, here's why" note that survives in its replicated public metadata.
+- The other machines have **first-hand evidence** — they themselves have been refusing
+  that machine's messages (they can see their own "invalid signature" log).
+- The announcement **arrives from an address the peers already know** for that machine.
 
-Right now, if that token leaked, someone could read and change a lot — but they could
-**not** pretend to be one of your machines. Machine identity is protected by keys the
-token has no power over. Two separate locks.
+When all of that lines up — which is what an actual lost-key recovery looks like — the new
+key is accepted automatically. No tap, no approval. The incident from the 27th would have
+healed itself in minutes.
 
-Allowing re-announcement over the token merges those two locks into one. A leaked token
-would then be enough to impersonate a machine, or to redirect one machine's traffic to an
-address of the attacker's choosing.
+When it *doesn't* line up — the claim comes from an address nobody recognizes, or there's
+no rotation record, or two different claimants are fighting over the same machine — the
+claim is parked, nothing is stored, and you get one approve/deny button on your dashboard.
+That's the only moment a human is ever involved, and it's precisely the moment where
+"automatic" would mean "automatic for the attacker too."
 
-That may still be worth it. But it should be your call, made knowing that's the trade —
-not something I quietly implement because it was convenient.
+Every identity change also lands in a permanent ledger that keeps resurfacing until you
+acknowledge it — so even a change you didn't approve can't slip past unseen, no matter how
+noisy the notification queue is that day.
 
-## What I'd suggest
+## The address half
 
-**Two of the three pieces don't need that trade at all.**
+For the machine that can't see its own address, the answer needs no trust at all: the
+other machines record where its *authenticated* traffic actually comes from, confirm it
+over half an hour, dial it back to make sure it really answers as that machine, and only
+then use it — and never in place of an address that's already working. Fully automatic,
+because it's built on what the observers can verify themselves, not on what the boxed-in
+machine claims.
 
-First, a straightforward bug fix. When a machine is refusing another's messages, it
-currently gets filed as "that machine is probably asleep" — because the heartbeat stopped.
-But the heartbeat stopped *because of the refusal*. It's reading its own symptom as the
-innocent explanation. A machine that actively answers "no, I don't believe you" is
-demonstrably awake, and should be reported as a problem, loudly. This needs no new powers.
+## Safety rails, briefly
 
-Second, for the address problem, there's a nicer answer than letting a machine claim an
-address. The other machines already *know* the working address — they're connecting to it
-successfully every minute. Instead of trusting a claim, let them record what they
-observed. That's first-hand evidence rather than an assertion, and it adds no new risk.
+Announcements carry a strictly increasing generation number, so an old captured
+announcement can never be replayed and two rotations can't fight. One machine gets at most
+one automatic re-key a day, three per key generation — then it must go through you.
+Everything ships switched off for the fleet and in rehearsal mode on the dev machines
+first, and the file-editing hole that made all this possible gets closed in the very same
+change that opens the proper door.
 
-That leaves only the key case genuinely needing your decision. My suggestion there is a
-middle path: the machine can ask to re-announce itself, but it takes one tap from you on
-your dashboard, protected by your PIN. Your PIN is something the token doesn't grant, so a
-leaked token still can't impersonate anything on its own. The cost to you is one tap, and
-only when a key is actually lost — which has happened once in the mesh's lifetime.
+## What you need to decide
 
-## What you actually need to decide
-
-Just this: **is one PIN-protected tap an acceptable price for making a lost key
-self-repairable, given it means your PIN becomes the thing standing between a leaked token
-and a machine impersonation?**
-
-If you'd rather not, the fallback is honest and still much better than what happened: I
-detect the breakage within minutes and tell you loudly, and you or I repair it by hand.
-Nothing silently runs one-way for two days again either way.
+Nothing new — this is your least-human-effort directive, made survivable: zero taps for
+every legitimate case, one tap reserved for the case where the evidence itself says
+"this could be theft."

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -7,6 +7,9 @@ review-convergence: "2026-08-29T23:36:51.197Z"
 review-iterations: 5
 review-completed-at: "2026-08-29T23:36:51.197Z"
 review-report: "docs/specs/reports/machine-self-assertion-convergence.md"
+approved: true
+approved-at: "2026-08-30T16:18:00.000Z"
+approved-by: "verified-operator:telegram:7812716706"
 cross-model-review: "codex-cli:gpt-5.5"
 single-run-completable: true
 frontloaded-decisions: 12

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -1,0 +1,176 @@
+---
+title: Machine self-assertion — how a machine states a fact about itself it cannot prove locally
+slug: machine-self-assertion
+status: draft
+eli16-overview: docs/specs/machine-self-assertion.eli16.md
+---
+
+# Machine self-assertion
+
+## 1. The problem, stated once
+
+Two production failures in the same week share one shape.
+
+**A. The lost key (2026-08-27 → 2026-08-29, two days of one-way mesh).** The Studio's
+`.instar/machine/` identity files went missing. Its Ed25519 mesh keypair was regenerated;
+`machineId` and public metadata were restored from the Mini's replicated copy. The three
+peers still held the OLD `signingPublicKey`. Every outbound signed RPC from the Studio was
+refused `401 auth-rejected:signature-invalid` (10,968 consecutive failures per rope).
+Peer→Studio traffic kept working, so the mesh ran one-way and no layer noticed.
+
+The repair required a human with filesystem access to write the new public identity onto
+each peer. There is no in-product path: `POST /api/pair` is the only route that stores a
+remote identity, and it requires a pairing code minted by `instar pair` on the awake
+machine — which is the machine that cannot be trusted by its peers, because its key just
+changed.
+
+**B. The invisible address (2026-08-29, one machine unreachable-by-registry).** A peer
+whose agent runs inside WSL sees exactly one NIC: `eth0 172.22.96.135`, a virtual address
+unreachable from anywhere but its own Windows host. Tailscale runs on the Windows side,
+outside the VM. The agent advertises what it can see, so it advertises an address that
+cannot work, and it can never advertise `100.101.95.10` — the address every other machine
+actually reaches it on — because that address does not exist in its world.
+
+PR #1992 stopped the resulting data loss (peers no longer discard a proven rope because an
+advertisement omitted it). It did not, and cannot, give the machine a way to state the
+true address.
+
+**The shared shape:** a machine must assert a fact about itself — *this is my key*, *this
+is my address* — that it cannot prove from local evidence, to peers that have no
+independent way to verify it. In A the proof is gone (the old private key is lost, so no
+continuity signature is possible). In B the proof never existed locally (the address lives
+outside the machine's namespace).
+
+## 2. Why the obvious answer is not obviously right
+
+The mesh already has an authenticated channel between machines: the shared agent bearer
+token over TLS/Tailscale. That token is how the incident was actually repaired — an
+authenticated `POST /api/files/save` to each peer.
+
+So the tempting design is: *let a machine re-announce its identity over the bearer channel.*
+
+The cost is explicit and must not be buried. Today a leaked bearer token grants broad API
+access but **cannot forge a machine identity** — signature verification is a separate,
+stronger boundary rooted in keys the token does not control. Making identity assertable
+over the token collapses those two boundaries into one. A leaked token would then be able
+to:
+
+- substitute its own key for a legitimate machine's (impersonation on the mesh), and
+- redirect a machine's advertised endpoints to an attacker-controlled address
+  (interception of cross-machine traffic).
+
+This is a real widening, not a theoretical one, and it is the reason this document exists
+rather than a patch.
+
+## 3. Constraints any accepted option must satisfy
+
+1. **No silent two-day outage.** Whatever is chosen, a mesh that is refusing a peer's
+   signatures must become loudly visible fast. (Note: the alert DID fire correctly on
+   2026-08-28 07:31 and was buried in a 237-item attention queue — that failure is tracked
+   separately and is not solved here.)
+2. **A human action is acceptable; a human *discovery* is not.** Requiring an approval tap
+   is fine. Requiring the operator to notice the breakage themselves is not.
+3. **No new capability for an unauthenticated party.** Nothing here may be reachable
+   without existing authentication.
+4. **Reversible.** Every option ships behind a flag whose absence is today's behaviour.
+5. **Evidence over assertion, where evidence exists.** Where a machine CAN prove something
+   locally, the proof — not the claim — must be what is accepted.
+
+## 4. Options
+
+### Option 1 — Detect loudly, repair by hand (no new authority)
+
+Add no assertion path. Instead:
+- Classify a rope failing with `401 auth-rejected` distinctly from an unreachable one. A
+  peer that answers 401 is *provably alive* and must never be graded `peer-offline`.
+  Today's classifier reads a stopped heartbeat as the innocent explanation, but the
+  heartbeat stopped *because* of the very fault — a signal the fault suppresses cannot
+  distinguish the two cases.
+- Raise a dedicated, non-coalescing alert for the key-mismatch condition, with the exact
+  repair command.
+
+**Cost:** repair still requires filesystem access to each peer, so it fails constraint 2's
+spirit for a travelling operator. **Benefit:** zero new attack surface. Small, and it is
+strictly required regardless of which other option is chosen.
+
+### Option 2 — Operator-approved re-announce (one tap, PIN-gated)
+
+A machine detecting sustained `signature-invalid` to a peer raises an Attention item with
+a **dashboard-PIN-gated** approve action. On approval, the peer stores the new identity.
+
+Proof of possession is required: the claimant signs a peer-issued nonce with the NEW key,
+so approval binds the operator's decision to a specific key the claimant demonstrably
+holds. The bearer token alone never suffices — the PIN is a second, human-held factor the
+token does not grant, which keeps the boundary from collapsing (constraint 3, and the
+existing Know-Your-Principal standard).
+
+**Cost:** one operator tap per rotation event (rare — this is the first in the mesh's
+lifetime). **Benefit:** the widening is bounded by a factor an attacker holding only the
+token does not have.
+
+### Option 3 — Continuity-chained rotation (automatic, no human)
+
+A machine rotates by signing the new key with the OLD one; peers accept because the chain
+is unbroken. Fully automatic, no new trust in the bearer token.
+
+**This does not solve incident A.** The old private key was *lost* — that is precisely the
+scenario. Option 3 is worth building for *planned* rotation hygiene, but it is inert for
+the unplanned loss that actually happened. Recorded here so it is not mistaken for a
+solution to the incident.
+
+### Option 4 — Externally-observed endpoints (solves B specifically)
+
+For the address problem, the reachable address is a fact **other machines already know**:
+they connect to it successfully. Rather than letting the machine assert an address it
+cannot see, let peers record the address they *observed the connection arriving from*, and
+treat that observation as the endpoint.
+
+This satisfies constraint 5 exactly — it replaces an unprovable self-assertion with
+first-hand evidence held by the observer. It adds no authority to the bearer token, and
+degrades safely (no observation ⇒ today's behaviour).
+
+**Cost:** an observed source address can be a NAT boundary rather than a durable route, so
+observations need corroboration (repeated, from multiple peers) before being trusted, and
+must never displace a working advertised endpoint — only supplement a missing one.
+
+## 5. Recommendation
+
+**Option 1 + Option 4, and Option 2 only if the operator accepts the widening.**
+
+Option 1 is unconditional: the classifier bug is real regardless, and cheap.
+
+Option 4 solves the address case *without* touching the token boundary at all, which makes
+it strictly preferable to any self-assertion design for that half of the problem. The
+insight generalises: when a machine cannot prove a fact about itself, prefer moving the
+question to a party that CAN observe it over inventing a way to trust the claim.
+
+Option 2 remains the only answer for the key case, and it is the one that costs something.
+It should be the operator's explicit decision, taken with §2 in front of them, not folded
+into an implementation.
+
+## 6. What is deliberately not decided here
+
+Whether to accept the Option-2 widening. That is the operator's call.
+<!-- tracked: CMT-211 -->
+
+> **CMT-211** — Carry the machine-self-assertion decision to closure: (1) the operator's
+> accept-or-decline on the PIN-gated key re-announce path, taken with the token/identity
+> boundary-collapse cost stated (spec section 2); (2) classify a rope failing auth-rejected
+> as a PROVABLY-ALIVE peer rather than 'offline - expected', since the heartbeat that
+> grades it stopped because of the very fault; (3) scope the Tailscale key-expiry warning
+> to nodes that actually back a mesh peer endpoint, so a dead unrelated tailnet node stops
+> warning forever; (4) the externally-observed-endpoint path that lets peers record the
+> address they OBSERVED, which is what a NAT'd or VM-hosted agent cannot assert about
+> itself.
+
+## 7. Evidence
+
+- `logs/server.log` — 926 `[rope-probe] probe failed … auth-rejected:signature-invalid`.
+- `.instar/machine/identity.json` — `keysRotatedAt: 2026-08-28T02:01:55Z`, with the
+  recorded reason naming the lost private keys.
+- Peers' stored copies read directly at `/api/files/read` on each machine: old
+  `signingPublicKey` `MCowBQYDK2VwAyEAhPiJ…` vs current `MCowBQYDK2VwAyEAVfPs…`.
+- Mama PC interface table captured on-machine: `platform: linux`, `eth0 172.22.96.135`
+  only, no CGNAT address present.
+- Post-repair verification: signed mesh probes to all three peers returned the typed
+  `403 not-router` refusal (the exact success contract).

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -266,36 +266,72 @@ compared-flags set). Post-F1 the boundary is RESTORED with respect to DIRECT ide
 writes (scoped per §4.0's honest note): an uncorroborated bearer claimant reaches only the
 PIN quarantine.
 
-### 4.5 Escrowed recovery key (the cryptographic close — OPERATOR-GATED, see Open questions)
+### 4.5 Escrowed recovery key (the cryptographic close — ADOPTED, operator-approved 2026-08-29 topic 62395)
 
-The only mechanism that makes even the total-loss + address-change case zero-touch AND
-secure against a token-holder: at pair time each machine mints a SECOND ("recovery")
-keypair; peers store its PUBLIC half (replicated), and the PRIVATE half is escrowed OUTSIDE
-`.instar/machine/**` — in a location the bearer token / files API cannot read (the operator's
-vault, or a peer-held sealed copy). On rotation the machine signs the new signing key with
-the RECOVERY key; peers verify the continuity signature against the stored recovery pubkey →
-cryptographic legitimacy, because only the real machine holds the recovery private key. This
-becomes §4.1's condition 5 when present (superseding the 5a heuristic), giving a fully
-automatic, token-adversary-proof accept. It covers incident A and the double-fault case IFF
-the recovery private key survived the loss that took the signing key — which is an operator
-choice about WHERE to escrow it. Adopting escrow is the Open question below.
+The mechanism that makes even the total-loss + address-change case zero-touch AND secure
+against a token-holder. At pair time each machine mints a SECOND ("recovery") keypair. Its
+PUBLIC half is stored by peers (replicated as identity metadata, applied only through the
+§4.0 funnel). Its PRIVATE half is escrowed OUTSIDE `.instar/machine/**`, in a location the
+bearer token / files API cannot read.
+
+On rotation the machine signs the SIX-field binding of §4.1 with BOTH the new signing key
+(proof-of-possession) AND the RECOVERY key (continuity signature). Peers verify the
+continuity signature against the stored recovery public key → cryptographic legitimacy,
+because only the real machine holds the recovery private key. A valid continuity signature
+BECOMES §4.1's condition 5 (superseding the 5a source-address heuristic and, with it,
+condition 4's issued-refusal requirement — a continuity signature is strictly stronger
+first-hand evidence than either), giving a fully automatic, token-adversary-proof accept in
+every case where the recovery key survived — including the double-fault case 5a cannot cover.
+
+**Escrow location (operator-selectable at pair time; default the strongest available):**
+
+1. **Operator vault (default when a vault backend is configured).** The recovery private
+   key is sealed into the operator's SecretStore (AES-256-GCM, master key NOT derivable
+   from the bearer token). Survives total loss of `.instar/machine/**`. The one setup cost
+   Justin approved.
+2. **Peer-sealed shares (fallback / additional copy).** The recovery private key is split
+   (Shamir k-of-n over the pool) and each share sealed to a PEER machine's encryption key,
+   so recovery needs a quorum of peers to co-sign a recovery-key-use authorization — no
+   single compromised peer can wield it, and it survives as long as k peers survive.
+
+**The recovery key's own lifecycle (review-critical — it is now the root of trust):**
+
+- **Compromise / rotation of the recovery key itself** is an operator-only action (it
+  cannot be self-service, or a token-holder who somehow obtained it could entrench). It
+  goes through the §4.0 funnel with its own epoch, and rotating it re-seals fresh escrow.
+- **Recovery key never signs ordinary traffic** — it is used ONLY to authorize a signing-key
+  rotation, minimizing its exposure (it is offline/sealed except during a rotation event).
+- **Loss of the recovery key** (both the escrow AND the live copy gone) is the ONLY residual
+  case that falls back to §4.1's corroboration-or-PIN path — strictly no worse than the
+  pre-escrow design, and now genuinely rare (it requires losing two independently-escrowed
+  secrets at once).
+- **At-rest honesty:** the vault-escrow option means the recovery private key exists sealed
+  on this machine's disk (encrypted); the peer-shares option means k peers each hold a
+  sealed share. Neither is readable by the bearer token, but both are stated plainly so the
+  operator knows where the root-of-trust material physically lives.
 
 ## 5. Decision (operator directive 2026-08-29 + round-1/2 revision)
 
 - **Zero-touch for the single-fault legitimate case (incident A):** local rotation record +
   the peer's own issued 401s + the re-announce arriving from the incumbent-verified
   authenticated address + cross-peer agreement → automatic, minutes. This is the common case.
-- **Operator tap ONLY where evidence cannot distinguish recovery from takeover:** a
-  tunnel-only mesh with no verified direct address, the key-loss-AND-address-change double
-  fault, a cross-peer fingerprint conflict, or any uncorroborated/racing claim → PIN
-  quarantine. Under an ACTIVE token-holding adversary, §4.1's conflict rule means a
-  legitimate rotation can be FORCED to the tap by a racing claim — this fails SAFE (to a
-  human) and is correct; §5 states it plainly rather than claiming minutes unconditionally.
+- **Operator tap ONLY where evidence cannot distinguish recovery from takeover, AND the
+  escrowed recovery key is unavailable:** with escrow (§4.5) the continuity signature makes
+  the key-loss-AND-address-change double fault fully automatic, so the tap is reserved for
+  the genuinely-rare case where the recovery key ITSELF is also lost, or a cross-peer
+  fingerprint conflict, or (transitionally) a machine not yet carrying an escrowed recovery
+  key whose 5a address evidence is unsatisfiable. Under an ACTIVE token-holding adversary,
+  §4.1's conflict rule means a legitimate rotation can be FORCED to the tap by a racing
+  claim — this fails SAFE (to a human) and is correct; a valid continuity signature
+  short-circuits the conflict (cryptographic identity beats a racing bare claim).
 - **Observed endpoints:** fully automatic (§4.2).
-- **Escrow (§4.5):** would move the double-fault case from tap to automatic; adopting it is
-  the Open question.
-- Option 3 (continuity-chained PLANNED rotation) is subsumed by §4.5's continuity signature
-  when escrow is adopted; otherwise out of scope, inheriting §4.0's tombstone rule.
+- **Escrow (§4.5): ADOPTED** (operator-approved 2026-08-29). The escrowed recovery key's
+  continuity signature is the PRIMARY condition-5 evidence; it moves the double-fault case
+  (key loss + address change) from tap to fully automatic, and is token-adversary-proof. The
+  5a source-address heuristic remains as the fallback for the transitional window before
+  every machine has an escrowed recovery key, and the PIN quarantine remains for the now-rare
+  case where the recovery key itself is also lost.
+- Option 3 (continuity-chained PLANNED rotation) is SUBSUMED by §4.5's continuity signature.
 
 ### 5b. History (non-normative)
 
@@ -338,6 +374,7 @@ never post (prevents N-notices / zero-notices).
 | Cross-peer fingerprint agreement | invariant | Read-time equality check over replicated promoted identity (§4.1(6)); disagreement → quarantine, never a pick. |
 | Observed-endpoint promotion | invariant | Declared floor (§4.2): ≥3 obs/≥30 min local + dial-back + not-shared-egress + rotation quarantine. Pre-commitment: any adaptive/scored element added later makes this a judgment-candidate requiring floor+arbiter. |
 | One-notice raiser election | invariant | Claimant posts on first acceptance; episode-scoped dedupe on machineId+keyEpoch. |
+| Continuity-signature verification (§4.5) | invariant | Deterministic Ed25519 verify of the rotation binding against the stored recovery public key; a valid signature is condition-5 evidence superseding the 5a heuristic. Recovery-key rotation is an operator action through the §4.0 funnel. |
 | Quarantine approve/deny | invariant | Deterministic routing to the operator's single-use, content-hash-bound dashboard-PIN decision; the operator is the arbiter (Know Your Principal). The machine-side routing is deterministic; the human decision sits above the classified machine surface. |
 
 ## Frontloaded Decisions
@@ -379,8 +416,12 @@ never post (prevents N-notices / zero-notices).
    set ships in the SAME PR as the accept route; git-sync applies identity changes only
    through the §4.0 funnel; fleet sequencing is machine-coherence-gated; the bearer→RCE
    surface (`.claude/settings.json`, `.git/`, `.instar/hooks/`) is a tracked follow-up.
-10. **Escrow (§4.5):** designed but OPERATOR-GATED (Open questions) — its continuity
-    signature supersedes condition 5 when present; Option 3 continuity chaining folds into it.
+10. **Escrow (§4.5) — ADOPTED:** recovery keypair minted at pair time; public half
+    replicated (funnel-applied), private half escrowed to the operator vault (default) or
+    Shamir k-of-n peer-sealed shares; continuity signature is the primary condition-5
+    evidence; recovery-key rotation is operator-only through the §4.0 funnel; recovery key
+    signs ONLY rotations, never ordinary traffic. A transitional machine without an escrowed
+    recovery key uses the 5a fallback until it has one.
 11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness consumer;
     it blocks stale-owner-release death evidence for that peer.
 12. **Migration & rollout parity:** `migrateConfig()` adds the two config blocks
@@ -394,21 +435,19 @@ never post (prevents N-notices / zero-notices).
 
 ## Open questions
 
-**OQ1 — Adopt the escrowed recovery key (§4.5)?** This is the one genuine operator
-decision. Adopting it makes even the total-loss + address-change case zero-touch and
-cryptographically secure against a token-holder, at the cost of the operator managing where
-the recovery private key is escrowed (their vault, or a peer-sealed copy) so it survives a
-loss that takes the signing key. Declining it means that specific rare double-fault case
-degrades to the PIN tap (still safe, still visible, just not zero-touch). Everything else in
-this spec is independent of OQ1. — pending operator input.
+*(none)*
 
-**OQ2 — bearer→RCE surface** (`.claude/settings.json` hook commands, `.git/hooks/**`,
-`.instar/hooks/**`): close in this spec's PR set, or track as separate pre-existing-debt
-hardening? §4.4's boundary claim is scoped to direct identity writes until resolved. —
-pending operator/maintainer decision.
+> **Resolved operator decisions (were OQ1/OQ2, now settled — recorded for the reader):**
+> Escrowed recovery key — ADOPTED (operator-approved 2026-08-29, topic 62395: "Approved"
+> against the Option-A recommendation); folded in as §4.5's normative primary mechanism,
+> default escrow location the operator vault, resolved into §4.5 / §5 / FD10.
+> bearer→RCE surface (`.claude/settings.json` hook commands, `.git/hooks/**`,
+> `.instar/hooks/**`) — tracked as SEPARATE pre-existing-debt hardening (it predates and is
+> independent of this spec, which neither creates nor widens it); §4.4's boundary claim
+> stays scoped to "restored with respect to DIRECT identity writes" and cites it as the
+> named follow-up rather than blocking on it.
 
-<!-- tracked: CMT-211 -->
-
+> <!-- tracked: CMT-211 -->
 > **CMT-211** — Carry the machine-self-assertion decision to closure: (1) the operator's
 > accept-or-decline on the PIN-gated key re-announce path, taken with the token/identity
 > boundary-collapse cost stated (spec section 2); (2) classify a rope failing auth-rejected

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -3,6 +3,15 @@ title: Machine self-assertion — how a machine states a fact about itself it ca
 slug: machine-self-assertion
 status: draft
 eli16-overview: docs/specs/machine-self-assertion.eli16.md
+review-convergence: "2026-08-29T23:36:51.197Z"
+review-iterations: 5
+review-completed-at: "2026-08-29T23:36:51.197Z"
+review-report: "docs/specs/reports/machine-self-assertion-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 12
+cheap-to-change-tags: 0
+contested-then-cleared: 3
 ---
 
 # Machine self-assertion
@@ -659,6 +668,32 @@ never post (prevents N-notices / zero-notices).
 > the bearer→RCE hardening (OQ2) remains a tracked follow-up. The immutable carrier text
 > (written pre-review) predates all of this — this annotation, not the carrier, reflects the
 > standing state.
+
+## Maturation plan
+
+- **test-agent-live:** live from the first build. The §4.0 funnel invariants (keyEpoch /
+  recoveryEpoch monotonicity, tombstone, first-establishment PIN gate), the §4.1 acceptance
+  composite, the challenge binding, and the observed-endpoint promotion floor are all
+  unit-testable without a second machine, including the negative rehearsals (uncorroborated →
+  quarantine, replayed/superseded → refuse).
+- **dev-agent-live:** ships behind the three flags (FD3) in dryRun on a development agent —
+  every accept path logs a would-accept/would-quarantine verdict (claimant AND peer side)
+  while the legacy corroboration path stays authoritative. The keychain-backed vault-escrow
+  and the recovery-key mint are exercised live on the dev pair; the recovery blob's survival
+  is proven by the FD3 rehearsal that DELETES `.instar/machine/**` and recovers end-to-end.
+- **fleet:** with a release, after: (a) ≥14 days dryRun on the dev pair with zero false
+  would-accept verdicts, (b) the negative rehearsals pass from the ledger, (c) one live-pair
+  rotation accepted, (d) the machine-coherence version gate confirms the accept route is
+  fleet-wide before re-announce enables (FD4/§4.4 sequencing), and (e) the F1 never-editable/
+  never-sync closure ships in the same PR as the accept route.
+- **graduation criterion:** a real key rotation on one machine is auto-accepted by its peers
+  in minutes with zero operator action (the incident-A replay); an injected uncorroborated /
+  replayed / cross-peer-conflicting claim quarantines to the PIN; and no active-paired
+  keychain-backed machine's recovery pubkey remains unestablished at its peers past horizon H.
+- **dark-window:** the whole feature ships dark on the fleet and dryRun-first on dev; the
+  window ends per-flag when its graduation criterion above is met and inspected. The
+  bearer→RCE hardening (OQ2) and Shamir peer-shares are explicitly OUT of this window — their
+  own follow-on specs.
 
 ## Reference (internal codes used above, for outside readers)
 

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -7,6 +7,12 @@ eli16-overview: docs/specs/machine-self-assertion.eli16.md
 
 # Machine self-assertion
 
+Glossary for outside readers: a **rope** is one transport between two of the agent's
+machines (Tailscale / LAN / Cloudflare tunnel); the **attention queue** is the durable
+operator-notification store; **Know Your Principal** is the house standard that an
+unverified identity is a question, not a fact; topic ids (e.g. 62395) name Telegram
+conversations where operator directives were given.
+
 ## 1. The problem, stated once
 
 Two production failures in the same week share one shape.
@@ -32,161 +38,304 @@ cannot work, and it can never advertise `100.101.95.10` — the address every ot
 actually reaches it on — because that address does not exist in its world.
 
 PR #1992 stopped the resulting data loss (peers no longer discard a proven rope because an
-advertisement omitted it). It did not, and cannot, give the machine a way to state the
-true address.
+advertisement omitted it). PR #1995 closed the detection gap (a peer answering typed auth
+refusals classifies `auth-rejected` — provably alive — never `peer-offline — expected`).
+Neither gives the machine a way to state the true fact.
 
 **The shared shape:** a machine must assert a fact about itself — *this is my key*, *this
 is my address* — that it cannot prove from local evidence, to peers that have no
-independent way to verify it. In A the proof is gone (the old private key is lost, so no
-continuity signature is possible). In B the proof never existed locally (the address lives
-outside the machine's namespace).
+independent way to verify it from the claim alone.
 
-## 2. Why the obvious answer is not obviously right
+## 2. The security boundary, corrected twice
 
-The mesh already has an authenticated channel between machines: the shared agent bearer
-token over TLS/Tailscale. That token is how the incident was actually repaired — an
-authenticated `POST /api/files/save` to each peer.
+The mesh has an authenticated channel between machines: the shared agent bearer token over
+TLS/Tailscale. The tempting design is: *let a machine re-announce its identity over the
+bearer channel.* The cost as originally analyzed: today a leaked bearer token grants broad
+API access but cannot forge a machine identity — signature verification is a separate,
+stronger boundary. Making identity assertable over the token collapses those two
+boundaries into one.
 
-So the tempting design is: *let a machine re-announce its identity over the bearer channel.*
-
-The cost is explicit and must not be buried. Today a leaked bearer token grants broad API
-access but **cannot forge a machine identity** — signature verification is a separate,
-stronger boundary rooted in keys the token does not control. Making identity assertable
-over the token collapses those two boundaries into one. A leaked token would then be able
-to:
-
-- substitute its own key for a legitimate machine's (impersonation on the mesh), and
-- redirect a machine's advertised endpoints to an attacker-controlled address
-  (interception of cross-machine traffic).
-
-This is a real widening, not a theoretical one, and it is the reason this document exists
-rather than a patch.
-
-**CORRECTION (2026-08-29, verified live):** the two-lock separation described above does
-not hold on current deployments. The dashboard files API (`POST /api/files/save`,
+**Correction 1 (2026-08-29, verified live):** on DEFAULT-CONFIGURED deployments that
+separation does not hold. The dashboard files API (`POST /api/files/save`,
 bearer-token-authenticated, default-editable over the whole project directory) accepts
-writes to `.instar/machines/<id>/identity.json` — this is exactly how the incident was
-repaired, and all three peers accepted the write with the token alone. A leaked bearer
-token can therefore ALREADY rewrite what a machine believes about a peer's identity, with
-NO proof of anything. The boundary §2 worried about collapsing is already collapsed.
+writes to `.instar/machines/<id>/identity.json` — exactly how incident A was repaired.
 
-Consequence: an automatic re-announce that REQUIRES proof-of-possession (the claimant
-answers a peer-issued challenge signed with the NEW key) is strictly STRONGER than the
-status quo path, not weaker. The genuine hardening opportunity is the separate follow-up
-of closing the files-API hole (make `.instar/machines/**` and `.instar/machine/**`
-never-editable), after which the §2 analysis becomes true again and would need
-re-examination — recorded below as follow-up F1.
+**Correction 2 (round-1 review):** correction 1 does NOT license a proof-free automatic
+path, for four independently sufficient reasons:
+
+1. **Deployment-dependence.** A deployment with narrowed files-API `allowedPaths` still
+   has the two-lock separation; for it, a bearer-gated re-announce is a genuine widening
+   today.
+2. **Temporal contingency.** F1 (closing the files-API identity hole) destroys the
+   "already collapsed" justification the moment it lands, leaving the auto path as the
+   designed-in collapse.
+3. **Proof-of-possession is liveness, not legitimacy.** Signing a challenge with the NEW
+   key is tautologically satisfiable by any attacker who just minted a keypair. Against
+   the leaked-token adversary — the threat this spec is about — bare PoP constrains
+   nothing.
+4. **The notice channel is proven insufficient as the sole compensating control.** The
+   2026-08-28 alert for incident A fired correctly and drowned in a 237-item attention
+   queue. Post-hoc visibility through that surface cannot backstop an identity rewrite.
+
+The design below therefore requires INDEPENDENT CORROBORATION for any automatic accept,
+and degrades to a human approval — never to a proof-free accept — when corroboration is
+absent.
 
 ## 3. Constraints any accepted option must satisfy
 
-1. **No silent two-day outage.** Whatever is chosen, a mesh that is refusing a peer's
-   signatures must become loudly visible fast. (Note: the alert DID fire correctly on
-   2026-08-28 07:31 and was buried in a 237-item attention queue — that failure is tracked
-   separately and is not solved here.)
-2. **A human action is acceptable; a human *discovery* is not.** Requiring an approval tap
-   is fine. Requiring the operator to notice the breakage themselves is not.
-3. **No new capability for an unauthenticated party.** Nothing here may be reachable
-   without existing authentication.
-4. **Reversible.** Every option ships behind a flag whose absence is today's behaviour.
-5. **Evidence over assertion, where evidence exists.** Where a machine CAN prove something
-   locally, the proof — not the claim — must be what is accepted.
+1. **No silent multi-day outage.** A mesh refusing a peer's signatures becomes loudly
+   visible within minutes (shipped: PR #1995's `auth-rejected` classification + alert).
+2. **Least human dependence (operator directive, 2026-08-29, topic 62395), bounded by
+   safety.** The common, legitimate case must need zero human action. A human action is
+   acceptable exactly where the evidence cannot distinguish legitimate recovery from
+   takeover; a human *discovery* is never acceptable.
+3. **No new capability for an unauthenticated party.** Everything requires existing
+   authentication.
+4. **Reversible.** Every mechanism ships behind a named flag whose absence is today's
+   behaviour, dark on the fleet, dryRun-first on dev (concrete flags in
+   `## Frontloaded Decisions`).
+5. **Evidence over assertion.** Where anyone — the claimant or the accepting peer — CAN
+   verify from first-hand or otherwise-unforgeable evidence, that evidence, not the
+   claim, is what is accepted.
 
-## 4. Options
+## 4. Design
 
-### Option 1 — Detect loudly, repair by hand (no new authority)
+### 4.1 Key rotation re-announce (incident A)
 
-Add no assertion path. Instead:
-- Classify a rope failing with `401 auth-rejected` distinctly from an unreachable one. A
-  peer that answers 401 is *provably alive* and must never be graded `peer-offline`.
-  Today's classifier reads a stopped heartbeat as the innocent explanation, but the
-  heartbeat stopped *because* of the very fault — a signal the fault suppresses cannot
-  distinguish the two cases.
-- Raise a dedicated, non-coalescing alert for the key-mismatch condition, with the exact
-  repair command.
+**Claimant-side trigger (deterministic, both-ways bounded):** a re-announce episode opens
+only when ALL of the following hold —
 
-**Cost:** repair still requires filesystem access to each peer, so it fails constraint 2's
-spirit for a travelling operator. **Benefit:** zero new attack surface. Small, and it is
-strictly required regardless of which other option is chosen.
+- The typed classification `auth-rejected:signature-invalid` (never transport failure;
+  unreachability FREEZES the episode clock) has been observed ≥K consecutive times
+  spanning ≥M minutes with zero interleaved successes, on every rope to that peer
+  (defaults: K=10, M=15 — Frontloaded Decision 1).
+- The machine holds a LOCAL ROTATION RECORD: `identity.json.keysRotatedAt` newer than the
+  failure onset, with a recorded reason. **Sustained 401s WITHOUT a local rotation record
+  are an attack/corruption signal** (a peer's stored copy was tampered, or this machine's
+  identity file was) — they route to the loud `auth-rejected` alert and NEVER to
+  re-announce. (P20: the 401 stream is the symbol; the rotation record is the
+  corroboration; no-signal-at-all is `unknown` and fails toward not-announcing.)
+- The per-machine re-announce budget is not exhausted (Frontloaded Decision 2; registered
+  as a SelfActionGovernor class).
 
-### Option 2 — Operator-approved re-announce (one tap, PIN-gated)
+**Challenge protocol:** the accepting peer mints a 32-byte single-use nonce, 60s TTL. The
+claimant's response signs `(nonce ‖ claimant machineId ‖ new signing pubkey ‖ new
+encryption pubkey ‖ challenger machineId)` with the NEW key. Replay, cross-peer reuse,
+and any field mismatch are typed refusals. The identity-store write is CAS-guarded
+against the identity version read at challenge issuance — a concurrent write between
+verify and store refuses rather than silently retrying. Challenge ISSUANCE (not just
+acceptance) is security-logged; per-machineId and per-source attempt caps persist across
+restarts (mirroring `/api/pair`'s brute-force discipline).
 
-A machine detecting sustained `signature-invalid` to a peer raises an Attention item with
-a **dashboard-PIN-gated** approve action. On approval, the peer stores the new identity.
+**Peer-side acceptance authority (the named authority — deterministic composite, an
+irreversible-action guard in Signal-vs-Authority's carve-out).** The 401-detector and the
+challenge check are SIGNALS. Acceptance requires ALL of:
 
-Proof of possession is required: the claimant signs a peer-issued nonce with the NEW key,
-so approval binds the operator's decision to a specific key the claimant demonstrably
-holds. The bearer token alone never suffices — the PIN is a second, human-held factor the
-token does not grant, which keeps the boundary from collapsing (constraint 3, and the
-existing Know-Your-Principal standard).
+1. Challenge signature verifies against the announced key (proof of possession —
+   necessary, never sufficient).
+2. The machineId has an EXISTING stored identity AND an active, non-revoked registry
+   entry. Re-announce is rotation-of-existing, NEVER enrollment; `/api/pair` remains the
+   sole enrollment path. A revoked machine cannot re-announce itself back into trust
+   (sticky revocation extends to this path explicitly).
+3. `keyEpoch` monotonicity: announcements carry an integer per-machine key epoch;
+   `epoch <= stored` is refused and logged. Wall-clock (`keysRotatedAt`) is displayed to
+   humans but never the ordering key. On accept, the OLD key is tombstoned at the stored
+   epoch — any future announcement (including a later continuity-chained one) rooted at
+   or below the tombstoned epoch is refused. Replay state stays keyed by machineId and
+   survives rotation; old-key envelopes are refused post-rotation regardless of nonce
+   freshness.
+4. **The peer's OWN first-hand evidence**: this peer has itself observed sustained
+   `auth-rejected` failures from the incumbent identity (its rope-health `auth-rejected`
+   classification, PR #1995). A takeover attempt against a peer whose stored key is
+   working is refused — an attacker cannot make a healthy peer accept without first
+   breaking that peer's view, which is itself loud.
+5. **Independent corroboration** (at least one):
+   - the re-announce arrived from a source address this peer has VERIFIED for that
+     machineId (an advertised-and-recently-alive endpoint, or a §4.2
+     observed-and-dial-back-verified one), OR
+   - the replicated public identity metadata (the same replication that restored the
+     Studio's record from the Mini) carries a rotation record consistent with the claim
+     (same keyEpoch, `keysRotatedAt` within skew bounds).
+6. Rate/breaker budget OK (Frontloaded Decision 2), and NO unacknowledged prior rotation
+   entry exists for this machineId in the identity-change ledger (§4.3).
 
-**Cost:** one operator tap per rotation event (rare — this is the first in the mesh's
-lifetime). **Benefit:** the widening is bounded by a factor an attacker holding only the
-token does not have.
+**All conditions met → automatic accept (zero human action — the legitimate-recovery
+case).** Any of 4–6 unmet → the claim is QUARANTINED, nothing is stored, and the operator
+gets a dashboard-PIN approve/deny action (Mobile-Complete: a tap, never a terminal
+command; the raw repair command appears only as the documented filesystem last resort).
+Two conflicting claims for one machineId inside a 10-minute settle window → BOTH
+quarantined, the peer keeps the last-verified identity, one URGENT non-coalescing item —
+never last-writer-wins on identity.
 
-### Option 3 — Continuity-chained rotation (automatic, no human)
+**Partial acceptance / version skew:** acceptance is per-peer with a durable claimant-side
+episode ledger (per-peer accepted/pending/refused, exponential backoff 1m→5m→30m→6h
+ceiling, 72h retry horizon, P19 give-up-loudly breaker). A route-absent peer classifies
+`peer-lacks-accept-route` (typed — a v-old peer, not a failure loop). The claimant is the
+SINGLE notice raiser: one HIGH, non-coalescing attention item per rotation episode keyed
+`machineId+keyEpoch`, posted on first acceptance and EDITED with per-peer outcomes
+(`accepted: mini, laptop · pending: mama-pc`), never re-posted per attempt. No re-announce
+is ever queued for delivery while a peer is dark — the next successful contact re-runs
+detection from live evidence.
 
-A machine rotates by signing the new key with the OLD one; peers accept because the chain
-is unbroken. Fully automatic, no new trust in the bearer token.
+### 4.2 Observed endpoints (incident B)
 
-**This does not solve incident A.** The old private key was *lost* — that is precisely the
-scenario. Option 3 is worth building for *planned* rotation hygiene, but it is inert for
-the unplanned loss that actually happened. Recorded here so it is not mistaken for a
-solution to the incident.
+Peers record the address they OBSERVE a machine's authenticated traffic arriving from —
+evidence held by the observer, replacing an unprovable self-assertion. Prior art:
+WireGuard/Tailscale endpoint roaming and STUN reflexive addressing; their load-bearing
+rule is imported: **update only on authenticated inbound traffic**.
 
-### Option 4 — Externally-observed endpoints (solves B specifically)
+- An observation is recorded ONLY from an inbound RPC whose envelope passed the FULL
+  `verifyEnvelope` chain (recipient-bound, registered key, fresh nonce) — never
+  bearer-only requests — and ONLY on direct listeners (Tailscale/LAN) where the socket
+  peer address is meaningful; never tunnel/proxy-fronted listeners, never
+  `X-Forwarded-For`.
+- Observations accumulate IN MEMORY per peer (bounded LRU, ≤8 candidate addresses, decay
+  window) — NEVER a per-request registry write. Only a corroborated, PROMOTED endpoint is
+  persisted, on change only, through the existing `PeerEndpointRecorder` chokepoint.
+- **Corroboration is local-first** (no new cross-machine merged read): ≥3 observations of
+  the same address spanning ≥30 minutes at THIS peer. Multi-peer agreement is a read-time
+  comparison over already-replicated promoted endpoints, never write-time observation
+  replication.
+- **Dial-back verification before promotion:** the recording peer dials the candidate and
+  completes a signed handshake to the SAME machineId. A raw NAT source port is never
+  persisted as a durable route; an address observed for ≥2 distinct machineIds (shared
+  NAT/exit-node egress) is refused promotion.
+- Promoted observations are provenance-tagged (`origin: observed`) and kept distinct from
+  advertised endpoints; resolver precedence: advertised-and-alive > observed-corroborated
+  > advertised-dead. `PeerEndpointRecorder.retainProvenOmitted` (invariant 2b) treats
+  observed entries as its own class so an advertisement can never wipe a verified
+  observation and vice versa.
+- **Rotation quarantine (anti-laundering):** all observations for a machineId are
+  discarded and observation-recording for it suspended for a cooldown window after ANY
+  identity rotation for that machineId — an accepted takeover must not be able to convert
+  itself into corroborated routing within the window; and per §4.1(5), an observation
+  recorded under a key later tombstoned never counts as corroboration for the NEXT
+  rotation.
 
-For the address problem, the reachable address is a fact **other machines already know**:
-they connect to it successfully. Rather than letting the machine assert an address it
-cannot see, let peers record the address they *observed the connection arriving from*, and
-treat that observation as the endpoint.
+### 4.3 Identity-change ledger (visibility that cannot be buried)
 
-This satisfies constraint 5 exactly — it replaces an unprovable self-assertion with
-first-hand evidence held by the observer. It adds no authority to the bearer token, and
-degrades safely (no observation ⇒ today's behaviour).
+Every identity write — pair, re-announce, quarantine, refusal, files-API (pre-F1, best
+effort) — appends a durable audit row (`logs/identity-changes.jsonl`: machineId, old/new
+key fingerprints, keyEpoch, path, accepted-by, corroboration used). Rotation entries carry
+an ACKNOWLEDGEMENT state: an unacked entry re-surfaces on a cadence until the operator
+acks (dashboard tap), and an unacked rotation SUSPENDS further automatic accepts for that
+machineId (they quarantine to the approval path instead). This is the structural answer
+to the buried-notice failure: if the operator will not approve before the change, they are
+structurally guaranteed to see it after. The Machines dashboard tab and `GET /pool`
+machine rows gain: signing-key fingerprint, `keysRotatedAt`, keyEpoch, and
+last-identity-write source, so stored-copy skew between peers is a read, not a forensic
+dig.
 
-**Cost:** an observed source address can be a NAT boundary rather than a durable route, so
-observations need corroboration (repeated, from multiple peers) before being trusted, and
-must never displace a working advertised endpoint — only supplement a missing one.
+### 4.4 F1 — closing the files-API identity hole (sequenced, not deferred)
 
-## 5. Decision (operator directive, 2026-08-29)
+- **Interim mitigation ships in the FIRST implementation PR of this spec, in the same PR
+  as the accept route:** `.instar/machine/**` and `.instar/machines/**` join the
+  files-API always-read-only list. Same-PR coupling guarantees an in-product repair path
+  exists at every instant the file hole is closed (closing it alone would recreate
+  incident A with NO repair path).
+- Fleet sequencing (hard constraint): accept-route deployed fleet-wide → re-announce
+  enabled → any further F1 hardening. A v-next claimant against a v-old peer is the typed
+  `peer-lacks-accept-route` case in §4.1 until migration completes.
+- Post-F1 the compensating controls ARE §4.1's corroboration + quarantine + ack-suspend
+  (this section IS the §2 re-run, done now rather than promised): with the files hole
+  closed, an uncorroborated bearer-token claimant can reach only the quarantine path,
+  which requires the operator's PIN — i.e. post-F1 the boundary is RESTORED to two locks
+  for the adversarial case while staying zero-touch for the corroborated one.
+
+## 5. Decision (operator directive 2026-08-29 + round-1 revision)
 
 The operator directed: *"I want the solution that takes the least amount of time/effort
-from the humans"* (topic 62395). Combined with the §2 correction — the widening Option 2's
-PIN existed to prevent is already the status quo — the decision is:
+from the humans"* (topic 62395). Round-1 review (8 reviewers, ~75 findings) established
+that a proof-free automatic accept is an identity mint for any bearer-token holder — it
+does not survive its own threat model. The decision as revised:
 
-**Option 1 + Option 4 + a fully-AUTOMATIC Option 2 variant (no PIN, no approval tap):**
-a machine detecting sustained `signature-invalid` re-announces automatically; the peer
-verifies proof-of-possession (challenge signed with the NEW key) and accepts; ONE loud
-notice is posted so the rotation is visible, never silent. This is zero-human-touch and
-strictly stronger than today's de-facto repair path (which requires no proof at all).
+- **Zero-touch for the legitimate case:** a real rotation (local rotation record +
+  peer-observed 401s + corroboration) is accepted automatically — no tap, no approval.
+  Incident A under this design: automatic recovery in minutes.
+- **A tap ONLY for the suspicious case:** an uncorroborated or conflicting claim
+  quarantines to a dashboard-PIN approve — the case where "least human effort" would
+  otherwise mean "attacker's least effort."
+- **Observed endpoints:** fully automatic (§4.2) — evidence-based, no human action ever.
+- Option 3 (continuity-chained planned rotation) is OUT OF SCOPE — its own follow-up,
+  with the §4.1(3) tombstone rule recorded as a hard requirement on its design.
 
-**Follow-up F1 (hardening, separate):** make `.instar/machine/**` and
-`.instar/machines/**` never-editable via the files API. Once F1 lands, the automatic
-re-announce becomes the ONLY non-pairing write path to a stored identity — at that point
-the proof-of-possession requirement is the load-bearing gate and this spec's §2 analysis
-should be re-run before any further loosening.
+### 5b. History (non-normative)
 
-## 5b. Original recommendation (superseded by §5)
+Superseded positions, kept for the record: the original recommendation (Option 1 +
+Option 4 + PIN-gated Option 2, pre-directive) and the intermediate fully-automatic
+decision (2026-08-29, pre-review). Neither is normative; §4/§5 above govern.
 
-**Option 1 + Option 4, and Option 2 only if the operator accepts the widening.**
+## Multi-machine posture
 
-Option 1 is unconditional: the classifier bug is real regardless, and cheap.
+| Surface | Posture | Justification |
+|---|---|---|
+| Stored peer identities (`.instar/machines/<id>/identity.json`) | machine-local | machine-local-justification: physical-credential-locality — each machine's stored copy of a peer's public key is that machine's own trust anchor; replicating trust anchors would let one compromised machine rewrite every machine's roots. Consequence owned in §4.1: per-peer delivery + per-peer acceptance ledger. The pre-existing public-metadata replication (which restored the Studio's record) is read-side corroboration input only — never authority. |
+| Observation ledger (§4.2, in-memory) | machine-local | machine-local-justification: physical-credential-locality — an observation is one observer's socket-level evidence, meaningful only at the machine that held the connection; corroboration is deliberately local-first so no new merged read or replication path exists. Promoted endpoints ride the EXISTING registry/lease replication unchanged. |
+| Re-announce episode state (claimant-side per-peer ledger) | machine-local | machine-local-justification: hardware-bound-resource — it describes THIS machine's key and its per-peer delivery progress; durable across restart so a crash mid-rotation cannot strand a half-converted mesh. |
+| Identity-change ledger + ack state (§4.3) | machine-local (per accepting peer) with a proxied-on-read pool view | Each peer's ledger records ITS OWN acceptance decisions (evidence, not shared truth); the dashboard machine rows merge fingerprint/epoch per machine at read time so skew is visible. Ack state lives with the raising side (claimant's episode item). |
+| Rotation notice | single raiser | The claimant posts the ONE episode item (first acceptance) and edits it; accepting peers never post (prevents N-notices / zero-notices). |
 
-Option 4 solves the address case *without* touching the token boundary at all, which makes
-it strictly preferable to any self-assertion design for that half of the problem. The
-insight generalises: when a machine cannot prove a fact about itself, prefer moving the
-question to a party that CAN observe it over inventing a way to trust the claim.
+## Decision points touched
 
-Option 2 remains the only answer for the key case, and it is the one that costs something.
-It should be the operator's explicit decision, taken with §2 in front of them, not folded
-into an implementation.
+| Decision point | Class | Floor / justification |
+|---|---|---|
+| Peer accept/refuse of a re-announce | invariant | Deterministic composite (§4.1 conditions 1–6): enumerable inputs, irreversible-action guard per Signal-vs-Authority's carve-out; explicitly not an LLM judgment. Any unmet condition fails CLOSED to quarantine + human approval. |
+| "Sustained signature-invalid" trigger | invariant | Counter ≥K over ≥M min, typed-401-only, rotation-record-gated (§4.1); triggers an announce attempt, blocks nothing. |
+| `auth-rejected` ⇒ provably-alive classification | invariant | Typed HTTP response class (shipped, PR #1995); feeds liveness consumers: it BLOCKS stale-owner-release death evidence for that peer (a 401-answering machine is alive on every transport that answers) and is a distinct rope-health class, never `peer-offline`. |
+| Observed-endpoint promotion | invariant | Declared floor: ≥3 observations ≥30 min local + dial-back signed handshake + not-shared-egress + rotation quarantine (§4.2). Pre-commitment: if any adaptive/scored element is ever added, this becomes a judgment-candidate and must then declare floor + arbiter. |
+| One-notice raiser election | invariant | Claimant posts on first acceptance; episode-scoped dedupe on machineId+keyEpoch. |
+| Quarantine approve/deny | human (operator) | Dashboard-PIN action; the one deliberate human decision point, reserved for evidence-ambiguous claims (Know Your Principal). |
 
-## 6. What is deliberately not decided here
+## Frontloaded Decisions
 
-~~Whether to accept the Option-2 widening.~~ DECIDED — see §5 (operator directive
-2026-08-29, recorded in the decision journal, session echo-mesh-liveness-reconciliation).
-Remaining open: none for direction; F1's implementation details are design work for its
-own PR.
+1. **Detection threshold:** typed `auth-rejected:signature-invalid` only; ≥10 consecutive
+   spanning ≥15 min, zero interleaved successes, on all ropes to the peer; unreachability
+   freezes the episode clock; local rotation record required (§4.1).
+2. **Re-announce brake:** max 1 automatic re-announce episode per peer per 24h, max 3 per
+   keyEpoch; budget exhausted → HIGH item, no further attempts; registered as a
+   SelfActionGovernor class; per-peer backoff 1m→5m→30m→6h; P19 breaker with
+   sustained-failure test (permanently-refusing peer + contested machineId → bounded
+   attempts, bounded notices).
+3. **Rollout ladder:** `multiMachine.identityReannounce = {enabled, dryRun}` and
+   `multiMachine.observedEndpoints = {enabled, dryRun, corroborationObservations: 3,
+   corroborationWindowMinutes: 30, ttlDays: 7}`. Both dev-gated dark on the fleet,
+   dryRun:true even on dev (peer-side would-accept verdicts logged too). Graduation:
+   ≥14 days dry-run with zero false would-accept verdicts on the dev pair + one live-pair
+   rotation rehearsal with per-peer acceptance verified. Flag absent = today's behaviour.
+4. **Challenge protocol:** as §4.1 (32-byte single-use nonce, 60s TTL, five-field signed
+   binding, CAS store, persisted attempt caps, issuance security-logged).
+5. **Partial acceptance:** per-peer state machine + durable pending ledger, 72h horizon,
+   typed `peer-lacks-accept-route`, single edited notice enumerating outcomes, HIGH
+   escalation naming un-accepted peers with a dashboard action (CLI repair as documented
+   last resort).
+6. **Conflict rule:** monotonic integer `keyEpoch`; conflicting claims within a 10-min
+   settle window → both quarantined, keep last-verified, one URGENT non-coalescing item;
+   never last-writer-wins; old-key tombstone at accepted rotation; replay state keyed by
+   machineId, survives rotation.
+7. **Notice channel:** one HIGH, non-coalescing attention item per episode, deduped on
+   machineId+keyEpoch, plus a rope-health-digest line; explicitly not medium (the
+   2026-08-28 alert died at normal priority in a 237-item queue). Plus the §4.3 must-ack
+   ledger with unacked-suspends-auto-accept semantics.
+8. **Observed-endpoint corroboration:** the §4.2 floor (3 obs / 30 min / dial-back /
+   not-shared / rotation-quarantine); in-memory LRU ≤8 candidates/peer; promotion-only
+   persistence via `PeerEndpointRecorder` with `origin: observed` provenance; resolver
+   precedence advertised-alive > observed-corroborated > advertised-dead.
+9. **F1 boundary:** interim never-editable entries for `.instar/machine/**` +
+   `.instar/machines/**` ship in the SAME PR as the accept route; fleet sequencing
+   accept-route → enable → further hardening; §4.4 records the post-F1 boundary analysis
+   now (no deferred re-run).
+10. **Option 3:** out of scope; its future design inherits the tombstone requirement.
+11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness
+    consumer; it blocks stale-owner-release death evidence for that peer.
+12. **Migration & rollout parity:** `migrateConfig()` adds the two config blocks
+    (existence-checked); `migrateClaudeMd()` adds the operator-facing "why did I get a
+    key-rotation notice / what is a quarantined identity claim" section; the files-API
+    never-editable additions ride `refreshHooksAndSettings`. Fleet sequencing per §4.4.
+
+## Open questions
+
+*(none)*
+
 <!-- tracked: CMT-211 -->
 
 > **CMT-211** — Carry the machine-self-assertion decision to closure: (1) the operator's
@@ -198,6 +347,13 @@ own PR.
 > warning forever; (4) the externally-observed-endpoint path that lets peers record the
 > address they OBSERVED, which is what a NAT'd or VM-hosted agent cannot assert about
 > itself.
+>
+> Status against this spec: (2) shipped (PR #1995) and (3) shipped (PR #1994). (1) is
+> RESOLVED by §5 as revised: the operator's directive selected least-human-effort; review
+> reshaped that into auto-when-corroborated / PIN-only-when-suspicious, so the PIN surface
+> survives solely as the quarantine approval (the immutable carrier text above predates
+> the revision — this annotation, not the carrier, reflects the standing decision). (4) is
+> §4.2 of this spec.
 
 ## 7. Evidence
 
@@ -210,3 +366,7 @@ own PR.
   only, no CGNAT address present.
 - Post-repair verification: signed mesh probes to all three peers returned the typed
   `403 not-router` refusal (the exact success contract).
+- Round-1 review inputs: standards-conformance gate (2 possible-violations: Know Your
+  Principal; Verify the State, Not Its Symbol), codex-cli:gpt-5.5 external (6),
+  claude-fable-5 clean-door (5), and six internal reviewers (security 12, adversarial 10,
+  scalability 8, integration 11, decision-completeness 13, lessons-aware 8).

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -110,7 +110,11 @@ including replication-apply:
   replication-apply writer. Without this the transitional-window `has-recovery-key:false`
   state is a poison point: whoever first lands a 0→1 recovery-pubkey write becomes the
   machine's root of trust. This is an enumerated funnel invariant with the same teeth as
-  monotonicity, not a prose expectation on callers.
+  monotonicity, not a prose expectation on callers. The legitimate establishment/propagation
+  channel is the operator-authenticated PAIRING-TRUST exchange (one operator action that
+  propagates the new pubkey to peers) — NOT git-replication (which the invariant refuses).
+  Authenticator class: the operator-minted pairing CODE for initial-pair ingestion; a
+  dashboard-PIN for standalone establishment / retro-mint on an already-paired machine.
 - **Tombstone:** the superseded key's fingerprint is recorded; any future write (including
   a continuity-chained or replicated one) rooted at or below a tombstoned epoch is refused.
 - **Sticky revocation:** a revoked machine cannot be written back to active except by an
@@ -145,6 +149,26 @@ boundary-restoration claim is therefore scoped to "restored with respect to DIRE
 writes," and the bearer→RCE surface is a tracked follow-up (Open questions).
 
 ### 4.1 Key rotation re-announce (incident A)
+
+**Acceptance state machine (read this first — the normative detail follows).**
+```
+detect sustained auth-rejected (typed 401, ≥K/≥M, local rotation record)  → open episode
+  → peer mints challenge nonce
+  → claimant signs six-field binding (+ recovery key if it has one)
+  → PEER EVALUATES, in order:
+       has-recovery-key(machineId)?  (non-tombstoned recovery pubkey on record)
+         YES → continuity signature REQUIRED (5-primary). valid + recovery-pubkey
+               cross-peer-consistent (or first-hand anchor) + keyEpoch==stored+1
+               + not-revoked  → ACCEPT.  missing/invalid/superseded → QUARANTINE (PIN).
+         NO  → 5a fallback: re-announce from an incumbent-verified authenticated
+               address?  yes → ACCEPT.  no (double fault / tunnel-only) → QUARANTINE (PIN).
+  → any cross-peer equal-epoch DIVERGENCE (signing bare-claim, or any recovery-pubkey)
+       → QUARANTINE (PIN, URGENT).   epoch LAG → converge + retry, never quarantine.
+  → ACCEPT writes through the §4.0 funnel; every outcome appends to the §4.3 ledger.
+```
+Every QUARANTINE is a single-use, content-hash-bound dashboard-PIN operator decision; ACCEPT
+is zero-touch. The rest of this section is the exact conditions.
+
 
 **Claimant-side trigger (deterministic, both-ways bounded):** an episode opens only when —
 
@@ -220,6 +244,11 @@ Auto-accept requires ALL of:
      epoch) is convergence, not divergence: it converges via funnel-applied replication and
      accepts on retry (never a quarantine).
    The §4.3 detector raises URGENT on a genuine (equal-epoch) divergence of either key.
+   **Live-peer set:** a peer counts as live for max-epoch derivation and divergence checks iff
+   it has produced a mesh-authenticated side-effect (a signed RPC this peer verified, or a
+   fresh capacity heartbeat) within the liveness window; `auth-rejected` counts as proof-of-
+   life (PR #1995) but a bare unreachable/dark peer does NOT participate (its stale copy is
+   neither a divergence vote nor a max-epoch source).
 7. Rate/breaker budget OK (FD2), and no unacked ACCEPTED rotation entry exists for this
    machineId (§4.3 — refusals/quarantines never arm the suspend).
 
@@ -347,6 +376,13 @@ the no-keychain machine — is already covered by the PIN fallback above. Replac
 one-time tap with a permanent quorum-crypto subsystem is a net-negative trade. If ever
 wanted, peer-shares is its own follow-on spec with its own convergence.
 
+**Why "dashboard-PIN" is the superior trust class (round-5).** Every "operator-authenticated,
+never bearer" gate here (first-establishment, recovery-key rotation, quarantine approval)
+rests on the dashboard PIN being a factor a bearer-token holder does NOT possess: the PIN is
+operator-held, is not derived from the bearer token, and the PIN-entry path authenticates the
+operator independently of the token. (A bearer→RCE holder who could serve altered dashboard
+assets is the OQ2 follow-up surface — out of this spec's closure scope, stated in §4.4.)
+
 **The recovery pubkey is now the root of trust and gets the SAME rigor as the signing key
 (round-3: adversarial #1/#2/#4, security #3, lessons F2).**
 
@@ -374,9 +410,13 @@ wanted, peer-shares is its own follow-on spec with its own convergence.
   propagated before relied upon. Two hard rules close the partition exploit (round-4
   adversarial N2): (i) a continuity signature verified against a BELOW-MAX (superseded)
   `recoveryEpoch` is REFUSED, so a peer lagging at a rotated-away recovery key cannot honor a
-  signature against the old key; (ii) when ZERO disagreeing live peers are reachable (a
-  partition), a recovery-pubkey the peer cannot cross-check FAILS TO QUARANTINE — never
-  accepted vacuously.
+  signature against the old key; (ii) a REPLICATED (non-anchor) recovery pubkey the peer
+  cannot cross-check against any disagreeing live peer FAILS TO QUARANTINE — never accepted
+  vacuously. Crucially, a recovery pubkey a peer established FIRST-HAND at pair time (its own
+  trust anchor — see the Multi-machine posture note) is AUTHORITATIVE for continuity
+  verification WITHOUT cross-peer corroboration: on a 2-machine mesh peer A holds B's recovery
+  anchor directly and needs no third peer, so legitimate double-fault auto-recovery is NOT
+  broken there. Rule (ii)'s quarantine scopes to replicated non-anchor pubkeys only.
 - **Recovery-key use is bound + replay-safe.** Every recovery-key use (continuity signature,
   and any recovery-key rotation) is over a single-use nonce covering
   `(machineId ‖ keyEpoch ‖ new-signing-fp ‖ new-recovery-fp ‖ recoveryEpoch)`.
@@ -390,10 +430,16 @@ wanted, peer-shares is its own follow-on spec with its own convergence.
 - Loss of BOTH the escrow AND the live copy falls back to §4.1's corroboration-or-PIN path
   (strictly no worse than pre-escrow) AND raises URGENT "recovery escrow missing" so a forced
   downgrade (an attacker deleting the sealed blob) is loud, never silent.
-- **At-rest honesty:** on a keychain-backed machine the recovery private key exists sealed on
-  disk, decryptable only via the OS keychain master key (which survives `.instar/machine/**`
-  loss and is not bearer-derivable — `SecretStore.ts:297`, `*.key` read-blocked at
-  `fileRoutes.ts:26`).
+- **At-rest honesty + blob survival (round-5).** The survival guarantee covers the MASTER KEY
+  (keychain, above) AND the sealed CIPHERTEXT: the recovery-key blob is stored OUTSIDE the
+  incident-A blast radius — in the OS keychain item itself, or under a sibling path the Studio
+  defect provably does not touch — NEVER under `.instar/machine/**` (else a keychain-backed
+  machine still loses the escrow in the double-fault: the keychain yields the master key but no
+  ciphertext remains). The FD3 graduation rehearsal DELETES `.instar/machine/**` and proves
+  recovery end-to-end, not merely "keychain unlockable." On a keychain-backed machine the
+  recovery private key is then decryptable only via the OS keychain master key (survives
+  `.instar/machine/**` loss, not bearer-derivable — `SecretStore.ts:297`, `*.key` read-blocked
+  at `fileRoutes.ts:26`).
 
 **Token-adversary-proof scope (honest, per §4.4).** The continuity signature is
 token-adversary-proof under "bearer WITHOUT code execution." A bearer→RCE path
@@ -562,7 +608,12 @@ never post (prevents N-notices / zero-notices).
       to peers), NOT on the machine's own self-reported keychain status or local mint (round-4
       N3/integration: a machine that minted locally but never propagated, or spoofed
       keychain:false, must still trip the alert). Keychain status is advisory context, not the
-      alert gate. So a stuck-transitional machine is an incident, not a silent weak path.
+      alert gate. A GENUINELY keychain-less machine (e.g. a headless Linux/WSL peer that can
+      never escrow) is not a perpetual incident: once the operator ACKNOWLEDGES it, it becomes
+      an accepted PIN-path state (the same accept-fallback discipline as a load-bearing-guard
+      gap — acknowledged, visible, suppressed), distinguishing a supported keychain-less config
+      from a stuck/spoofing one. So a stuck-transitional machine is an incident, an
+      acknowledged keychain-less one is an accepted risk, and neither is a silent weak path.
 11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness consumer;
     it blocks stale-owner-release death evidence for that peer.
 12. **Migration & rollout parity:** `migrateConfig()` adds the THREE config blocks

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -99,6 +99,10 @@ approve, AND git-sync replication-apply — pass through ONE serialized mutation
 including replication-apply:
 
 - **keyEpoch monotonicity:** refuse any write whose `keyEpoch <= stored`.
+- **recoveryEpoch monotonicity (independent):** the recovery pubkey field carries its own
+  monotonic `recoveryEpoch` + tombstone; refuse a write whose `recoveryEpoch <= stored`. A
+  signing-key rotation write that ALSO mutates the recovery pubkey is REFUSED — replacing the
+  recovery pubkey is a separate, dashboard-PIN-gated operator operation (§4.5).
 - **Tombstone:** the superseded key's fingerprint is recorded; any future write (including
   a continuity-chained or replicated one) rooted at or below a tombstoned epoch is refused.
 - **Sticky revocation:** a revoked machine cannot be written back to active except by an
@@ -110,7 +114,9 @@ of the following never-writable through any bearer-authenticated surface AND nev
 from an unverified replication pull:
 
 - `.instar/machine/**`, `.instar/machines/**` (identity files) — files-API never-editable
-  + `FileClassifier` never-sync; git-sync applies identity changes ONLY through §4.0's
+  + `FileClassifier` never-sync + added to `NEVER_SERVED_PREFIXES` (round-3: today identity/
+  key-file protection rides ONLY the `*.key` filename rule at `fileRoutes.ts:26`; the prefix
+  set does not yet contain `.instar/machine/`, so the directory must be added explicitly); git-sync applies identity changes ONLY through §4.0's
   funnel (epoch/tombstone/revocation checked), never file-level whole-file merge. A pulled
   commit that would change a stored `signingPublicKey` outside the funnel is refused and
   routed to quarantine + alert.
@@ -162,10 +168,13 @@ Auto-accept requires ALL of:
    revocation per §4.0).
 3. `keyEpoch == stored + 1` EXACTLY (round-2 H3/F4 — not merely `>`; an unbounded forward
    jump would let one takeover tombstone the whole epoch space and permanently lock out the
-   real machine). The claimant learns `stored` from the replicated public metadata it
-   restores from (the same copy that restored the machineId in incident A), so a key-lost
-   machine derives `stored+1` WITHOUT any refusal-oracle leak. Genesis: an absent stored
-   epoch reads as 0; migration backfills `keyEpoch: 0` (FD12).
+   real machine). The claimant learns `stored` as the MAX across live peers' replicated
+   public metadata (round-3: under partial acceptance peers can legitimately hold different
+   stored epochs; max-across-live-peers is the derivation, and condition 6 distinguishes a
+   lagging peer — same fingerprint, lower epoch — from a genuine fingerprint DIVERGENCE at
+   equal epoch: only the latter quarantines). A key-lost machine derives `stored+1` WITHOUT
+   any refusal-oracle leak. Genesis: an absent stored epoch reads as 0; migration backfills
+   `keyEpoch: 0` and `recoveryEpoch: 0` (FD12).
 4. **The peer's OWN ISSUED inbound-refusal evidence** (round-2 F1, the direction fix): this
    peer has itself REFUSED ≥K inbound envelopes claiming that machineId as
    `signature-invalid` over ≥M minutes — a new durable per-machineId issued-refusal counter
@@ -173,21 +182,27 @@ Auto-accept requires ALL of:
    peer does not hold in incident A because peer→claimant traffic kept working). Necessary,
    never sufficient — an attacker CAN induce it by sending new-key-signed traffic, which is
    why 4 never stands alone.
-5. **Independent corroboration — the verified source address (5a is the SOLE automatic
-   leg).** The re-announce arrived from an endpoint this peer VERIFIED under the INCUMBENT
-   key within a tight window before failure onset, over an AUTHENTICATED transport class
-   (Tailscale / tunnel-authenticated) — never a bare-LAN address (round-2 H4: closes
-   DHCP/ARP endpoint-hijack of a dark machine). In incident A this holds (the Studio's
-   Tailscale address was alive under the old key up to the rotation). **Replicated-metadata
-   corroboration (former 5b) is DROPPED as an automatic leg** (round-2: it rides a
-   replication channel whose `verifyPulledCommits()` is a stub, is itself the incident-A
-   write path, and is circular in the legitimate case); it survives only as display/advisory
-   in the §4.3 dashboard.
-6. **Cross-peer fingerprint agreement** (round-2 F1/F3 — the quorum replacement): a
-   read-time check over already-replicated PROMOTED identity. If any other LIVE peer holds a
-   DIFFERENT signing fingerprint for this machineId at this epoch, the claim QUARANTINES
-   (never last-writer-wins). An automated detector (§4.3) raises URGENT on such divergence
-   rather than leaving it to a human reading dashboard rows.
+5. **Condition-5 evidence — two paths, continuity FIRST (round-3 restructure).**
+   - **5-primary (continuity signature):** if the peer holds a non-tombstoned recovery
+     pubkey for this machineId (the `has-recovery-key` state), a valid continuity signature
+     (§4.5) against it is MANDATORY and sufficient for condition 5 — it supersedes 5a below,
+     and 5a is FORBIDDEN for that machineId (closes the downgrade). Cryptographic legitimacy
+     a token-holder cannot forge.
+   - **5a-fallback (verified source address, ONLY when no recovery pubkey is on record —
+     the transitional window):** the re-announce arrived from an endpoint this peer VERIFIED
+     under the INCUMBENT key within a tight window before failure onset, over an
+     AUTHENTICATED transport class (Tailscale / tunnel-authenticated) — never a bare-LAN
+     address (round-2 H4: closes DHCP/ARP endpoint-hijack). Incident A satisfies it (the
+     Studio's Tailscale address was alive under the old key up to the rotation).
+   - Replicated-metadata corroboration (former 5b) remains DROPPED as an automatic leg
+     (round-2); display/advisory only.
+6. **Cross-peer fingerprint agreement** (round-2 F1/F3 — the quorum replacement; round-3:
+   covers BOTH keys): a read-time check over already-replicated PROMOTED identity. If any
+   other LIVE peer holds a DIFFERENT signing fingerprint at this `keyEpoch` OR a different
+   recovery pubkey at this `recoveryEpoch`, the claim QUARANTINES (never last-writer-wins) —
+   a continuity-signature acceptance (5-primary) does NOT bypass this; it must still pass
+   recovery-pubkey cross-peer agreement, so one poisoned peer cannot be taken over in
+   isolation. The §4.3 detector raises URGENT on either divergence.
 7. Rate/breaker budget OK (FD2), and no unacked ACCEPTED rotation entry exists for this
    machineId (§4.3 — refusals/quarantines never arm the suspend).
 
@@ -207,6 +222,13 @@ is the SINGLE notice raiser: one HIGH non-coalescing item per episode keyed
 `machineId+keyEpoch`, posted on first acceptance and EDITED with per-peer outcomes.
 
 ### 4.2 Observed endpoints (incident B)
+
+**Why not a static `advertisedAddress` config override?** (round-3 external.) For incident B
+specifically — one machine with a known, stable Tailscale address it cannot self-see — an
+operator-set `advertisedAddress` is one config line and zero new machinery, and IS offered as
+the immediate manual fix. The observed-endpoint machinery below is the AUTOMATIC path so a
+NAT'd/VM machine recovers with no operator action at all (the least-human-effort directive);
+the two coexist — a static override always wins when set.
 
 As round-1/round-2: observation only from FULL-`verifyEnvelope` inbound RPCs on direct
 listeners (never bearer-only, never tunnel/proxy-fronted, never `X-Forwarded-For`);
@@ -270,45 +292,87 @@ PIN quarantine.
 
 The mechanism that makes even the total-loss + address-change case zero-touch AND secure
 against a token-holder. At pair time each machine mints a SECOND ("recovery") keypair. Its
-PUBLIC half is stored by peers (replicated as identity metadata, applied only through the
-§4.0 funnel). Its PRIVATE half is escrowed OUTSIDE `.instar/machine/**`, in a location the
-bearer token / files API cannot read.
+PUBLIC half is bound into the operator-minted pairing exchange and stored by peers (never
+introduced or replaced over the bearer re-announce path — that channel is the threat model).
+Its PRIVATE half is escrowed in the machine's SecretStore.
 
-On rotation the machine signs the SIX-field binding of §4.1 with BOTH the new signing key
-(proof-of-possession) AND the RECOVERY key (continuity signature). Peers verify the
-continuity signature against the stored recovery public key → cryptographic legitimacy,
-because only the real machine holds the recovery private key. A valid continuity signature
-BECOMES §4.1's condition 5 (superseding the 5a source-address heuristic and, with it,
-condition 4's issued-refusal requirement — a continuity signature is strictly stronger
-first-hand evidence than either), giving a fully automatic, token-adversary-proof accept in
-every case where the recovery key survived — including the double-fault case 5a cannot cover.
+On rotation the machine co-signs the SIX-field binding of §4.1 with BOTH the new signing key
+(possession) AND the RECOVERY key (continuity). A valid continuity signature verified
+against the peer's stored recovery public key is cryptographic legitimacy a token-holder
+cannot forge.
 
-**Escrow location (operator-selectable at pair time; default the strongest available):**
+**Escrow survival is VERIFIED, not assumed (round-3 critical — the load-bearing fix).** The
+recovery private key is sealed under SecretStore's AES-256-GCM master key. That master key
+is keychain-backed on machines with an OS keychain, but FILE-backed at
+`.instar/machine/secrets-master.key` (`SecretStore.ts:112`) on a keychain-less machine
+(headless Linux, WSL — incident B's Mama PC is `platform: linux`). A file-backed master key
+lives INSIDE the exact directory whose disappearance is incident A, so vault-escrow there
+does NOT survive the double-fault it exists for. Therefore:
 
-1. **Operator vault (default when a vault backend is configured).** The recovery private
-   key is sealed into the operator's SecretStore (AES-256-GCM, master key NOT derivable
-   from the bearer token). Survives total loss of `.instar/machine/**`. The one setup cost
-   Justin approved.
-2. **Peer-sealed shares (fallback / additional copy).** The recovery private key is split
-   (Shamir k-of-n over the pool) and each share sealed to a PEER machine's encryption key,
-   so recovery needs a quorum of peers to co-sign a recovery-key-use authorization — no
-   single compromised peer can wield it, and it survives as long as k peers survive.
+- Vault-escrow is offered ONLY when `SecretStore.isKeychainBacked === true`, checked at pair
+  time (`SecretStore.ts:446`). The silent keychain→file degradation is surfaced LOUDLY at
+  pair time, not left to a DegradationReporter note.
+- A machine WITHOUT a keychain-backed vault does NOT escrow a recovery key. It stays on the
+  §4.1 corroboration path (5a where the address is stable — incident A — else the PIN
+  quarantine), and its `has-recovery-key` state is explicitly FALSE and surfaced ("no
+  recovery escrow — this machine's rare double-fault recovery needs an operator tap"), so
+  the operator is never misled into believing protection exists.
 
-**The recovery key's own lifecycle (review-critical — it is now the root of trust):**
+**Shamir peer-sealed shares are OUT OF SCOPE of this spec** (round-3: lessons F3 /
+adversarial #3 / security #2). They degenerate on a small mesh (a 2-machine pool forces
+k=1, so one peer holds the whole key), do NOT raise the bar against THIS spec's shared-token
+adversary (the token reaches RCE on every peer to steal shares), and their only use case —
+the no-keychain machine — is already covered by the PIN fallback above. Replacing a rare
+one-time tap with a permanent quorum-crypto subsystem is a net-negative trade. If ever
+wanted, peer-shares is its own follow-on spec with its own convergence.
 
-- **Compromise / rotation of the recovery key itself** is an operator-only action (it
-  cannot be self-service, or a token-holder who somehow obtained it could entrench). It
-  goes through the §4.0 funnel with its own epoch, and rotating it re-seals fresh escrow.
-- **Recovery key never signs ordinary traffic** — it is used ONLY to authorize a signing-key
-  rotation, minimizing its exposure (it is offline/sealed except during a rotation event).
-- **Loss of the recovery key** (both the escrow AND the live copy gone) is the ONLY residual
-  case that falls back to §4.1's corroboration-or-PIN path — strictly no worse than the
-  pre-escrow design, and now genuinely rare (it requires losing two independently-escrowed
-  secrets at once).
-- **At-rest honesty:** the vault-escrow option means the recovery private key exists sealed
-  on this machine's disk (encrypted); the peer-shares option means k peers each hold a
-  sealed share. Neither is readable by the bearer token, but both are stated plainly so the
-  operator knows where the root-of-trust material physically lives.
+**The recovery pubkey is now the root of trust and gets the SAME rigor as the signing key
+(round-3: adversarial #1/#2/#4, security #3, lessons F2).**
+
+- **Own epoch + tombstone.** The recovery pubkey carries its own monotonic `recoveryEpoch`
+  and tombstone in `.instar/state/identity-epochs.json`, independent of the signing
+  `keyEpoch`. The §4.0 funnel REFUSES any signing-key rotation write that also mutates the
+  recovery pubkey — replacing the recovery pubkey is a SEPARATE, dashboard-PIN-gated operator
+  operation (never bearer-reachable), so a single signing-key takeover cannot install an
+  attacker recovery pubkey and entrench.
+- **Mandatory-when-present (closes the downgrade).** If a peer holds a non-tombstoned
+  recovery pubkey for a machineId, a valid continuity signature is MANDATORY for auto-accept
+  and the 5a heuristic is FORBIDDEN for that machineId. The stored recovery pubkey (in the
+  funnel-protected never-editable identity store) IS the `has-recovery-key` flag — not
+  spoofable — and its presence disables the weaker path, so a token-holder cannot omit the
+  continuity signature to force 5a.
+- **Cross-peer agreement extends to the recovery pubkey.** A continuity signature may accept
+  (and short-circuit §4.1(6)'s signing-fingerprint conflict) ONLY if the recovery pubkey it
+  verifies against is cross-peer-consistent at its `recoveryEpoch`; a recovery pubkey that
+  diverges across live peers QUARANTINES (URGENT), so one poisoned peer cannot be taken over
+  in isolation. The §4.3 divergence detector covers the recovery pubkey too.
+- **Recovery-key use is bound + replay-safe.** Every recovery-key use (continuity signature,
+  and any recovery-key rotation) is over a single-use nonce covering
+  `(machineId ‖ keyEpoch ‖ new-signing-fp ‖ new-recovery-fp ‖ recoveryEpoch)`.
+
+**The recovery key's own lifecycle:**
+
+- Rotation is DASHBOARD-PIN-gated (never bearer), through the §4.0 funnel, with its own
+  epoch; it re-seals fresh escrow.
+- It signs ONLY signing-key rotations, never ordinary traffic — sealed/offline except during
+  a rotation event.
+- Loss of BOTH the escrow AND the live copy falls back to §4.1's corroboration-or-PIN path
+  (strictly no worse than pre-escrow) AND raises URGENT "recovery escrow missing" so a forced
+  downgrade (an attacker deleting the sealed blob) is loud, never silent.
+- **At-rest honesty:** on a keychain-backed machine the recovery private key exists sealed on
+  disk, decryptable only via the OS keychain master key (which survives `.instar/machine/**`
+  loss and is not bearer-derivable — `SecretStore.ts:297`, `*.key` read-blocked at
+  `fileRoutes.ts:26`).
+
+**Token-adversary-proof scope (honest, per §4.4).** The continuity signature is
+token-adversary-proof under "bearer WITHOUT code execution." A bearer→RCE path
+(`.claude/settings.json` hooks, `.git/hooks/**`, `.instar/hooks/**` — pre-existing debt,
+tracked follow-up) reaches private-key theft on any machine and is out of this spec's closure
+scope; §4.4's boundary claim and this one are both scoped to direct writes.
+
+Prior art (for reviewers): monotonic epochs + exact-increment + tombstones + an offline
+recovery key is TUF/DID root-key rotation; the `== stored+1` rule is TUF's fast-forward
+defense.
 
 ## 5. Decision (operator directive 2026-08-29 + round-1/2 revision)
 
@@ -325,12 +389,14 @@ every case where the recovery key survived — including the double-fault case 5
   claim — this fails SAFE (to a human) and is correct; a valid continuity signature
   short-circuits the conflict (cryptographic identity beats a racing bare claim).
 - **Observed endpoints:** fully automatic (§4.2).
-- **Escrow (§4.5): ADOPTED** (operator-approved 2026-08-29). The escrowed recovery key's
-  continuity signature is the PRIMARY condition-5 evidence; it moves the double-fault case
-  (key loss + address change) from tap to fully automatic, and is token-adversary-proof. The
-  5a source-address heuristic remains as the fallback for the transitional window before
-  every machine has an escrowed recovery key, and the PIN quarantine remains for the now-rare
-  case where the recovery key itself is also lost.
+- **Escrow (§4.5): ADOPTED** (operator-approved 2026-08-29), scoped to KEYCHAIN-BACKED
+  vault-escrow only (round-3: a file-backed vault does not survive incident A; Shamir
+  peer-shares dropped to a follow-on spec). On a keychain-backed machine the continuity
+  signature is the PRIMARY, MANDATORY condition-5 evidence and makes the double-fault case
+  fully automatic + token-adversary-proof; 5a is used ONLY for a machineId with no recovery
+  pubkey on record. A machine without a keychain-backed vault carries no recovery key, is
+  surfaced as such, and uses 5a (incident A) or the PIN (double fault) — never silently
+  "protected".
 - Option 3 (continuity-chained PLANNED rotation) is SUBSUMED by §4.5's continuity signature.
 
 ### 5b. History (non-normative)
@@ -374,7 +440,8 @@ never post (prevents N-notices / zero-notices).
 | Cross-peer fingerprint agreement | invariant | Read-time equality check over replicated promoted identity (§4.1(6)); disagreement → quarantine, never a pick. |
 | Observed-endpoint promotion | invariant | Declared floor (§4.2): ≥3 obs/≥30 min local + dial-back + not-shared-egress + rotation quarantine. Pre-commitment: any adaptive/scored element added later makes this a judgment-candidate requiring floor+arbiter. |
 | One-notice raiser election | invariant | Claimant posts on first acceptance; episode-scoped dedupe on machineId+keyEpoch. |
-| Continuity-signature verification (§4.5) | invariant | Deterministic Ed25519 verify of the rotation binding against the stored recovery public key; a valid signature is condition-5 evidence superseding the 5a heuristic. Recovery-key rotation is an operator action through the §4.0 funnel. |
+| has-recovery-key predicate + downgrade posture | invariant | The `has-recovery-key` state = a non-tombstoned recovery pubkey on record in the funnel-protected identity store (not spoofable). When TRUE, a continuity signature is MANDATORY and 5a is FORBIDDEN for that machineId; a re-announce lacking a valid continuity signature QUARANTINES (never falls to 5a) — closes the omit-the-signature downgrade. |
+| Continuity-signature verification (§4.5) | invariant | Deterministic Ed25519 verify of the rotation binding against the stored recovery public key at its `recoveryEpoch`; a valid signature is condition-5 evidence, MANDATORY-when-present, and must still pass recovery-pubkey cross-peer agreement (§4.1(6)). Recovery-key rotation is dashboard-PIN-gated through the §4.0 funnel, never bearer. |
 | Quarantine approve/deny | invariant | Deterministic routing to the operator's single-use, content-hash-bound dashboard-PIN decision; the operator is the arbiter (Know Your Principal). The machine-side routing is deterministic; the human decision sits above the classified machine surface. |
 
 ## Frontloaded Decisions
@@ -387,10 +454,12 @@ never post (prevents N-notices / zero-notices).
    scalability F3 — a governor deny parks the per-peer entry in the pending ledger, never
    consumes an attempt); backoff 1m→5m→30m→6h; P19 breaker. A CAS refusal is a retryable
    per-peer attempt, NOT a new episode and NOT a keyEpoch-budget consumer.
-3. **Rollout ladder:** `multiMachine.identityReannounce = {enabled, dryRun}` and
+3. **Rollout ladder:** `multiMachine.identityReannounce = {enabled, dryRun}`,
    `multiMachine.observedEndpoints = {enabled, dryRun, corroborationObservations: 3,
-   corroborationWindowMinutes: 30, ttlDays: 7, rotationQuarantineHours: 1}`. Dev-gated dark
-   on fleet, dryRun:true on dev (peer-side would-accept verdicts logged too). Graduation:
+   corroborationWindowMinutes: 30, ttlDays: 7, rotationQuarantineHours: 1}`, and
+   `multiMachine.recoveryKeyEscrow = {enabled, dryRun}` (keychain-gated at pair time). All
+   dev-gated dark on fleet, dryRun:true on dev (peer-side would-accept verdicts logged too).
+   Graduation:
    ≥14 days dry-run with zero false would-accept verdicts PLUS required NEGATIVE rehearsals
    (round-2 lessons F5 — silence is not health): an injected uncorroborated claim MUST
    quarantine, a replayed/old-epoch claim MUST be refused, a cross-peer-conflict claim MUST
@@ -416,16 +485,36 @@ never post (prevents N-notices / zero-notices).
    set ships in the SAME PR as the accept route; git-sync applies identity changes only
    through the §4.0 funnel; fleet sequencing is machine-coherence-gated; the bearer→RCE
    surface (`.claude/settings.json`, `.git/`, `.instar/hooks/`) is a tracked follow-up.
-10. **Escrow (§4.5) — ADOPTED:** recovery keypair minted at pair time; public half
-    replicated (funnel-applied), private half escrowed to the operator vault (default) or
-    Shamir k-of-n peer-sealed shares; continuity signature is the primary condition-5
-    evidence; recovery-key rotation is operator-only through the §4.0 funnel; recovery key
-    signs ONLY rotations, never ordinary traffic. A transitional machine without an escrowed
-    recovery key uses the 5a fallback until it has one.
+10. **Escrow (§4.5) — ADOPTED, keychain-vault only.** Flag
+    `multiMachine.recoveryKeyEscrow = {enabled, dryRun}` (dark-on-fleet, dryRun-on-dev; in
+    the FD3 ladder + FD12 `migrateConfig`). Recovery keypair minted at pair time on a
+    machine whose `SecretStore.isKeychainBacked === true`; public half bound into the
+    operator-minted pairing exchange + replicated (funnel-applied with its own
+    `recoveryEpoch`/tombstone); private half sealed in the keychain-backed vault. Continuity
+    signature is the primary, MANDATORY condition-5 evidence when a recovery pubkey is on
+    record; recovery-key rotation is dashboard-PIN-gated through the funnel; the recovery key
+    signs ONLY rotations. A machine WITHOUT a keychain-backed vault mints no recovery key,
+    surfaces `has-recovery-key:false`, and uses 5a/PIN — never silent. Shamir peer-shares
+    are OUT OF SCOPE (own follow-on spec).
+    - **Retro-mint (FD12):** existing already-paired machines have no recovery keypair; on
+      first post-upgrade boot a keychain-backed machine mints + escrows one and establishes
+      its recovery pubkey via an operator-confirmed step (the pairing-trust channel, never
+      the bearer re-announce path). Without this, "until it has one" is unreachable.
+    - **De-pair teardown:** on de-pair, the machine destroys its sealed recovery key and
+      peers tombstone its recovery pubkey; there are no peer-held shares to re-seal (Shamir
+      dropped), so the round-2 k-of-n-below-k hazard does not arise.
+    - **Transitional-window closure:** graduation adds "no machine remains without an
+      escrowed recovery key past horizon H (keychain-backed machines only)" as a tracked,
+      alerting condition, so a stuck-transitional machine is an incident, not a silent weak
+      path.
 11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness consumer;
     it blocks stale-owner-release death evidence for that peer.
-12. **Migration & rollout parity:** `migrateConfig()` adds the two config blocks
-    (existence-checked); `migrateClaudeMd()` adds the operator-facing "why did I get a
+12. **Migration & rollout parity:** `migrateConfig()` adds the THREE config blocks
+    (identityReannounce, observedEndpoints, recoveryKeyEscrow — existence-checked); the
+    stored identity schema gains a `recoveryPublicKey` field and `.instar/state/identity-epochs.json`
+    gains a `recoveryEpoch`/tombstone per machineId (backfilled absent-reads-as-0, no recovery
+    pubkey ⇒ `has-recovery-key:false`); the retro-mint path (FD10) mints recovery keypairs for
+    existing keychain-backed machines on first post-upgrade boot; `migrateClaudeMd()` adds the operator-facing "why did I get a
     key-rotation notice / what is a quarantined identity claim" section; the
     never-editable/never-sync additions ride `refreshHooksAndSettings`; keyEpoch genesis =
     absent-reads-as-0, migration backfills `keyEpoch: 0` into every existing stored identity
@@ -462,6 +551,20 @@ never post (prevents N-notices / zero-notices).
 > designed in §4–§5 here; the only decision still parked on the operator is OQ1 (escrow),
 > which the immutable carrier text (written pre-review) does not capture — this annotation,
 > not the carrier, reflects the standing state.
+
+## Reference (internal codes used above, for outside readers)
+
+- **Round-1/2/3 H*/F*/OQ*** — finding ids from the convergence review rounds (this spec's own
+  process); resolutions are folded into the sections they annotate.
+- **FD*** — Frontloaded Decision N in the section above.
+- **P19** — the constitution's "No Unbounded Loops" standard (brakes: max-attempts, backoff,
+  breaker). **P20** — "Verify the State, Not Its Symbol."
+- **WS4.1 remote-ack / WS4.4** — multi-machine-seamlessness spec increments (the signed
+  operator-ack route; pool-stable reads).
+- **Amendment 3** — the 2026-08-22 narrowing of the machine-local-justification taxonomy.
+- **TUF / DID** — The Update Framework / Decentralized Identifiers; §4.5's epoch+tombstone+
+  offline-recovery-key rotation mirrors their root-key rotation model.
+- **5a / condition N** — the §4.1 acceptance-composite legs.
 
 ## 7. Evidence
 

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -11,7 +11,8 @@ Glossary for outside readers: a **rope** is one transport between two of the age
 machines (Tailscale / LAN / Cloudflare tunnel); the **attention queue** is the durable
 operator-notification store; **Know Your Principal** is the house standard that an
 unverified identity is a question, not a fact; topic ids (e.g. 62395) name Telegram
-conversations where operator directives were given.
+conversations where operator directives were given; a **fingerprint** is the short hash of
+a machine's Ed25519 signing public key.
 
 ## 1. The problem, stated once
 
@@ -22,20 +23,16 @@ Two production failures in the same week share one shape.
 `machineId` and public metadata were restored from the Mini's replicated copy. The three
 peers still held the OLD `signingPublicKey`. Every outbound signed RPC from the Studio was
 refused `401 auth-rejected:signature-invalid` (10,968 consecutive failures per rope).
-Peer→Studio traffic kept working, so the mesh ran one-way and no layer noticed.
-
-The repair required a human with filesystem access to write the new public identity onto
-each peer. There is no in-product path: `POST /api/pair` is the only route that stores a
-remote identity, and it requires a pairing code minted by `instar pair` on the awake
-machine — which is the machine that cannot be trusted by its peers, because its key just
-changed.
+Peer→Studio traffic kept working (the peers' keys were unchanged, so the Studio still
+accepted them), so the mesh ran one-way and no layer noticed. **The Studio's Tailscale
+address did NOT change** — this is load-bearing below.
 
 **B. The invisible address (2026-08-29, one machine unreachable-by-registry).** A peer
 whose agent runs inside WSL sees exactly one NIC: `eth0 172.22.96.135`, a virtual address
 unreachable from anywhere but its own Windows host. Tailscale runs on the Windows side,
 outside the VM. The agent advertises what it can see, so it advertises an address that
 cannot work, and it can never advertise `100.101.95.10` — the address every other machine
-actually reaches it on — because that address does not exist in its world.
+actually reaches it on.
 
 PR #1992 stopped the resulting data loss (peers no longer discard a proven rope because an
 advertisement omitted it). PR #1995 closed the detection gap (a peer answering typed auth
@@ -46,295 +43,369 @@ Neither gives the machine a way to state the true fact.
 is my address* — that it cannot prove from local evidence, to peers that have no
 independent way to verify it from the claim alone.
 
-## 2. The security boundary, corrected twice
+## 2. The security boundary, corrected three times
 
 The mesh has an authenticated channel between machines: the shared agent bearer token over
 TLS/Tailscale. The tempting design is: *let a machine re-announce its identity over the
-bearer channel.* The cost as originally analyzed: today a leaked bearer token grants broad
-API access but cannot forge a machine identity — signature verification is a separate,
-stronger boundary. Making identity assertable over the token collapses those two
-boundaries into one.
+bearer channel.*
 
-**Correction 1 (2026-08-29, verified live):** on DEFAULT-CONFIGURED deployments that
-separation does not hold. The dashboard files API (`POST /api/files/save`,
-bearer-token-authenticated, default-editable over the whole project directory) accepts
-writes to `.instar/machines/<id>/identity.json` — exactly how incident A was repaired.
+**Correction 1 (2026-08-29, verified live):** on DEFAULT-CONFIGURED deployments the
+"bearer cannot forge identity" separation does not hold — the files API
+(`POST /api/files/save`) accepts writes to `.instar/machines/<id>/identity.json`, exactly
+how incident A was repaired.
 
 **Correction 2 (round-1 review):** correction 1 does NOT license a proof-free automatic
-path, for four independently sufficient reasons:
+path — proof-of-possession of a NEW key is tautologically satisfiable by any keypair the
+attacker just minted. Auto-accept must be CORROBORATED, degrading to a human approval when
+corroboration is absent.
 
-1. **Deployment-dependence.** A deployment with narrowed files-API `allowedPaths` still
-   has the two-lock separation; for it, a bearer-gated re-announce is a genuine widening
-   today.
-2. **Temporal contingency.** F1 (closing the files-API identity hole) destroys the
-   "already collapsed" justification the moment it lands, leaving the auto path as the
-   designed-in collapse.
-3. **Proof-of-possession is liveness, not legitimacy.** Signing a challenge with the NEW
-   key is tautologically satisfiable by any attacker who just minted a keypair. Against
-   the leaked-token adversary — the threat this spec is about — bare PoP constrains
-   nothing.
-4. **The notice channel is proven insufficient as the sole compensating control.** The
-   2026-08-28 alert for incident A fired correctly and drowned in a 237-item attention
-   queue. Post-hoc visibility through that surface cannot backstop an identity rewrite.
+**Correction 3 (round-2 review — the irreducible limit, stated honestly).** Round 2
+established, with code references, that EVERY corroboration signal a peer can gather —
+the 401s it issued, its outbound-probe results, an observed source address, replicated
+metadata — is inducible or writable by a bearer-token holder, because AFTER TOTAL KEY LOSS
+there is no pre-established secret that distinguishes the legitimate machine from a
+token-holder. Two consequences the design now owns:
 
-The design below therefore requires INDEPENDENT CORROBORATION for any automatic accept,
-and degrades to a human approval — never to a proof-free accept — when corroboration is
-absent.
+1. **The corroboration heuristics REDUCE the attack surface; they do not close it.** They
+   are therefore used to decide whether a claim may auto-accept OR must go to the operator
+   — never to manufacture certainty that isn't there.
+2. **A cryptographic close exists only with a pre-established recovery secret** (§4.5,
+   escrowed recovery key). Whether to adopt it is the one genuine operator decision this
+   spec surfaces (Open questions), because it trades "manage recovery material" against
+   "one tap in the rare double-fault case."
 
 ## 3. Constraints any accepted option must satisfy
 
 1. **No silent multi-day outage.** A mesh refusing a peer's signatures becomes loudly
-   visible within minutes (shipped: PR #1995's `auth-rejected` classification + alert).
+   visible within minutes (shipped: PR #1995).
 2. **Least human dependence (operator directive, 2026-08-29, topic 62395), bounded by
-   safety.** The common, legitimate case must need zero human action. A human action is
+   safety.** The common, legitimate case needs zero human action; a human action is
    acceptable exactly where the evidence cannot distinguish legitimate recovery from
    takeover; a human *discovery* is never acceptable.
-3. **No new capability for an unauthenticated party.** Everything requires existing
-   authentication.
+3. **No new capability for an unauthenticated party.**
 4. **Reversible.** Every mechanism ships behind a named flag whose absence is today's
-   behaviour, dark on the fleet, dryRun-first on dev (concrete flags in
-   `## Frontloaded Decisions`).
-5. **Evidence over assertion.** Where anyone — the claimant or the accepting peer — CAN
-   verify from first-hand or otherwise-unforgeable evidence, that evidence, not the
-   claim, is what is accepted.
+   behaviour, dark on the fleet, dryRun-first on dev.
+5. **Evidence over assertion.** Where anyone CAN verify from first-hand or unforgeable
+   evidence, that evidence — not the claim — is accepted.
 
 ## 4. Design
 
+### 4.0 The single serialized identity-store funnel (foundation for everything below)
+
+ALL writers to a stored peer identity — `/api/pair`, re-announce accept, quarantine
+approve, AND git-sync replication-apply — pass through ONE serialized mutation funnel
+(`IdentityStore.apply`, single-writer per process). No writer touches
+`.instar/machines/<id>/identity.json` directly. The funnel enforces, on EVERY write
+including replication-apply:
+
+- **keyEpoch monotonicity:** refuse any write whose `keyEpoch <= stored`.
+- **Tombstone:** the superseded key's fingerprint is recorded; any future write (including
+  a continuity-chained or replicated one) rooted at or below a tombstoned epoch is refused.
+- **Sticky revocation:** a revoked machine cannot be written back to active except by an
+  operator-minted pairing code (an operator action).
+
+**Stored-key write-path closure (the round-2 critical).** The corroboration a peer relies
+on is only as trustworthy as the files feeding it. The FIRST implementation PR makes ALL
+of the following never-writable through any bearer-authenticated surface AND never-applied
+from an unverified replication pull:
+
+- `.instar/machine/**`, `.instar/machines/**` (identity files) — files-API never-editable
+  + `FileClassifier` never-sync; git-sync applies identity changes ONLY through §4.0's
+  funnel (epoch/tombstone/revocation checked), never file-level whole-file merge. A pulled
+  commit that would change a stored `signingPublicKey` outside the funnel is refused and
+  routed to quarantine + alert.
+- `.instar/state/identity-epochs.json` (the dedicated epoch/tombstone store — NOT inside
+  `identity.json`) — never-editable, never-served, never-sync, single-writer via the
+  funnel.
+- `state/rope-health.json` and the new issued-refusal counter store (§4.1 condition 4),
+  and `logs/identity-changes.jsonl` (§4.3) — every file read by an auto-accept condition.
+
+The rule, stated normatively: **the never-editable/never-sync set = the identity files ∪
+the epoch store ∪ every file read by an auto-accept condition.** A corroboration input a
+bearer token can still write is not corroboration.
+
+**Honest scope note (round-2 finding):** a bearer token that can edit `.claude/settings.json`
+hook commands, `.git/hooks/**`, or `.instar/hooks/**` still reaches code execution and thus
+private-key theft. Closing those is pre-existing debt beyond this spec; §4.4's
+boundary-restoration claim is therefore scoped to "restored with respect to DIRECT identity
+writes," and the bearer→RCE surface is a tracked follow-up (Open questions).
+
 ### 4.1 Key rotation re-announce (incident A)
 
-**Claimant-side trigger (deterministic, both-ways bounded):** a re-announce episode opens
-only when ALL of the following hold —
+**Claimant-side trigger (deterministic, both-ways bounded):** an episode opens only when —
 
-- The typed classification `auth-rejected:signature-invalid` (never transport failure;
-  unreachability FREEZES the episode clock) has been observed ≥K consecutive times
-  spanning ≥M minutes with zero interleaved successes, on every rope to that peer
-  (defaults: K=10, M=15 — Frontloaded Decision 1).
-- The machine holds a LOCAL ROTATION RECORD: `identity.json.keysRotatedAt` newer than the
-  failure onset, with a recorded reason. **Sustained 401s WITHOUT a local rotation record
-  are an attack/corruption signal** (a peer's stored copy was tampered, or this machine's
-  identity file was) — they route to the loud `auth-rejected` alert and NEVER to
-  re-announce. (P20: the 401 stream is the symbol; the rotation record is the
-  corroboration; no-signal-at-all is `unknown` and fails toward not-announcing.)
-- The per-machine re-announce budget is not exhausted (Frontloaded Decision 2; registered
-  as a SelfActionGovernor class).
+- Typed `auth-rejected:signature-invalid` (never transport failure; unreachability FREEZES
+  the episode clock; the all-ropes conjunction skips ropes that are idle/never-observed
+  rather than blocking on them) observed ≥K consecutive times spanning ≥M minutes with zero
+  interleaved successes (K=10, M=15 — FD1).
+- A LOCAL ROTATION RECORD (`keysRotatedAt` newer than failure onset, with reason) — this is
+  claimant-side HYGIENE that gates the benign trigger, NOT peer-verifiable corroboration
+  (an attacker speaks the challenge protocol directly and never needs it). 401s without a
+  rotation record route to the loud `auth-rejected` alert, never to re-announce.
+- Re-announce budget not exhausted (FD2; SelfActionGovernor class).
 
 **Challenge protocol:** the accepting peer mints a 32-byte single-use nonce, 60s TTL. The
-claimant's response signs `(nonce ‖ claimant machineId ‖ new signing pubkey ‖ new
-encryption pubkey ‖ challenger machineId)` with the NEW key. Replay, cross-peer reuse,
-and any field mismatch are typed refusals. The identity-store write is CAS-guarded
-against the identity version read at challenge issuance — a concurrent write between
-verify and store refuses rather than silently retrying. Challenge ISSUANCE (not just
-acceptance) is security-logged; per-machineId and per-source attempt caps persist across
-restarts (mirroring `/api/pair`'s brute-force discipline).
+response signs the SIX-field binding `(nonce ‖ claimant machineId ‖ new signing pubkey ‖
+new encryption pubkey ‖ challenger machineId ‖ keyEpoch)` with the NEW key — **keyEpoch is
+inside the signature** (round-2 H2), so the monotonicity/tombstone value cannot be altered
+in flight. Replay, cross-peer reuse, and any field mismatch are typed refusals; a refusal
+NEVER discloses the stored epoch (no probing oracle). Challenge issuance is security-logged;
+per-machineId and per-source attempt caps persist across restarts.
 
-**Peer-side acceptance authority (the named authority — deterministic composite, an
-irreversible-action guard in Signal-vs-Authority's carve-out).** The 401-detector and the
-challenge check are SIGNALS. Acceptance requires ALL of:
+**Peer-side acceptance authority (a deterministic composite that only ever REFUSES on its
+own authority; per `docs/signal-vs-authority.md` § "Safety guards on irreversible actions").**
+Auto-accept requires ALL of:
 
-1. Challenge signature verifies against the announced key (proof of possession —
-   necessary, never sufficient).
-2. The machineId has an EXISTING stored identity AND an active, non-revoked registry
-   entry. Re-announce is rotation-of-existing, NEVER enrollment; `/api/pair` remains the
-   sole enrollment path. A revoked machine cannot re-announce itself back into trust
-   (sticky revocation extends to this path explicitly).
-3. `keyEpoch` monotonicity: announcements carry an integer per-machine key epoch;
-   `epoch <= stored` is refused and logged. Wall-clock (`keysRotatedAt`) is displayed to
-   humans but never the ordering key. On accept, the OLD key is tombstoned at the stored
-   epoch — any future announcement (including a later continuity-chained one) rooted at
-   or below the tombstoned epoch is refused. Replay state stays keyed by machineId and
-   survives rotation; old-key envelopes are refused post-rotation regardless of nonce
-   freshness.
-4. **The peer's OWN first-hand evidence**: this peer has itself observed sustained
-   `auth-rejected` failures from the incumbent identity (its rope-health `auth-rejected`
-   classification, PR #1995). A takeover attempt against a peer whose stored key is
-   working is refused — an attacker cannot make a healthy peer accept without first
-   breaking that peer's view, which is itself loud.
-5. **Independent corroboration** (at least one):
-   - the re-announce arrived from a source address this peer has VERIFIED for that
-     machineId (an advertised-and-recently-alive endpoint, or a §4.2
-     observed-and-dial-back-verified one), OR
-   - the replicated public identity metadata (the same replication that restored the
-     Studio's record from the Mini) carries a rotation record consistent with the claim
-     (same keyEpoch, `keysRotatedAt` within skew bounds).
-6. Rate/breaker budget OK (Frontloaded Decision 2), and NO unacknowledged prior rotation
-   entry exists for this machineId in the identity-change ledger (§4.3).
+1. Challenge signature verifies against the announced key (necessary, never sufficient).
+2. The machineId has an EXISTING stored identity AND an active, non-revoked registry entry
+   (rotation-not-enrollment; `/api/pair` remains the sole enrollment path; sticky
+   revocation per §4.0).
+3. `keyEpoch == stored + 1` EXACTLY (round-2 H3/F4 — not merely `>`; an unbounded forward
+   jump would let one takeover tombstone the whole epoch space and permanently lock out the
+   real machine). The claimant learns `stored` from the replicated public metadata it
+   restores from (the same copy that restored the machineId in incident A), so a key-lost
+   machine derives `stored+1` WITHOUT any refusal-oracle leak. Genesis: an absent stored
+   epoch reads as 0; migration backfills `keyEpoch: 0` (FD12).
+4. **The peer's OWN ISSUED inbound-refusal evidence** (round-2 F1, the direction fix): this
+   peer has itself REFUSED ≥K inbound envelopes claiming that machineId as
+   `signature-invalid` over ≥M minutes — a new durable per-machineId issued-refusal counter
+   in `MeshRpc`'s verify path (NOT the prober's outbound `auth-rejected`, which the accepting
+   peer does not hold in incident A because peer→claimant traffic kept working). Necessary,
+   never sufficient — an attacker CAN induce it by sending new-key-signed traffic, which is
+   why 4 never stands alone.
+5. **Independent corroboration — the verified source address (5a is the SOLE automatic
+   leg).** The re-announce arrived from an endpoint this peer VERIFIED under the INCUMBENT
+   key within a tight window before failure onset, over an AUTHENTICATED transport class
+   (Tailscale / tunnel-authenticated) — never a bare-LAN address (round-2 H4: closes
+   DHCP/ARP endpoint-hijack of a dark machine). In incident A this holds (the Studio's
+   Tailscale address was alive under the old key up to the rotation). **Replicated-metadata
+   corroboration (former 5b) is DROPPED as an automatic leg** (round-2: it rides a
+   replication channel whose `verifyPulledCommits()` is a stub, is itself the incident-A
+   write path, and is circular in the legitimate case); it survives only as display/advisory
+   in the §4.3 dashboard.
+6. **Cross-peer fingerprint agreement** (round-2 F1/F3 — the quorum replacement): a
+   read-time check over already-replicated PROMOTED identity. If any other LIVE peer holds a
+   DIFFERENT signing fingerprint for this machineId at this epoch, the claim QUARANTINES
+   (never last-writer-wins). An automated detector (§4.3) raises URGENT on such divergence
+   rather than leaving it to a human reading dashboard rows.
+7. Rate/breaker budget OK (FD2), and no unacked ACCEPTED rotation entry exists for this
+   machineId (§4.3 — refusals/quarantines never arm the suspend).
 
-**All conditions met → automatic accept (zero human action — the legitimate-recovery
-case).** Any of 4–6 unmet → the claim is QUARANTINED, nothing is stored, and the operator
-gets a dashboard-PIN approve/deny action (Mobile-Complete: a tap, never a terminal
-command; the raw repair command appears only as the documented filesystem last resort).
-Two conflicting claims for one machineId inside a 10-minute settle window → BOTH
-quarantined, the peer keeps the last-verified identity, one URGENT non-coalescing item —
-never last-writer-wins on identity.
+**All met → automatic accept (zero human action).** Any of 4–7 unmet, OR 5a unsatisfiable
+(a tunnel-only mesh with no verified direct address, OR incident A+B simultaneously where
+the address ALSO changed) → the claim QUARANTINES: nothing is stored, and the operator gets
+a single-use, content-hash-bound (machineId+keyEpoch+new-key fingerprint) dashboard-PIN
+approve/deny (round-2 H7: TOCTOU-safe, mirroring the matrix-acceptance flow; a swapped claim
+voids the approval). Two conflicting claims for one machineId within a 10-minute settle
+window → BOTH quarantine, one URGENT item deduped per machineId per window (round-2 H8:
+repeat conflicts fold into the standing item).
 
-**Partial acceptance / version skew:** acceptance is per-peer with a durable claimant-side
-episode ledger (per-peer accepted/pending/refused, exponential backoff 1m→5m→30m→6h
-ceiling, 72h retry horizon, P19 give-up-loudly breaker). A route-absent peer classifies
-`peer-lacks-accept-route` (typed — a v-old peer, not a failure loop). The claimant is the
-SINGLE notice raiser: one HIGH, non-coalescing attention item per rotation episode keyed
-`machineId+keyEpoch`, posted on first acceptance and EDITED with per-peer outcomes
-(`accepted: mini, laptop · pending: mama-pc`), never re-posted per attempt. No re-announce
-is ever queued for delivery while a peer is dark — the next successful contact re-runs
-detection from live evidence.
+**Partial acceptance / version skew:** per-peer acceptance with a durable claimant-side
+episode ledger (accepted/pending/refused, backoff 1m→5m→30m→6h, 72h horizon, P19
+give-up-loudly). Route-absent peers classify typed `peer-lacks-accept-route`. The claimant
+is the SINGLE notice raiser: one HIGH non-coalescing item per episode keyed
+`machineId+keyEpoch`, posted on first acceptance and EDITED with per-peer outcomes.
 
 ### 4.2 Observed endpoints (incident B)
 
-Peers record the address they OBSERVE a machine's authenticated traffic arriving from —
-evidence held by the observer, replacing an unprovable self-assertion. Prior art:
-WireGuard/Tailscale endpoint roaming and STUN reflexive addressing; their load-bearing
-rule is imported: **update only on authenticated inbound traffic**.
+As round-1/round-2: observation only from FULL-`verifyEnvelope` inbound RPCs on direct
+listeners (never bearer-only, never tunnel/proxy-fronted, never `X-Forwarded-For`);
+in-memory bounded LRU (≤8/peer, decay); corroboration LOCAL-FIRST (≥3 obs / ≥30 min at this
+peer); dial-back signed-handshake verification to the SAME machineId before promotion; raw
+NAT source ports never persisted; an address observed for ≥2 machineIds (shared egress)
+refused promotion; promotion-only persistence via `PeerEndpointRecorder` with
+`origin: observed` and resolver precedence advertised-alive > observed-corroborated >
+advertised-dead; `retainProvenOmitted` treats observed entries as their own class.
 
-- An observation is recorded ONLY from an inbound RPC whose envelope passed the FULL
-  `verifyEnvelope` chain (recipient-bound, registered key, fresh nonce) — never
-  bearer-only requests — and ONLY on direct listeners (Tailscale/LAN) where the socket
-  peer address is meaningful; never tunnel/proxy-fronted listeners, never
-  `X-Forwarded-For`.
-- Observations accumulate IN MEMORY per peer (bounded LRU, ≤8 candidate addresses, decay
-  window) — NEVER a per-request registry write. Only a corroborated, PROMOTED endpoint is
-  persisted, on change only, through the existing `PeerEndpointRecorder` chokepoint.
-- **Corroboration is local-first** (no new cross-machine merged read): ≥3 observations of
-  the same address spanning ≥30 minutes at THIS peer. Multi-peer agreement is a read-time
-  comparison over already-replicated promoted endpoints, never write-time observation
-  replication.
-- **Dial-back verification before promotion:** the recording peer dials the candidate and
-  completes a signed handshake to the SAME machineId. A raw NAT source port is never
-  persisted as a durable route; an address observed for ≥2 distinct machineIds (shared
-  NAT/exit-node egress) is refused promotion.
-- Promoted observations are provenance-tagged (`origin: observed`) and kept distinct from
-  advertised endpoints; resolver precedence: advertised-and-alive > observed-corroborated
-  > advertised-dead. `PeerEndpointRecorder.retainProvenOmitted` (invariant 2b) treats
-  observed entries as its own class so an advertisement can never wipe a verified
-  observation and vice versa.
-- **Rotation quarantine (anti-laundering):** all observations for a machineId are
-  discarded and observation-recording for it suspended for a cooldown window after ANY
-  identity rotation for that machineId — an accepted takeover must not be able to convert
-  itself into corroborated routing within the window; and per §4.1(5), an observation
-  recorded under a key later tombstoned never counts as corroboration for the NEXT
-  rotation.
+**Rotation quarantine — honest bound (round-2 F6):** after ANY rotation for a machineId,
+observations for it are discarded and recording suspended for
+`rotationQuarantineHours ≥ corroborationWindowMinutes + margin` (FD8). This prevents
+WITHIN-WINDOW laundering only; it is a bounded delay, not durable protection. Durable
+protection that an accepted-takeover's address cannot be laundered into the NEXT rotation
+comes from §4.0's tombstone (an observation under a later-tombstoned key never corroborates)
+plus §4.1(5a)'s incumbent-key binding — NOT from the cooldown. Once identity is taken over,
+routing-to-attacker is downstream of that, not a new grant.
 
 ### 4.3 Identity-change ledger (visibility that cannot be buried)
 
-Every identity write — pair, re-announce, quarantine, refusal, files-API (pre-F1, best
-effort) — appends a durable audit row (`logs/identity-changes.jsonl`: machineId, old/new
-key fingerprints, keyEpoch, path, accepted-by, corroboration used). Rotation entries carry
-an ACKNOWLEDGEMENT state: an unacked entry re-surfaces on a cadence until the operator
-acks (dashboard tap), and an unacked rotation SUSPENDS further automatic accepts for that
-machineId (they quarantine to the approval path instead). This is the structural answer
-to the buried-notice failure: if the operator will not approve before the change, they are
-structurally guaranteed to see it after. The Machines dashboard tab and `GET /pool`
-machine rows gain: signing-key fingerprint, `keysRotatedAt`, keyEpoch, and
-last-identity-write source, so stored-copy skew between peers is a read, not a forensic
-dig.
+Every identity write appends a durable row to `logs/identity-changes.jsonl` (machineId,
+old/new fingerprints, keyEpoch, path, accepted-by, corroboration used). A small durable
+UNACKED-ROTATION INDEX (bounded by pool size) is maintained at append time — the ack
+cadence tick and §4.1(7) read the INDEX, never a full-ledger scan (round-2 scalability F2).
+An unacked ACCEPTED rotation (only accepted — never a refusal/quarantine, round-2 F2)
+suspends further AUTOMATIC accepts for that machineId; a fully-corroborated fresh rotation
+OVERRIDES the suspend (so an operator who never taps cannot permanently strand recovery).
+Re-surface follows the single-edited-item discipline with widening backoff (24h; priority
+escalates after 72h), NOT a re-post stream.
+
+**Ack locus (round-2 F4, resolved):** ONE operator dashboard ack, propagated to the
+suspending peers as a signed operator-authenticated ack over the WS4.1 remote-ack route
+(named, not an unnamed cross-machine write); each peer's suspend lifts when the propagated
+ack lands. The accepting-peer ledger + must-ack is the ATTACK-VISIBILITY BACKSTOP (the
+claimant notice is only the benign-case dedupe — in a takeover the "claimant" is the
+attacker's script and posts nothing), and the must-ack re-surface rides the HIGH
+non-coalescing lane.
+
+**Automated divergence detector:** over the replicated promoted-identity merge, an
+URGENT non-coalescing item when two LIVE peers hold different fingerprints for one machineId
+at one epoch (§4.1(6)'s machinery) — divergence detection is NOT contingent on a human
+reading rows. The dashboard/`GET /pool` fingerprint+epoch+last-write-source fields ride the
+EXISTING capacity-heartbeat / shared poll-cache payload (round-2 scalability F6 — no new
+fan-out); the ledger pool read is the named `GET /identity-changes?scope=pool`,
+dark-peer-tolerant.
 
 ### 4.4 F1 — closing the files-API identity hole (sequenced, not deferred)
 
-- **Interim mitigation ships in the FIRST implementation PR of this spec, in the same PR
-  as the accept route:** `.instar/machine/**` and `.instar/machines/**` join the
-  files-API always-read-only list. Same-PR coupling guarantees an in-product repair path
-  exists at every instant the file hole is closed (closing it alone would recreate
-  incident A with NO repair path).
-- Fleet sequencing (hard constraint): accept-route deployed fleet-wide → re-announce
-  enabled → any further F1 hardening. A v-next claimant against a v-old peer is the typed
-  `peer-lacks-accept-route` case in §4.1 until migration completes.
-- Post-F1 the compensating controls ARE §4.1's corroboration + quarantine + ack-suspend
-  (this section IS the §2 re-run, done now rather than promised): with the files hole
-  closed, an uncorroborated bearer-token claimant can reach only the quarantine path,
-  which requires the operator's PIN — i.e. post-F1 the boundary is RESTORED to two locks
-  for the adversarial case while staying zero-touch for the corroborated one.
+Interim never-editable/never-sync additions (§4.0's full set) ship in the SAME PR as the
+accept route — closing the file hole alone would recreate incident A with no repair path.
+Fleet sequencing (accept-route deployed → re-announce enabled → further hardening) is made
+MECHANICAL, not willpower (round-2 integration F7): the enable flip / FD3 graduation checks
+pool version coherence via the existing machine-coherence guard (every registered-online
+machine ≥ the accept-route version; per-machine flag divergence joins that guard's
+compared-flags set). Post-F1 the boundary is RESTORED with respect to DIRECT identity
+writes (scoped per §4.0's honest note): an uncorroborated bearer claimant reaches only the
+PIN quarantine.
 
-## 5. Decision (operator directive 2026-08-29 + round-1 revision)
+### 4.5 Escrowed recovery key (the cryptographic close — OPERATOR-GATED, see Open questions)
 
-The operator directed: *"I want the solution that takes the least amount of time/effort
-from the humans"* (topic 62395). Round-1 review (8 reviewers, ~75 findings) established
-that a proof-free automatic accept is an identity mint for any bearer-token holder — it
-does not survive its own threat model. The decision as revised:
+The only mechanism that makes even the total-loss + address-change case zero-touch AND
+secure against a token-holder: at pair time each machine mints a SECOND ("recovery")
+keypair; peers store its PUBLIC half (replicated), and the PRIVATE half is escrowed OUTSIDE
+`.instar/machine/**` — in a location the bearer token / files API cannot read (the operator's
+vault, or a peer-held sealed copy). On rotation the machine signs the new signing key with
+the RECOVERY key; peers verify the continuity signature against the stored recovery pubkey →
+cryptographic legitimacy, because only the real machine holds the recovery private key. This
+becomes §4.1's condition 5 when present (superseding the 5a heuristic), giving a fully
+automatic, token-adversary-proof accept. It covers incident A and the double-fault case IFF
+the recovery private key survived the loss that took the signing key — which is an operator
+choice about WHERE to escrow it. Adopting escrow is the Open question below.
 
-- **Zero-touch for the legitimate case:** a real rotation (local rotation record +
-  peer-observed 401s + corroboration) is accepted automatically — no tap, no approval.
-  Incident A under this design: automatic recovery in minutes.
-- **A tap ONLY for the suspicious case:** an uncorroborated or conflicting claim
-  quarantines to a dashboard-PIN approve — the case where "least human effort" would
-  otherwise mean "attacker's least effort."
-- **Observed endpoints:** fully automatic (§4.2) — evidence-based, no human action ever.
-- Option 3 (continuity-chained planned rotation) is OUT OF SCOPE — its own follow-up,
-  with the §4.1(3) tombstone rule recorded as a hard requirement on its design.
+## 5. Decision (operator directive 2026-08-29 + round-1/2 revision)
+
+- **Zero-touch for the single-fault legitimate case (incident A):** local rotation record +
+  the peer's own issued 401s + the re-announce arriving from the incumbent-verified
+  authenticated address + cross-peer agreement → automatic, minutes. This is the common case.
+- **Operator tap ONLY where evidence cannot distinguish recovery from takeover:** a
+  tunnel-only mesh with no verified direct address, the key-loss-AND-address-change double
+  fault, a cross-peer fingerprint conflict, or any uncorroborated/racing claim → PIN
+  quarantine. Under an ACTIVE token-holding adversary, §4.1's conflict rule means a
+  legitimate rotation can be FORCED to the tap by a racing claim — this fails SAFE (to a
+  human) and is correct; §5 states it plainly rather than claiming minutes unconditionally.
+- **Observed endpoints:** fully automatic (§4.2).
+- **Escrow (§4.5):** would move the double-fault case from tap to automatic; adopting it is
+  the Open question.
+- Option 3 (continuity-chained PLANNED rotation) is subsumed by §4.5's continuity signature
+  when escrow is adopted; otherwise out of scope, inheriting §4.0's tombstone rule.
 
 ### 5b. History (non-normative)
 
-Superseded positions, kept for the record: the original recommendation (Option 1 +
-Option 4 + PIN-gated Option 2, pre-directive) and the intermediate fully-automatic
-decision (2026-08-29, pre-review). Neither is normative; §4/§5 above govern.
+Superseded: the original PIN-gated recommendation; the intermediate fully-automatic
+proof-free decision (killed round 1); the round-1 corroboration design whose 5(b) replicated
+leg and condition-4 direction were corrected in round 2. §4/§5 above govern.
 
 ## Multi-machine posture
 
-| Surface | Posture | Justification |
-|---|---|---|
-| Stored peer identities (`.instar/machines/<id>/identity.json`) | machine-local | machine-local-justification: physical-credential-locality — each machine's stored copy of a peer's public key is that machine's own trust anchor; replicating trust anchors would let one compromised machine rewrite every machine's roots. Consequence owned in §4.1: per-peer delivery + per-peer acceptance ledger. The pre-existing public-metadata replication (which restored the Studio's record) is read-side corroboration input only — never authority. |
-| Observation ledger (§4.2, in-memory) | machine-local | machine-local-justification: physical-credential-locality — an observation is one observer's socket-level evidence, meaningful only at the machine that held the connection; corroboration is deliberately local-first so no new merged read or replication path exists. Promoted endpoints ride the EXISTING registry/lease replication unchanged. |
-| Re-announce episode state (claimant-side per-peer ledger) | machine-local | machine-local-justification: hardware-bound-resource — it describes THIS machine's key and its per-peer delivery progress; durable across restart so a crash mid-rotation cannot strand a half-converted mesh. |
-| Identity-change ledger + ack state (§4.3) | machine-local (per accepting peer) with a proxied-on-read pool view | Each peer's ledger records ITS OWN acceptance decisions (evidence, not shared truth); the dashboard machine rows merge fingerprint/epoch per machine at read time so skew is visible. Ack state lives with the raising side (claimant's episode item). |
-| Rotation notice | single raiser | The claimant posts the ONE episode item (first acceptance) and edits it; accepting peers never post (prevents N-notices / zero-notices). |
+Each machine-local surface carries a standalone closed-taxonomy marker (Amendment 3,
+2026-08-22) on its own line, followed by the surface it justifies:
+
+- machine-local-justification: physical-credential-locality impossible-because="the-ed25519-mesh-private-key-IS-this-machine-identity-relocating-it-merges-two-machines" permanence=permanent
+  — **Re-announce episode state + the claimant's per-peer delivery ledger:** tracks THIS
+  machine's own private key and its delivery progress; durable across restart so a crash
+  mid-rotation cannot strand a half-converted mesh.
+- machine-local-justification: physical-credential-locality impossible-because="a-trust-anchor-meaning-is-what-THIS-machine-verified-first-hand-a-replicated-copy-is-corroboration-not-an-anchor" permanence=permanent
+  — **Stored peer identities (`.instar/machines/<id>/identity.json`) + the epoch/tombstone
+  store:** machine-local trust anchors; replication is applied only through the §4.0 funnel,
+  never as authority.
+- machine-local-justification: hardware-bound-resource impossible-because="an-observation-is-this-machine-own-socket-level-network-vantage-the-connection-that-arrived-on-this-host-interface" permanence=permanent
+  — **Observation ledger (§4.2, in-memory):** corroboration is local-first, so no new
+  merged read or replication path exists.
+- machine-local-justification: physical-credential-locality impossible-because="each-peer-records-ITS-OWN-accept-refuse-decisions-as-first-hand-evidence-a-shared-ledger-would-make-one-machine-decision-authoritative-over-another-trust-anchor" permanence=permanent
+  — **Identity-change ledger + issued-refusal counter (§4.1(4)/§4.3):** machine-local per
+  peer; the pool view is proxied-on-read (`GET /identity-changes?scope=pool`) and the
+  operator ack propagates via the WS4.1 signed remote-ack route.
+
+Rotation notice: single raiser — the claimant posts the one episode item; accepting peers
+never post (prevents N-notices / zero-notices).
 
 ## Decision points touched
 
 | Decision point | Class | Floor / justification |
 |---|---|---|
-| Peer accept/refuse of a re-announce | invariant | Deterministic composite (§4.1 conditions 1–6): enumerable inputs, irreversible-action guard per Signal-vs-Authority's carve-out; explicitly not an LLM judgment. Any unmet condition fails CLOSED to quarantine + human approval. |
+| Peer accept/refuse of a re-announce | invariant | Deterministic composite (§4.1 conditions 1–7): enumerable inputs; per `docs/signal-vs-authority.md` § "Safety guards on irreversible actions" a deterministic guard may hard-REFUSE (false pass catastrophic, false block cheap). It never affirmatively grants in ambiguity — any unmet condition fails CLOSED to quarantine + the operator's PIN. Not an LLM judgment. |
 | "Sustained signature-invalid" trigger | invariant | Counter ≥K over ≥M min, typed-401-only, rotation-record-gated (§4.1); triggers an announce attempt, blocks nothing. |
-| `auth-rejected` ⇒ provably-alive classification | invariant | Typed HTTP response class (shipped, PR #1995); feeds liveness consumers: it BLOCKS stale-owner-release death evidence for that peer (a 401-answering machine is alive on every transport that answers) and is a distinct rope-health class, never `peer-offline`. |
-| Observed-endpoint promotion | invariant | Declared floor: ≥3 observations ≥30 min local + dial-back signed handshake + not-shared-egress + rotation quarantine (§4.2). Pre-commitment: if any adaptive/scored element is ever added, this becomes a judgment-candidate and must then declare floor + arbiter. |
+| `auth-rejected` ⇒ provably-alive classification | invariant | Typed HTTP response class (shipped, PR #1995); blocks stale-owner-release death evidence for that peer; distinct rope-health class, never `peer-offline`. |
+| Issued inbound-refusal counter feeding condition 4 | invariant | Deterministic per-machineId count of THIS peer's `signature-invalid` refusals (§4.1(4)); an input, blocks nothing. |
+| Cross-peer fingerprint agreement | invariant | Read-time equality check over replicated promoted identity (§4.1(6)); disagreement → quarantine, never a pick. |
+| Observed-endpoint promotion | invariant | Declared floor (§4.2): ≥3 obs/≥30 min local + dial-back + not-shared-egress + rotation quarantine. Pre-commitment: any adaptive/scored element added later makes this a judgment-candidate requiring floor+arbiter. |
 | One-notice raiser election | invariant | Claimant posts on first acceptance; episode-scoped dedupe on machineId+keyEpoch. |
-| Quarantine approve/deny | human (operator) | Dashboard-PIN action; the one deliberate human decision point, reserved for evidence-ambiguous claims (Know Your Principal). |
+| Quarantine approve/deny | invariant | Deterministic routing to the operator's single-use, content-hash-bound dashboard-PIN decision; the operator is the arbiter (Know Your Principal). The machine-side routing is deterministic; the human decision sits above the classified machine surface. |
 
 ## Frontloaded Decisions
 
 1. **Detection threshold:** typed `auth-rejected:signature-invalid` only; ≥10 consecutive
-   spanning ≥15 min, zero interleaved successes, on all ropes to the peer; unreachability
-   freezes the episode clock; local rotation record required (§4.1).
-2. **Re-announce brake:** max 1 automatic re-announce episode per peer per 24h, max 3 per
-   keyEpoch; budget exhausted → HIGH item, no further attempts; registered as a
-   SelfActionGovernor class; per-peer backoff 1m→5m→30m→6h; P19 breaker with
-   sustained-failure test (permanently-refusing peer + contested machineId → bounded
-   attempts, bounded notices).
+   over ≥15 min, zero interleaved successes, all non-idle ropes; unreachability freezes the
+   clock; local rotation record required.
+2. **Re-announce brake:** SelfActionGovernor class, TARGET KEY = destination peer machineId,
+   per-target ceiling 1/24h, max 3 per keyEpoch, census-scaled total ≥ peer count (round-2
+   scalability F3 — a governor deny parks the per-peer entry in the pending ledger, never
+   consumes an attempt); backoff 1m→5m→30m→6h; P19 breaker. A CAS refusal is a retryable
+   per-peer attempt, NOT a new episode and NOT a keyEpoch-budget consumer.
 3. **Rollout ladder:** `multiMachine.identityReannounce = {enabled, dryRun}` and
    `multiMachine.observedEndpoints = {enabled, dryRun, corroborationObservations: 3,
-   corroborationWindowMinutes: 30, ttlDays: 7}`. Both dev-gated dark on the fleet,
-   dryRun:true even on dev (peer-side would-accept verdicts logged too). Graduation:
-   ≥14 days dry-run with zero false would-accept verdicts on the dev pair + one live-pair
-   rotation rehearsal with per-peer acceptance verified. Flag absent = today's behaviour.
-4. **Challenge protocol:** as §4.1 (32-byte single-use nonce, 60s TTL, five-field signed
-   binding, CAS store, persisted attempt caps, issuance security-logged).
+   corroborationWindowMinutes: 30, ttlDays: 7, rotationQuarantineHours: 1}`. Dev-gated dark
+   on fleet, dryRun:true on dev (peer-side would-accept verdicts logged too). Graduation:
+   ≥14 days dry-run with zero false would-accept verdicts PLUS required NEGATIVE rehearsals
+   (round-2 lessons F5 — silence is not health): an injected uncorroborated claim MUST
+   quarantine, a replayed/old-epoch claim MUST be refused, a cross-peer-conflict claim MUST
+   quarantine, each verified from the ledger; and one benign live-pair rotation accepted.
+   Flag absent = today's behaviour. Enable gated on machine-coherence version check (§4.4).
+4. **Challenge protocol:** 32-byte single-use nonce, 60s TTL, SIX-field signed binding
+   (incl. keyEpoch), CAS store via the §4.0 funnel, persisted attempt caps, issuance
+   security-logged, refusals never disclose the stored epoch.
 5. **Partial acceptance:** per-peer state machine + durable pending ledger, 72h horizon,
-   typed `peer-lacks-accept-route`, single edited notice enumerating outcomes, HIGH
-   escalation naming un-accepted peers with a dashboard action (CLI repair as documented
-   last resort).
-6. **Conflict rule:** monotonic integer `keyEpoch`; conflicting claims within a 10-min
-   settle window → both quarantined, keep last-verified, one URGENT non-coalescing item;
-   never last-writer-wins; old-key tombstone at accepted rotation; replay state keyed by
-   machineId, survives rotation.
-7. **Notice channel:** one HIGH, non-coalescing attention item per episode, deduped on
-   machineId+keyEpoch, plus a rope-health-digest line; explicitly not medium (the
-   2026-08-28 alert died at normal priority in a 237-item queue). Plus the §4.3 must-ack
-   ledger with unacked-suspends-auto-accept semantics.
-8. **Observed-endpoint corroboration:** the §4.2 floor (3 obs / 30 min / dial-back /
-   not-shared / rotation-quarantine); in-memory LRU ≤8 candidates/peer; promotion-only
-   persistence via `PeerEndpointRecorder` with `origin: observed` provenance; resolver
-   precedence advertised-alive > observed-corroborated > advertised-dead.
-9. **F1 boundary:** interim never-editable entries for `.instar/machine/**` +
-   `.instar/machines/**` ship in the SAME PR as the accept route; fleet sequencing
-   accept-route → enable → further hardening; §4.4 records the post-F1 boundary analysis
-   now (no deferred re-run).
-10. **Option 3:** out of scope; its future design inherits the tombstone requirement.
-11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness
-    consumer; it blocks stale-owner-release death evidence for that peer.
+   typed `peer-lacks-accept-route`, single edited notice, HIGH escalation naming
+   un-accepted peers with a dashboard action (CLI last resort).
+6. **Conflict rule:** monotonic integer `keyEpoch == stored+1`; conflicting claims within a
+   10-min settle window → both quarantine, keep last-verified, one URGENT deduped per
+   machineId per window; old-key tombstone; replay state keyed by machineId, survives
+   rotation.
+7. **Notice channel:** one HIGH non-coalescing item per episode deduped on machineId+keyEpoch
+   + a rope-health-digest line; the §4.3 must-ack ledger ALSO on the HIGH non-coalescing lane;
+   explicitly not medium.
+8. **Observed-endpoint corroboration:** §4.2 floor incl. `rotationQuarantineHours ≥
+   corroborationWindowMinutes + margin`; LRU ≤8; promotion-only persistence with
+   `origin: observed`; precedence advertised-alive > observed-corroborated > advertised-dead.
+9. **Stored-key write-path closure + F1 boundary:** §4.0's full never-editable/never-sync
+   set ships in the SAME PR as the accept route; git-sync applies identity changes only
+   through the §4.0 funnel; fleet sequencing is machine-coherence-gated; the bearer→RCE
+   surface (`.claude/settings.json`, `.git/`, `.instar/hooks/`) is a tracked follow-up.
+10. **Escrow (§4.5):** designed but OPERATOR-GATED (Open questions) — its continuity
+    signature supersedes condition 5 when present; Option 3 continuity chaining folds into it.
+11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness consumer;
+    it blocks stale-owner-release death evidence for that peer.
 12. **Migration & rollout parity:** `migrateConfig()` adds the two config blocks
     (existence-checked); `migrateClaudeMd()` adds the operator-facing "why did I get a
-    key-rotation notice / what is a quarantined identity claim" section; the files-API
-    never-editable additions ride `refreshHooksAndSettings`. Fleet sequencing per §4.4.
+    key-rotation notice / what is a quarantined identity claim" section; the
+    never-editable/never-sync additions ride `refreshHooksAndSettings`; keyEpoch genesis =
+    absent-reads-as-0, migration backfills `keyEpoch: 0` into every existing stored identity
+    and epoch-store row (round-2 integration F2); `/api/pair` on an existing machineId writes
+    `stored+1` (never claimant-supplied) and MAY clear revocation (operator action), through
+    the §4.0 funnel (round-2 integration F3).
 
 ## Open questions
 
-*(none)*
+**OQ1 — Adopt the escrowed recovery key (§4.5)?** This is the one genuine operator
+decision. Adopting it makes even the total-loss + address-change case zero-touch and
+cryptographically secure against a token-holder, at the cost of the operator managing where
+the recovery private key is escrowed (their vault, or a peer-sealed copy) so it survives a
+loss that takes the signing key. Declining it means that specific rare double-fault case
+degrades to the PIN tap (still safe, still visible, just not zero-touch). Everything else in
+this spec is independent of OQ1. — pending operator input.
+
+**OQ2 — bearer→RCE surface** (`.claude/settings.json` hook commands, `.git/hooks/**`,
+`.instar/hooks/**`): close in this spec's PR set, or track as separate pre-existing-debt
+hardening? §4.4's boundary claim is scoped to direct identity writes until resolved. —
+pending operator/maintainer decision.
 
 <!-- tracked: CMT-211 -->
 
@@ -348,25 +419,30 @@ decision (2026-08-29, pre-review). Neither is normative; §4/§5 above govern.
 > address they OBSERVED, which is what a NAT'd or VM-hosted agent cannot assert about
 > itself.
 >
-> Status against this spec: (2) shipped (PR #1995) and (3) shipped (PR #1994). (1) is
-> RESOLVED by §5 as revised: the operator's directive selected least-human-effort; review
-> reshaped that into auto-when-corroborated / PIN-only-when-suspicious, so the PIN surface
-> survives solely as the quarantine approval (the immutable carrier text above predates
-> the revision — this annotation, not the carrier, reflects the standing decision). (4) is
-> §4.2 of this spec.
+> Status against this spec: (2) shipped (PR #1995), (3) shipped (PR #1994). (1) and (4) are
+> designed in §4–§5 here; the only decision still parked on the operator is OQ1 (escrow),
+> which the immutable carrier text (written pre-review) does not capture — this annotation,
+> not the carrier, reflects the standing state.
 
 ## 7. Evidence
 
 - `logs/server.log` — 926 `[rope-probe] probe failed … auth-rejected:signature-invalid`.
-- `.instar/machine/identity.json` — `keysRotatedAt: 2026-08-28T02:01:55Z`, with the
-  recorded reason naming the lost private keys.
-- Peers' stored copies read directly at `/api/files/read` on each machine: old
-  `signingPublicKey` `MCowBQYDK2VwAyEAhPiJ…` vs current `MCowBQYDK2VwAyEAVfPs…`.
-- Mama PC interface table captured on-machine: `platform: linux`, `eth0 172.22.96.135`
-  only, no CGNAT address present.
-- Post-repair verification: signed mesh probes to all three peers returned the typed
-  `403 not-router` refusal (the exact success contract).
-- Round-1 review inputs: standards-conformance gate (2 possible-violations: Know Your
-  Principal; Verify the State, Not Its Symbol), codex-cli:gpt-5.5 external (6),
-  claude-fable-5 clean-door (5), and six internal reviewers (security 12, adversarial 10,
-  scalability 8, integration 11, decision-completeness 13, lessons-aware 8).
+- `.instar/machine/identity.json` — `keysRotatedAt: 2026-08-28T02:01:55Z`, recorded reason
+  naming the lost private keys.
+- Peers' stored copies read at `/api/files/read`: old `signingPublicKey` `MCowBQYDK2VwAyEAhPiJ…`
+  vs current `MCowBQYDK2VwAyEAVfPs…`.
+- Mama PC interface table: `platform: linux`, `eth0 172.22.96.135` only, no CGNAT address.
+- Post-repair verification: signed mesh probes to all three peers returned typed `403
+  not-router`.
+- Code-verified round-2 findings: `GitSync.verifyPulledCommits()` returns `[]`
+  (`src/core/GitSync.ts:735`); `NEVER_EDITABLE_PREFIXES` omits `state/` and identity files
+  (`src/server/fileRoutes.ts:299`); PR #1995's `auth-rejected` is an OUTBOUND-probe
+  classification (`src/core/ropeProbeContract.ts:57`), which the accepting peer does not hold
+  in incident A.
+- Round-1 review: standards gate (2), codex-cli:gpt-5.5 (6), claude-fable-5 clean-door (5),
+  6 internal (security 12, adversarial 10, scalability 8, integration 11,
+  decision-completeness 13, lessons-aware 8).
+- Round-2 review: standards gate (1, fixed), codex-cli:gpt-5.5 (5, MINOR), claude-fable-5
+  clean-door (5, MINOR), 6 internal (security 8, adversarial 6, scalability 6, integration
+  8, decision-completeness 6, lessons-aware 6) — all convergent on the condition-4 direction
+  fix, the replication-channel trust gap, and the escrow close.

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -103,6 +103,14 @@ including replication-apply:
   monotonic `recoveryEpoch` + tombstone; refuse a write whose `recoveryEpoch <= stored`. A
   signing-key rotation write that ALSO mutates the recovery pubkey is REFUSED — replacing the
   recovery pubkey is a separate, dashboard-PIN-gated operator operation (§4.5).
+- **Recovery-pubkey FIRST-establishment invariant (round-4 — Structure > Willpower):** a
+  recovery-pubkey write from ABSENT/epoch-0 to a value (the retro-mint / initial-pair
+  ingestion) is NOT merely a monotonic 0→1 write the funnel waves through — it REQUIRES
+  dashboard-PIN operator authentication and is REFUSED from any bearer-authenticated or
+  replication-apply writer. Without this the transitional-window `has-recovery-key:false`
+  state is a poison point: whoever first lands a 0→1 recovery-pubkey write becomes the
+  machine's root of trust. This is an enumerated funnel invariant with the same teeth as
+  monotonicity, not a prose expectation on callers.
 - **Tombstone:** the superseded key's fingerprint is recorded; any future write (including
   a continuity-chained or replicated one) rooted at or below a tombstoned epoch is refused.
 - **Sticky revocation:** a revoked machine cannot be written back to active except by an
@@ -174,7 +182,9 @@ Auto-accept requires ALL of:
    lagging peer — same fingerprint, lower epoch — from a genuine fingerprint DIVERGENCE at
    equal epoch: only the latter quarantines). A key-lost machine derives `stored+1` WITHOUT
    any refusal-oracle leak. Genesis: an absent stored epoch reads as 0; migration backfills
-   `keyEpoch: 0` and `recoveryEpoch: 0` (FD12).
+   `keyEpoch: 0` and `recoveryEpoch: 0` (FD12). (Refusals still never ECHO the stored epoch —
+   not as a secrecy claim, since a bearer holder reads it from replicated public metadata
+   anyway, but to avoid a convenient probing oracle in the refusal path itself.)
 4. **The peer's OWN ISSUED inbound-refusal evidence** (round-2 F1, the direction fix): this
    peer has itself REFUSED ≥K inbound envelopes claiming that machineId as
    `signature-invalid` over ≥M minutes — a new durable per-machineId issued-refusal counter
@@ -197,12 +207,19 @@ Auto-accept requires ALL of:
    - Replicated-metadata corroboration (former 5b) remains DROPPED as an automatic leg
      (round-2); display/advisory only.
 6. **Cross-peer fingerprint agreement** (round-2 F1/F3 — the quorum replacement; round-3:
-   covers BOTH keys): a read-time check over already-replicated PROMOTED identity. If any
-   other LIVE peer holds a DIFFERENT signing fingerprint at this `keyEpoch` OR a different
-   recovery pubkey at this `recoveryEpoch`, the claim QUARANTINES (never last-writer-wins) —
-   a continuity-signature acceptance (5-primary) does NOT bypass this; it must still pass
-   recovery-pubkey cross-peer agreement, so one poisoned peer cannot be taken over in
-   isolation. The §4.3 detector raises URGENT on either divergence.
+   covers BOTH keys; round-4: precise continuity carve-out). A read-time check over
+   already-replicated PROMOTED identity. Two divergence classes, treated differently:
+   - **Recovery-pubkey divergence** (different recovery pubkey at equal `recoveryEpoch`
+     across live peers): ALWAYS quarantines — a continuity-signature acceptance NEVER
+     bypasses recovery-pubkey agreement (that is the poisoned-root case; one poisoned peer
+     must not be takeable in isolation).
+   - **Signing-fingerprint divergence** (different signing fp at equal `keyEpoch`): quarantines
+     for a BARE claim; a VALID continuity signature (verified against a cross-peer-CONSISTENT
+     recovery pubkey) MAY short-circuit it — cryptographic identity outranks a racing bare
+     claim, which is the whole point of the recovery key. A lagging peer (same fp, lower
+     epoch) is convergence, not divergence: it converges via funnel-applied replication and
+     accepts on retry (never a quarantine).
+   The §4.3 detector raises URGENT on a genuine (equal-epoch) divergence of either key.
 7. Rate/breaker budget OK (FD2), and no unacked ACCEPTED rotation entry exists for this
    machineId (§4.3 — refusals/quarantines never arm the suspend).
 
@@ -309,9 +326,13 @@ is keychain-backed on machines with an OS keychain, but FILE-backed at
 lives INSIDE the exact directory whose disappearance is incident A, so vault-escrow there
 does NOT survive the double-fault it exists for. Therefore:
 
-- Vault-escrow is offered ONLY when `SecretStore.isKeychainBacked === true`, checked at pair
-  time (`SecretStore.ts:446`). The silent keychain→file degradation is surfaced LOUDLY at
-  pair time, not left to a DegradationReporter note.
+- Vault-escrow is offered ONLY when `SecretStore.isKeychainBacked === true`, evaluated LIVE
+  from the OS at pair time (`SecretStore.ts:446`) — never a persisted, bearer-writable flag
+  (any cache of it joins §4.0's never-editable/never-sync set). The silent keychain→file
+  degradation is surfaced LOUDLY at pair time, not left to a DegradationReporter note.
+  Graduation rehearsals must also verify the keychain is UNLOCKABLE at recovery time (a
+  freshly-rebooted headless machine may have a locked keychain pre-login — round-4 external),
+  not merely keychain-backed at pair time.
 - A machine WITHOUT a keychain-backed vault does NOT escrow a recovery key. It stays on the
   §4.1 corroboration path (5a where the address is stable — incident A — else the PIN
   quarantine), and its `has-recovery-key` state is explicitly FALSE and surfaced ("no
@@ -344,8 +365,18 @@ wanted, peer-shares is its own follow-on spec with its own convergence.
 - **Cross-peer agreement extends to the recovery pubkey.** A continuity signature may accept
   (and short-circuit §4.1(6)'s signing-fingerprint conflict) ONLY if the recovery pubkey it
   verifies against is cross-peer-consistent at its `recoveryEpoch`; a recovery pubkey that
-  diverges across live peers QUARANTINES (URGENT), so one poisoned peer cannot be taken over
-  in isolation. The §4.3 divergence detector covers the recovery pubkey too.
+  diverges across live peers at equal `recoveryEpoch` QUARANTINES (URGENT), so one poisoned
+  peer cannot be taken over in isolation. `recoveryEpoch` gets the SAME max-across-live-peers
+  derivation and lag-vs-divergence distinction as `keyEpoch`: a recovery-KEY rotation
+  propagating unevenly means peers still at the older `recoveryEpoch` cannot verify a
+  new-recovery-key continuity signature and DEGRADE TO PIN (the safe direction — availability,
+  never takeover). Recovery-key rotation is therefore expected rare and must be fully
+  propagated before relied upon. Two hard rules close the partition exploit (round-4
+  adversarial N2): (i) a continuity signature verified against a BELOW-MAX (superseded)
+  `recoveryEpoch` is REFUSED, so a peer lagging at a rotated-away recovery key cannot honor a
+  signature against the old key; (ii) when ZERO disagreeing live peers are reachable (a
+  partition), a recovery-pubkey the peer cannot cross-check FAILS TO QUARANTINE — never
+  accepted vacuously.
 - **Recovery-key use is bound + replay-safe.** Every recovery-key use (continuity signature,
   and any recovery-key rotation) is over a single-use nonce covering
   `(machineId ‖ keyEpoch ‖ new-signing-fp ‖ new-recovery-fp ‖ recoveryEpoch)`.
@@ -369,6 +400,19 @@ token-adversary-proof under "bearer WITHOUT code execution." A bearer→RCE path
 (`.claude/settings.json` hooks, `.git/hooks/**`, `.instar/hooks/**` — pre-existing debt,
 tracked follow-up) reaches private-key theft on any machine and is out of this spec's closure
 scope; §4.4's boundary claim and this one are both scoped to direct writes.
+
+**Alternatives considered (round-4 external):**
+- *Tailscale `whois` as corroboration* — the tailnet node key survives `.instar/machine/**`
+  loss and is stronger than 5a's recency heuristic for incident A; it is adopted as an
+  ADDITIONAL 5a-tier signal where the mesh runs over Tailscale (it cannot help incident B's
+  WSL topology, where the node key lives outside the agent's namespace — the §4.2 case). It
+  does NOT replace the recovery key, which is the only leg that closes the token-adversary
+  gap after total loss.
+- *Operator-held CA root (SSH-CA / SPIFFE-style)* — one pinned offline operator key signing
+  all machine identities would replace per-machine recovery keys with one verify. Rejected as
+  the default because it is a single escrow SPOF and a single operator-managed secret across
+  the whole fleet; the per-machine recovery key keeps the blast radius to one machine and
+  needs no always-available central signer. Recorded so the decentralized choice is explicit.
 
 Prior art (for reviewers): monotonic epochs + exact-increment + tombstones + an offline
 recovery key is TUF/DID root-key rotation; the `== stored+1` rule is TUF's fast-forward
@@ -437,7 +481,7 @@ never post (prevents N-notices / zero-notices).
 | "Sustained signature-invalid" trigger | invariant | Counter ≥K over ≥M min, typed-401-only, rotation-record-gated (§4.1); triggers an announce attempt, blocks nothing. |
 | `auth-rejected` ⇒ provably-alive classification | invariant | Typed HTTP response class (shipped, PR #1995); blocks stale-owner-release death evidence for that peer; distinct rope-health class, never `peer-offline`. |
 | Issued inbound-refusal counter feeding condition 4 | invariant | Deterministic per-machineId count of THIS peer's `signature-invalid` refusals (§4.1(4)); an input, blocks nothing. |
-| Cross-peer fingerprint agreement | invariant | Read-time equality check over replicated promoted identity (§4.1(6)); disagreement → quarantine, never a pick. |
+| Cross-peer fingerprint agreement | invariant | Read-time check over replicated promoted identity (§4.1(6)). Equal-epoch RECOVERY-pubkey divergence always quarantines (a continuity signature never bypasses it). Equal-epoch SIGNING-fp divergence quarantines a bare claim but a valid continuity signature (against a cross-peer-consistent recovery pubkey) may short-circuit it. Epoch lag is convergence, not divergence. |
 | Observed-endpoint promotion | invariant | Declared floor (§4.2): ≥3 obs/≥30 min local + dial-back + not-shared-egress + rotation quarantine. Pre-commitment: any adaptive/scored element added later makes this a judgment-candidate requiring floor+arbiter. |
 | One-notice raiser election | invariant | Claimant posts on first acceptance; episode-scoped dedupe on machineId+keyEpoch. |
 | has-recovery-key predicate + downgrade posture | invariant | The `has-recovery-key` state = a non-tombstoned recovery pubkey on record in the funnel-protected identity store (not spoofable). When TRUE, a continuity signature is MANDATORY and 5a is FORBIDDEN for that machineId; a re-announce lacking a valid continuity signature QUARANTINES (never falls to 5a) — closes the omit-the-signature downgrade. |
@@ -482,7 +526,10 @@ never post (prevents N-notices / zero-notices).
    corroborationWindowMinutes + margin`; LRU ≤8; promotion-only persistence with
    `origin: observed`; precedence advertised-alive > observed-corroborated > advertised-dead.
 9. **Stored-key write-path closure + F1 boundary:** §4.0's full never-editable/never-sync
-   set ships in the SAME PR as the accept route; git-sync applies identity changes only
+   set ships in the SAME PR as the accept route, enforced by a STATIC MANIFEST test that ties
+   every file read by an auto-accept condition to a protected storage class (round-4 external:
+   the "every file read by a condition" rule must be mechanically checked, not a denylist that
+   silently drifts as conditions are added); git-sync applies identity changes only
    through the §4.0 funnel; fleet sequencing is machine-coherence-gated; the bearer→RCE
    surface (`.claude/settings.json`, `.git/`, `.instar/hooks/`) is a tracked follow-up.
 10. **Escrow (§4.5) — ADOPTED, keychain-vault only.** Flag
@@ -496,17 +543,26 @@ never post (prevents N-notices / zero-notices).
     signs ONLY rotations. A machine WITHOUT a keychain-backed vault mints no recovery key,
     surfaces `has-recovery-key:false`, and uses 5a/PIN — never silent. Shamir peer-shares
     are OUT OF SCOPE (own follow-on spec).
-    - **Retro-mint (FD12):** existing already-paired machines have no recovery keypair; on
-      first post-upgrade boot a keychain-backed machine mints + escrows one and establishes
+    - **Retro-mint (this FD10; migration mechanics in FD12):** existing already-paired
+      machines have no recovery keypair; on first post-upgrade boot (idempotent — skipped once
+      a recovery pubkey exists) a keychain-backed machine mints + escrows one and establishes
       its recovery pubkey via an operator-confirmed step (the pairing-trust channel, never
       the bearer re-announce path). Without this, "until it has one" is unreachable.
-    - **De-pair teardown:** on de-pair, the machine destroys its sealed recovery key and
-      peers tombstone its recovery pubkey; there are no peer-held shares to re-seal (Shamir
-      dropped), so the round-2 k-of-n-below-k hazard does not arise.
-    - **Transitional-window closure:** graduation adds "no machine remains without an
-      escrowed recovery key past horizon H (keychain-backed machines only)" as a tracked,
-      alerting condition, so a stuck-transitional machine is an incident, not a silent weak
-      path.
+    - **De-pair teardown:** de-pair/revocation INITIATION is a dashboard-PIN operator op,
+      never bearer-reachable. On de-pair, the machine destroys its sealed recovery key and
+      peers tombstone its recovery pubkey; the recovery-pubkey tombstone is ATOMIC-WITH-
+      REVOCATION per peer (a tombstoned-recovery entry MUST also read revoked, else the peer
+      quarantines) — so a partial propagation cannot leave a peer with `has-recovery-key:false`
+      AND an active registry entry, which would re-open 5a in isolation (round-4 adversarial
+      N1). No peer-held shares to re-seal (Shamir dropped), so the round-2 k-of-n hazard does
+      not arise.
+    - **Transitional-window closure:** graduation adds "no active-paired machine's recovery
+      pubkey remains UNESTABLISHED AT ITS PEERS past horizon H" as a tracked, alerting
+      condition — keyed on the peer-observable `has-recovery-key` (recovery pubkey propagated
+      to peers), NOT on the machine's own self-reported keychain status or local mint (round-4
+      N3/integration: a machine that minted locally but never propagated, or spoofed
+      keychain:false, must still trip the alert). Keychain status is advisory context, not the
+      alert gate. So a stuck-transitional machine is an incident, not a silent weak path.
 11. **Liveness propagation:** `auth-rejected` is proof-of-life for every liveness consumer;
     it blocks stale-owner-release death evidence for that peer.
 12. **Migration & rollout parity:** `migrateConfig()` adds the THREE config blocks
@@ -548,9 +604,10 @@ never post (prevents N-notices / zero-notices).
 > itself.
 >
 > Status against this spec: (2) shipped (PR #1995), (3) shipped (PR #1994). (1) and (4) are
-> designed in §4–§5 here; the only decision still parked on the operator is OQ1 (escrow),
-> which the immutable carrier text (written pre-review) does not capture — this annotation,
-> not the carrier, reflects the standing state.
+> designed in §4–§5. OQ1 (escrow) is RESOLVED — adopted, operator-approved 2026-08-29; only
+> the bearer→RCE hardening (OQ2) remains a tracked follow-up. The immutable carrier text
+> (written pre-review) predates all of this — this annotation, not the carrier, reflects the
+> standing state.
 
 ## Reference (internal codes used above, for outside readers)
 

--- a/docs/specs/machine-self-assertion.md
+++ b/docs/specs/machine-self-assertion.md
@@ -62,6 +62,21 @@ to:
 This is a real widening, not a theoretical one, and it is the reason this document exists
 rather than a patch.
 
+**CORRECTION (2026-08-29, verified live):** the two-lock separation described above does
+not hold on current deployments. The dashboard files API (`POST /api/files/save`,
+bearer-token-authenticated, default-editable over the whole project directory) accepts
+writes to `.instar/machines/<id>/identity.json` — this is exactly how the incident was
+repaired, and all three peers accepted the write with the token alone. A leaked bearer
+token can therefore ALREADY rewrite what a machine believes about a peer's identity, with
+NO proof of anything. The boundary §2 worried about collapsing is already collapsed.
+
+Consequence: an automatic re-announce that REQUIRES proof-of-possession (the claimant
+answers a peer-issued challenge signed with the NEW key) is strictly STRONGER than the
+status quo path, not weaker. The genuine hardening opportunity is the separate follow-up
+of closing the files-API hole (make `.instar/machines/**` and `.instar/machine/**`
+never-editable), after which the §2 analysis becomes true again and would need
+re-examination — recorded below as follow-up F1.
+
 ## 3. Constraints any accepted option must satisfy
 
 1. **No silent two-day outage.** Whatever is chosen, a mesh that is refusing a peer's
@@ -133,7 +148,25 @@ degrades safely (no observation ⇒ today's behaviour).
 observations need corroboration (repeated, from multiple peers) before being trusted, and
 must never displace a working advertised endpoint — only supplement a missing one.
 
-## 5. Recommendation
+## 5. Decision (operator directive, 2026-08-29)
+
+The operator directed: *"I want the solution that takes the least amount of time/effort
+from the humans"* (topic 62395). Combined with the §2 correction — the widening Option 2's
+PIN existed to prevent is already the status quo — the decision is:
+
+**Option 1 + Option 4 + a fully-AUTOMATIC Option 2 variant (no PIN, no approval tap):**
+a machine detecting sustained `signature-invalid` re-announces automatically; the peer
+verifies proof-of-possession (challenge signed with the NEW key) and accepts; ONE loud
+notice is posted so the rotation is visible, never silent. This is zero-human-touch and
+strictly stronger than today's de-facto repair path (which requires no proof at all).
+
+**Follow-up F1 (hardening, separate):** make `.instar/machine/**` and
+`.instar/machines/**` never-editable via the files API. Once F1 lands, the automatic
+re-announce becomes the ONLY non-pairing write path to a stored identity — at that point
+the proof-of-possession requirement is the load-bearing gate and this spec's §2 analysis
+should be re-run before any further loosening.
+
+## 5b. Original recommendation (superseded by §5)
 
 **Option 1 + Option 4, and Option 2 only if the operator accepts the widening.**
 
@@ -150,7 +183,10 @@ into an implementation.
 
 ## 6. What is deliberately not decided here
 
-Whether to accept the Option-2 widening. That is the operator's call.
+~~Whether to accept the Option-2 widening.~~ DECIDED — see §5 (operator directive
+2026-08-29, recorded in the decision journal, session echo-mesh-liveness-reconciliation).
+Remaining open: none for direction; F1's implementation details are design work for its
+own PR.
 <!-- tracked: CMT-211 -->
 
 > **CMT-211** — Carry the machine-self-assertion decision to closure: (1) the operator's

--- a/docs/specs/reports/machine-self-assertion-convergence.md
+++ b/docs/specs/reports/machine-self-assertion-convergence.md
@@ -1,0 +1,80 @@
+# Convergence Report — Machine self-assertion
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass ran through the agent's codex CLI on every round, alongside a
+clean-door Anthropic read (claude-fable-5). Both external families reviewed all five rounds.
+
+## ELI10 Overview
+
+Twice in one week a machine couldn't tell the others something true about itself. In the
+first incident the Studio's identity files vanished, its keys were regenerated, and the
+other machines kept rejecting its messages for two days because they still held the old key
+— a silent, one-way outage. In the second, a machine running inside a nested Linux
+environment couldn't see the address everyone actually reaches it on, so it kept advertising
+one that works from nowhere.
+
+This spec is how a machine safely states "this is my new key" or "this is my address" to
+peers that can't verify the claim from the claim alone. The hard part is honest: after a
+machine loses its key entirely, nothing cryptographic distinguishes a genuine recovery from
+someone who stole the shared machine password and is impersonating it — unless a recovery
+secret was set up in advance. So the design does two things. For the common case (key lost,
+address unchanged — the actual incident), it recovers fully automatically by checking
+evidence the peers already hold: their own record of refusing the machine's messages, plus
+the re-announce arriving from an address they'd verified under the old key. For the rare
+worst case (key AND address both lost), the operator approved adding a **recovery key** —
+minted once at setup, stored where the shared password can't reach it — so even that case is
+zero-touch and impossible to forge. Where a machine can't hold a recovery key safely (a
+server with no OS keychain), it honestly says so and asks for one tap in that rare case,
+rather than pretending to be protected.
+
+The whole thing ships switched off, in rehearsal mode first, and is fully reversible.
+
+## Original vs Converged
+
+The first draft said: let a machine re-announce its new key automatically, proving it holds
+the new key. Five rounds of review (including two non-Anthropic models) killed that: *anyone*
+who just generated a key can prove they hold it, so combined with the shared password it was
+an identity-forgery machine whose only trace was one notification into a queue that had
+already been shown to bury alerts.
+
+What changed, round by round:
+- **Rounds 1–2** replaced the proof-free accept with a corroborated one (the peer's own
+  refusal evidence + a verified source address + cross-peer agreement), a monotonic epoch +
+  tombstone so identities can't be rolled back or raced, and a **must-acknowledge
+  identity-change ledger** so no key swap can slip past unseen — and established the honest
+  limit that after total loss only a pre-established secret closes the gap.
+- **Round 3** adopted the operator's chosen recovery-key, then caught that sealing it in the
+  local vault does NOT survive the incident on a keychain-less machine (the vault's own key
+  lives in the very folder that vanishes), and that a distributed peer-share scheme
+  degenerated on small meshes and didn't beat the threat model — so it was simplified to a
+  keychain-verified vault only, with an honest "no protection here, one tap" fallback.
+- **Rounds 4–5** gave the recovery key the same rigor as the signing key (its own epoch,
+  tombstone, cross-peer agreement, and a structural rule that establishing it the first time
+  requires the operator, not the password), pinned where the sealed blob lives so it too
+  survives, and made first-hand recovery anchors authoritative so 2-machine meshes stay
+  zero-touch.
+
+## Iteration Summary
+
+| Round | External verdict | Design-class findings | Outcome |
+|-------|------------------|-----------------------|---------|
+| 1 | SERIOUS / SERIOUS | ~40 across 8 reviewers | proof-free accept killed; corroboration+PIN designed |
+| 2 | (internal) | condition-4 direction, replication-stub leg, quorum gap | corroboration corrected; ledger; keyEpoch |
+| 3 | MINOR / MINOR | escrow: vault doesn't survive; Shamir degenerate; recovery-pubkey unhardened | escrow → keychain-only; Shamir dropped; recovery-pubkey rigor |
+| 4 | MINOR / MINOR | first-establishment invariant; recovery-epoch lag; de-pair atomicity | folded; all round-3 findings verified CLOSED |
+| 5 | MINOR / MINOR | ciphertext location (completion); all else precision | **CONVERGED** — security + adversarial finals both declare sound |
+
+## Convergence verdict
+
+Converged at round 5. Both the security and adversarial reviewers, on their final pass,
+independently declared no remaining DESIGN-class exploit and the escrow root-of-trust sound;
+the remaining items were precision/wording, all failing safe, and are folded. Every critical
+finding across five rounds is closed. External verdicts improved monotonically
+(SERIOUS→MINOR) and stabilized. The spec is ready for operator review and the
+`approved: true` build sign-off.
+
+Honest scope note: this is a converged DESIGN. It is a substantial Tier-2 build (a serialized
+identity funnel, recovery-key lifecycle, migration/retro-mint, per-peer acceptance, observed
+endpoints) and will be built and re-reviewed increment-by-increment under /instar-dev with
+its own tests and the dark→dryRun→graduate rollout ladder specified in FD3.

--- a/upgrades/side-effects/machine-self-assertion-approval.md
+++ b/upgrades/side-effects/machine-self-assertion-approval.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — Machine self-assertion approval
+
+**Version / slug:** `machine-self-assertion-approval`  
+**Date:** `2026-09-01`  
+**Author:** `echo`  
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Records the verified operator's 2026-08-30 build approval on the already-converged machine self-assertion spec and closes its decision carrier. This is documentation and workflow metadata only; runtime behavior does not change.
+
+## Decision-point inventory
+
+No runtime decision point is added or modified. The change records an already-made operator decision.
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable.
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+## 3. Level-of-abstraction fit
+
+The approval belongs in spec frontmatter because the Instar development gate reads that metadata before permitting implementation commits. The carrier status belongs in the existing spec carrier.
+
+## 4. Signal vs authority compliance
+
+- [x] No — this change has no block/allow surface.
+
+The operator is the authority for build approval; this commit only persists that authenticated decision.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point.
+
+## 5. Interactions
+
+The `approved: true` field unlocks the existing instar-dev implementation gate. It does not alter runtime state, fire recovery behavior, or overlap another runtime check.
+
+## 6. External surfaces
+
+GitHub readers can see that the spec is approved. No agent, user, external-service, persistent-runtime-state, timing, or operator-action surface changes.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Replicated through git as spec metadata. It emits no user-facing notice, holds no runtime durable state, and generates no URL.
+
+## 8. Rollback cost
+
+Revert this documentation commit. No data migration, agent repair, or runtime rollback is required.
+
+## Conclusion
+
+The approval is correctly recorded and the implementation gate may now proceed. No runtime side effect or unresolved concern was identified.
+
+## Second-pass review
+
+Not required: documentation-only approval metadata.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## ELI16 — How a machine proves something about itself it can't see

Twice in one week a machine couldn't tell the others something true about itself: the Studio lost its keys and got rejected for two days, and a WSL machine can't see its own reachable address. This spec is how a machine safely re-announces "this is my new key" / "this is my address" to peers that can't verify the claim alone.

The honest crux: after a machine loses its key entirely, nothing cryptographic separates a real recovery from someone who stole the shared machine password — unless a recovery secret was set up beforehand. So: the common case (key lost, address unchanged — the real incident) recovers fully automatically from evidence peers already hold; the rare double-fault is closed by an operator-approved **recovery key** minted once at setup and stored where the password can't reach. Machines that can't safely hold one (no OS keychain) say so honestly and ask for one tap in that rare case.

Full plain-English overview: `docs/specs/machine-self-assertion.eli16.md`.

## Status: CONVERGED (design), NOT yet build-approved

This is a **converged design spec**, not code. It carries `review-convergence` + the convergence report, but NOT `approved: true` — that operator sign-off is required before any implementation begins under /instar-dev.

## Review: 5 rounds, 40 reviewer passes

External verdicts improved monotonically and stabilized: **SERIOUS → SERIOUS → MINOR → MINOR → MINOR** (codex-cli GPT-5.5 + a clean-door Anthropic read each round, plus six internal reviewers). Both the security and adversarial reviewers' final passes independently declared **no remaining DESIGN-class exploit; the escrow root-of-trust is sound.**

What review changed (the proof-free first draft was killed in round 1):
- Corroborated auto-accept (the peer's own issued-refusal evidence + a verified source address + cross-peer agreement), monotonic epoch + tombstone, a must-acknowledge identity-change ledger.
- Operator-approved escrowed recovery key — hardened to **keychain-backed vault only** after review caught that the local vault's master key lives in the very directory the incident deletes; Shamir peer-shares dropped (degenerate on small meshes, don't beat the threat model).
- The recovery key given the signing key's full rigor (own epoch/tombstone, cross-peer agreement, a structural first-establishment PIN gate), and its sealed blob pinned outside the blast radius with a rehearsal that deletes `.instar/machine/**` and proves end-to-end recovery.

## What's already shipped (the actual bugs)

The three detection/data fixes from the same incident are already on main: **#1992** (don't discard a working rope), **#1994** (scope expiry warnings to real mesh devices), **#1995** (a refusing peer is awake, not offline).

## Rollout

Dark on the fleet, dryRun-first on dev, dark→dryRun→graduate ladder in the Maturation plan; a substantial Tier-2 build to be implemented and re-reviewed increment-by-increment.

Convergence report: `docs/specs/reports/machine-self-assertion-convergence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o9kgd1afVCgzEnqJaqmsi