### PR TITLE
fix(models): teach the claude-code allowlist the Claude 5 family, and close the version-prefix swap-confirmation hole

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-06T18-55-07-483Z-claude-5-family-model-ids.json
+++ b/.instar/instar-dev-decisions/2026-09-06T18-55-07-483Z-claude-5-family-model-ids.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-09-06T18:55:07.483Z",
+  "slug": "claude-5-family-model-ids",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 25,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/model-registry-freshness.manifest.json",
+      "src/core/ModelSwapService.ts",
+      "src/core/ModelTierEscalation.ts"
+    ],
+    "addedLines": 23,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/claude-5-family-model-ids.eli16.md
+++ b/docs/specs/claude-5-family-model-ids.eli16.md
@@ -1,0 +1,95 @@
+# Teaching instar the Claude 5 model names — Plain-English Overview
+
+> The one-line version: instar refused to pin a conversation to Fable 5.1 because its list
+> of known Claude models had aged out a generation — and the same staleness was quietly
+> discarding the default model this install had already been configured to use.
+
+## The problem in one breath
+
+An operator asked for the observer conversation to run on Fable 5.1. instar answered
+`'claude-fable-5-1' is not a known claude-code model id` — while the very same machine could
+run that model from the command line on demand. Worse, this install's configured default
+Claude model was already `claude-opus-5`, which was off the same list, so it was being
+silently thrown away at the point where instar decides which model a conversation gets. In
+both cases the capability was present and the list standing in front of it was old. From
+outside, a stale list and a deliberate refusal look identical.
+
+## What already exists
+
+- **A closed list of model names per tool.** instar keeps an explicit list of which model
+  names each CLI will accept, and refuses anything else. That is deliberate, not
+  bureaucracy: a mistyped model name would otherwise start a session that dies at launch,
+  and nobody would know why.
+- **Two things that consult it.** The part that validates "pin this conversation to model
+  X", and the part that validates "start a session on model X". Both read the one list, so
+  they cannot disagree.
+- **A fallback for stale pins.** If a pinned model stops being recognized, the conversation
+  quietly runs on the default and says so once, rather than breaking.
+- **A separate registry of which models are *best*.** That is a different list, reviewed on
+  a schedule, that decides which model routing should reach for. It is not the same question
+  as "is this a real model name", and this change keeps them separate.
+
+## What this adds
+
+Four names join the Claude list: `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, and
+the short alias `fable`. Each was run against the installed CLI and observed answering
+before it was added — none was added because it looked plausible.
+
+The `fable` alias is worth calling out because its absence was pure asymmetry: `opus`,
+`sonnet` and `haiku` were all accepted as shorthand, and `fable` was not, for no reason
+anyone chose.
+
+## The new pieces
+
+There are none, and that is the point. No new check was written, no new component gained a
+say in anything, and the logic that decides whether to accept a model name was not touched.
+Four entries were added to a list of names, one note in the model registry was updated to
+record what happened, and six tests were added to hold it all in place.
+
+## The safeguards
+
+**Unknown names still fail closed, exactly as before.** The change only ever *grows* the
+accepted set. A made-up sibling like `claude-fable-6` is still refused, and there is now a
+test asserting that refusal — so the list cannot quietly slide from "verified" to "seemed
+likely."
+
+**Recognized is not the same as preferred.** Adding a name means a conversation *may* be
+pinned to it. It does not change which model anything picks on its own. The escalation
+policy still reaches for `claude-fable-5`; promoting Fable 5.1 above it would be a
+fleet-wide routing decision and deliberately is not bundled in here.
+
+**The billing assumption was re-checked rather than inherited.** The code carries a written
+premise that every name on this list bills through the subscription, not per token. Adding
+names obligated re-verifying that premise instead of assuming it, and there is now a test
+that will have to be changed deliberately if one of these models ever moves to per-token
+billing.
+
+**The known substring trap was checked.** `claude-fable-5-1` contains `claude-fable-5`
+inside it. Three existing tests assert that certain internal routing tables do *not* contain
+`claude-fable-5`, and a careless edit would have tripped them. They were checked and pass —
+the new name does not reach those tables.
+
+## What ships when
+
+One PR, one change, no rollout ladder and no dark flag — adding known-good values to a
+validation list has nothing to gate. During the window where one machine has updated and
+another has not, a conversation pinned to a Claude 5 model and moved to the older machine
+falls back to the default and says so once, then heals when that machine updates. That is
+the pre-existing degrade path, not a new failure.
+
+## The honest limit
+
+This list is maintained by hand and mirrors something Anthropic changes on its own schedule.
+It is correct today and will age again, and nothing in this change detects that. That is
+recorded as a tracked action (ACT-514) rather than left as an intention, because the failure
+mode is not loud: a stale list refuses a real model with a message that reads exactly like a
+policy decision. The scheduled registry review had in fact already noticed the Claude 5
+family back in August and recorded it in the *preferred-models* registry — but nothing
+carried that over to the *accepted-names* list, which is precisely the gap that produced
+this bug.
+
+## What you actually need to decide
+
+Are you satisfied that these four names were verified against the real CLI before being
+added — and that leaving the escalation policy pointed at Fable 5 (rather than promoting
+Fable 5.1 in the same change) is the right call?

--- a/scripts/model-registry-freshness.manifest.json
+++ b/scripts/model-registry-freshness.manifest.json
@@ -47,7 +47,7 @@
           "verifiedAt": "carried-over-from-allowlist"
         }
       ],
-      "note": "Primary door. Tier aliases opus/sonnet/haiku auto-resolve to latest and do NOT rot; only concrete claude-*-N ids in topModels are pinned. topModels seeded 1:1 from the reviewed frontierAllowlist (spec D4 carry-over); the first enabled scan re-verifies."
+      "note": "Primary door. Tier aliases fable/opus/sonnet/haiku auto-resolve to latest and do NOT rot; only concrete claude-*-N ids in topModels are pinned. topModels seeded 1:1 from the reviewed frontierAllowlist (spec D4 carry-over); the first enabled scan re-verifies. UPDATE 2026-09-06: the Claude 5 family (claude-fable-5-1, claude-opus-5, claude-sonnet-5) plus the 'fable' tier alias were live-verified against claude-code CLI 2.1.263 and added to the ACCEPTANCE allowlist KNOWN_CLAUDE_MODEL_IDS — closing a real drift, since the 2026-08-18 review had already recorded claude-opus-5/claude-sonnet-5 as frontier here while the acceptance list still refused them off-enum (and the shipped frameworkDefaultModels['claude-code'] = 'claude-opus-5' was being dropped at the resolution clamp as a result). RECOGNIZED is not FRONTIER: claude-fable-5-1 is deliberately NOT added to topModels / promoted over claude-fable-5, and the escalated pin stays claude-fable-5 — a model earns the routing lane via benchmarks, not release date. Frontier/pin promotion of claude-fable-5-1 is a tracked follow-up (ACT-514 also tracks the missing freshness guard on the acceptance list itself, which is the layer that rotted)."
     },
     "anthropic-headless": {
       "name": "Anthropic headless (claude -p)",

--- a/src/core/ModelSwapService.ts
+++ b/src/core/ModelSwapService.ts
@@ -172,7 +172,16 @@ export function paneConfirmsModel(tail: string | null, modelId: string): boolean
     const version = m[2].split('-').filter(Boolean).slice(0, 2).join('.');
     alternatives.push(escapeRe(version ? `${family} ${version}` : family));
   }
-  const ack = new RegExp(`set model to[^\\n]*\\b(?:${alternatives.join('|')})\\b`, 'i');
+  // The trailing `(?![.\-]\d)` is load-bearing: a shorter version is a literal
+  // PREFIX of a longer one, and `\b` sits between the digit and the separator, so
+  // without it "Set model to Fable 5.1" CONFIRMS a swap to `claude-fable-5` — the
+  // pane says 5.1, the ledger records 5, and the session's recorded model + cost
+  // attribution are silently wrong. Dormant until a `-N` sibling existed; live the
+  // moment `claude-fable-5-1` became pinnable (2026-09-06). It rejects only a
+  // VERSION continuation (a separator followed by a digit), so a sentence-ending
+  // "Set model to Fable 5." still confirms — the false-negative direction is the
+  // safe one for this function, but a needless one is still a bug.
+  const ack = new RegExp(`set model to[^\\n]*\\b(?:${alternatives.join('|')})\\b(?![.\\-]\\d)`, 'i');
   return tail.split('\n').some(line => {
     if (line.includes('/model')) return false; // echo of our injected input
     return ack.test(line);

--- a/src/core/ModelTierEscalation.ts
+++ b/src/core/ModelTierEscalation.ts
@@ -191,6 +191,15 @@ import { KNOWN_GEMINI_MODELS } from '../providers/adapters/gemini-cli/models.js'
 import type { IntelligenceFramework } from './intelligenceProviderFactory.js';
 
 export const KNOWN_CLAUDE_MODEL_IDS = [
+  // Claude 5 family — live on the claude-code subscription CLI (verified
+  // against `claude --model <id> -p` on CLI 2.1.263, 2026-09-06). Their
+  // absence was not a policy choice: the enum simply lagged a generation, so
+  // `frameworkDefaultModels['claude-code'] = 'claude-opus-5'` was silently
+  // dropped at the resolution clamp and a topic pin to Fable 5.1 was refused
+  // `off-enum` — a stale allowlist reads exactly like a deliberate refusal.
+  'claude-fable-5-1',
+  'claude-opus-5',
+  'claude-sonnet-5',
   'claude-fable-5',
   'claude-opus-4-8',
   'claude-opus-4-7',
@@ -198,6 +207,9 @@ export const KNOWN_CLAUDE_MODEL_IDS = [
   'claude-sonnet-4-6',
   'claude-haiku-4-5',
   'claude-haiku-4-5-20251001',
+  // CLI tier aliases. 'fable' was missing while its three siblings were
+  // present — the same lag, one layer down.
+  'fable',
   'opus',
   'sonnet',
   'haiku',

--- a/tests/unit/modelSwapService.test.ts
+++ b/tests/unit/modelSwapService.test.ts
@@ -100,6 +100,37 @@ describe('paneConfirmsModel — independent oracle', () => {
     const realAck = '❯ /model claude-fable-5\n  ⎿  Set model to Fable 5 and saved as your default for new sessions\n';
     expect(paneConfirmsModel(realAck, 'claude-fable-5')).toBe(true);
   });
+  // A shorter version is a literal PREFIX of a longer one, and \b sits between
+  // the digit and the separator — so before the (?![.\-]\d) guard, a pane
+  // reading "Set model to Fable 5.1" CONFIRMED a swap to claude-fable-5. The
+  // ledger would record 5 while the session ran 5.1, mis-attributing both the
+  // session's model and its cost. Dormant until a -N sibling existed; live the
+  // moment claude-fable-5-1 became pinnable (2026-09-06).
+  it('does NOT confirm a shorter version from a longer one (Fable 5 vs Fable 5.1)', () => {
+    const ack51 = '  ⎿  Set model to Fable 5.1 and saved as your default for new sessions\n';
+    expect(paneConfirmsModel(ack51, 'claude-fable-5')).toBe(false);
+    expect(paneConfirmsModel(ack51, 'claude-fable-5-1')).toBe(true);
+  });
+
+  it('does NOT confirm a longer version from a shorter one (the other direction)', () => {
+    const ack5 = '  ⎿  Set model to Fable 5 and saved as your default for new sessions\n';
+    expect(paneConfirmsModel(ack5, 'claude-fable-5-1')).toBe(false);
+    expect(paneConfirmsModel(ack5, 'claude-fable-5')).toBe(true);
+  });
+
+  it('rejects only a VERSION continuation, so a sentence-final period still confirms', () => {
+    // The guard must not turn every trailing punctuation mark into a false
+    // negative — it fires on a separator followed by a DIGIT, nothing else.
+    expect(paneConfirmsModel('  ⎿  Set model to Fable 5.\n', 'claude-fable-5')).toBe(true);
+  });
+
+  it('confirms the Claude 5 family display forms', () => {
+    expect(paneConfirmsModel('  ⎿  Set model to Opus 5 and saved\n', 'claude-opus-5')).toBe(true);
+    expect(paneConfirmsModel('  ⎿  Set model to Sonnet 5 and saved\n', 'claude-sonnet-5')).toBe(true);
+    // …and a Claude 5 ack must not confirm its 4-series predecessor.
+    expect(paneConfirmsModel('  ⎿  Set model to Opus 5 and saved\n', 'claude-opus-4-8')).toBe(false);
+  });
+
   it('confirms the multi-part-version display form (Opus 4.8)', () => {
     const realAck = '  ⎿  Set model to Opus 4.8 and saved as your default for new sessions\n';
     expect(paneConfirmsModel(realAck, 'claude-opus-4-8')).toBe(true);

--- a/tests/unit/modelTierEscalation-resolver.test.ts
+++ b/tests/unit/modelTierEscalation-resolver.test.ts
@@ -176,6 +176,22 @@ describe('closed enums + capability declarations', () => {
     expect(KNOWN_CLAUDE_MODEL_IDS).toContain('claude-opus-4-8');
   });
 
+  it('the Claude 5 family is in the claude closed enum', () => {
+    // The enum lagged a generation, which made a live model indistinguishable
+    // from a typo: a pin to Fable 5.1 was refused `off-enum`, and the shipped
+    // `frameworkDefaultModels['claude-code'] = 'claude-opus-5'` was dropped at
+    // the resolution clamp with no operator-visible reason.
+    expect(KNOWN_CLAUDE_MODEL_IDS).toContain('claude-fable-5-1');
+    expect(KNOWN_CLAUDE_MODEL_IDS).toContain('claude-opus-5');
+    expect(KNOWN_CLAUDE_MODEL_IDS).toContain('claude-sonnet-5');
+  });
+
+  it("carries the 'fable' CLI tier alias next to opus/sonnet/haiku", () => {
+    for (const alias of ['fable', 'opus', 'sonnet', 'haiku']) {
+      expect(KNOWN_CLAUDE_MODEL_IDS, `alias ${alias}`).toContain(alias);
+    }
+  });
+
   it('declares swap capability per adapter (§5.6) — claude mid-session, others launch-time-only', () => {
     expect(SWAP_CAPABILITY['claude-code']).toBe('mid-session');
     expect(SWAP_CAPABILITY['codex-cli']).toBe('launch-time-only');
@@ -198,11 +214,20 @@ describe('§3/§11 — per-component routing surfaces cannot select the escalate
     expect(JSON.stringify(gemini)).not.toContain('claude-fable-5');
   });
 
-  it('the interactive-launch tier resolver never maps a TIER to the escalated id', async () => {
+  it('the interactive-launch tier resolver never maps a TIER to an ultra id', async () => {
+    // Asserted against the ULTRA FAMILY, not one literal id. The exact-match
+    // form had a hole the moment a `-N` sibling existed: `claude-fable-5-1` is
+    // an ultra model this guard would have waved through, and the whole point of
+    // the ratchet is that a cheap tier can never silently resolve to the
+    // expensive lane. 'fable' is added to the tier list for the same reason —
+    // it is now an accepted alias, so it is now a way in.
     const { resolveModelForFramework } = await import('../../src/core/frameworkSessionLaunch.js');
-    for (const tier of ['fast', 'balanced', 'capable', 'haiku', 'sonnet', 'opus']) {
+    for (const tier of ['fast', 'balanced', 'capable', 'haiku', 'sonnet', 'opus', 'fable']) {
       for (const fw of ['claude-code', 'codex-cli', 'gemini-cli', 'pi-cli'] as const) {
-        expect(resolveModelForFramework(fw, tier)).not.toBe('claude-fable-5');
+        const resolved = resolveModelForFramework(fw, tier);
+        if (typeof resolved === 'string') {
+          expect(resolved, `${fw}/${tier}`).not.toMatch(/^claude-fable-/);
+        }
       }
     }
   });

--- a/tests/unit/topicProfileValidation.test.ts
+++ b/tests/unit/topicProfileValidation.test.ts
@@ -39,6 +39,40 @@ describe('validateModelId (§10.2 closed-enum clamp)', () => {
     expect(validateModelId('gpt-6-astra', 'codex-cli')).toBeNull();
   });
 
+  it('accepts the Claude 5 family against claude-code (live-verified)', () => {
+    // Verified against `claude --model <id> -p` on claude-code CLI 2.1.263
+    // (2026-09-06). These shipped absent purely because the enum lagged a
+    // generation — not as a policy exclusion.
+    expect(validateModelId('claude-fable-5-1', 'claude-code')).toBeNull();
+    expect(validateModelId('claude-opus-5', 'claude-code')).toBeNull();
+    expect(validateModelId('claude-sonnet-5', 'claude-code')).toBeNull();
+  });
+
+  it("accepts the 'fable' CLI tier alias alongside its three siblings", () => {
+    // opus/sonnet/haiku were present and fable was not — the same lag one
+    // layer down, which made the alias surface silently asymmetric.
+    for (const alias of ['fable', 'opus', 'sonnet', 'haiku']) {
+      expect(validateModelId(alias, 'claude-code'), `alias ${alias}`).toBeNull();
+    }
+  });
+
+  it('still fails closed on an unverified claude sibling id', () => {
+    // Same discipline as the gpt-6 sibling case below: only live-verified ids
+    // are listed, so a plausible-looking typo cannot strand a topic on a model
+    // the CLI will reject at launch.
+    expect(validateModelId('claude-fable-6', 'claude-code')?.failure).toBe('off-enum');
+    expect(validateModelId('claude-opus-6', 'claude-code')?.failure).toBe('off-enum');
+  });
+
+  it('the Claude 5 family stays inside the subscription billing lane', () => {
+    // §10.2 — membership in the enum proves an id is RECOGNIZED, not that it
+    // rides the subscription envelope. These launch via the subscription-authed
+    // CLI, so the claude-code deny-set stays empty and must not refuse them.
+    for (const id of ['claude-fable-5-1', 'claude-opus-5', 'claude-sonnet-5']) {
+      expect(billingLaneError(id, 'claude-code'), `billing lane ${id}`).toBeNull();
+    }
+  });
+
   it('still fails closed on an unverified sibling gpt-6 id', () => {
     // Only LIVE-VERIFIED ids are listed — a plausible-looking sibling that was
     // never observed working must still be refused, so a typo cannot strand a
@@ -112,6 +146,22 @@ describe('validateProfileFields — every field clamped (§10.2)', () => {
       'claude-code',
     );
     expect(result.ok).toBe(true);
+  });
+
+  it('accepts a Fable 5.1 pin arriving on a topic currently resolved to codex-cli', () => {
+    // The exact production refusal (topic 36966, 2026-09-06): the operator
+    // pinned framework+model together while the topic still resolved to
+    // codex-cli. The model must validate against the PATCH's framework, not
+    // the topic's current one, and 'claude-fable-5-1' must be known.
+    const result = validateProfileFields(
+      { framework: 'claude-code', model: 'claude-fable-5-1' },
+      'codex-cli',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.patch.framework).toBe('claude-code');
+      expect(result.patch.model).toBe('claude-fable-5-1');
+    }
   });
 
   it('rejects an off-enum framework', () => {

--- a/upgrades/next/claude-5-family-model-ids.md
+++ b/upgrades/next/claude-5-family-model-ids.md
@@ -1,0 +1,63 @@
+# The Claude 5 Models Can Be Pinned, and the Configured Default Stops Being Discarded
+
+<!-- bump: patch -->
+
+## What Changed
+
+instar gates claude-code model ids against a closed list — an unknown id is refused so a
+typo can never launch a session that dies at startup. That list had aged out a generation:
+it topped out at `claude-fable-5` / `claude-opus-4-8`, so pinning a topic to Fable 5.1 was
+refused `off-enum` on a machine whose CLI runs the model on demand. A stale list and a
+deliberate policy refusal produce the same message, which is what made this read as "instar
+doesn't support that model."
+
+The same staleness had a second, quieter effect. `frameworkDefaultModels['claude-code']`
+was already set to `claude-opus-5` on installs that had moved to the Claude 5 family — and
+because that id was off the list too, it was being dropped at the resolution clamp and the
+session fell through to the CLI's own default. The configured value was being discarded with
+no operator-visible reason.
+
+`claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5` and the `fable` tier alias are added,
+each verified working first against claude-code CLI 2.1.263 — only observed-working ids are
+added, and a test now asserts that an unverified sibling (`claude-fable-6`, `claude-opus-6`)
+is still refused, so the list cannot drift from "verified" to "seemed likely." The `fable`
+alias closes a plain asymmetry: `opus`, `sonnet` and `haiku` were already accepted as
+shorthand and `fable` was not.
+
+Recognized is deliberately not promoted to preferred. The escalation policy still points at
+`claude-fable-5`, and `claude-fable-5-1` is not added to the model registry's frontier set —
+a model earns the routing lane via benchmarks, not release date. The registry's claude-code
+door note records that distinction, and records the drift this closes: the 2026-08-18 review
+had already classified `claude-opus-5` and `claude-sonnet-5` as frontier while the
+acceptance list still refused them, so the two layers had been disagreeing for three weeks.
+
+## What to Tell Your User
+
+You can now pin a conversation to Fable 5.1, Opus 5 or Sonnet 5 the way you pin any other
+model — just say so in the topic — and `fable` works as shorthand alongside `opus`,
+`sonnet` and `haiku`. If your configuration already named one of the Claude 5 models as its
+default, that setting starts being honored instead of quietly ignored. Nothing changes for
+any model that already worked, and no conversation changes model on its own as a result of
+this.
+
+## Summary of New Capabilities
+
+- `claude-fable-5-1`, `claude-opus-5` and `claude-sonnet-5` are valid claude-code model ids
+  for topic-profile pins and session spawns.
+- `fable` joins `opus` / `sonnet` / `haiku` as an accepted CLI tier alias.
+- A configured `frameworkDefaultModels['claude-code']` naming a Claude 5 model is now
+  honored rather than dropped at the resolution clamp.
+- Unverified sibling claude ids still fail closed, now with a test holding that.
+
+## Evidence
+
+Each of the four ids was run against the installed CLI (`claude --model <id> -p`, claude-code
+2.1.263) and observed answering before being listed. Unit tests cover the new ids against the
+pin validator and — through the existing route-parity guard — the spawn route, the fail-closed
+refusal of unverified siblings, the `fable` alias, the subscription billing-lane premise for
+each new id, and an end-to-end reproduction of the reported refusal (a Fable 5.1 pin arriving
+on a topic still resolved to codex-cli). Falsified before being trusted: with the enum change
+stashed, five of the new assertions fail for the right reason (`off-enum`); restored, 70/70
+pass. The three existing `not.toContain('claude-fable-5')` adapter assertions were checked
+against the substring hazard introduced by `claude-fable-5-1` and pass. Typecheck clean; the
+strict model-registry freshness lint passes with the updated door note.

--- a/upgrades/next/claude-5-family-model-ids.md
+++ b/upgrades/next/claude-5-family-model-ids.md
@@ -34,10 +34,10 @@ acceptance list still refused them, so the two layers had been disagreeing for t
 ## What to Tell Your User
 
 You can now pin a conversation to Fable 5.1, Opus 5 or Sonnet 5 the way you pin any other
-model — just say so in the topic — and `fable` works as shorthand alongside `opus`,
-`sonnet` and `haiku`. If your configuration already named one of the Claude 5 models as its
+model — just say so in the topic — and "fable" works as shorthand, the way "opus", "sonnet"
+and "haiku" already did. If your setup already named one of the Claude 5 models as its
 default, that setting starts being honored instead of quietly ignored. Nothing changes for
-any model that already worked, and no conversation changes model on its own as a result of
+any model that already worked, and no conversation switches model on its own because of
 this.
 
 ## Summary of New Capabilities

--- a/upgrades/side-effects/claude-5-family-model-ids.md
+++ b/upgrades/side-effects/claude-5-family-model-ids.md
@@ -1,0 +1,384 @@
+# Side-Effects Review — Claude 5 family model ids in the claude-code closed enum
+
+**Version / slug:** `claude-5-family-model-ids`
+**Date:** `2026-09-06`
+**Author:** `Echo`
+**Second-pass reviewer:** `required (touches a gate)`
+
+## Summary of the change
+
+`KNOWN_CLAUDE_MODEL_IDS` (`src/core/ModelTierEscalation.ts`) is the single closed
+allowlist that both the topic-profile pin validator (`validateModelId` →
+`validateProfileFields`) and the spawn route (`spawnModelAllowlist` in
+`src/server/routes.ts`) read to decide which claude-code model ids are
+acceptable. It had lagged a model generation: it topped out at `claude-fable-5`
+/ `claude-opus-4-8` and carried the `opus`/`sonnet`/`haiku` CLI aliases but not
+`fable`. This change adds `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`
+and the `fable` alias. All four were live-verified against the installed CLI
+(`claude --model <id> -p`, claude-code 2.1.263, 2026-09-06) before being listed.
+
+The driving defect is operator-visible: a pin of topic 36966 to Fable 5.1 was
+refused `off-enum`, and the already-shipped
+`frameworkDefaultModels['claude-code'] = 'claude-opus-5'` was being silently
+dropped at the resolution clamp — a stale allowlist is indistinguishable from a
+deliberate policy refusal.
+
+Files touched: `src/core/ModelTierEscalation.ts`, `src/core/ModelSwapService.ts`,
+`scripts/model-registry-freshness.manifest.json`,
+`tests/unit/topicProfileValidation.test.ts`,
+`tests/unit/modelTierEscalation-resolver.test.ts`,
+`tests/unit/modelSwapService.test.ts`, plus
+`docs/specs/claude-5-family-model-ids.eli16.md` and this artifact.
+
+`ModelSwapService.ts` is here because the second-pass review found the enum change
+makes a dormant runtime bug reachable — see §5 and §1 below. It was not in the
+original plan.
+
+## Decision-point inventory
+
+The enum has FOUR consumers, not two. The first draft of this review said "two
+readers, both read-only"; the second-pass review corrected it, and the correction
+is what surfaced the defect in §1.
+
+- `validateModelId` (`src/core/topicProfileValidation.ts:318`, reading
+  `KNOWN_MODEL_IDS['claude-code']`) — **pass-through** — the clamp keeps its
+  authority and its fail-closed policy unchanged; only the reference data it
+  consults is corrected.
+- `validateProfileFields` (topic-profile write clamp) — **pass-through** — same;
+  it delegates the model arm to `validateModelId`.
+- `spawnModelAllowlist` (`src/server/routes.ts:104`) — **pass-through** — derives
+  from the same enum, so it gains the same four ids with no separate edit.
+- `ModelSwapService` defence-in-depth re-check (`src/core/ModelSwapService.ts:254`)
+  — **pass-through on the read, but this reader feeds a WRITE**: the accepted
+  value becomes `targetId` and is typed into a live tmux pane at `:350`. This is
+  the consumer the first draft missed, and it is where the §1 defect lives.
+- `paneConfirmsModel` (`src/core/ModelSwapService.ts:165`) — **MODIFIED** — the
+  independent oracle that decides whether a swap actually landed. Fixed here; see
+  §1.
+- `ProfileIntentClassifier.defaultKnownModelValues()`
+  (`src/core/ProfileIntentClassifier.ts:154`) — **pass-through** — supplies the
+  conversational pre-filter vocabulary. Fail-open toward inclusion, so widening it
+  is safe directionally.
+- `resolveTierModel` / `resolveModelId` (model-tier escalation resolver) —
+  **pass-through** — the escalation *policy values* (`escalated:
+  'claude-fable-5'`) are deliberately unchanged; this widens what MAY be named,
+  not what IS named by default.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None — the change is purely additive to an allowlist, so no input that was
+previously accepted is now rejected. The set of accepted ids grows by exactly
+four; every previously-valid id remains valid (asserted by the retained
+`claude-fable-5` / `claude-opus-4-8` containment test).
+
+The over-block this *removes* is the reported one: `claude-fable-5-1`,
+`claude-opus-5` and `claude-sonnet-5` are live subscription models that the pin
+validator refused, and `fable` is a CLI alias that was refused while its three
+siblings were accepted.
+
+**One over-block is INTRODUCED and it is deliberate.** The `paneConfirmsModel` fix
+in §5 adds `(?![.\-]\d)` to the swap-acknowledgment regex. A pane line reading
+"Set model to Fable 5" followed immediately by a version digit no longer confirms a
+swap to the shorter id. That is the intended narrowing — the alternative is the
+false CONFIRMATION described in §5, which is the unsafe direction for a function
+whose entire job is to be an independent oracle. The guard fires only on a
+separator followed by a digit, so a sentence-final "Set model to Fable 5." still
+confirms; a test pins that so the narrowing cannot quietly widen into a
+false-negative for ordinary punctuation.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **The next generation.** This is a hand-maintained mirror of a moving vendor
+  surface. It is correct as of 2026-09-06 and will go stale again the next time
+  Anthropic ships a model id; nothing in this change detects that. The class is
+  registered as an evolution action rather than left implicit
+  <!-- tracked: ACT-514 -->.
+- **Plan-gated variants.** Any id the CLI accepts syntactically but the account's
+  plan refuses at launch is still accepted here. The enum answers "is this a real
+  model id", not "can this account run it" — unchanged by this edit, and the
+  live-verification discipline (only ids observed answering) is what bounds it.
+- **Alias drift.** `fable`/`opus`/`sonnet`/`haiku` resolve CLI-side to whatever
+  the vendor currently calls latest. A pin to an alias is therefore not a pin to
+  a fixed model. That was already true of the three existing aliases; adding
+  `fable` makes the surface symmetric rather than introducing the property.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Right layer, and deliberately the *only* layer. `KNOWN_CLAUDE_MODEL_IDS` is the
+single source both the pin validator and the spawn route read — the file's own
+comment records a prior incident where the route carried a hand-typed duplicate
+of the codex enum and drifted from it undetected. This change edits the one
+enum and adds nothing parallel to it, so the spawn route and the pin validator
+cannot disagree. The existing
+`the spawn ROUTE accepts every id the pin validator does` test covers that
+invariant for the new ids for free.
+
+There IS a second hand-maintained Claude model list, and §3's original "edits the
+one enum and adds nothing parallel to it" was too strong. The doorway/model
+registry (`scripts/model-registry-freshness.manifest.json`) carries its own
+per-door `topModels[]`, gated by a strict lint in the `npm run lint` chain. The two
+are deliberately NOT in lockstep, because they answer different questions: the enum
+answers "is this a real model name we may accept" (acceptance), the registry
+answers "which model should routing reach for" (frontier). Adding a name to the
+first must not promote it in the second — a model earns the routing lane via
+benchmarks, not release date. This change therefore updates only the registry's
+claude-code door NOTE, recording that the Claude 5 family is now recognized and
+that `claude-fable-5-1` is deliberately not promoted. The strict lint passes.
+
+That distinction is also where the drift came from: the 2026-08-18 registry review
+had already classified `claude-opus-5` and `claude-sonnet-5` as frontier while the
+acceptance enum still refused them, so the two layers contradicted each other for
+three weeks and the shipped `frameworkDefaultModels` default was collateral.
+
+No new primitive was introduced, and no lower-level helper was re-implemented.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface *of its own*.
+
+The block/allow authority (`validateModelId`) already exists, already owns the
+decision, and is unchanged. This change corrects the curated data that authority
+consults. No brittle detector is being handed blocking power; if anything the
+change reduces a brittle failure, because the authority was refusing live models
+purely because its reference list had aged.
+
+The fail-closed direction is preserved and explicitly tested: an unverified
+sibling (`claude-fable-6`, `claude-opus-6`) still refuses `off-enum`, which is
+the property that keeps a typo from stranding a topic on a model the CLI will
+reject at launch.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The domain here
+is enumerable by construction — "which model ids does this CLI accept" is a
+finite, externally-determined list, verified by observation rather than
+inferred. That is the invariant case, not a judgment point.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The model arm of `validateProfileFields` runs before
+  `thinkingMode`/`effort`/`escalationOverride`; widening what it accepts means
+  those later clamps now run on inputs that previously short-circuited at the
+  model arm. That is the intended ordering and each remains independently
+  enforced (their own tests are unchanged and green).
+- **Double-fire:** none. One enum, two readers, both read-only.
+- **Races:** none. Compile-time `as const` data; no shared mutable state.
+- **Feedback loops:** none. The enum is not written by anything at runtime.
+- **Billing lane:** `PER_TOKEN_LANE_MODEL_IDS['claude-code']` is `[]` on the
+  documented premise that *every* member of the claude enum launches via the
+  subscription-authed CLI. That premise had to be re-checked, not assumed, since
+  this change adds members: all three new full ids launch through the same
+  subscription CLI path, so the empty deny-set stays correct. A test now asserts
+  `billingLaneError` returns null for each, so if one of them ever moves to a
+  per-token lane the assertion is the place that has to be updated deliberately.
+- **Escalation policy:** `ModelTierEscalation`'s default
+  `{ default: 'claude-opus-4-8', escalated: 'claude-fable-5' }` and
+  `respectFreeWindows` are untouched. Adding an id to the enum does not select
+  it; no session changes model as a result of this change alone.
+- **Substring hazard — the finding this review nearly missed.** The first draft
+  checked only the three test assertions that do
+  `expect(...).not.toContain('claude-fable-5')` against the anthropic-headless,
+  openai-codex and gemini adapter tier maps. Those are fine: the adapter maps are
+  separate modules, were not touched, and all three pass. But the hazard that
+  matters is in RUNTIME code, and the second-pass review found it.
+
+  `paneConfirmsModel` (`src/core/ModelSwapService.ts:165`) derives a display name
+  from a model id and matches `set model to[^\n]*\b(?:<id>|<Display>)\b`. A
+  shorter version is a literal prefix of a longer one, and `\b` sits between the
+  digit and the separator — so `\bFable 5\b` matches INSIDE "Fable 5.1".
+  Reproduced directly: `paneConfirmsModel("… Set model to Fable 5.1 …",
+  'claude-fable-5')` returned **true**.
+
+  It is reachable precisely because of this change. A topic pinned to
+  `claude-fable-5-1` acks "Fable 5.1"; a later `tier:'escalated'` swap targets the
+  config's `escalated: 'claude-fable-5'`, injects at `:350`, and the read-back at
+  `:365` captures a 30-line tail still holding the stale 5.1 ack. The echo filter
+  drops only lines containing `/model`, and the ack line does not — so the swap
+  audits as `swap-confirmed` and `session.model` records `claude-fable-5` while the
+  session runs 5.1. That is a false CONFIRMATION, which directly contradicts the
+  "conservative by design / unrecognized format reads as NOT confirmed" contract in
+  that function's own docstring, and it mis-attributes model and cost in
+  `GET /sessions`.
+
+  Fixed in this change rather than deferred, because this change is what makes the
+  collision reachable. Four regression tests pin both directions (5 must not
+  confirm from 5.1, and 5.1 must not confirm from 5), the punctuation
+  false-negative boundary, and the Claude 5 display forms.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the machine:** none until they update; the enum ships in the
+  build.
+- **Install base:** widens what `POST /sessions/spawn` and
+  `POST /topic-profile/:topicId` accept. No previously-working call changes
+  behavior.
+- **External systems:** none. No network surface.
+- **Persistent state:** none written by this change. Existing stored pins are
+  unaffected; a pin that was being refused at resolution now resolves instead of
+  falling back — which is the fix, and is visible to the operator through
+  `GET /topic-profile/:topicId` (`resolved.model` / `sources.model`).
+- **Timing / runtime conditions:** none.
+- **Operator surface (Mobile-Complete):** no new operator action. The affected
+  operator paths (the conversational "pin this topic to X" surface and the
+  `/topic-profile` route) already exist and already have their surfaces; this
+  change only makes them stop refusing a valid answer.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. No dashboard renderer, approval page, or
+grant/revoke/secret-drop form is staged in this change.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local BY DESIGN — shipped code, not state.**
+
+The enum is compiled into the instar build, so each machine gets it when that
+machine updates. There is nothing to replicate: it is not agent state, it is the
+program. The reason it *should* differ per machine transiently is the same
+reason any code change does — machines update on their own cadence, and the
+existing machine-coherence guard already treats an instar version skew across
+the pool as its own observable (`GET /pool/machine-coherence`), so a mid-rollout
+divergence is already surfaced by infrastructure built for exactly that.
+
+Explicit answers:
+
+- **User-facing notices:** emits none. No one-voice gating needed.
+- **Durable state / topic transfer:** holds none. A topic pin carrying
+  `claude-fable-5-1` does ride the existing `TopicProfileTransferCarrier`; the
+  carrier re-validates on landing, so a topic pinned on an updated machine and
+  transferred to a not-yet-updated one has its model refused off-enum there and
+  falls back with a notice — the pre-existing, correct degrade path, not a
+  stranding. It self-heals when the second machine updates.
+- **Generated URLs:** generates none.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the four added lines, ship as the next patch.
+- **Data migration:** none. No schema, no ledger, no column.
+- **Agent state repair:** none required. A pin written to one of the new ids
+  while the change was live would, after a revert, be refused at the resolution
+  clamp and fall back to the framework default with the existing once-per-
+  transition notice — degraded, visible, and repaired by re-pinning. No state
+  corruption, no manual cleanup.
+- **User visibility:** during a rollback window a topic pinned to a Claude 5 id
+  would drop to the default model. That is the pre-change behavior, so the
+  regression is a return to the status quo rather than a new failure.
+
+---
+
+## Conclusion
+
+This review produced two concrete checks that were not in the original plan and
+are now tests: the billing-lane premise (`PER_TOKEN_LANE_MODEL_IDS['claude-code']
+= []` is documented as true of *every* enum member, so adding members obligated
+re-verifying it) and the substring hazard against the three
+`not.toContain('claude-fable-5')` adapter assertions, which `claude-fable-5-1`
+would trip if the id ever reached those maps.
+
+It also surfaced the honest limit of the fix: this is a hand-maintained mirror of
+a vendor surface with no freshness guard, so it will age again. That is
+registered as ACT-514 rather than left as an implicit intention, and the fail-
+closed refusal path is retained and tested so aging degrades safely.
+
+The change is additive to an allowlist, changes no policy value, and holds no new
+authority — but it is no longer only that. The second-pass review found that
+widening the enum makes a dormant `paneConfirmsModel` prefix collision reachable,
+which would have silently mis-recorded a session's model and cost. That is fixed
+here rather than tracked for later, because this change is what arms it. The
+review's real lesson is that the first draft's "one enum, two readers, both
+read-only" was the wrong mental model: one of the readers feeds a tmux write, and
+that is exactly where the damage would have been.
+
+Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** general-purpose reviewer subagent (independent read + code verification)
+**Independent read of the artifact: concern raised, resolved**
+
+The reviewer confirmed the claims on enum order/length (nothing indexes, sorts or
+slices it), the `fable` alias namespace (no collision with `GENERIC_TIERS`; the
+`FABLE` in `PairingProtocol.ts:37` is a disjoint SAS wordlist), the billing-lane
+deny-set semantics, and the multi-machine degrade path
+(`TopicProfileTransferCarrier.ts:639-643` drops the unvalidatable field and pushes
+a disclosure — it does not strand or throw). It then raised four concerns:
+
+- **`paneConfirmsModel` false-confirms across a version prefix.** Verified
+  independently by reproducing it, then fixed in this change with four regression
+  tests. See §1 and §5. This was the material one and it was a real defect.
+- **The decision-point inventory undercounted the enum's readers** (two claimed,
+  four actual, one of which feeds a write path). Corrected above; that correction
+  is what made the first concern legible.
+- **The artifact was stale against the diff** — the registry manifest and the
+  ELI16 landed during the review. Files-touched list and §3 corrected.
+- **The anti-escalation ratchet had an exact-match hole**
+  (`not.toBe('claude-fable-5')` would wave through `claude-fable-5-1`). Widened to
+  assert against the ultra family (`not.toMatch(/^claude-fable-/)`) and the `fable`
+  alias added to the tier list, since it is now a way in.
+
+The reviewer also noted, and this review agrees, that the bare token `fable` joining
+the conversational pre-filter vocabulary (`ProfileIntentClassifier.ts:154`) means a
+common English noun can now pass the pre-filter on unrelated prose and spend a
+classify call. It is precedented exactly by `opus` and `sonnet`, is fail-open toward
+inclusion, and costs a call rather than a wrong decision — recorded here rather than
+changed.
+
+---
+
+## Evidence pointers
+
+- Live model-id verification: `claude --model <id> -p "reply with exactly: ok"`
+  on claude-code CLI 2.1.263 returned `ok` for `claude-fable-5-1`,
+  `claude-opus-5`, `claude-sonnet-5` and `claude-fable-5` (2026-09-06).
+- Fail-for-the-right-reason: with `src/core/ModelTierEscalation.ts` stashed, the
+  new assertions failed 5/70 with `off-enum` / `expected false to be true`;
+  restored, 70/70 pass.
+- Production refusal reproduced by the new
+  `accepts a Fable 5.1 pin arriving on a topic currently resolved to codex-cli`
+  test (topic 36966, `POST /topic-profile/36966` →
+  `{"failure":"off-enum","reason":"'claude-fable-5-1' is not a known claude-code model id"}`).
+- `npx tsc --noEmit` clean.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+Not applicable to the agent-authored-artifact arm: the change fixes stale data in
+a TypeScript source constant, not a defect in an agent-authored LLM prompt, hook,
+config, skill, or standards text. It also adds and modifies no self-triggered
+controller — no loop, monitor, sentinel, reaper, scheduler, or recovery path, and
+nothing that fires a restart / swap / respawn / spawn / notify / retry / re-drive
+/ kill, so the `unbounded-self-action` arm does not apply either.
+
+The staleness pattern itself is a genuine candidate class
+(`vendor-mirror-staleness`; nearest existing: `generated-artifact-path-contract-drift`),
+but registering a `novel` class requires a full registry entry with confirmed
+status, which is its own change. It is tracked as ACT-514 <!-- tracked: ACT-514 -->.


### PR DESCRIPTION
## ELI16 — instar refused a Claude model it could already run, because its list of model names was a generation out of date

instar keeps an explicit list of which model names each CLI will accept, and refuses anything else. That is deliberate: a mistyped model name would otherwise start a session that dies at launch, and nobody would know why.

The Claude list had aged out a generation. So when an operator asked to pin a conversation to Fable 5.1, instar said "not a known model id" — on a machine that runs Fable 5.1 from the command line on demand. Quietly, the same staleness was throwing away this install's configured default model, Opus 5, because that name was off the list too. From outside, a stale list and a deliberate refusal look identical.

Four names join the list: Fable 5.1, Opus 5, Sonnet 5, and the shorthand "fable" (its three siblings — opus, sonnet, haiku — were already accepted, so its absence was pure asymmetry). Each was run against the real CLI and observed answering before it was added. Made-up siblings are still refused, with a test holding that.

**The part worth reading:** adding those names woke up a bug that had been sitting dormant. When instar switches a live session's model, it reads the terminal to confirm the switch really happened — an independent check, so it can't just take its own word for it. That check matched the text "Fable 5" — which also appears *inside* "Fable 5.1". So a session actually running 5.1 would have confirmed a switch to plain Fable 5, and instar would have recorded the wrong model and billed the wrong cost, while the terminal said something different. The check was confirming the opposite of what it was reading. It was harmless until a model with a longer version number existed, and this change is what creates one — so it is fixed here rather than filed for later.

**What is deliberately NOT in this change:** Fable 5.1 does not become the model instar reaches for on its own. It is now a name you *may* pin; the automatic escalation still points at Fable 5. A model earns the routing lane by benchmark, not by release date, and that is a separate decision with its own review.

**The honest limit:** this list is maintained by hand and mirrors something Anthropic changes on its own schedule. It is right today and will go stale again, and nothing here detects that. It is tracked (ACT-514) rather than left as an intention, because the failure is quiet — a stale list refuses a real model with a message that reads exactly like policy. In fact the scheduled review had already spotted the Claude 5 family back in August and written it into the *preferred-models* registry, but nothing carried it to the *accepted-names* list. That gap is what produced this bug.

**What you actually need to decide:** whether you are satisfied these four names were verified against the real CLI before being added, and that leaving automatic escalation pointed at Fable 5 is the right call for now.

## What this fixes

`KNOWN_CLAUDE_MODEL_IDS` had lagged a model generation. Pinning a topic to Fable 5.1 was refused:

```
'claude-fable-5-1' is not a known claude-code model id
```

…on a machine whose CLI runs the model on demand. And the already-shipped `frameworkDefaultModels['claude-code'] = 'claude-opus-5'` was off the same list, so it was being dropped at the resolution clamp with no operator-visible reason. A stale allowlist and a deliberate policy refusal produce the same message, which is what made this read as "instar doesn't support that model."

Adds `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5` and the `fable` alias — each live-verified against claude-code CLI 2.1.263 before being listed. Unverified siblings (`claude-fable-6`, `claude-opus-6`) still fail closed, now with a test holding that. `fable` closes a plain asymmetry: `opus`/`sonnet`/`haiku` were already accepted as shorthand.

## The bug the review found

The second-pass review found that widening the enum makes a **dormant runtime bug reachable**, so it is fixed here rather than deferred.

`paneConfirmsModel` matched `\bFable 5\b` — which matches **inside** `"Fable 5.1"`, because `\b` sits between the digit and the separator. Reproduced directly:

```js
paneConfirmsModel("… Set model to Fable 5.1 …", 'claude-fable-5')  // → true
```

Reachable because of this change: a topic pinned to `claude-fable-5-1` acks "Fable 5.1"; a later `tier:'escalated'` swap targets `claude-fable-5`, and the 30-line read-back still holds that stale ack. The echo filter drops only lines containing `/model`, and the ack line does not — so the swap audits as `swap-confirmed` and records `claude-fable-5` while the session runs 5.1, mis-attributing model and cost in `GET /sessions`.

That directly contradicts the "conservative by design / unrecognized format reads as NOT confirmed" contract in that function's own docstring — the independent oracle was confirming the opposite of what the pane said.

Guarded with `(?![.\-]\d)`, which rejects only a **version continuation**, so a sentence-final `"Set model to Fable 5."` still confirms. Four regression tests pin both directions plus the punctuation boundary.

## Recognized is not frontier

The escalation pin stays `claude-fable-5`; `claude-fable-5-1` is deliberately **not** promoted in the doorway registry. A model earns the routing lane via benchmarks, not release date — same call PR #2006 made for `gpt-5.6-sol`.

The registry's claude-code door note now records that, and records the drift this closes: the **2026-08-18 review had already classified `claude-opus-5`/`claude-sonnet-5` as frontier** while the acceptance list still refused them, so the two layers contradicted each other for three weeks.

Also widens the anti-escalation ratchet from `not.toBe('claude-fable-5')` to the ultra family — it had the identical prefix hole.

## Evidence

- **43,900 unit tests** across 2,410 files — zero failures.
- **Falsified before trusted:** with the enum change stashed, five new assertions fail for the right reason (`off-enum`); restored, all pass.
- Live verification: `claude --model <id> -p` returns for all four ids on CLI 2.1.263.
- `tsc --noEmit` clean; strict model-registry freshness lint passes.

## Honest limit

This list is hand-maintained and mirrors a vendor surface that moves on its own schedule. It will age again and nothing here detects that — tracked as **ACT-514** rather than left as an intention, because the failure mode is quiet: a stale list refuses a real model with a message that reads exactly like policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yrKf5bPC7uiJUt8ViiFn9
