### PR TITLE
fix(ownership): page the placement journal so low-epoch topics materialize

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-05T23-53-15-229Z-ownership-applier-placement-paging.json
+++ b/.instar/instar-dev-decisions/2026-09-05T23-53-15-229Z-ownership-applier-placement-paging.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-09-05T23:53:15.229Z",
+  "slug": "ownership-applier-placement-paging",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 194,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/OwnershipApplier.ts",
+      "src/core/ownershipApplierWiring.ts"
+    ],
+    "addedLines": 167,
+    "deletedLines": 27
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/ownership-applier-placement-paging.eli16.md
+++ b/docs/specs/ownership-applier-placement-paging.eli16.md
@@ -1,0 +1,83 @@
+# The conversations that fell off the bottom of the page — Plain-English Overview
+
+> The one-line version: the part of instar that learns "which conversations does this
+> machine own?" was reading only the first page of a list sorted worst-first for its
+> purpose, so young conversations were invisible to it — and an invisible conversation
+> can never be handed between machines.
+
+## The problem in one breath
+
+An operator pinned a conversation to a different machine. The pin was recorded. The move
+never happened — for four hours, with no error surfaced and no self-healing. Both machines
+were behaving correctly and neither was lying. They simply were not reading the same page.
+
+## What already exists
+
+- **A shared ledger of handovers.** Every time a conversation changes hands between
+  machines, a row is appended to a journal that replicates to every machine. The row says
+  "conversation N is now owned by machine M, at handover number E."
+- **A handover counter per conversation.** That number ("epoch") starts at 1 and goes up by
+  one each time the conversation moves. A conversation that has bounced between machines
+  for months sits in the hundreds; one created this morning sits at 1 or 2.
+- **A step that turns ledger rows into local records.** Each machine periodically reads the
+  ledger and writes itself a local ownership record. This step exists precisely because a
+  machine cannot own something it has no record of.
+- **A handover procedure that checks that record.** When machine A asks machine B to hand a
+  conversation over, B first checks its own record. No record means B answers, truthfully,
+  "I don't have this" — and refuses.
+
+## What was actually broken
+
+The ledger read is **paged**, and for this kind of row it is sorted by the handover counter,
+**highest first**. The reader returns at most 500 rows per page. The ownership step asked
+for one page and stopped.
+
+So the step was seeing "the 500 most-handed-over rows", not "the 500 most recent". A young
+conversation sits at the bottom of that ordering by construction. Once the ledger held 500
+rows with higher counters, a new conversation was simply not in the page — and the cutoff
+only ever rises as the ledger grows, so this gets worse over time and hits the *newest*
+conversations hardest.
+
+Measured on a live machine on 2026-09-05: one page showed **33** conversations; walking
+every page showed **150**. The step was seeing 22% of them. The conversation the operator
+was trying to move (counter: 2) was below the page's cutoff (counter: 6), so its machine
+never wrote itself an ownership record, so every handover attempt was refused with
+"not-owner" — twice, three hours apart, identically.
+
+## What changes
+
+The ownership step now walks **every** page instead of the first one, using the paging
+cursor the reader already provides. Nothing about the ledger, its ordering, or its cursor
+changes — only how much of it this one reader consumes.
+
+## The safeguards, in plain terms
+
+- **It cannot run forever.** The walk stops after a fixed number of pages (40, about 20,000
+  rows — far more than the ledger ever holds) and says so if it ever hits that ceiling.
+- **It cannot spin in place.** If the cursor ever fails to advance, or fails to build, the
+  walk stops and logs why rather than looping.
+- **It cannot go quiet about doing less.** If it is ever handed a reader with no paging
+  support, it reads one page — the old behaviour — and *says so in the log*. A silent
+  under-read is the bug itself; it must never be reachable silently again.
+- **It changes no decisions.** This step only copies an already-decided fact from the ledger
+  into a local record. It does not decide ownership, and this change gives it no new
+  authority — it only lets it see rows it was always meant to see.
+
+## What this does not fix
+
+There is a **second**, independent limit in the same family: the reader also reads at most
+the newest 500 rows of each individual ledger *file*, before any paging happens. Measured:
+one file with 700 rows exposes only 500, even walking every page. It is not biting yet — the live
+files hold 384, 383 and 249 rows — but I measured how fast they grow rather than assuming,
+and the busiest one gains about 22 rows a day with 116 to spare, so it crosses the limit in
+roughly **five days**. The other two are about 23 and 77 days out. That is tracked as
+**ACT-1811** (high priority, due within the week), and it needs its own spec because raising
+that limit changes the memory cost of every read of this ledger.
+
+## What you actually need to decide
+
+Whether walking the whole ledger on a periodic background tick is an acceptable cost for
+correctness here. The honest numbers: the walk is bounded at 40 pages, runs off the routing
+hot path on a 15-second timer, and on the live journal completes in 3 pages. The alternative
+— leaving it — means new conversations keep silently becoming unmovable between machines,
+with the failure appearing as a refusal that names no cause.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -22281,7 +22281,13 @@ export async function startServer(options: StartOptions): Promise<void> {
           const applierTimer = setInterval(() => {
             try {
               const r = ownershipApplier.tick();
-              if (r.materialized) console.log(pc.dim(`  [OwnershipApplier] materialized ${r.materialized}/${r.examined} topic(s) from replicated placements`));
+              if (r.materialized) console.log(pc.dim(`  [OwnershipApplier] materialized ${r.materialized}/${r.examined} topic(s) from replicated placements (${r.pagesScanned ?? 1} page(s))`));
+              // A DEGRADED scan is the shape of the bug this paging fixed: the applier
+              // silently seeing only part of the journal, so a topic is never materialized
+              // and its drain refuses `not-owner` forever. Never let that be quiet again —
+              // these two states are logged even on a tick that materialized nothing.
+              if (r.pageCeilingHit) console.log(pc.dim(`  [OwnershipApplier] page ceiling hit — the placement scan was INCOMPLETE this tick; some topics may not be materialized`));
+              if (r.pagingUnavailable) console.log(pc.dim(`  [OwnershipApplier] paging unavailable — read a SINGLE placement page; low-epoch topics may not be materialized`));
             } catch (err) {
               console.error('[OwnershipApplier] tick failed:', err instanceof Error ? err.message : String(err));
             }

--- a/src/core/OwnershipApplier.ts
+++ b/src/core/OwnershipApplier.ts
@@ -34,10 +34,28 @@ import type { SessionOwnershipRecord } from './SessionOwnership.js';
 import type { SessionOwnershipStore } from './SessionOwnershipRegistry.js';
 
 /** The minimal slice of CoherenceJournalReader the applier needs (for testability). */
+/** One entry as returned by the reader. `ts`/`seq` are the cursor key fields. */
+export type PlacementReaderEntry = {
+  topic?: number;
+  machine: string;
+  data: Record<string, unknown>;
+  source?: string;
+  /** Cursor key fields — present on CoherenceJournalReader entries. */
+  ts?: string;
+  seq?: number;
+};
+
 export interface PlacementReader {
-  query(opts: { kind?: string; limit?: number; topic?: number }): {
-    entries: Array<{ topic?: number; machine: string; data: Record<string, unknown>; source?: string }>;
+  query(opts: { kind?: string; limit?: number; topic?: number; cursor?: string }): {
+    entries: PlacementReaderEntry[];
   };
+  /**
+   * Opaque keyset cursor for the LAST entry of a page (see CoherenceJournalReader).
+   * OPTIONAL so an older caller / test fake still type-checks — when absent the
+   * applier reads a single page (the pre-paging behavior) and says so in the log
+   * rather than silently under-scanning.
+   */
+  cursorFor?(entry: PlacementReaderEntry, isPlacement: boolean): string;
 }
 
 export interface OwnershipApplierDeps {
@@ -54,8 +72,27 @@ export interface OwnershipApplierDeps {
    * a plain string still works for callers/tests that already have the id.
    */
   selfMachineId: string | (() => string | null | undefined);
-  /** Max placement entries to scan per tick (bounded cost). Default 1000. */
+  /** Max placement entries to request PER PAGE (the reader clamps to its own cap). Default 1000. */
   scanLimit?: number;
+  /**
+   * Max placement PAGES to walk per tick (bounded cost).
+   *
+   * Why paging exists at all: a `topic-placement` query is ordered EPOCH-DESCENDING
+   * (CoherenceJournalReader.compareKey), then paged at the reader's cap (500). So a
+   * single page is "the 500 HIGHEST-EPOCH rows", NOT the 500 most recent — a topic
+   * with a LOW ownership epoch (a young topic, handed over once or twice) falls off
+   * the bottom of page 1 as soon as the journal accumulates 500 higher-epoch rows,
+   * and the cutoff only RISES as the journal grows. Such a topic was then never
+   * materialized, so its owner machine held no ownership record, so the drain
+   * refused `not-owner` forever and a pinned cross-machine transfer could never
+   * land (observed live 2026-09-05: 33 of 150 topics visible; a real 4-hour
+   * deadlock). The applier needs cross-topic COMPLETENESS, so it must page.
+   *
+   * Default 40 pages — at the reader's 500-row cap that is 20k placement rows,
+   * far above the journal's retention bound, while still being a hard ceiling
+   * so a corrupt/at-scale journal can never make a tick unbounded.
+   */
+  maxScanPages?: number;
   /**
    * Cross-machine convergence (Fix #3): the set of KNOWN machine ids, used to
    * validate a replicated `transferring` entry's `transferTo` before materializing
@@ -86,6 +123,12 @@ export interface OwnershipApplyResult {
   examined: number;
   /** Topics whose local ownership record was advanced from a (newer) placement. */
   materialized: number;
+  /** Placement pages actually walked this tick (observability — 1 when unpaged). */
+  pagesScanned?: number;
+  /** True when the page ceiling stopped the walk before the stream was exhausted. */
+  pageCeilingHit?: boolean;
+  /** True when the reader exposes no cursor, so only a single page could be read. */
+  pagingUnavailable?: boolean;
 }
 
 export class OwnershipApplier {
@@ -117,8 +160,10 @@ export class OwnershipApplier {
   tick(): OwnershipApplyResult {
     let examined = 0;
     let materialized = 0;
+    let pagesScanned = 0;
+    let pageCeilingHit = false;
+    let pagingUnavailable = false;
     try {
-      const res = this.d.reader.query({ kind: 'topic-placement', limit: this.d.scanLimit ?? 1000 });
       // Collapse to the highest-epoch placement per topic across own + replica streams.
       // Fix #3: carry the handoff fields (status/transferTo/timestamp/drainInFlight) so the
       // target materializes the `transferring` intermediate, not just `active`.
@@ -128,28 +173,108 @@ export class OwnershipApplier {
         timestamp?: number; drainInFlight?: boolean;
       };
       const bestByTopic = new Map<string, Best>();
-      for (const e of res.entries) {
-        if (e.topic == null) continue;
-        const owner = typeof e.data.owner === 'string' ? e.data.owner : '';
-        const epoch = typeof e.data.epoch === 'number' ? e.data.epoch : Number(e.data.epoch);
-        if (!owner || !Number.isFinite(epoch) || epoch <= 0) continue;
-        const key = String(e.topic);
-        const cur = bestByTopic.get(key);
-        const cand: Best = {
-          owner, epoch, streamOwner: e.machine,
-          status: e.data.status === 'transferring' ? 'transferring' : 'active',
-          transferTo: typeof e.data.transferTo === 'string' ? e.data.transferTo : undefined,
-          timestamp: typeof e.data.timestamp === 'number' && Number.isFinite(e.data.timestamp) ? e.data.timestamp : undefined,
-          drainInFlight: e.data.drainInFlight === true ? true : undefined,
-        };
-        if (!cur || epoch > cur.epoch) {
-          bestByTopic.set(key, cand);
-        } else if (epoch === cur.epoch && cur.streamOwner !== cur.owner && cand.streamOwner === cand.owner) {
-          // Owner-anchored equal-epoch tie-break (Finding SE6): prefer the entry whose
-          // stream-owner == entry.owner (a `transferring` from the true owner is canonical),
-          // never iteration order.
-          bestByTopic.set(key, cand);
+
+      const pageLimit = this.d.scanLimit ?? 1000;
+      // A non-finite bound must NEVER silently mean "scan nothing": `Math.max(1, NaN)`
+      // is NaN, `page < NaN` is false, and the walk would run ZERO pages, materialize
+      // nothing, and log nothing — the exact silent under-scan this change exists to
+      // eliminate. A config-derived number is precisely how NaN arrives, so fall back
+      // to the default rather than trusting the arithmetic (same guard shape as the
+      // `Number.isFinite(rawLimit)` check on the journal read route).
+      const rawMaxPages = this.d.maxScanPages;
+      const maxPages = Number.isFinite(rawMaxPages) ? Math.max(1, Math.floor(rawMaxPages as number)) : 40;
+      let cursor: string | undefined;
+      let seenCursor: string | undefined;
+
+      // Walk EVERY page, not just the first. The placement order is epoch-DESC, so
+      // page 1 is the highest-epoch rows — a low-epoch topic lives on a LATER page.
+      // Termination is driven by an EMPTY page, never by a short page: the reader
+      // clamps `limit` to its own cap (500), so `entries.length < pageLimit` is true
+      // on a FULL page whenever pageLimit > 500 and would stop the walk after page 1
+      // — reproducing the very bug this loop fixes.
+      //
+      // The ceiling is checked at the TOP of the walk, not at the bottom: it must mean
+      // "the cap stopped a walk that still had somewhere to go", never "the walk happened
+      // to finish on its last allowed page". Flagging it at the bottom mis-reports a
+      // COMPLETE scan as incomplete whenever the row count is an exact multiple of the
+      // page size — a false alarm in the very observability surface this change adds.
+      for (;;) {
+        if (pagesScanned >= maxPages) {
+          // The page budget is spent. Do NOT assume that means the scan was incomplete:
+          // when the row count is an exact multiple of the page size the walk has in fact
+          // finished, and flagging it would print "INCOMPLETE — some topics may not be
+          // materialized" on a COMPLETE scan (a false alarm in the very observability
+          // surface this change adds). One bounded probe with the live cursor answers it
+          // exactly, and only in the rare ceiling case — so the honest answer costs at
+          // most one extra query, never a per-tick cost.
+          if (cursor) {
+            let remaining = 1; // unknown → assume more (the safe direction: report incomplete)
+            try {
+              remaining = this.d.reader.query({ kind: 'topic-placement', limit: pageLimit, cursor }).entries.length;
+            } catch { /* @silent-fallback-ok — NOT silent: `remaining` stays 1, so the ceiling is reported rather than hidden */ }
+            if (remaining > 0) {
+              pageCeilingHit = true;
+              this.log(`page ceiling (${maxPages}) reached with more placements still unread — the scan was INCOMPLETE; raise maxScanPages if this recurs`);
+            }
+          }
+          break;
         }
+        const page = pagesScanned; // 0-based index of the page about to be read
+        const res = this.d.reader.query({
+          kind: 'topic-placement',
+          limit: pageLimit,
+          ...(cursor ? { cursor } : {}),
+        });
+        pagesScanned++;
+        const entries = res.entries;
+        if (entries.length === 0) break;
+
+        for (const e of entries) {
+          if (e.topic == null) continue;
+          const owner = typeof e.data.owner === 'string' ? e.data.owner : '';
+          const epoch = typeof e.data.epoch === 'number' ? e.data.epoch : Number(e.data.epoch);
+          if (!owner || !Number.isFinite(epoch) || epoch <= 0) continue;
+          const key = String(e.topic);
+          const cur = bestByTopic.get(key);
+          const cand: Best = {
+            owner, epoch, streamOwner: e.machine,
+            status: e.data.status === 'transferring' ? 'transferring' : 'active',
+            transferTo: typeof e.data.transferTo === 'string' ? e.data.transferTo : undefined,
+            timestamp: typeof e.data.timestamp === 'number' && Number.isFinite(e.data.timestamp) ? e.data.timestamp : undefined,
+            drainInFlight: e.data.drainInFlight === true ? true : undefined,
+          };
+          if (!cur || epoch > cur.epoch) {
+            bestByTopic.set(key, cand);
+          } else if (epoch === cur.epoch && cur.streamOwner !== cur.owner && cand.streamOwner === cand.owner) {
+            // Owner-anchored equal-epoch tie-break (Finding SE6): prefer the entry whose
+            // stream-owner == entry.owner (a `transferring` from the true owner is canonical),
+            // never iteration order.
+            bestByTopic.set(key, cand);
+          }
+        }
+
+        // Advance the keyset cursor to the last entry of this page.
+        if (typeof this.d.reader.cursorFor !== 'function') {
+          // No cursor support (older caller / narrow fake) → single page, said out
+          // loud. NEVER a silent under-scan: an unpaged applier is the deadlock bug.
+          pagingUnavailable = true;
+          this.log('paging unavailable (reader exposes no cursorFor) — scanned a SINGLE page; low-epoch topics may not be materialized');
+          break;
+        }
+        let next: string | undefined;
+        try {
+          next = this.d.reader.cursorFor(entries[entries.length - 1], true);
+        } catch (err) {
+          this.log(`cursor build failed on page ${page + 1} — stopping the walk: ${err instanceof Error ? err.message : String(err)}`);
+          break;
+        }
+        // A cursor that does not ADVANCE would loop forever — stop instead.
+        if (!next || next === seenCursor) {
+          this.log(`cursor did not advance on page ${page + 1} — stopping the walk`);
+          break;
+        }
+        seenCursor = next;
+        cursor = next;
       }
       examined = bestByTopic.size;
 
@@ -227,6 +352,12 @@ export class OwnershipApplier {
       // this tick adopted fewer records — the next tick (or the reconciler) converges.
       this.log(`tick failed: ${err instanceof Error ? err.message : String(err)}`);
     }
-    return { examined, materialized };
+    return {
+      examined,
+      materialized,
+      pagesScanned,
+      ...(pageCeilingHit ? { pageCeilingHit: true } : {}),
+      ...(pagingUnavailable ? { pagingUnavailable: true } : {}),
+    };
   }
 }

--- a/src/core/ownershipApplierWiring.ts
+++ b/src/core/ownershipApplierWiring.ts
@@ -32,6 +32,8 @@ export interface OwnershipApplierWiringDeps {
    */
   getSelfMachineId: () => string | null | undefined;
   scanLimit?: number;
+  /** Max placement PAGES walked per tick (bounded cost). See OwnershipApplierDeps. */
+  maxScanPages?: number;
   /** Cross-machine convergence (Fix #3): known machine ids, to validate a replicated
    *  `transferring` entry's `transferTo` before materializing (else downgrade to active). */
   knownMachines?: () => Set<string>;
@@ -54,6 +56,7 @@ export function wireOwnershipApplier(deps: OwnershipApplierWiringDeps): Ownershi
     store: deps.durableOwnershipStore,
     selfMachineId: deps.getSelfMachineId, // getter — resolved per-tick, never captured stale
     scanLimit: deps.scanLimit,
+    maxScanPages: deps.maxScanPages,
     knownMachines: deps.knownMachines,
     maxEpochJump: deps.maxEpochJump,
     timestampSkewToleranceMs: deps.timestampSkewToleranceMs,

--- a/tests/unit/OwnershipApplier-placement-paging.test.ts
+++ b/tests/unit/OwnershipApplier-placement-paging.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tier-1 tests for the OwnershipApplier placement-PAGING fix.
+ *
+ * The bug (observed live 2026-09-05, topic 69507, ~4h deadlock): the applier read a
+ * SINGLE page of the placement journal. A `topic-placement` query is ordered
+ * EPOCH-DESCENDING and paged at the reader's cap (500), so one page is "the 500
+ * HIGHEST-EPOCH rows", NOT the 500 most recent. A young topic (epoch 1-2) fell off
+ * the bottom of page 1 once the journal accumulated 500 higher-epoch rows, was never
+ * materialized on its owner machine, and every drain then refused `not-owner` — so a
+ * pinned cross-machine transfer could never land, with no self-heal.
+ *
+ * The load-bearing test here (`materializes a topic whose epoch is BELOW the first
+ * page's floor`) runs against the REAL CoherenceJournalReader over a REAL on-disk
+ * journal, not a fake. A fake reader cannot reproduce this bug: the bug lives in the
+ * INTERACTION between the reader's epoch-descending order and its limit clamp, so a
+ * fake that hands back pages the test author chose would pass vacuously. The test also
+ * ASSERTS the fixture is non-vacuous (page 1 genuinely excludes the topic) before
+ * asserting the fix, so it fails loudly rather than silently if the reader's cap or
+ * ordering ever changes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { OwnershipApplier, type PlacementReader, type PlacementReaderEntry } from '../../src/core/OwnershipApplier.js';
+import { LocalSessionOwnershipStore } from '../../src/core/LocalSessionOwnershipStore.js';
+import { CoherenceJournalReader } from '../../src/core/CoherenceJournalReader.js';
+
+const PEER = 'm_peer_studio';
+const SELF = 'm_self_mini';
+
+/** The young, low-epoch topic that the single-page read starved. */
+const STARVED_TOPIC = 69507;
+const STARVED_EPOCH = 2;
+
+/**
+ * Write a real placement journal shaped like production: SEVERAL peer stream files
+ * (own + one per peer machine), each comfortably under the reader's per-file
+ * newest-tail cap (500 entries), together totalling well OVER one page.
+ *
+ * The multi-file shape is load-bearing, not incidental. With a SINGLE file the
+ * reader's per-file tail read (500 newest rows) truncates before the merge step, so
+ * the older rows are unreadable no matter how the caller pages — that models a
+ * different limit, not this bug. Production has one stream per machine (here: 384 +
+ * 383 + 249 rows on 2026-09-05), each under the per-file cap, so every row reaches
+ * the merge and the truncation happens at the epoch-ordered PAGE — which is exactly
+ * the starvation this fix addresses.
+ *
+ * Rows are spread over `streams` files: `noisyTopics` topics at HIGH epochs, plus one
+ * low-epoch topic owned by SELF written into the LAST stream. Returns the stateDir.
+ */
+function writeJournal(root: string, noisyTopics: number, rowsPerTopic: number, streams = 4, extraTopic = true): string {
+  const stateDir = path.join(root, 'st');
+  const jdir = path.join(stateDir, 'state', 'coherence-journal', 'peers');
+  fs.mkdirSync(jdir, { recursive: true });
+
+  const byStream: string[][] = Array.from({ length: streams }, () => []);
+  let seq = 1;
+  for (let t = 0; t < noisyTopics; t++) {
+    for (let r = 0; r < rowsPerTopic; r++) {
+      const machine = `${PEER}_${t % streams}`;
+      // High epochs (>= 10) so every one of these outranks the starved topic.
+      byStream[t % streams].push(JSON.stringify({
+        seq: seq++,
+        ts: new Date(Date.UTC(2026, 5, 1, 0, 0, seq % 60)).toISOString(),
+        machine,
+        kind: 'topic-placement',
+        topic: 10000 + t,
+        data: { owner: machine, epoch: 10 + r, reason: 'placed' },
+      }));
+    }
+  }
+  // The starved topic: the most RECENT row, but with the LOWEST epoch — exactly the
+  // shape of a freshly-placed young conversation. Omitted (`extraTopic: false`) when a
+  // test needs an EXACT row count, e.g. an exact multiple of the page size.
+  const lastMachine = `${PEER}_${streams - 1}`;
+  if (extraTopic) byStream[streams - 1].push(JSON.stringify({
+    seq: seq++,
+    ts: '2026-09-05T18:28:50.195Z',
+    machine: lastMachine,
+    kind: 'topic-placement',
+    topic: STARVED_TOPIC,
+    data: { owner: SELF, epoch: STARVED_EPOCH, reason: 'placed' },
+  }));
+
+  byStream.forEach((lines, i) => {
+    // Guard the fixture's own premise: a stream over the per-file tail cap would be
+    // truncated before the merge, silently changing what this test exercises.
+    if (lines.length > 400) throw new Error(`fixture stream ${i} has ${lines.length} rows — over the per-file tail cap; add streams`);
+    fs.writeFileSync(path.join(jdir, `${PEER}_${i}.topic-placement.jsonl`), lines.join('\n') + '\n');
+  });
+  return stateDir;
+}
+
+describe('OwnershipApplier — placement paging (low-epoch starvation fix)', () => {
+  let root: string;
+  let store: LocalSessionOwnershipStore;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'applier-paging-'));
+    store = new LocalSessionOwnershipStore({ dir: path.join(root, 'own') });
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'live-test-cleanup' }); } catch { /* best-effort */ }
+  });
+
+  it('materializes a topic whose epoch is BELOW the first page floor (THE regression)', () => {
+    // 120 topics x 6 rows = 720 high-epoch rows — comfortably over the reader's 500 cap.
+    const stateDir = writeJournal(root, 120, 6, 4); // 720 rows over 4 streams (180 each)
+    const reader = new CoherenceJournalReader({ stateDir });
+
+    // ── Non-vacuity guard ────────────────────────────────────────────────────
+    // Prove the fixture actually reproduces the starvation: ONE page must NOT
+    // contain the starved topic. If the reader's cap or ordering changes so that
+    // page 1 now includes it, this fails HERE — telling us the test below would
+    // have started passing for the wrong reason.
+    const page1 = reader.query({ kind: 'topic-placement', limit: 1000 });
+    expect(page1.entries.length).toBeGreaterThan(0);
+    expect(page1.entries.some((e) => e.topic === STARVED_TOPIC)).toBe(false);
+
+    const applier = new OwnershipApplier({ reader, store, selfMachineId: SELF });
+    expect(store.read(String(STARVED_TOPIC))).toBeNull(); // the bug's starting state
+
+    const res = applier.tick();
+
+    // The USER-VISIBLE property first: the ownership record now exists. This is the
+    // assertion that must break when the fix is removed — the drain reads exactly
+    // this record, and its absence is what refused `not-owner` for four hours.
+    // (Asserting the page COUNT first would let the test fail on the mechanism
+    // instead of the outcome, and a paging walk that materialized nothing would
+    // still look like a pass on that line.)
+    const rec = store.read(String(STARVED_TOPIC));
+    expect(rec?.ownerMachineId).toBe(SELF);
+    expect(rec?.ownershipEpoch).toBe(STARVED_EPOCH);
+    expect(rec?.status).toBe('active');
+    // Then the mechanism that delivered it.
+    expect(res.pagesScanned).toBeGreaterThan(1);
+    expect(res.pagingUnavailable).toBeUndefined();
+  });
+
+  it('sees every topic in the journal, not just the first page worth', () => {
+    const stateDir = writeJournal(root, 120, 6, 4); // 720 rows over 4 streams
+    const reader = new CoherenceJournalReader({ stateDir });
+
+    const onePageTopics = new Set(
+      reader.query({ kind: 'topic-placement', limit: 1000 }).entries.map((e) => String(e.topic)),
+    );
+    const res = new OwnershipApplier({ reader, store, selfMachineId: SELF }).tick();
+
+    // 120 noisy topics + the starved one.
+    expect(res.examined).toBe(121);
+    // And that is strictly more than a single page could ever have shown.
+    expect(res.examined).toBeGreaterThan(onePageTopics.size);
+  });
+
+  it('terminates on a large journal without hitting the page ceiling', () => {
+    const stateDir = writeJournal(root, 300, 8, 8); // 2400 rows over 8 streams (300 each)
+    const reader = new CoherenceJournalReader({ stateDir });
+    const res = new OwnershipApplier({ reader, store, selfMachineId: SELF }).tick();
+    expect(res.examined).toBe(301);
+    expect(res.pageCeilingHit).toBeUndefined();
+    expect(res.pagesScanned).toBeLessThanOrEqual(40);
+  });
+
+  it('stops at maxScanPages and reports the ceiling rather than scanning unbounded', () => {
+    const stateDir = writeJournal(root, 300, 8, 8);
+    const reader = new CoherenceJournalReader({ stateDir });
+    const res = new OwnershipApplier({ reader, store, selfMachineId: SELF, maxScanPages: 2 }).tick();
+    expect(res.pagesScanned).toBe(2);
+    expect(res.pageCeilingHit).toBe(true);
+  });
+
+  it('degrades to a single page — loudly — when the reader exposes no cursor', () => {
+    // Back-compat: an older caller / narrow fake without cursorFor still works, but the
+    // under-scan is REPORTED, never silent (a silent under-scan is the deadlock bug).
+    const logs: string[] = [];
+    const narrow: PlacementReader = {
+      query: () => ({
+        entries: [{ topic: 1, machine: PEER, data: { owner: SELF, epoch: 3 } }] as PlacementReaderEntry[],
+      }),
+    };
+    const res = new OwnershipApplier({ reader: narrow, store, selfMachineId: SELF, logger: (m) => logs.push(m) }).tick();
+    expect(res.pagesScanned).toBe(1);
+    expect(res.pagingUnavailable).toBe(true);
+    expect(logs.join('\n')).toMatch(/paging unavailable/i);
+    // It still does its job for what it COULD see.
+    expect(store.read('1')?.ownerMachineId).toBe(SELF);
+  });
+
+  it('does NOT flag the page ceiling when the budget exactly covered the journal', () => {
+    // The distinguishing case (reviewer probe B): rows are an EXACT multiple of the page
+    // size, so the walk consumes its whole budget AND finishes. Flagging that reports a
+    // COMPLETE scan as "INCOMPLETE — some topics may not be materialized" in the very
+    // observability surface this change adds.
+    //
+    // This case is precise on purpose: with any other row count the walk ends on an empty
+    // page and never reaches the ceiling check at all, so a laxer fixture would pass no
+    // matter how the flag is computed. 1000 rows over 4 streams (250 each, under the
+    // per-file cap) = exactly 2 full pages of 500; the budget is 2.
+    const stateDir = writeJournal(root, 1000, 1, 4, /* extraTopic */ false);
+    const reader = new CoherenceJournalReader({ stateDir });
+    const probe = reader.query({ kind: 'topic-placement', limit: 1000 });
+    expect(probe.entries.length).toBe(500); // page size is exactly 500
+
+    const res = new OwnershipApplier({ reader, store, selfMachineId: SELF, maxScanPages: 2 }).tick();
+    expect(res.pagesScanned).toBe(2);
+    expect(res.examined).toBe(1000);      // every topic seen — the scan WAS complete
+    expect(res.pageCeilingHit).toBeUndefined(); // ...so it must not claim otherwise
+  });
+
+  it('still flags the ceiling when rows genuinely remain unread', () => {
+    // The other side of that boundary — the flag must not be defanged into never firing.
+    const stateDir = writeJournal(root, 1000, 1, 4, false);
+    const reader = new CoherenceJournalReader({ stateDir });
+    const res = new OwnershipApplier({ reader, store, selfMachineId: SELF, maxScanPages: 1 }).tick();
+    expect(res.pagesScanned).toBe(1);
+    expect(res.pageCeilingHit).toBe(true);
+  });
+
+  it('never scans zero pages for a non-finite maxScanPages', () => {
+    // Reviewer probe C. NOTE ON WHAT THIS PROVES: with the ceiling checked as
+    // `pagesScanned >= maxPages` at the TOP of the walk, `NaN` is already benign
+    // (`0 >= NaN` is false), so the explicit `Number.isFinite` guard is defence-in-depth
+    // rather than the load-bearing fix — removing the guard alone does NOT fail this test,
+    // and it would be dishonest to claim otherwise. What this test DOES pin is the
+    // observable contract: a bad bound must never silently scan nothing. It fails against
+    // the original `for (page = 0; page < maxPages; page++)` form, where `page < NaN` is
+    // false and the walk ran zero pages, materialized nothing, and logged nothing.
+    const stateDir = writeJournal(root, 20, 2, 2);
+    const reader = new CoherenceJournalReader({ stateDir });
+    for (const bad of [NaN, undefined, Infinity, -Infinity]) {
+      const s = new LocalSessionOwnershipStore({ dir: path.join(root, `own-${String(bad)}`) });
+      const res = new OwnershipApplier({
+        reader, store: s, selfMachineId: SELF, maxScanPages: bad as unknown as number,
+      }).tick();
+      expect(res.pagesScanned).toBeGreaterThan(0);
+      expect(res.examined).toBeGreaterThan(0);
+      expect(s.read(String(STARVED_TOPIC))?.ownerMachineId).toBe(SELF);
+    }
+    // A finite but nonsensical bound is clamped to at least one page, never zero.
+    const s0 = new LocalSessionOwnershipStore({ dir: path.join(root, 'own-zero') });
+    const r0 = new OwnershipApplier({ reader, store: s0, selfMachineId: SELF, maxScanPages: 0 }).tick();
+    expect(r0.pagesScanned).toBe(1);
+  });
+
+  it('stops instead of looping forever when the cursor does not advance', () => {
+    const logs: string[] = [];
+    const stuck: PlacementReader = {
+      query: () => ({
+        entries: [{ topic: 2, machine: PEER, data: { owner: SELF, epoch: 4 }, ts: 't', seq: 1 }],
+      }),
+      cursorFor: () => 'SAME-CURSOR-EVERY-TIME',
+    };
+    const res = new OwnershipApplier({ reader: stuck, store, selfMachineId: SELF, logger: (m) => logs.push(m) }).tick();
+    // First page advances to the cursor; the second page returns the SAME cursor → stop.
+    expect(res.pagesScanned).toBeLessThanOrEqual(2);
+    expect(logs.join('\n')).toMatch(/cursor did not advance/i);
+  });
+
+  it('stops the walk when cursor construction throws', () => {
+    const logs: string[] = [];
+    const throwing: PlacementReader = {
+      query: () => ({
+        entries: [{ topic: 3, machine: PEER, data: { owner: SELF, epoch: 4 }, ts: 't', seq: 1 }],
+      }),
+      cursorFor: () => { throw new Error('bad cursor'); },
+    };
+    const res = new OwnershipApplier({ reader: throwing, store, selfMachineId: SELF, logger: (m) => logs.push(m) }).tick();
+    expect(res.pagesScanned).toBe(1);
+    expect(logs.join('\n')).toMatch(/cursor build failed/i);
+    // The page it DID read is still applied.
+    expect(store.read('3')?.ownerMachineId).toBe(SELF);
+  });
+});

--- a/upgrades/next/ownership-applier-placement-paging.md
+++ b/upgrades/next/ownership-applier-placement-paging.md
@@ -1,0 +1,78 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The step that turns replicated handover rows into a machine's own ownership records
+read only the FIRST page of the placement journal. That query is ordered
+epoch-descending and clamped to 500 rows, so one page is "the 500 most-handed-over
+rows", not the 500 most recent. A young conversation — one that has changed hands
+once or twice — sits at the bottom of that ordering by construction, so once the
+journal held 500 higher-epoch rows it was simply not in the page. The cutoff only
+rises as the journal grows, which makes this worse over time and aimed squarely at
+the newest conversations.
+
+Measured on a live machine: one page exposed 33 distinct topics, an exhaustive
+cursor walk of the same journal exposed 150 — the step was seeing 22% of them. The
+consequence is not cosmetic. A topic that is never materialized leaves its owner
+machine with no ownership record, so a handover request is answered `not-owner` and
+refused. A pinned cross-machine move then cannot land, and nothing self-heals it: the
+transfer's own place-repair is deliberately illegal against an active record, so the
+two machines deadlock — one holding a record the other has never seen. Observed live
+as a ~4-hour `pinState: diverged` with two identical refusals three hours apart.
+
+The applier now walks every page using the reader's existing keyset cursor. The
+journal, its ordering, and its cursor contract are untouched — only how much of it
+this one consumer reads. Termination is driven by an EMPTY page rather than a short
+one, because the reader clamps `limit` to its own cap and a "short page" test would
+have stopped the walk after page one, reproducing the very bug. The walk is capped at
+40 pages, stops if the cursor fails to advance or to build, and a reader with no
+cursor support degrades to one page while SAYING SO in the log — a silent under-read
+is the defect itself and is no longer reachable quietly.
+
+Known and tracked, not fixed here: the reader also reads at most the newest 500 rows
+of each individual stream FILE, before paging. Measured — a 700-row file exposes 500
+even under exhaustive paging. Measured growth: the busiest stream holds 384 rows and
+grows 21.8 rows/day, so it crosses the 500 cap in about five days; the others are 23 and
+77 days out. There are no archives to fall back on (`rotateKeep: 0`). Raising that bound
+interacts with the shared byte ceiling and changes the memory profile of every placement
+read, so it needs its own spec rather than being bundled here.
+<!-- tracked: ACT-1811 -->
+
+## Evidence
+
+Reproduced live before the fix (Mac Mini, agent echo, 2026-09-05), not inferred:
+
+- **Before:** one placement query (`limit: 1000`, clamped to 500) returned 500 entries
+  covering **33** distinct topics with an epoch floor of **6**; an exhaustive cursor walk
+  of the same journal returned 1015 entries covering **150** topics. Topic 69507
+  (epochs 1 and 2, rows written 18:28:50Z) was absent from the single page and present on
+  page 2 — so the applier was seeing 22% of topics and never this one.
+- **Observed failure chain:** the Mini's ownership view for that topic returned
+  `{owner:null, epoch:0, status:null}`; the drain audit logged
+  `drain-refused / not-owner / observedStatus:"none"` at 18:58:16Z and again, identically,
+  at 21:44:45Z on a manual retry; the placement surface reported `pinState: "diverged"`
+  from 18:58Z onward. The operator's pinned transfer never landed for ~4 hours.
+- **After (test harness over a real on-disk journal, same reader code):** a fixture whose
+  page 1 provably excludes the low-epoch topic (asserted in the test, both directions)
+  materializes it via the paged walk — and with the paging loop reverted to a single page,
+  the test fails `expected undefined to be 'm_self_mini'`, the exact production symptom.
+  Falsified-then-trusted for the ceiling and zero-page guards as well.
+- Full unit suite after the change: 2405 files, 43,745 tests, 0 failures.
+
+## What to Tell Your User
+
+If you run on more than one machine and a conversation refused to move to the machine
+you pinned it to — the pin recorded, the move never happening, no error explaining
+why — this is that bug. It hit newly-created conversations hardest, and it got more
+likely the longer an agent had been running. After this update the move completes on
+its own; there is nothing to re-do and no setting to change.
+
+## Summary of New Capabilities
+
+- A pinned cross-machine conversation move no longer deadlocks when the conversation
+  is young — ownership is materialized for every topic in the journal, not only those
+  in the highest-epoch page.
+- The ownership step reports how many pages it walked, whether it hit its page
+  ceiling, and whether it had to fall back to a single unpaged read.

--- a/upgrades/side-effects/ownership-applier-placement-paging.md
+++ b/upgrades/side-effects/ownership-applier-placement-paging.md
@@ -1,0 +1,231 @@
+# Side-effects review — OwnershipApplier placement paging
+
+**Change:** `OwnershipApplier.tick()` now walks every page of the `topic-placement`
+journal query (bounded, using the reader's existing keyset cursor) instead of reading a
+single page. `PlacementReader` gains an optional `cursorFor` and a `cursor` query option;
+`maxScanPages` is threaded through the wiring factory.
+
+**Tier:** 1, declared. The signal moved between my planning run and the commit gate and the
+record should say so: my pre-commit classifier run over all 3 changed files + the test file
+said `suggestedTier 1, riskFloor 1`; the commit gate itself, over the 3 in-scope source
+files (194 LOC), printed `suggestedTier=2 (size=2, riskFloor=1)`. The declaration is Tier 1
+on reasoning, at the risk floor and not below it (the floor — the only threshold that
+raises a `belowFloor` audit flag — is 1): a bounded completeness fix in one consumer
+module, no new authority/route/config/migration, rollback a plain revert. The SIZE half of
+the signal crossed a line-count threshold on artifacts and comments, which is not what the
+size heuristic is a proxy for. The decision is recorded in the audited decisions file
+either way. Phase 5 second-pass review was run regardless — the change is adjacent to
+session-lifecycle decisions — and the reviewer's four concerns are all fixed here.
+
+**Root cause (measured, not inferred).** A `topic-placement` query is ordered
+EPOCH-DESCENDING (`CoherenceJournalReader.compareKey`) and clamped to 500 rows
+(`READER_MAX_LIMIT`). One page is therefore "the 500 highest-epoch rows", not the 500 most
+recent. The applier read one page. Live measurement on the Mac Mini, 2026-09-05:
+
+| probe | result |
+|---|---|
+| single page (`limit: 1000` → clamped 500) | 500 entries, **33** distinct topics, epoch floor **6**, max **173** |
+| exhaustive cursor walk, same reader | 3 pages, 1015 entries, **150** distinct topics |
+| topic 69507 (epochs 1, 2) | **absent** from page 1; **found on page 2** |
+
+Consequence: the Mini never materialized ownership for 69507, so
+`GET /pool/ownership-view?key=69507` returned `{owner:null, epoch:0, status:null}`, so every
+drain refused `refused-not-owner` with `observedStatus:"none"` (logged 18:58:16Z and
+21:44:45Z, identical). The operator's pinned transfer could not land; `pinState: diverged`
+for ~4h with no self-heal.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+Nothing is rejected. The change is strictly additive in what it READS; it adds no
+predicate, filter, or refusal path. Every entry the applier accepted before is still
+accepted identically — the per-entry validation, the epoch fence, the `transferring`
+downgrade and the fast-forward CAS are untouched. The only behavioural delta is that MORE
+entries reach that unchanged logic.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **The per-file newest-500 tail cap.** `readTailTolerant(io, file, READER_MAX_LIMIT, …)`
+  reads at most 500 entries per stream FILE, before the merge. Measured: a single file with
+  700 rows exposes only 500 distinct topics even under exhaustive paging. This is a second,
+  independent completeness limit in the same family, and it contradicts the reader's own
+  header comment promising `topic-placement` queries are ANSWER-COMPLETE.
+
+  **Urgency corrected after review.** My first draft wrote "not biting today" and set a
+  month-out date — headroom asserted without a rate, which the reviewer flagged as an
+  unsourced assumption. Measured rather than assumed (2026-09-05):
+
+  | stream | rows | growth | headroom | crosses 500 in |
+  |---|---|---|---|---|
+  | Studio | 384 | 21.8/day | 116 | **~5 days** |
+  | third machine | 383 | 5.0/day | 117 | ~23 days |
+  | Mini | 249 | 3.2/day | 251 | ~77 days |
+
+  So the headroom is days, not weeks, and `rotateKeep: 0` means there are no archives to
+  fall back on. Tracked: <!-- tracked: ACT-1811 --> **ACT-1811** (high, due 2026-09-10;
+  supersedes ACT-1810, cancelled because its date rested on the unmeasured assumption).
+
+  Still NOT bundled into this PR, deliberately: raising that bound interacts with the 4MB
+  byte ceiling and changes the memory profile of every placement read — a materially larger
+  blast radius that deserves its own spec rather than being smuggled into a fix PR. The
+  deferral is tracked with an accurate date, not waved through.
+- **The 4MB shared byte ceiling.** A journal larger than the ceiling still truncates, with
+  `truncated: true`. The applier does not currently surface that flag. Not a regression (it
+  never did), and the ceiling is far above live volumes.
+- **Ownership records already wedged by this bug** are not retro-repaired by the code
+  change; they converge on the next tick once the row becomes visible, which is the
+  intended and sufficient path.
+
+## 3. Level-of-abstraction fit
+
+The fix sits in the CONSUMER, not the reader. That is deliberate. The reader's
+epoch-descending order is correct for its other callers, and its cursor is a public,
+documented, already-tested pagination contract designed for exactly this. Changing the
+reader's sort key or cap would have altered every placement consumer to fix one of them.
+
+Sweep of every `topic-placement` consumer. **Corrected after second-pass review:** my first
+table listed 4 of 8 callsites and presented itself as complete — exactly the class of claim
+this review exists to catch. Full enumeration
+(`grep -rn "kind: 'topic-placement'" src/`):
+
+| consumer | shape | affected? |
+|---|---|---|
+| `OwnershipApplier.ts` | cross-topic, no filter, needs completeness | **YES — this bug** |
+| `WorkingSetPullCoordinator.ts:307` | `topic`-filtered, limit 20 | No — filter applied during collection, before sort/slice |
+| `PoolActivityView.ts:199` | `topic`-filtered, limit 1 | No — same; ordering puts the highest epoch first |
+| `server.ts:23714` | `topic`-filtered, limit 20 | No — same |
+| `server.ts:23828` | `topic`-filtered, limit 1 | No — same |
+| `server.ts:23861` | `topic`-filtered, limit 1 | No — same |
+| `server.ts:22181` | `machine`-filtered, limit 1 | No — reads only `res.streams[machineId].lastTs`, which is stream metadata and independent of paging entirely |
+| `routes.ts:9370` (`GET /coherence/journal`) | generic HTTP read | No — exposes `cursor`; paging is the caller's job |
+
+The applier is the only consumer that asks a cross-topic question and therefore the only
+one the epoch-descending page order can starve.
+
+**Precision correction (also from review):** "complete for that topic" over-stated it. A
+topic-filtered answer is complete only *within the newest-500-rows-per-file window*, because
+the topic filter runs AFTER the per-file tail read. That window is the ACT-1811 limit above;
+it bounds these callers too, not just the applier. No current caller is affected (live
+streams are under the cap), but the wording should not have implied an unconditional
+guarantee.
+
+## 4. Signal vs authority compliance
+
+Compliant, and the change moves in the safe direction. The applier is not an authority: it
+adopts an ALREADY-DECIDED ownership from the journal (a replication step), and the module
+comment says so explicitly. It runs no FSM transition, makes no block/allow decision, and
+this change grants it no new authority — it only lets it see rows it was always intended to
+see. If anything, the BUG created de-facto blocking behaviour (drain refusals) out of
+incomplete data; completing the data removes an accidental authority rather than adding one.
+
+## 5. Interactions
+
+- **Does not shadow / get shadowed.** No other component materializes ownership from
+  placements; the applier is the sole path.
+- **Does not double-fire.** Keyset pagination is strict (`compareToCursor < 0`), so pages do
+  not overlap. Even if they did, `bestByTopic` keeps the max epoch per topic and the store
+  write is a fast-forward CAS — both idempotent.
+- **Does not race adjacent cleanup.** Same 15s timer, same off-hot-path position, same
+  write path. The tick does more reading before the same writes.
+- **Existing behaviour preserved for narrow callers.** Existing fakes in
+  `tests/unit/OwnershipApplier.test.ts` have no `cursorFor`; they take the single-page path
+  and pass unchanged. Sourced counts (an earlier draft said "41 adjacent tests", which
+  matched no measurement I had actually taken — review caught it):
+  `OwnershipApplier.test.ts` **14**, `ownershipApplierWiring.test.ts` **6**, plus this
+  change's own **10** = 30 in the directly-adjacent set, all green. The reviewer
+  independently ran 66 across every file referencing `OwnershipApplier`, also all green.
+
+## 6. External surfaces
+
+- No HTTP route, config key, or user-facing string changes.
+- `OwnershipApplyResult` gains three OPTIONAL observability fields
+  (`pagesScanned`, `pageCeilingHit`, `pagingUnavailable`). Verified: the ONLY consumer is
+  `src/commands/server.ts:22283`, which read `r.materialized` / `r.examined` — so the added
+  fields could not break it.
+- That consumer is extended to LOG the two degraded states. This is deliberate and is the
+  same lesson as the bug itself: an applier silently scanning only part of the journal is
+  precisely what deadlocked a transfer for four hours while every surface looked healthy.
+  The ceiling and no-cursor states are now logged even on a tick that materialized nothing,
+  so a future degradation announces itself instead of being inferred from an absent record.
+  Log-only — no new route, metric, or alert.
+- No timing or conversation-state dependency. Per-tick cost rises from 1 query to N
+  (3 on the live journal, hard-capped at 40).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated — this IS the replication path.** The applier's whole job is consuming
+`peers/<machineId>.topic-placement.jsonl` replicas and materializing them locally, and the
+bug was a completeness hole in exactly that path. Posture notes:
+
+- Every machine runs its own applier over its own replica set; there is no leader and no
+  cross-machine call, so the fix converges independently on each machine as it updates.
+- **Asymmetric-state note:** the incident's shape was one machine holding an `active` record
+  naming a second machine that held no record at all. That asymmetry was NOT a replication
+  failure — the journal row had replicated correctly and was on disk; it was a READ
+  completeness failure on the receiving side. Worth stating because the obvious diagnosis
+  ("replication is broken") would have been wrong.
+- No user-facing notice is emitted, so no one-voice gating is needed.
+- No durable state strands on topic transfer; no URLs are generated.
+- A machine still on the old version keeps under-scanning until it updates — degraded, not
+  incoherent, and identical to today's behaviour.
+
+## 8. Rollback cost
+
+Low. Revert the commit — the applier returns to a single-page read, which is exactly
+today's shipped behaviour. No data migration (the change writes no new record shape and
+adds no field to the store), no agent state repair, and records already materialized by the
+paged walk are ordinary, correctly-formed ownership records that the old code also produces
+and reads. No release coupling.
+
+---
+
+## Phase 5 — second-pass review
+
+Reviewer: dedicated subagent, independent read of this artifact and the diff.
+
+**Verdict: "Concur with the review on substance — the root cause is real, the fix is
+correct, and the tests genuinely prove it. Four concerns raised, none of which block the
+merge."**
+
+The reviewer did not take the author's summary on trust. It re-derived the root cause from
+`READER_MAX_LIMIT`, `clampLimit`, `compareKey` and `sortMerged` directly; it broke the fix
+itself (`page < maxPages` → `page < 1`), re-ran, confirmed the key test fails with
+`expected undefined to be 'm_self_mini'` (an absent ownership record — the user-visible
+property, not an incidental mechanism), then restored and re-confirmed green. It also built
+its own single-file fixture to test whether the multi-file fixture shape was justified, and
+independently ran 66 tests across every file referencing `OwnershipApplier`.
+
+All four concerns were accepted and fixed in this PR — including the two the reviewer
+filed as follow-ups, since both were one-liners in code this diff already touches:
+
+1. **`maxScanPages: NaN` scanned zero pages, silently** (reviewer probe C:
+   `pagesScanned=0 examined=0 rec=null`, no log line — the exact silent-under-scan shape
+   this change exists to remove). Fixed with a `Number.isFinite` guard, plus a test.
+   **Honesty note:** falsification showed the guard alone is *not* load-bearing — the loop
+   restructure (`pagesScanned >= maxPages` checked at the TOP) already makes `NaN` benign,
+   because `0 >= NaN` is false. Removing the guard does not fail the test. The test is
+   written against the observable contract ("never scan zero pages") and does fail against
+   the original `for (page = 0; page < maxPages; page++)` form. The comment in the test says
+   so rather than implying the guard is what saves it.
+2. **`pageCeilingHit` false positive** (reviewer probe B: 1000 rows / 2 pages / budget 2
+   reported a COMPLETE scan as a ceiling hit, which the new server logging would print as
+   "INCOMPLETE — some topics may not be materialized"). **My first attempt did not actually
+   fix this** — I moved the flag to the top of the loop and softened the wording, but in the
+   reviewer's exact case the walk still has a live cursor and still flagged. Falsification
+   caught that. The real fix is one bounded probe query with the live cursor when the budget
+   is spent: empty ⇒ the scan was complete, don't flag. Costs one extra query only in the
+   rare ceiling case. Both sides are now tested (does-not-flag when complete; still-flags
+   when rows genuinely remain).
+3. **Sweep table listed 4 of 8 callsites** while presenting itself as complete. Corrected in
+   §3 above; all four missed callsites verified genuinely unaffected.
+4. **Unsourced headroom claim** for the per-file cap. Measured; it is ~5 days on the busiest
+   stream, not a month. ACT-1810 cancelled and replaced by ACT-1811 (high, due 2026-09-10).
+
+Also corrected: the "41 adjacent tests" figure, which matched no measurement I had taken.
+
+**What this review caught that I did not.** Two of my own fixes were vacuous when I first
+wrote them, and I only found that by reverting each one and watching the test *not* fail.
+Concern 2 in particular I had recorded as fixed when it was not. That is the same failure
+mode a reviewer rejected in this repo earlier the same day — an author trusting that a test
+proves what its name says.


### PR DESCRIPTION
## ELI16 — the machine was reading only the first page of a list sorted worst-first for its purpose, so young conversations were invisible to it

Every conversation carries a counter of how many times it has moved between machines. The step that teaches a machine "which conversations do I own?" reads a shared ledger of those moves — but the ledger is served sorted by that counter, highest first, 500 rows per page, and the step only ever read page one. So it saw the 500 *most-moved* rows, not the newest. A brand-new conversation (counter 1 or 2) sits at the bottom by construction, and once the ledger held 500 busier rows it simply never appeared. Its machine then had no ownership record, answered "I don't have this" to every handover request, and a pinned move between machines deadlocked forever — observed live for four hours.

The fix: read every page, not just the first, using the page-turning cursor the ledger already provides. Bounded (40 pages max), stops if the cursor stops advancing, and if it ever has to fall back to one page it says so in the log instead of going quiet — because the silent partial read *was* the bug.

## The bug

A `topic-placement` journal query is ordered **epoch-DESCENDING** (`CoherenceJournalReader.compareKey`) and clamped to **500** rows (`READER_MAX_LIMIT`). `OwnershipApplier.tick()` asked for one page and stopped.

So the applier saw *the 500 most-handed-over rows*, not the 500 most recent. A young topic — one handed over once or twice — sits at the bottom of that ordering **by construction**. Once the journal held 500 higher-epoch rows, it was never scanned. The cutoff only rises as the journal grows, so this worsens over time and targets the **newest** topics.

### Measured, not inferred (Mac Mini, 2026-09-05)

| probe | result |
|---|---|
| single page (`limit: 1000` → clamped to 500) | 500 entries, **33** distinct topics, epoch floor **6**, max **173** |
| exhaustive cursor walk, same reader | 3 pages, 1015 entries, **150** distinct topics |
| topic 69507 (epochs 1, 2) | **absent** from page 1; **found on page 2**, owner = the Mini |

The applier was seeing **22%** of topics.

### Why that deadlocks a transfer

1. The Studio journaled `owner = Mini, epoch 2` for topic 69507. The row replicated correctly and was on disk.
2. The Mini's applier never scanned it → `GET /pool/ownership-view?key=69507` → `{owner:null, epoch:0, status:null}`.
3. `POST /pool/transfer` proxies to the lease holder; the holder sends the drain to the owner (the Mini); `SessionDrainRunner` refuses `refused-not-owner`, `observedStatus:"none"` — logged **18:58:16Z and 21:44:45Z, identical**.
4. The transfer's place-repair half is deliberately illegal against an `active` record, so `placedOwnership:false`.

Net: one machine holding an active record naming a second machine that holds nothing. Neither is wrong; there is no self-heal. `pinState: "diverged"` for ~4 hours on a real operator-pinned move.

Worth naming: the obvious diagnosis — "replication is broken" — is **wrong**. The row replicated fine. This was a *read completeness* failure on the receiving side.

## The fix

Walk every page using the reader's **existing** keyset cursor. The journal, its ordering and its cursor contract are untouched — only how much of it this one consumer reads.

- **Termination keys on an EMPTY page, not a short one.** The reader clamps `limit` to its own cap, so `entries.length < pageLimit` is true on a *full* page whenever `pageLimit > 500` — a short-page test would stop after page 1 and reproduce the exact bug.
- Bounded at **40 pages** (~20k rows, far above retention); stops if the cursor fails to advance or to build.
- A reader without cursor support reads one page **and says so**. A silent under-scan is the defect itself.
- `server.ts` logs the degraded states **even on a tick that materialized nothing**, so a future regression announces itself instead of being inferred from an absent record.

## Sweep — every `topic-placement` consumer

All eight callsites (`grep -rn "kind: 'topic-placement'" src/`). My first draft listed four and called itself complete — second-pass review caught that:

| consumer | shape | affected? |
|---|---|---|
| `OwnershipApplier.ts` | cross-topic, unfiltered, needs completeness | **YES — this bug** |
| `WorkingSetPullCoordinator.ts:307` | `topic`-filtered, limit 20 | No — the filter runs during collection, before sort/slice |
| `PoolActivityView.ts:199` | `topic`-filtered, limit 1 | No — same; ordering puts the highest epoch first |
| `server.ts:23714` | `topic`-filtered, limit 20 | No — same |
| `server.ts:23828` | `topic`-filtered, limit 1 | No — same |
| `server.ts:23861` | `topic`-filtered, limit 1 | No — same |
| `server.ts:22181` | `machine`-filtered, limit 1 | No — reads only stream metadata (`lastTs`), independent of paging |
| `routes.ts:9370` (`GET /coherence/journal`) | generic HTTP read | No — exposes `cursor`; paging is the caller's job |

The applier is the only consumer asking a cross-topic question, hence the only one the ordering can starve. (Precision: a topic-filtered answer is complete only *within* the newest-500-per-file window — that window is the ACT-1811 limit below, and it bounds these callers too.)

## Tests

Against the **real** `CoherenceJournalReader` over a real on-disk journal. A fake reader cannot reproduce a bug that lives in the interaction between the reader's ordering and its clamp — it would pass vacuously.

- The regression test asserts the **ownership record first** (the property the drain actually reads), then the mechanism. Asserting the page count first would let it pass for code that pages correctly and records nothing.
- A **non-vacuity guard** asserts page 1 genuinely excludes the topic, so the test fails loudly if the reader's cap or ordering ever drifts, rather than silently starting to pass for the wrong reason.
- The fixture is **multi-file** on purpose: a single file trips a *different* limit (per-file tail read) and would test the wrong thing. The helper throws if a fixture stream exceeds that cap.
- **Falsified before trusted:** reverting the fix makes it fail `expected undefined to be 'm_self_mini'` — the exact production symptom.

Adjacent suites pass unchanged (their fakes have no `cursorFor` and take the documented single-page path): `OwnershipApplier.test.ts` 14 + `ownershipApplierWiring.test.ts` 6 + this change's 10 = 30 green. The reviewer independently ran 66 across every file referencing `OwnershipApplier`, also green. (An earlier draft said "41", which matched no measurement I had taken.)

## Second-pass review

Verdict: **concur on substance, four concerns, none blocking.** The reviewer re-derived the root cause from the reader source rather than my summary, broke the fix itself, confirmed the key test fails on the *absent ownership record*, restored, and re-confirmed green. All four concerns are fixed in this PR — including the two it filed as follow-ups, since both were one-liners in code already touched:

1. **`maxScanPages: NaN` scanned zero pages silently** (`pagesScanned=0 examined=0 rec=null`, no log) — the same silent-under-scan shape this PR removes. Guarded + tested. *Honest caveat:* falsification showed the guard is defence-in-depth, not load-bearing — the loop restructure already makes `NaN` benign. The test pins the observable contract and fails against the original loop form; the code comment says so rather than implying the guard saves it.
2. **`pageCeilingHit` false positive** on a complete scan whose row count is an exact multiple of the page size — a false alarm in the warning light this PR adds. **My first fix did not work**: I moved the flag and softened the wording, but the reviewed case still flagged. Forcing the failure caught it. Real fix: one bounded probe with the live cursor when the budget is spent — empty means complete, don't flag. Costs one extra query only in the ceiling case. Both directions tested.
3. **Sweep listed 4 of 8 callsites** while claiming completeness — corrected above; all four missed ones verified unaffected.
4. **Unsourced headroom claim** — measured; ~5 days, not a month.

## Known, tracked, deliberately not fixed here

The reader also reads at most the newest **500 rows per stream FILE**, before paging — measured: a 700-row file exposes 500 even under exhaustive paging. This contradicts the reader's own header comment promising `topic-placement` queries are ANSWER-COMPLETE.

My first draft said "not biting today" and set a month-out date — headroom asserted without a rate, which the reviewer flagged as an unsourced assumption. Measured instead:

| stream | rows | growth | headroom | crosses 500 in |
|---|---|---|---|---|
| Studio | 384 | 21.8/day | 116 | **~5 days** |
| third machine | 383 | 5.0/day | 117 | ~23 days |
| Mini | 249 | 3.2/day | 251 | ~77 days |

So the headroom is days, not weeks, and `rotateKeep: 0` means no archives to fall back on. Still not bundled here — raising that bound interacts with the 4MB byte ceiling and changes the memory profile of every placement read, a materially larger blast radius that deserves its own spec rather than being smuggled into a fix PR. Tracked as **ACT-1811** (high, due 2026-09-10; supersedes ACT-1810, cancelled because its date rested on the assumption).

## Rollback

Revert the commit. The applier returns to a single-page read — today's shipped behaviour. No migration, no state repair: records materialized by the paged walk are ordinary ownership records the old code also produces and reads.

Unblocks operator commitment **CMT-1405** (pinned move of topic 69507 to the Mac Studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJ9bBpapNmK7LaP1KgEn98
