### PR TITLE
fix(asp): label agent-signed inbound messages and never auto-bind the operator from them

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-02T16-20-06-134Z-asp-signed-inbound-label.json
+++ b/.instar/instar-dev-decisions/2026-09-02T16-20-06-134Z-asp-signed-inbound-label.json
@@ -1,0 +1,37 @@
+{
+  "ts": "2026-09-02T16:20:06.134Z",
+  "slug": "asp-signed-inbound-label",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 12,
+  "loc": 303,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/AspAuthorshipJoin.ts",
+      "src/core/AspInboundClassifier.ts",
+      "src/core/ForwardedTopicContext.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/core/SessionManager.ts",
+      "src/core/aspClassifierRef.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/shared/signedInbound.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts",
+      "src/types/pipeline.ts"
+    ],
+    "addedLines": 284,
+    "deletedLines": 19
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/asp-signed-inbound-label.eli16.md
+++ b/docs/specs/asp-signed-inbound-label.eli16.md
@@ -1,0 +1,42 @@
+# Agent-Signed Inbound Messages Are Labelled — Plain-English Overview
+
+> The one-line version: when I sign a message and send it through your Telegram account, the session that receives it is now told "this is the agent, signed, via Justin's account", and that message can never make you the operator of that topic.
+
+## The problem in one breath
+
+I can already sign a message and send it through your logged-in Telegram, and the infrastructure can already prove I wrote it. But that proof only landed in an audit ledger. The session on the receiving end was still told the message came from you, and the automatic "who is the operator of this topic" binding still treated my message as evidence that you were present and in charge. That is exactly the identity mix-up the constitution forbids: a session acting on a name it did not verify.
+
+## What already exists
+
+- **Agent-signature provenance** — I can sign a message with my own key; every inbound message is checked, and a verdict (human, agent-verified, rejected) is written to a ledger. The ledger stores a hash, never the body.
+- **The injection tag** — every inbound message reaches a session prefixed with a tag naming the topic and the sender. It was built from the Telegram sender only.
+- **Topic-operator auto-bind** — the first authorised sender in a topic is recorded as that topic's verified operator, from the authenticated sender id.
+- **Thread history on session start** — a fresh session reads the recent history of its topic, one line per message, labelled by sender.
+
+## What this adds
+
+The routing path now reads the classifier's own verdict for each message, at the one place both ways a message can arrive converge. When the verdict is "agent-verified", three things follow. The tag the session sees names the signing agent and the account that carried the message. The thread-history line says the same. And the operator auto-bind is refused, because the account holder did not author the message.
+
+Secondary changes: the classifier remembers its verdicts by message id in a bounded in-memory map, because a signed message can only be verified once (the nonce is single-use, so a second check would call the genuine message a replay). The read-time history join now exposes the signing agent's id, but only on a verified verdict. The CLAUDE.md awareness section gains one bullet, and existing agents receive it through the migration.
+
+## The new pieces
+
+- **A small shared helper module** — resolves the platform message id from either ingress, asks the classifier for its verdict, decides whether auto-bind is permitted, and renders the history label. It reads in-process state only, never message content, so a body that merely claims to be signed cannot mint the label. It never throws; on any doubt the message is delivered unlabelled, exactly as today.
+
+## The safeguards
+
+**Prevents a forged label.** The label comes from the classifier's cryptographic verdict, keyed by message id. Nothing parses the message text for a signature at routing time.
+
+**Prevents identity bleed.** An agent-signed message can no longer seat the carrying account's owner as a topic's verified operator. Everything a human actually types keeps today's behaviour, byte for byte.
+
+**Prevents a delivery regression.** Every helper fails toward delivering the message unlabelled. A missing classifier, a missing id, or a thrown error means "unsigned", never "dropped".
+
+**Does not grant anything.** The label says who wrote the message. It carries no permission, role, or trust; treating "signed by the agent" as authorisation remains a defect.
+
+## What ships when
+
+One change, one pull request. It is live the moment the server restarts on the new version. No configuration, no state migration; the awareness bullet reaches existing agents through the normal CLAUDE.md migration.
+
+## What you need to decide
+
+Nothing. This is the structural half of the sister-topic review loop you approved: it makes the receiving Codex session see my review requests as a peer's requests, not as your instructions.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -37,6 +37,8 @@ function localSlackRelayReadiness(stateDir: string): { ready: true } | { ready: 
   return slackReplyRelayReadiness(stateDir, template);
 }
 import { buildAspInboundClassifier } from '../core/AspInboundClassifier.js';
+import { setAspClassifierRef, getAspClassifierRef } from '../core/aspClassifierRef.js';
+import { resolveInboundTelegramMessageId, resolveSignedByAgent, operatorAutoBindPermitted } from '../messaging/shared/signedInbound.js';
 import { StandDownRegistry } from '../core/StandDownRegistry.js';
 import { BASELINE_PROCESS_PATTERNS } from '../core/baselineProcessPatterns.js';
 import { StandDownAudit } from '../core/StandDownAudit.js';
@@ -2388,6 +2390,24 @@ export function wireTelegramRouting(
       ? userManager.resolveFromTelegramUserId(telegramUserId)
       : null;
 
+    // Agent-signed inbound (ASP). A message an agent SIGNED and delivered through
+    // a human's account is labelled as agent traffic for the receiving session and
+    // NEVER binds that human as the topic's operator. The verdict is the
+    // classifier's own — computed once at log time (single-use nonce), read here
+    // by platform message id from in-process state, never from content.
+    const inboundMessageId = resolveInboundTelegramMessageId(msg);
+    const signedByAgent = resolveSignedByAgent(getAspClassifierRef(), topicId, inboundMessageId);
+    // This point OWNS the field: it is always (re)written from the classifier's
+    // verdict, so a value that arrived on the Message from anywhere else — a
+    // wire body, a replay, a queue row — can never survive to the injection.
+    {
+      const { signedByAgent: _ignored, ...rest } = msg.metadata ?? {};
+      msg.metadata = signedByAgent ? { ...rest, signedByAgent } : rest;
+    }
+    if (signedByAgent) {
+      console.log(`[telegram] topic ${topicId} message ${inboundMessageId ?? '?'} is agent-signed by "${signedByAgent}" — labelled for the session; operator auto-bind skipped`);
+    }
+
     // Topic-operator auto-bind (Know Your Principal #898, increment 2e — the
     // POLLING-path writer; the lifeline-forward path already binds in routes.ts
     // #909). This onTopicMessage seam is the convergence BOTH ingress paths
@@ -2400,7 +2420,7 @@ export function wireTelegramRouting(
     // no store / unauthorized / error → no-op and routing continues.
     try {
       const opStore = getTopicOperatorStore?.() ?? null;
-      if (opStore && telegramUserId && telegram.isAuthorizedSender(telegramUserId)) {
+      if (opStore && operatorAutoBindPermitted(signedByAgent) && telegramUserId && telegram.isAuthorizedSender(telegramUserId)) {
         // A lifeline-forwarded Message.id may contain a Date.now fallback used
         // only for internal routing. Establishment evidence must use the raw
         // Telegram id carried separately; absent stays absent and fails closed.
@@ -2835,7 +2855,10 @@ export function wireTelegramRouting(
           // `reinjectStuck` (the no-loss recovery re-injection) and read here so
           // the tag can say so out loud. Read from the first-party Message
           // metadata, never from `content` — content cannot forge it.
-          { reDelivered: msg.metadata?.replay === true },
+          {
+            reDelivered: msg.metadata?.replay === true,
+            signedByAgent: typeof msg.metadata?.signedByAgent === 'string' ? msg.metadata.signedByAgent : undefined,
+          },
         );
         if (injected === false) {
           console.error(`[telegram→session] Injection FAILED for topic ${topicId} into ${targetSession}; not sending delivery confirmation`);
@@ -15278,6 +15301,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             // entirely when this agent has no canonical identity.
             try {
               const aspClassifier = buildAspInboundClassifier(config.stateDir, config.projectName);
+              setAspClassifierRef(aspClassifier);
               if (aspClassifier) {
                 const beforeAspCb = telegram.onMessageLogged;
                 telegram.onMessageLogged = (entry) => {

--- a/src/core/AspAuthorshipJoin.ts
+++ b/src/core/AspAuthorshipJoin.ts
@@ -31,9 +31,19 @@ export class AspAuthorshipJoin {
     private readonly classificationStartMs = ASP_CLASSIFICATION_START,
   ) {}
 
-  join<T extends AuthorshipMessage>(messages: readonly T[]): Array<T & { authorship: MessageAuthorship }> {
+  join<T extends AuthorshipMessage>(
+    messages: readonly T[],
+  ): Array<T & { authorship: MessageAuthorship; authorshipAgentId: string | null }> {
     const verdicts = this.readVerdicts();
-    return messages.map((message) => ({ ...message, authorship: this.resolve(message, verdicts) }));
+    return messages.map((message) => {
+      const authorship = this.resolve(message, verdicts);
+      // The agent id rides ONLY a verified verdict — a rejected or unresolved row
+      // must not name an agent it could not prove.
+      const authorshipAgentId = authorship === 'agent-verified'
+        ? verdicts.get(key(message.topicId, message.messageId))?.agentId ?? null
+        : null;
+      return { ...message, authorship, authorshipAgentId };
+    });
   }
 
   private resolve(message: AuthorshipMessage, verdicts: Map<string, AspClassificationRecord>): MessageAuthorship {

--- a/src/core/AspInboundClassifier.ts
+++ b/src/core/AspInboundClassifier.ts
@@ -86,6 +86,26 @@ export interface AspClassifierCounters {
 
 const TAG_HINT = '⟦asp1 ';
 
+/**
+ * The part of a verdict the ROUTING path needs, kept in memory by message id.
+ *
+ * The nonce is single-use, so a message can be verified exactly ONCE — at log
+ * time, before routing. Anything downstream that needs to know "was this
+ * agent-signed?" must read that one verdict rather than verify again (a second
+ * verify would classify the genuine message as a replay). Bounded so a busy
+ * bot cannot grow it without limit; the durable ledger remains the authority.
+ */
+export interface AspRecentVerdict {
+  classification: AspVerdict['classification'];
+  agentId: string | null;
+}
+
+const RECENT_VERDICT_CAP = 1000;
+
+function recentKey(topicId: number | null | undefined, messageId: number): string {
+  return `${topicId ?? 'none'}:${messageId}`;
+}
+
 export class AspInboundClassifier {
   private readonly opts: AspInboundClassifierOptions;
   private readonly now: () => number;
@@ -93,6 +113,7 @@ export class AspInboundClassifier {
     seen: 0, human: 0, agentVerified: 0, rejected: 0, errors: 0, recorded: 0,
     skippedOutbound: 0,
   };
+  private readonly recent = new Map<string, AspRecentVerdict>();
 
   constructor(opts: AspInboundClassifierOptions) {
     this.opts = opts;
@@ -138,6 +159,8 @@ export class AspInboundClassifier {
       else if (verdict.classification === 'agent-verified') this.counters.agentVerified += 1;
       else this.counters.rejected += 1;
 
+      this.remember(entry, verdict);
+
       const tagged = entry.text.includes(TAG_HINT);
       const onlyTagged = this.opts.onlyRecordTagged ?? true;
       if (!onlyTagged || tagged) this.record(entry, verdict);
@@ -158,6 +181,32 @@ export class AspInboundClassifier {
     return (entry: AspInboundEntry) => {
       this.classify(entry);
     };
+  }
+
+  /**
+   * The verdict recorded for one inbound message, by (topic, message id) —
+   * for the routing path, which runs AFTER log-time classification and must
+   * not verify again. `null` when the message was never classified here
+   * (no id, evicted, or arrived before this process started).
+   */
+  verdictFor(topicId: number | null | undefined, messageId: number | null | undefined): AspRecentVerdict | null {
+    if (typeof messageId !== 'number' || !Number.isFinite(messageId)) return null;
+    return this.recent.get(recentKey(topicId, messageId)) ?? null;
+  }
+
+  private remember(entry: AspInboundEntry, verdict: AspVerdict): void {
+    if (typeof entry.messageId !== 'number' || !Number.isFinite(entry.messageId)) return;
+    const key = recentKey(entry.topicId, entry.messageId);
+    this.recent.delete(key);
+    this.recent.set(key, {
+      classification: verdict.classification,
+      agentId: 'agentId' in verdict ? verdict.agentId ?? null : null,
+    });
+    while (this.recent.size > RECENT_VERDICT_CAP) {
+      const oldest = this.recent.keys().next().value;
+      if (oldest === undefined) break;
+      this.recent.delete(oldest);
+    }
   }
 
   private record(entry: AspInboundEntry, verdict: AspVerdict): void {

--- a/src/core/ForwardedTopicContext.ts
+++ b/src/core/ForwardedTopicContext.ts
@@ -15,6 +15,7 @@
  */
 
 import { formatLocalTimestamp } from '../utils/localTime.js';
+import { historySenderLabel } from '../messaging/shared/signedInbound.js';
 
 /** One historical message, matching TelegramAdapter.getTopicHistory()'s shape. */
 export interface ForwardedHistoryMessage {
@@ -22,6 +23,9 @@ export interface ForwardedHistoryMessage {
   text?: string;
   senderName?: string;
   timestamp?: string | number;
+  /** Read-time ASP authorship from the previous machine's history read. */
+  authorship?: string;
+  authorshipAgentId?: string | null;
 }
 
 /**
@@ -41,7 +45,7 @@ export function formatForwardedTopicContext(
   if (topicName) lines.push(`Topic: ${topicName}`);
   lines.push('');
   for (const m of messages) {
-    const sender = m.fromUser ? (m.senderName || 'User') : 'Agent';
+    const sender = historySenderLabel(m);
     // Local time + tz label — unlabeled UTC here caused the 2026-06-05
     // "9:23pm" incoherency (see src/utils/localTime.ts).
     const ts = formatLocalTimestamp(m.timestamp);

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -237,6 +237,15 @@ Claude Code's ultracode mode is xhigh effort plus dynamic workflow orchestration
  * standing ruling is that authentication never settles what a message may
  * DECIDE, and the template is where every agent reads it.
  */
+/**
+ * The signed-inbound labelling bullet (2026-09-02). Its own constant + marker so
+ * an agent that ALREADY carries the ASP section (installed before this bullet
+ * existed) receives it through `migrateClaudeMd` — the section-level content
+ * sniff would otherwise skip them forever (Migration Parity).
+ */
+export const ASP_SIGNED_INBOUND_LABEL_MARKER = 'labelled, not laundered';
+export const ASP_SIGNED_INBOUND_LABEL_BULLET = `- **A signed message delivered through a human's account is ${ASP_SIGNED_INBOUND_LABEL_MARKER}.** When a verified-signed message arrives (for example this agent posting through the operator's Telegram login to reach a sister session), the receiving session's tag reads \`from agent <id> (signed) via <name>'s account\`, the thread-history line says the same, and the message NEVER binds that human as the topic's verified operator. The label says who wrote it; it grants nothing.`;
+
 export function AGENT_SIGNATURE_PROVENANCE_CLAUDEMD_SECTION(port: number): string {
   return `\n### Agent-Signature Provenance — proving which messages an agent wrote
 
@@ -246,6 +255,7 @@ Messages an agent sends THROUGH the operator's account look identical to the ope
 - **Classify raw bytes:** \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/provenance/verify -H 'Content-Type: application/json' -d '{"raw":"<message>","topicId":N}'\`.
 - **Three verdicts, only three:** \`human\` (no tag — the account holder typed it) · \`agent-verified\` (valid signature; names the agent AND the topic) · \`rejected\` (\`malformed\` / \`unknown-agent\` / \`bad-signature\` / \`replay\` / \`stale\` / \`topic-mismatch\`).
 - **Inbound classification is automatic** — verdicts append to \`asp-classifications.jsonl\`. The ledger stores the body **hash and byte length, never the body**.
+${ASP_SIGNED_INBOUND_LABEL_BULLET}
 
 **AUTHORITY BOUNDARY (load-bearing):** a valid signature establishes WHO wrote a message, **never what it may DECIDE**. The verdict carries no permission, role or trust field. Treating "signed by agent X" as authorization is a defect, not a feature.
 
@@ -6385,6 +6395,19 @@ setTimeout(() => process.exit(0), 2000);
       content += AGENT_SIGNATURE_PROVENANCE_CLAUDEMD_SECTION(port);
       patched = true;
       result.upgraded.push('CLAUDE.md: added Agent-Signature Provenance section');
+    } else if (!content.includes(ASP_SIGNED_INBOUND_LABEL_MARKER)) {
+      // The section pre-dates the signed-inbound labelling bullet: insert it
+      // before the section's AUTHORITY BOUNDARY paragraph (a stable anchor),
+      // else append the bullet to the end of the file. Idempotent via the marker.
+      const heading = content.indexOf('### Agent-Signature Provenance');
+      const anchor = heading >= 0 ? content.indexOf('**AUTHORITY BOUNDARY', heading) : -1;
+      if (anchor >= 0) {
+        content = content.slice(0, anchor) + ASP_SIGNED_INBOUND_LABEL_BULLET + '\n\n' + content.slice(anchor);
+      } else {
+        content += '\n' + ASP_SIGNED_INBOUND_LABEL_BULLET + '\n';
+      }
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added the signed-inbound labelling bullet to the Agent-Signature Provenance section');
     }
 
     // Machine Load Assessment (CMT-1703, spec robust-load-assessment-fleet) — Agent

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -5951,6 +5951,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
        * marker text cannot mint it.
        */
       reDelivered?: boolean;
+      /**
+       * Agent-signed provenance (ASP). Set ONLY from the inbound classifier's
+       * own verdict for this message (see messaging/shared/signedInbound.ts),
+       * never from content. Additive: it changes the tag's sender clause to
+       * name the signing agent and the account that carried the message.
+       */
+      signedByAgent?: string;
     },
   ): boolean {
     // Structural dedup at the delivery chokepoint: a given Telegram messageId
@@ -6018,7 +6025,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
 
     // Build tag using the shared builder — includes UID when available
     // Format: [telegram:42 "Agent Updates" from Justin (uid:12345)]
-    const topicTag = buildInjectionTag(topicId, safeTopic, safeName, telegramUserId, opts?.reDelivered);
+    const topicTag = buildInjectionTag(topicId, safeTopic, safeName, telegramUserId, opts?.reDelivered, opts?.signedByAgent);
     const taggedText = `${topicTag} ${transformed}`;
 
     if (taggedText.length <= FILE_THRESHOLD) {
@@ -6036,7 +6043,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // to ride here too — the observed 2026-08-20 re-deliveries were all long
     // messages, i.e. exactly this branch. buildInjectionTag(topicId) with a
     // falsy flag returns `[telegram:N]`, byte-identical to the previous literal.
-    const refTag = buildInjectionTag(topicId, undefined, undefined, undefined, opts?.reDelivered);
+    const refTag = buildInjectionTag(topicId, undefined, undefined, undefined, opts?.reDelivered, opts?.signedByAgent);
     const ref = `${refTag} [Long message saved to ${filepath} — read it to see the full message]`;
     return this.injectMessage(tmuxSession, ref) !== false;
   }

--- a/src/core/aspClassifierRef.ts
+++ b/src/core/aspClassifierRef.ts
@@ -1,0 +1,21 @@
+/**
+ * Process-wide handle to the inbound ASP classifier.
+ *
+ * The classifier is built in the messaging wiring (commands/server.ts) AFTER
+ * the HTTP route context exists (server/AgentServer.ts), and both the polling
+ * ingress and the lifeline-forward ingress must read the SAME classifier's
+ * verdicts (single-use nonce: a message is verified once, at log time, and
+ * every later reader asks this one instance). A module-level reference is the
+ * smallest seam that lets both read it without a construction-order dance.
+ */
+import type { AspInboundClassifier } from './AspInboundClassifier.js';
+
+let ref: AspInboundClassifier | null = null;
+
+export function setAspClassifierRef(classifier: AspInboundClassifier | null): void {
+  ref = classifier;
+}
+
+export function getAspClassifierRef(): AspInboundClassifier | null {
+  return ref;
+}

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -267,6 +267,8 @@ interface LogEntry {
   provenance: MessageProvenance;
   /** Joined at read time from the ASP classification authority. */
   authorship?: MessageAuthorship;
+  /** The signing agent's id — present only when `authorship` is `agent-verified`. */
+  authorshipAgentId?: string | null;
 }
 
 /**

--- a/src/messaging/shared/signedInbound.ts
+++ b/src/messaging/shared/signedInbound.ts
@@ -1,0 +1,103 @@
+/**
+ * Agent-signed inbound messages — the routing-side helpers.
+ *
+ * An agent can SIGN a message and deliver it through a human's account (the
+ * "tenet-5 channel": this agent driving the operator's logged-in Telegram).
+ * Cryptographically the infrastructure already knows who wrote it — the ASP
+ * classifier records the verdict at log time. But that verdict lived only in
+ * a ledger: the RECEIVING session was still told the message came `from
+ * <the human>`, and the topic-operator auto-bind still seated that human as
+ * the topic's verified operator on the strength of a message they did not
+ * write. That is the identity-bleed rule 28 (Know Your Principal) forbids.
+ *
+ * These helpers close it structurally, in the one place both ingress paths
+ * converge. Every decision reads IN-PROCESS state (the classifier's own
+ * verdict, keyed by platform message id) — never message content, so a body
+ * that merely claims to be signed cannot mint the label.
+ *
+ * AUTHORITY BOUNDARY: the label says WHO wrote the message. It grants nothing
+ * and it withholds one thing only — operator auto-bind from a message the
+ * account holder did not author.
+ */
+import type { AspInboundClassifier } from '../../core/AspInboundClassifier.js';
+import type { MessageAuthorship } from '../../core/AspAuthorshipJoin.js';
+
+/** Agent ids are constrained by the ASP tag grammar; keep the label to that charset. */
+const AGENT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function sanitizeSignedAgentId(agentId: unknown): string | null {
+  return typeof agentId === 'string' && AGENT_ID_RE.test(agentId) ? agentId : null;
+}
+
+/**
+ * The platform (Telegram) message id of an inbound Message, from whichever
+ * ingress built it. The polling path stamps `id: "tg-<messageId>"`; the
+ * lifeline-forward path carries the raw id separately in
+ * `metadata.telegramMessageId` because its `id` may hold a Date.now fallback
+ * that must never be read as a platform id.
+ */
+export function resolveInboundTelegramMessageId(msg: {
+  id?: string;
+  metadata?: Record<string, unknown>;
+}): number | null {
+  const meta = msg.metadata ?? {};
+  if (meta.viaLifeline === true) {
+    const raw = meta.telegramMessageId;
+    const n = typeof raw === 'number' ? raw : Number(typeof raw === 'string' ? raw : NaN);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+  const m = typeof msg.id === 'string' ? /^tg-(\d+)$/.exec(msg.id) : null;
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * The signing agent's id when the classifier's OWN verdict for this message is
+ * `agent-verified`; null otherwise (human, rejected, unclassified, no
+ * classifier). Never throws — a helper on the delivery path must not.
+ */
+export function resolveSignedByAgent(
+  classifier: Pick<AspInboundClassifier, 'verdictFor'> | null | undefined,
+  topicId: number | null | undefined,
+  messageId: number | null | undefined,
+): string | null {
+  try {
+    const verdict = classifier?.verdictFor(topicId, messageId) ?? null;
+    if (!verdict || verdict.classification !== 'agent-verified') return null;
+    return sanitizeSignedAgentId(verdict.agentId);
+  } catch {
+    /* @silent-fallback-ok: a labelling helper must never break delivery; an
+       unlabelled message is today's behaviour, a dropped one is a regression. */
+    return null;
+  }
+}
+
+/**
+ * Operator auto-bind is refused for an agent-signed message: the account holder
+ * did not author it, so it is not evidence that they are present, let alone
+ * that they are the operator. Everything else keeps today's behaviour.
+ */
+export function operatorAutoBindPermitted(signedByAgent: string | null | undefined): boolean {
+  return !signedByAgent;
+}
+
+/**
+ * The sender label a thread-history line shows. Reads the read-time authorship
+ * join (the durable ledger's verdict), so a fresh session's bootstrap history
+ * tells the same truth the live injection tag tells.
+ */
+export function historySenderLabel(m: {
+  fromUser: boolean;
+  senderName?: string;
+  authorship?: MessageAuthorship | string;
+  authorshipAgentId?: string | null;
+}): string {
+  if (!m.fromUser) return 'Agent';
+  const human = m.senderName || 'User';
+  if (m.authorship === 'agent-verified') {
+    const agent = sanitizeSignedAgentId(m.authorshipAgentId) ?? 'unknown';
+    return `agent ${agent} (signed, via ${human}'s account)`;
+  }
+  return human;
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -9,6 +9,7 @@
  */
 
 import express, { type Express, type Request, type Response } from 'express';
+import { getAspClassifierRef } from '../core/aspClassifierRef.js';
 import type { Server } from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -4046,6 +4047,7 @@ export class AgentServer {
       processFootprintMonitor: this.processFootprintMonitor,
       approvalLedger: this.approvalLedger,
       topicOperatorStore: this.topicOperatorStore,
+      getAspClassifier: getAspClassifierRef,
       coordination: this.coordination,
       deliveredMandateStore: this.deliveredMandateStore,
       // WS5.2 R4a — operator side: package an issued mandate with the asymmetric issuance signature

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -324,6 +324,7 @@ import { HomeostasisMonitor } from '../monitoring/HomeostasisMonitor.js';
 import { readReaperAuditPage } from '../monitoring/SessionReaper.js';
 import type { TelegramAdapter } from '../messaging/TelegramAdapter.js';
 import { coerceMessageProvenance, type MessageProvenance } from '../messaging/shared/MessageProvenance.js';
+import { historySenderLabel, resolveSignedByAgent } from '../messaging/shared/signedInbound.js';
 import type { RelationshipManager } from '../core/RelationshipManager.js';
 import type { FeedbackManager } from '../core/FeedbackManager.js';
 import type { DispatchManager } from '../core/DispatchManager.js';
@@ -1253,6 +1254,8 @@ export interface RouteContext {
    *  The principal whose decisions the agent enacts, established only from the
    *  authenticated sender uid. Null when stateDir is unavailable. */
   topicOperatorStore: import('../users/TopicOperatorStore.js').TopicOperatorStore | null;
+  /** The inbound ASP classifier, once built — a getter because it is constructed after this context. */
+  getAspClassifier?: () => import('../core/AspInboundClassifier.js').AspInboundClassifier | null;
   /** Coordination Mandate enforcement (docs/specs/coordination-mandate.md §4).
    *  Deny-by-default gate + signed store + hash-chained audit. Null when stateDir
    *  is unavailable. Issuance/revocation are PIN-gated, never Bearer-only. */
@@ -22711,7 +22714,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
               historyLines.push(`Topic: ${topicName}`);
               historyLines.push(``);
               for (const m of history) {
-                const sender = m.fromUser ? (m.senderName || 'User') : 'Agent';
+                const sender = historySenderLabel(m);
                 const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
                 const histText = (m.text || '').slice(0, 2000);
                 historyLines.push(`[${ts}] ${sender}: ${histText}`);
@@ -23319,7 +23322,19 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     // "Caroline" bug). Placed AFTER the a2a-hook short-circuit so agent-to-agent bot
     // messages never bind. Fail-soft: no store / unauthorized / error -> no-op and
     // routing continues; setOperator is idempotent on the same uid.
-    if (ctx.topicOperatorStore && fromUserId !== undefined && fromUserId !== null
+    // Agent-signed inbound (ASP): a message an agent SIGNED and delivered through
+    // this human's account is not evidence the human is present, so it never
+    // binds them. The verdict is the classifier's own, cached when the message
+    // was logged above (single-use nonce — never re-verified), read by message id.
+    const lifelineSignedByAgent = resolveSignedByAgent(
+      ctx.getAspClassifier?.() ?? null,
+      typeof topicId === 'number' ? topicId : null,
+      typeof messageId === 'number' ? messageId : Number(messageId) || null,
+    );
+    if (lifelineSignedByAgent) {
+      console.log(`[telegram-forward] topic ${topicId} message ${messageId ?? '?'} is agent-signed by "${lifelineSignedByAgent}" — operator auto-bind skipped`);
+    }
+    if (ctx.topicOperatorStore && !lifelineSignedByAgent && fromUserId !== undefined && fromUserId !== null
         && typeof topicId === 'number') {
       try {
         if (ctx.telegram?.isAuthorizedSender?.(fromUserId)) {
@@ -23486,9 +23501,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
               historyLines.push(`Topic: ${topicName}`);
               historyLines.push(``);
               for (const m of history) {
-                const sender = m.fromUser
-                  ? (m.senderName || 'User')
-                  : 'Agent';
+                const sender = historySenderLabel(m);
                 const ts = formatLocalTimestamp(m.timestamp); // local + tz label (see src/utils/localTime.ts)
                 const histText = (m.text || '').slice(0, 2000);
                 historyLines.push(`[${ts}] ${sender}: ${histText}`);

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -280,19 +280,26 @@ export function buildInjectionTag(
   senderName?: string,
   telegramUserId?: number,
   reDelivered?: boolean,
+  signedByAgent?: string,
 ): string {
   const uidSuffix = telegramUserId ? ` (uid:${telegramUserId})` : '';
   const reDeliverySuffix = reDelivered === true ? ` — ${RE_DELIVERY_MARKER}` : '';
+  const topicPart = topicName ? ` "${topicName}"` : '';
 
-  if (topicName && senderName) {
-    return `[telegram:${topicId} "${topicName}" from ${senderName}${uidSuffix}${reDeliverySuffix}]`;
-  } else if (topicName) {
-    return `[telegram:${topicId} "${topicName}"${reDeliverySuffix}]`;
+  // Agent-signed provenance (ASP). `signedByAgent` is an IN-PROCESS parameter
+  // carried from the classifier's own verdict — never parsed from content, so a
+  // body that merely claims a signature cannot mint this label. The human whose
+  // account carried the message is still named: the session must know the
+  // channel, and must NOT read the message as that human speaking.
+  const safeAgent = signedByAgent && /^[A-Za-z0-9_-]{1,64}$/.test(signedByAgent) ? signedByAgent : undefined;
+  let fromPart = '';
+  if (safeAgent) {
+    fromPart = ` from agent ${safeAgent} (signed)` + (senderName ? ` via ${senderName}'s account${uidSuffix}` : '');
   } else if (senderName) {
-    return `[telegram:${topicId} from ${senderName}${uidSuffix}${reDeliverySuffix}]`;
-  } else {
-    return `[telegram:${topicId}${reDeliverySuffix}]`;
+    fromPart = ` from ${senderName}${uidSuffix}`;
   }
+
+  return `[telegram:${topicId}${topicPart}${fromPart}${reDeliverySuffix}]`;
 }
 
 /**

--- a/tests/unit/PostUpdateMigrator-aspSignedInboundBullet.test.ts
+++ b/tests/unit/PostUpdateMigrator-aspSignedInboundBullet.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The signed-inbound labelling bullet reaches EXISTING agents (Migration
+ * Parity): an agent whose CLAUDE.md already carries the ASP section — installed
+ * before this bullet existed — would be skipped forever by the section-level
+ * content sniff. A bullet-level marker closes that, idempotently.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  PostUpdateMigrator,
+  AGENT_SIGNATURE_PROVENANCE_CLAUDEMD_SECTION,
+  ASP_SIGNED_INBOUND_LABEL_MARKER,
+  ASP_SIGNED_INBOUND_LABEL_BULLET,
+} from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({ projectDir, stateDir: path.join(projectDir, '.instar'), port: 4042, hasTelegram: false, projectName: 'test' });
+}
+function run(m: PostUpdateMigrator): MigrationResult {
+  const r: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(r);
+  return r;
+}
+
+describe('PostUpdateMigrator — signed-inbound labelling bullet', () => {
+  let projectDir: string; let claudeMd: string;
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-asp-bullet-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMd = path.join(projectDir, 'CLAUDE.md');
+  });
+  afterEach(() => SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-aspSignedInboundBullet.test.ts:cleanup' }));
+
+  it('the generated section carries the bullet (new agents)', () => {
+    expect(AGENT_SIGNATURE_PROVENANCE_CLAUDEMD_SECTION(4042)).toContain(ASP_SIGNED_INBOUND_LABEL_MARKER);
+    expect(ASP_SIGNED_INBOUND_LABEL_BULLET).toContain("from agent <id> (signed) via <name>'s account");
+    expect(ASP_SIGNED_INBOUND_LABEL_BULLET).toContain('NEVER binds that human');
+  });
+
+  it('inserts the bullet into a pre-existing section that lacks it, before the AUTHORITY BOUNDARY', () => {
+    const old = AGENT_SIGNATURE_PROVENANCE_CLAUDEMD_SECTION(4042).replace(ASP_SIGNED_INBOUND_LABEL_BULLET + '\n', '');
+    expect(old).not.toContain(ASP_SIGNED_INBOUND_LABEL_MARKER);
+    fs.writeFileSync(claudeMd, '# CLAUDE.md\n' + old);
+    const r = run(newMigrator(projectDir));
+    const after = fs.readFileSync(claudeMd, 'utf8');
+    expect(r.upgraded.some((u) => u.includes('signed-inbound labelling bullet'))).toBe(true);
+    expect(after.split(ASP_SIGNED_INBOUND_LABEL_MARKER).length - 1).toBe(1);
+    expect(after.indexOf(ASP_SIGNED_INBOUND_LABEL_MARKER)).toBeLessThan(after.indexOf('**AUTHORITY BOUNDARY'));
+    expect(after.split('### Agent-Signature Provenance').length - 1).toBe(1);
+  });
+
+  it('is idempotent', () => {
+    fs.writeFileSync(claudeMd, '# CLAUDE.md\n' + AGENT_SIGNATURE_PROVENANCE_CLAUDEMD_SECTION(4042));
+    run(newMigrator(projectDir));
+    const once = fs.readFileSync(claudeMd, 'utf8');
+    run(newMigrator(projectDir));
+    expect(fs.readFileSync(claudeMd, 'utf8')).toBe(once);
+    expect(once.split(ASP_SIGNED_INBOUND_LABEL_MARKER).length - 1).toBe(1);
+  });
+});

--- a/tests/unit/asp-authorship-join-agentid.test.ts
+++ b/tests/unit/asp-authorship-join-agentid.test.ts
@@ -1,0 +1,42 @@
+/**
+ * AspAuthorshipJoin exposes the signing agent id ONLY on a verified verdict, so
+ * a thread-history line can name the agent without ever naming one it could not
+ * prove.
+ */
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { AspAuthorshipJoin } from '../../src/core/AspAuthorshipJoin.js';
+
+const TOPIC = 52075;
+const AFTER = '2026-09-02T07:00:00.000Z';
+const hash = (t: string) => createHash('sha256').update(t).digest('hex');
+
+describe('AspAuthorshipJoin — authorshipAgentId', () => {
+  it('rides a verified verdict and nothing else', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'asp-join-agent-'));
+    const ledger = path.join(dir, 'asp-classifications.jsonl');
+    fs.writeFileSync(ledger, [
+      { messageId: 1, topicId: TOPIC, classification: 'agent-verified', agentId: 'echo', bodyHash: hash('signed prose') },
+      { messageId: 2, topicId: TOPIC, classification: 'rejected', agentId: 'echo', bodyHash: hash('replayed prose') },
+      { messageId: 3, topicId: TOPIC, classification: 'human', agentId: null, bodyHash: hash('Justin prose') },
+    ].map((r) => JSON.stringify(r)).join('\n'));
+
+    const rows = new AspAuthorshipJoin(ledger).join([
+      { messageId: 1, topicId: TOPIC, text: 'signed prose', fromUser: true, timestamp: AFTER },
+      { messageId: 2, topicId: TOPIC, text: 'replayed prose', fromUser: true, timestamp: AFTER },
+      { messageId: 3, topicId: TOPIC, text: 'Justin prose', fromUser: true, timestamp: AFTER },
+      { messageId: 4, topicId: TOPIC, text: 'unresolved', fromUser: true, timestamp: AFTER },
+      { messageId: 5, topicId: TOPIC, text: 'ours', fromUser: false, timestamp: AFTER },
+    ]);
+    expect(rows.map((r) => [r.authorship, r.authorshipAgentId])).toEqual([
+      ['agent-verified', 'echo'],
+      ['rejected', null],
+      ['human', null],
+      ['UNRESOLVED', null],
+      ['agent-outbound', null],
+    ]);
+  });
+});

--- a/tests/unit/asp-inbound-classifier-verdictFor.test.ts
+++ b/tests/unit/asp-inbound-classifier-verdictFor.test.ts
@@ -1,0 +1,83 @@
+/**
+ * AspInboundClassifier.verdictFor — the routing path's read of the ONE
+ * log-time verdict. The nonce is single-use, so verifying again downstream
+ * would classify the genuine message as a replay; the classifier remembers
+ * its verdict by (topic, message id) instead.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { AspInboundClassifier } from '../../src/core/AspInboundClassifier.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { signMessage, MemorySeenNonceStore } from '../../src/core/agentSignatureProvenance.js';
+
+const AGENT = 'echo';
+const TOPIC = 52075;
+let dir: string;
+let keys: { publicKey: Buffer; privateKey: Buffer };
+
+function keypair() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+  return {
+    publicKey: Buffer.from(publicKey.export({ type: 'spki', format: 'der' })).subarray(-32),
+    privateKey: Buffer.from(privateKey.export({ type: 'pkcs8', format: 'der' })).subarray(-32),
+  };
+}
+function make() {
+  return new AspInboundClassifier({
+    ledgerPath: path.join(dir, 'asp-classifications.jsonl'),
+    resolvePublicKey: (id) => (id === AGENT ? keys.publicKey : null),
+    seenNonces: new MemorySeenNonceStore(),
+  });
+}
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'asp-verdictfor-')); keys = keypair(); });
+afterEach(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/asp-inbound-classifier-verdictFor.test.ts' }));
+
+describe('AspInboundClassifier.verdictFor', () => {
+  it('remembers an agent-verified verdict by (topic, message id) with the agent id', () => {
+    const c = make();
+    const { text } = signMessage({ agentId: AGENT, topicId: TOPIC, body: 'review round 1', privateKey: keys.privateKey });
+    c.classify({ topicId: TOPIC, text, messageId: 501, fromUser: true });
+    expect(c.verdictFor(TOPIC, 501)).toEqual({ classification: 'agent-verified', agentId: AGENT });
+  });
+
+  it('remembers a human verdict as human (no agent id)', () => {
+    const c = make();
+    c.classify({ topicId: TOPIC, text: 'plain operator prose', messageId: 502, fromUser: true });
+    expect(c.verdictFor(TOPIC, 502)).toEqual({ classification: 'human', agentId: null });
+  });
+
+  it('remembers a replay as rejected — the second copy of a signed message is not the agent', () => {
+    const c = make();
+    const { text } = signMessage({ agentId: AGENT, topicId: TOPIC, body: 'once', privateKey: keys.privateKey });
+    c.classify({ topicId: TOPIC, text, messageId: 503, fromUser: true });
+    c.classify({ topicId: TOPIC, text, messageId: 504, fromUser: true });
+    expect(c.verdictFor(TOPIC, 503)?.classification).toBe('agent-verified');
+    expect(c.verdictFor(TOPIC, 504)?.classification).toBe('rejected');
+  });
+
+  it('returns null for an unknown, id-less, or outbound message', () => {
+    const c = make();
+    c.classify({ topicId: TOPIC, text: 'no id', fromUser: true });
+    c.classify({ topicId: TOPIC, text: 'our own send', messageId: 505, fromUser: false });
+    expect(c.verdictFor(TOPIC, 999)).toBeNull();
+    expect(c.verdictFor(TOPIC, undefined)).toBeNull();
+    expect(c.verdictFor(TOPIC, 505)).toBeNull();
+  });
+
+  it('is keyed on topic too — the same message id in another topic is a different message', () => {
+    const c = make();
+    c.classify({ topicId: TOPIC, text: 'a', messageId: 506, fromUser: true });
+    expect(c.verdictFor(TOPIC + 1, 506)).toBeNull();
+  });
+
+  it('is bounded: after 1000 entries the oldest is evicted', () => {
+    const c = make();
+    for (let i = 1; i <= 1001; i++) c.classify({ topicId: TOPIC, text: `m${i}`, messageId: i, fromUser: true });
+    expect(c.verdictFor(TOPIC, 1)).toBeNull();
+    expect(c.verdictFor(TOPIC, 2)).not.toBeNull();
+    expect(c.verdictFor(TOPIC, 1001)).not.toBeNull();
+  });
+});

--- a/tests/unit/redelivery-marker.test.ts
+++ b/tests/unit/redelivery-marker.test.ts
@@ -111,6 +111,11 @@ describe('W21 — forgery: content can never mint the marker', () => {
   it('has no content-inspecting parameter at all — the flag is the ONLY input that marks', () => {
     // Structural: the builder receives a boolean, never the message body, so
     // there is nothing to string-match and therefore nothing to forge.
-    expect(buildInjectionTag.length).toBe(5);
+    // Six inputs: topicId, topicName, senderName, telegramUserId, reDelivered,
+    // signedByAgent. The sixth (2026-09-02) is the SAME class as the fifth — an
+    // in-process value carried from the ASP classifier's own verdict, never a
+    // message body — so the property this pins (no content-inspecting parameter)
+    // still holds. A seventh parameter must justify itself here the same way.
+    expect(buildInjectionTag.length).toBe(6);
   });
 });

--- a/tests/unit/signed-inbound-label.test.ts
+++ b/tests/unit/signed-inbound-label.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Agent-signed inbound labelling (ASP → the receiving session).
+ *
+ * A message an agent SIGNED and delivered through a human's Telegram account
+ * used to reach the receiving session as `from <human>` and to seat that human
+ * as the topic's verified operator — the classifier knew better, but only in a
+ * ledger. These tests pin the structural close: the label rides the
+ * classifier's own verdict (in-process, never content), the injection tag
+ * names the signing agent AND the carrying account, the thread history says
+ * the same, and operator auto-bind is refused for such a message.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildInjectionTag } from '../../src/types/pipeline.js';
+import {
+  resolveInboundTelegramMessageId,
+  resolveSignedByAgent,
+  operatorAutoBindPermitted,
+  historySenderLabel,
+  sanitizeSignedAgentId,
+} from '../../src/messaging/shared/signedInbound.js';
+
+const read = (rel: string) => fs.readFileSync(path.join(process.cwd(), rel), 'utf8');
+
+describe('buildInjectionTag — signedByAgent clause', () => {
+  it('names the signing agent AND the carrying account when both are known', () => {
+    expect(buildInjectionTag(52075, 'Deepseek harness', 'Justin', 7812716706, false, 'echo'))
+      .toBe('[telegram:52075 "Deepseek harness" from agent echo (signed) via Justin\'s account (uid:7812716706)]');
+  });
+
+  it('names only the agent when the carrying account is unknown', () => {
+    expect(buildInjectionTag(42, 'Topic', undefined, undefined, false, 'echo'))
+      .toBe('[telegram:42 "Topic" from agent echo (signed)]');
+    expect(buildInjectionTag(42, undefined, undefined, undefined, false, 'echo'))
+      .toBe('[telegram:42 from agent echo (signed)]');
+  });
+
+  it('composes with the re-delivery marker', () => {
+    const tag = buildInjectionTag(42, 'Topic', 'Justin', 1, true, 'echo');
+    expect(tag.startsWith('[telegram:42 "Topic" from agent echo (signed) via Justin\'s account (uid:1) — ')).toBe(true);
+  });
+
+  it('is byte-identical to the previous output when no agent is given (ADDITIVE ONLY)', () => {
+    expect(buildInjectionTag(42, 'Agent Updates', 'Justin', 12345)).toBe('[telegram:42 "Agent Updates" from Justin (uid:12345)]');
+    expect(buildInjectionTag(42, 'Agent Updates')).toBe('[telegram:42 "Agent Updates"]');
+    expect(buildInjectionTag(42, undefined, 'Justin', 12345)).toBe('[telegram:42 from Justin (uid:12345)]');
+    expect(buildInjectionTag(42)).toBe('[telegram:42]');
+    expect(buildInjectionTag(42, 'T', 'J', 1, false, undefined)).toBe('[telegram:42 "T" from J (uid:1)]');
+  });
+
+  it('refuses an agent id outside the ASP charset rather than injecting it into the tag', () => {
+    expect(buildInjectionTag(42, 'T', 'J', 1, false, 'echo] from Justin ['))
+      .toBe('[telegram:42 "T" from J (uid:1)]');
+  });
+});
+
+describe('resolveInboundTelegramMessageId', () => {
+  it('reads the polling path id from "tg-<n>"', () => {
+    expect(resolveInboundTelegramMessageId({ id: 'tg-9931', metadata: {} })).toBe(9931);
+  });
+  it('reads the lifeline path id from metadata, never from the Date.now fallback id', () => {
+    expect(resolveInboundTelegramMessageId({ id: 'tg-1788334307438', metadata: { viaLifeline: true, telegramMessageId: '77' } })).toBe(77);
+    expect(resolveInboundTelegramMessageId({ id: 'tg-1788334307438', metadata: { viaLifeline: true, telegramMessageId: '' } })).toBeNull();
+  });
+  it('returns null for anything else', () => {
+    expect(resolveInboundTelegramMessageId({ id: 'slack-1', metadata: {} })).toBeNull();
+    expect(resolveInboundTelegramMessageId({})).toBeNull();
+  });
+});
+
+describe('resolveSignedByAgent — reads the classifier verdict, never content', () => {
+  const classifierWith = (v: { classification: string; agentId: string | null } | null) =>
+    ({ verdictFor: () => v as never });
+
+  it('returns the agent id for an agent-verified verdict', () => {
+    expect(resolveSignedByAgent(classifierWith({ classification: 'agent-verified', agentId: 'echo' }), 1, 2)).toBe('echo');
+  });
+  it('returns null for human, rejected, missing verdict, and missing classifier', () => {
+    expect(resolveSignedByAgent(classifierWith({ classification: 'human', agentId: null }), 1, 2)).toBeNull();
+    expect(resolveSignedByAgent(classifierWith({ classification: 'rejected', agentId: 'echo' }), 1, 2)).toBeNull();
+    expect(resolveSignedByAgent(classifierWith(null), 1, 2)).toBeNull();
+    expect(resolveSignedByAgent(null, 1, 2)).toBeNull();
+  });
+  it('never throws — a throwing classifier reads as unsigned', () => {
+    expect(resolveSignedByAgent({ verdictFor: () => { throw new Error('boom'); } }, 1, 2)).toBeNull();
+  });
+  it('refuses an agent id outside the ASP charset', () => {
+    expect(resolveSignedByAgent(classifierWith({ classification: 'agent-verified', agentId: 'bad id' }), 1, 2)).toBeNull();
+    expect(sanitizeSignedAgentId('echo-2')).toBe('echo-2');
+    expect(sanitizeSignedAgentId(42)).toBeNull();
+  });
+});
+
+describe('operatorAutoBindPermitted', () => {
+  it('refuses auto-bind for an agent-signed message and permits it otherwise', () => {
+    expect(operatorAutoBindPermitted('echo')).toBe(false);
+    expect(operatorAutoBindPermitted(null)).toBe(true);
+    expect(operatorAutoBindPermitted(undefined)).toBe(true);
+  });
+});
+
+describe('historySenderLabel — the bootstrap history tells the same truth', () => {
+  it('labels an agent-verified row with the agent and the carrying account', () => {
+    expect(historySenderLabel({ fromUser: true, senderName: 'Justin', authorship: 'agent-verified', authorshipAgentId: 'echo' }))
+      .toBe("agent echo (signed, via Justin's account)");
+  });
+  it('keeps today\'s labels for everything else', () => {
+    expect(historySenderLabel({ fromUser: true, senderName: 'Justin', authorship: 'human' })).toBe('Justin');
+    expect(historySenderLabel({ fromUser: true, senderName: 'Justin', authorship: 'rejected', authorshipAgentId: 'echo' })).toBe('Justin');
+    expect(historySenderLabel({ fromUser: true })).toBe('User');
+    expect(historySenderLabel({ fromUser: false, senderName: 'x' })).toBe('Agent');
+  });
+  it('never names an agent it cannot prove', () => {
+    expect(historySenderLabel({ fromUser: true, senderName: 'J', authorship: 'agent-verified', authorshipAgentId: null }))
+      .toBe("agent unknown (signed, via J's account)");
+  });
+});
+
+describe('wiring — the label and the bind-skip sit at the convergence point (source-level)', () => {
+  const server = read('src/commands/server.ts');
+  const sm = read('src/core/SessionManager.ts');
+  const routes = read('src/server/routes.ts');
+  const fwd = read('src/core/ForwardedTopicContext.ts');
+
+  it('server.ts resolves the verdict BEFORE the operator auto-bind and gates the bind on it', () => {
+    const resolveAt = server.indexOf('resolveSignedByAgent(getAspClassifierRef(), topicId, inboundMessageId)');
+    const bindAt = server.indexOf('operatorAutoBindPermitted(signedByAgent) && telegramUserId && telegram.isAuthorizedSender(telegramUserId)');
+    const setAt = server.indexOf('opStore.setAuthenticatedOperator(topicId, {');
+    expect(resolveAt).toBeGreaterThan(0);
+    expect(bindAt).toBeGreaterThan(resolveAt);
+    expect(setAt).toBeGreaterThan(bindAt);
+  });
+  it('server.ts keeps a reference to the built classifier (the single verifier)', () => {
+    expect(server).toContain('setAspClassifierRef(aspClassifier);');
+    expect(read('src/server/AgentServer.ts')).toContain('getAspClassifier: getAspClassifierRef,');
+  });
+  it('server.ts passes signedByAgent into the injection from in-process metadata', () => {
+    expect(server).toContain("signedByAgent: typeof msg.metadata?.signedByAgent === 'string' ? msg.metadata.signedByAgent : undefined");
+  });
+  it('SessionManager passes the option to BOTH the inline tag and the long-message reference tag', () => {
+    expect(sm).toContain('buildInjectionTag(topicId, safeTopic, safeName, telegramUserId, opts?.reDelivered, opts?.signedByAgent)');
+    expect(sm).toContain('buildInjectionTag(topicId, undefined, undefined, undefined, opts?.reDelivered, opts?.signedByAgent)');
+  });
+  it('routes.ts gates the lifeline-side operator bind on the same verdict, after the message is logged', () => {
+    const logAt = routes.indexOf('ctx.telegram.logInboundMessage({');
+    const resolveAt = routes.indexOf("resolveSignedByAgent(\n      ctx.getAspClassifier?.() ?? null,");
+    const gateAt = routes.indexOf('if (ctx.topicOperatorStore && !lifelineSignedByAgent && fromUserId !== undefined');
+    const bindAt = routes.indexOf("ingress: 'telegram-lifeline-forward'");
+    expect(logAt).toBeGreaterThan(0);
+    expect(resolveAt).toBeGreaterThan(logAt);
+    expect(gateAt).toBeGreaterThan(resolveAt);
+    expect(bindAt).toBeGreaterThan(gateAt);
+  });
+  it('server.ts owns the metadata field — it is rewritten from the verdict, never trusted from the Message', () => {
+    expect(server).toContain('const { signedByAgent: _ignored, ...rest } = msg.metadata ?? {};');
+    expect(server).toContain('msg.metadata = signedByAgent ? { ...rest, signedByAgent } : rest;');
+  });
+  it('every thread-history renderer uses the shared label', () => {
+    expect((routes.match(/const sender = historySenderLabel\(m\);/g) ?? []).length).toBe(2);
+    expect(routes).not.toContain("const sender = m.fromUser ? (m.senderName || 'User') : 'Agent';");
+    expect(fwd).toContain('const sender = historySenderLabel(m);');
+  });
+});

--- a/upgrades/next/asp-signed-inbound-label.md
+++ b/upgrades/next/asp-signed-inbound-label.md
@@ -1,0 +1,49 @@
+# Agent-Signed Inbound Messages Are Labelled, Not Laundered
+
+<!-- bump: patch -->
+
+## What Changed
+
+A message an agent signs and delivers through a human's Telegram account (for
+example, this agent posting through the operator's own login to reach a sister
+session) was already recognised by the signature classifier, but that verdict
+lived only in a ledger. The receiving session was still told the message came
+from the human, and the topic-operator auto-bind still seated that human as the
+topic's verified operator on the strength of a message they did not write.
+
+Now the routing path reads the classifier's own verdict for each message (by
+platform message id, from in-process state, never from content) at the point
+where both ingress paths converge. A verified-signed message is injected with a
+tag that names the signing agent and the account that carried it, the thread
+history a fresh session reads says the same, and operator auto-bind is refused
+for it. Existing agents receive the awareness bullet through the CLAUDE.md
+migration.
+
+## What to Tell Your User
+
+If I post a message into one of my own topics through your Telegram account,
+the session on the other end now sees it labelled as coming from me, signed,
+via your account, rather than as you speaking. That message can never make
+you the operator of that topic by itself; only a message you actually wrote
+does that. Nothing changes for messages you type yourself.
+
+## Summary of New Capabilities
+
+- A verified agent-signed message delivered through a human's account is
+  injected with a tag naming the signing agent and the carrying account, and the
+  thread history a fresh session reads carries the same label.
+- Operator auto-bind is refused for such a message; a human's own messages keep
+  today's behaviour exactly.
+- The signature classifier now answers "what was the verdict for this message?"
+  for the routing path without verifying twice.
+
+## Evidence
+
+Unit tests cover the tag builder's new clause (byte-identical output when
+absent, charset-sanitised agent id), the classifier's bounded per-message
+verdict lookup (verified, human, replay-rejected, id-less, outbound, eviction),
+the read-time authorship join exposing the agent id only on a verified verdict,
+the history label, the auto-bind refusal, and the idempotent CLAUDE.md
+migration. Source-level wiring tests pin that the verdict is resolved before
+the auto-bind, that the bind is gated on it, that the injection carries it, and
+that every thread-history renderer uses the shared label.

--- a/upgrades/side-effects/asp-signed-inbound-label.md
+++ b/upgrades/side-effects/asp-signed-inbound-label.md
@@ -1,0 +1,117 @@
+# Side-Effects Review — Agent-signed inbound messages are labelled, not laundered
+
+**Version / slug:** `asp-signed-inbound-label`
+**Date:** `2026-09-02`
+**Author:** `Echo`
+**Second-pass reviewer:** `Codex independent reviewer (see below)`
+
+## Summary of the change
+
+A message an agent signs and delivers through a human's Telegram account already receives an `agent-verified` verdict from the ASP inbound classifier, but that verdict lived only in a ledger. The receiving session was still told the message came `from <human>`, and the topic-operator auto-bind still seated that human as the topic's verified operator. This change reads the classifier's own verdict at the routing convergence point (`telegram.onTopicMessage` in `src/commands/server.ts`), by platform message id from in-process state, and does three things for a verified-signed message: the injection tag names the signing agent and the carrying account (`src/types/pipeline.ts`, `src/core/SessionManager.ts`), the thread-history renderers say the same via one shared label (`src/server/routes.ts`, `src/core/ForwardedTopicContext.ts`, `src/core/AspAuthorshipJoin.ts`), and operator auto-bind is refused. The classifier gains a bounded per-message verdict lookup (`src/core/AspInboundClassifier.ts`); the helpers live in `src/messaging/shared/signedInbound.ts`; the CLAUDE.md awareness bullet and its idempotent migration live in `src/core/PostUpdateMigrator.ts`.
+
+## Decision-point inventory
+
+- `telegram.onTopicMessage` operator auto-bind (`src/commands/server.ts`) — modify — the bind is additionally gated on "this message is not agent-signed"; every other condition is unchanged.
+- Lifeline-forward operator auto-bind (`src/server/routes.ts`) — modify — the same gate, on the same cached verdict (the message is logged, and therefore classified, before this bind runs).
+- `AspInboundClassifier.classify` — pass-through — unchanged verdict logic; it now also remembers each verdict by message id.
+- `buildInjectionTag` / `injectTelegramMessage` — modify — an additive sender clause; no block/allow surface.
+- Thread-history renderers — modify — label only; no block/allow surface.
+
+---
+
+## 1. Over-block
+
+The only thing this change withholds is operator auto-bind, and only for a message whose signature the classifier verified as an agent's. A human's own message is never withheld: an unsigned message, a message with a malformed or forged tag (`rejected`), and a message the classifier never saw all keep today's auto-bind behaviour. Over-block would require the classifier to verify a signature a human typed — which requires the agent's private key. If a topic's very first message is agent-signed, that topic simply has no verified operator until the human writes; that is the correct state, not a regression.
+
+## 2. Under-block
+
+An agent that never signs its messages is still indistinguishable from the account holder (the ASP limit already stated in the awareness section). The durable inbound queue path (`dmsg.senderEnvelope`, ships dark) does not carry the flag yet, so a message delivered through that path would arrive with today's tag; it still cannot mis-bind, because the bind decision happens at the convergence point before either delivery path. A message classified before this process started (ledger only, no in-memory verdict) is labelled by the history join but injected with today's tag. Rejected-but-genuine signatures (the plain-text-only limit) fall to `human` behaviour, which is the pre-existing fail direction.
+
+## 3. Level-of-abstraction fit
+
+This is a low-level invariant at the identity layer, exactly where Know Your Principal says it belongs: the one place both ingress paths converge, reading the one cryptographic authority that already exists. It does not add a second verifier (the nonce is single-use, so it must not), and it does not add a judgment. The higher-level gate it feeds is the existing operator-binding path, which now has a truthful input.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface beyond withholding one automatic grant on cryptographic proof.
+
+The label is a signal to the session. The one authority it exercises — refusing operator auto-bind — is deterministic on an exact, unforgeable match (a valid Ed25519 signature bound to a single-use nonce), which is the ruled shape for structure deciding alone. It never blocks, delays, rewrites, or drops a message; every failure path delivers the message unlabelled.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. "Was this message signed by an agent?" is enumerable (verified / not), and the auto-bind refusal is a safety guard on an identity grant, deterministic by design.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the verdict is read from the classifier, which runs on the `onMessageLogged` seam BEFORE routing on both ingress paths (polling: `appendToLog` precedes `onTopicMessage`; lifeline: `logInboundMessage` precedes the `onTopicMessage` fire in `routes.ts`). If logging is deduplicated for a repeated message id, the first verdict is reused, which is correct.
+- **Double-fire:** none. The classifier still verifies exactly once; the routing path reads, never re-verifies (a second verify would classify the genuine message as a replay).
+- **Races:** the in-memory map is written and read on the same event-loop turn sequence; bounded at 1000 entries with oldest-first eviction.
+- **Feedback loops:** none. The label does not feed the classifier.
+- The `routes.ts` lifeline-side operator bind runs BEFORE the convergence point, so gating only the convergence point would have left an agent-signed lifeline message able to seat the operator (raised by the second-pass reviewer). It is now gated on the same verdict, read through a context getter to the one classifier; the log call that classifies the message precedes it in the same handler.
+- The convergence point OWNS `metadata.signedByAgent`: it is rewritten from the verdict on every message and removed when the verdict is not agent-verified, so a value arriving on the Message from a wire body, a replay, or a queue row can never reach the injection (also raised by the second-pass reviewer).
+
+---
+
+## 6. External surfaces
+
+- Other agents on the same machine: none.
+- Install base: every agent gets the labelling on the next server restart; the awareness bullet arrives through the CLAUDE.md migration.
+- External systems: none. No Telegram send changes.
+- Persistent state: none new. The ASP ledger format is unchanged; the history join reads it as before and adds a derived field.
+- Timing: none.
+- Operator surface: no operator-facing actions.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Proxied-on-read.** The verdict is machine-local by nature (the classifier on the receiving machine verifies the signature and holds the nonce store), and the label follows the message to whichever session is injected on that machine. For a topic that has moved, the forwarded thread history carries `authorship` and `authorshipAgentId` from the previous machine's history read, so the relayed history block shows the same label. It emits no user-facing notice, holds no durable state that could strand on transfer, and generates no URL.
+
+---
+
+## 8. Rollback cost
+
+Pure code change — revert and ship a patch. No persistent state, no data migration. The awareness bullet would then overstate behaviour until a correcting migration lands; a rollback would carry one.
+
+---
+
+## Conclusion
+
+The change closes a real identity-bleed path with the smallest possible authority: one deterministic refusal on cryptographic proof, and otherwise labels. The review moved the verdict lookup from "verify again at routing" (wrong: single-use nonce) to "remember the log-time verdict by message id", and added the charset sanitisation on the agent id so a ledger row can never inject text into a tag. Two honest limits are recorded above (dark inbound-queue path; lifeline-side first bind). Clear to ship after the independent second pass and the full test gate.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Codex independent reviewer (GPT-5.6, read-only, artifact + diff)
+**Independent read of the artifact:** concern on the first pass, both points accepted and fixed. (1) The lifeline-forward operator bind ran before the convergence point, so the claimed under-block protection did not hold for that ingress — now gated on the same verdict. (2) The injection trusted a pre-existing `metadata.signedByAgent` — the convergence point now rewrites the field from the verdict and strips any other value. The reviewer confirmed the auto-bind at the convergence point depends only on the classifier-derived value, that no second signature verification occurs, that the tag change is backward-compatible, and that the label grants no authority. Second pass on the revised diff (same reviewer, same read-only setup): **concur, no issues** — the lifeline-forward bind is gated on the cached verdict after the log call, the convergence point owns the metadata field, no second verification exists, and the label grants no authority.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/signed-inbound-label.test.ts`
+- `tests/unit/asp-inbound-classifier-verdictFor.test.ts`
+- `tests/unit/asp-authorship-join-agentid.test.ts`
+- `tests/unit/PostUpdateMigrator-aspSignedInboundBullet.test.ts`
+- `tests/unit/redelivery-marker.test.ts` (parameter-count guard updated with its reasoning)
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. This change fixes routing code (TypeScript source), not an LLM prompt, hook, config, skill, or standards text, and it adds no self-triggered controller: nothing here fires a restart, swap, respawn, spawn, notify, retry, re-drive, or kill on its own.


### PR DESCRIPTION
## ELI16 — when I sign a message and send it through your Telegram account, the receiving session is told it is me, and it can never make you that topic's operator

> The one-line version: when I sign a message and send it through your Telegram account, the session that receives it is now told "this is the agent, signed, via Justin's account", and that message can never make you the operator of that topic.

### The problem in one breath

I can already sign a message and send it through your logged-in Telegram, and the infrastructure can already prove I wrote it. But that proof only landed in an audit ledger. The session on the receiving end was still told the message came from you, and the automatic "who is the operator of this topic" binding still treated my message as evidence that you were present and in charge. That is exactly the identity mix-up the constitution forbids: a session acting on a name it did not verify.

### What already exists

- **Agent-signature provenance** — I can sign a message with my own key; every inbound message is checked, and a verdict (human, agent-verified, rejected) is written to a ledger. The ledger stores a hash, never the body.
- **The injection tag** — every inbound message reaches a session prefixed with a tag naming the topic and the sender. It was built from the Telegram sender only.
- **Topic-operator auto-bind** — the first authorised sender in a topic is recorded as that topic's verified operator, from the authenticated sender id.
- **Thread history on session start** — a fresh session reads the recent history of its topic, one line per message, labelled by sender.

### What this adds

The routing path now reads the classifier's own verdict for each message, at the one place both ways a message can arrive converge. When the verdict is "agent-verified", three things follow. The tag the session sees names the signing agent and the account that carried the message. The thread-history line says the same. And the operator auto-bind is refused, because the account holder did not author the message.

Secondary changes: the classifier remembers its verdicts by message id in a bounded in-memory map, because a signed message can only be verified once (the nonce is single-use, so a second check would call the genuine message a replay). The read-time history join now exposes the signing agent's id, but only on a verified verdict. The CLAUDE.md awareness section gains one bullet, and existing agents receive it through the migration.

### The new pieces

- **A small shared helper module** — resolves the platform message id from either ingress, asks the classifier for its verdict, decides whether auto-bind is permitted, and renders the history label. It reads in-process state only, never message content, so a body that merely claims to be signed cannot mint the label. It never throws; on any doubt the message is delivered unlabelled, exactly as today.

### The safeguards

**Prevents a forged label.** The label comes from the classifier's cryptographic verdict, keyed by message id. Nothing parses the message text for a signature at routing time.

**Prevents identity bleed.** An agent-signed message can no longer seat the carrying account's owner as a topic's verified operator. Everything a human actually types keeps today's behaviour, byte for byte.

**Prevents a delivery regression.** Every helper fails toward delivering the message unlabelled. A missing classifier, a missing id, or a thrown error means "unsigned", never "dropped".

**Does not grant anything.** The label says who wrote the message. It carries no permission, role, or trust; treating "signed by the agent" as authorisation remains a defect.

### What ships when

One change, one pull request. It is live the moment the server restarts on the new version. No configuration, no state migration; the awareness bullet reaches existing agents through the normal CLAUDE.md migration.

## What this is

A message an agent SIGNS and delivers through a human's Telegram account (the tenet-5 channel: this agent posting through the operator's own login to reach a sister session) was already classified `agent-verified` by the ASP inbound classifier — but only in the ledger. The receiving session was still told the message came `from <human>`, and the topic-operator auto-bind seated that human as the topic's verified operator on the strength of a message they did not write. That is the identity bleed Know Your Principal forbids.

## What changes

- The classifier remembers each verdict by (topic, message id) in a bounded map; the nonce is single-use, so downstream readers ask for the one log-time verdict instead of verifying again.
- Both ingress paths read that verdict: the polling convergence point (`telegram.onTopicMessage`) and the lifeline-forward route, through a small shared reference module. Operator auto-bind is refused for an agent-signed message on both paths.
- The injection tag for such a message reads `from agent <id> (signed) via <name>'s account (uid:N)`; the long-message reference line carries the same; every thread-history renderer shows `agent <id> (signed, via <name>'s account)` from the read-time authorship join, which now exposes the signing agent id only on a verified verdict.
- The convergence point OWNS `metadata.signedByAgent`: it is rewritten from the verdict on every message and stripped otherwise, so a value arriving on the Message from a wire body, replay, or queue row can never mint the label.
- Awareness: one bullet in the Agent-Signature Provenance CLAUDE.md section, delivered to existing agents by an idempotent migration keyed on its own marker (the section-level sniff would have skipped them forever).

Everything a human types keeps today's behaviour byte for byte. Every helper fails toward delivering the message unlabelled.

## Review

Independent second pass (Codex, read-only, artifact + diff): first pass raised two concerns — the lifeline-side bind ran before the convergence point, and the injection trusted a pre-existing metadata field — both fixed; second pass on the revised diff: concur, no issues. Side-effects artifact: `upgrades/side-effects/asp-signed-inbound-label.md`.

Tier: declared Tier 1; the gate's risk floor said Tier 2 because the diff touches the Telegram adapter (one optional type field) and the migrator (one additive awareness bullet). Recorded as a below-floor override with that reasoning, not blocked.

## Verification

- Full unit suite green locally in two shards: 20,693 + 30,066 tests, 0 failures.
- New tests: tag builder clause + charset sanitisation; classifier `verdictFor` (verified / human / replay-rejected / id-less / outbound / eviction); authorship join agent id; history label; auto-bind refusal; migration idempotence; source-level wiring (verdict resolved before both binds, bind gated, injection carries the option, field ownership, every history renderer uses the shared label).
- Local pre-push smoke was skipped (affected-set listing timed out); CI is the authority.

## Multi-machine posture

Proxied-on-read: the verdict is machine-local by nature (the receiving machine verifies and holds the nonce store); a moved topic's relayed history carries the authorship fields so the label survives the move. No notices, no durable state, no URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwWruMtvzhD6TdyQzSgk13
