### PR TITLE
fix: bound paid Telegram recovery retries

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-10T04-35-07-273Z-telegram-recovery-review-budget.json
+++ b/.instar/instar-dev-decisions/2026-09-10T04-35-07-273Z-telegram-recovery-review-budget.json
@@ -1,0 +1,45 @@
+{
+  "ts": "2026-09-10T04:35:07.273Z",
+  "slug": "telegram-recovery-review-budget",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 67,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts",
+      "src/messaging/telegram-origin/OriginAwareness.ts",
+      "src/messaging/telegram-origin/OriginStore.ts",
+      "src/messaging/telegram-origin/OriginStore.worker.ts",
+      "src/messaging/telegram-origin/OriginStoreBackend.ts",
+      "src/messaging/telegram-origin/StoreTypes.ts",
+      "src/messaging/telegram-origin/TelegramOriginRuntime.ts"
+    ],
+    "addedLines": 62,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      2010
+    ],
+    "notes": "Pre-claim failures repeated paid review without consuming a transport attempt. Durable spacing now precedes recovery review."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/telegram-origin/recovery-review-budget.test.ts",
+      "howCaught": "Recovery tick formerly repeated paid review after pre-claim refusal without a debit. Atomic fifteen-minute reservation precedes review, survives restart and concurrent owners, permits exactly 24 automatic starts within the original six-hour lifetime, and refuses all starts after expiry."
+    }
+  },
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -22,7 +22,7 @@ import { originToolGuardHook } from '../messaging/telegram-origin/OriginToolGuar
  */
 
 import fs from 'node:fs';
-import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
+import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
 import { migrateTelegramOriginDisplay } from '../messaging/telegram-origin/OriginConfig.js';
 import path from 'node:path';
 import os from 'node:os';
@@ -6244,6 +6244,12 @@ setTimeout(() => process.exit(0), 2000);
       result.upgraded.push('CLAUDE.md: added Telegram origin detector health awareness');
     }
 
+    if (!content.includes('Queued-message review pacing:')) {
+      content += '\n' + telegramOriginRecoveryAwareness();
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added queued-message review pacing awareness');
+    }
+
     const refreshedOriginCanary = refreshOriginCanaryStartupAwareness(content);
     if (refreshedOriginCanary !== content) {
       content = refreshedOriginCanary;
@@ -10639,6 +10645,7 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
         ['Origin lease renewal dependency:', telegramOriginLeaseAwareness],
         ['Message origins on your phone:', telegramOriginDashboardAwareness],
         ['Origin detector health:', telegramOriginDetectorAwareness],
+        ['Queued-message review pacing:', telegramOriginRecoveryAwareness],
       ] as const) {
         if (claudeMd.includes(marker) && !appended.includes(marker)) {
           appended = appended.trimEnd() + '\n\n' + render();

--- a/src/messaging/telegram-origin/OriginAwareness.ts
+++ b/src/messaging/telegram-origin/OriginAwareness.ts
@@ -18,6 +18,10 @@ export function telegramOriginLeaseAwareness(): string {
   return 'Origin lease renewal dependency: an enabled Telegram origin writer enrolls the existing current-holder renewal timer so ordinary installations keep a confirmed lease beyond its TTL. Explicit `multiMachine.leaseSelfHeal.resilientRenew.enabled: false` remains an opt-out; lease expiry still holds sends. Observe-only roles, higher-epoch holders and failed partition confirmations remain fenced. Without an origin writer, the standalone renewal feature keeps its development-agent default. Never change identity records or bypass `holdsLease` to clear a delivery hold.\n';
 }
 
+export function telegramOriginRecoveryAwareness(): string {
+  return 'Queued-message review pacing: automatic origin recovery reserves a durable 15-minute interval per original operation before reviewing or attempting delivery. Failed reviews, send refusals and process restarts cannot reset that interval. Existing origin audit records expose `recovery.attempts` and `recovery.nextAttemptAt`; these count recovery starts, not Telegram sends or tokens. A due retry still checks current policy. The original deadline and transport attempt limit remain in force, and retained messages are not guaranteed delivered. New replies are independent; never rewrite or resend a held message merely to bypass this interval.\n';
+}
+
 export function telegramOriginAwareness(port: number): string {
   return `
 ### Telegram message origin
@@ -33,6 +37,7 @@ ${telegramOriginCertificationAwareness()}
 ${telegramOriginLeaseAwareness()}
 ${telegramOriginDashboardAwareness()}
 ${telegramOriginDetectorAwareness()}
+${telegramOriginRecoveryAwareness()}
 Ordinary bot messages and fixed outage notices share the credential owner's bounded send capacity across server and Lifeline processes. A \`credential-capacity-unavailable\` result retains the original operation for recovery; never replace it with a new message. An unavailable or stale capacity owner holds sends. Recording-worker failure does not disable the independent notice queue or its current permission checks.
 
 Claude and Codex tool hooks direct raw Telegram writes to the recorded relay or typed browser broker. Managed Telegram profiles belong to the broker; generic browser tools cannot use them. This cooperative hook is not an operating-system sandbox. Other enabled harnesses must prove equivalent enrollment before activation; a hook being installed is not proof of complete sender coverage.

--- a/src/messaging/telegram-origin/OriginStore.ts
+++ b/src/messaging/telegram-origin/OriginStore.ts
@@ -139,6 +139,7 @@ export class OriginStore {
   recoverableAdmissions(input: { limit?: number; now?: number } = {}): Promise<OriginAdmission[]> { return this.call('recoverableAdmissions', input); }
   /** Advances a durable scan cursor; selection grants no execution claim. */
   takeRecoverableAdmissions(input: { limit?: number; now?: number } = {}): Promise<OriginAdmission[]> { return this.call('takeRecoverableAdmissions', input); }
+  reserveRecoveryAttempt(input: { operationId: string; now?: number }): Promise<boolean> { return this.call('reserveRecoveryAttempt', input); }
   isUnavailable(): boolean { return this.unavailable; }
   getChild(childId: string): Promise<StoredChild | null> { return this.call('getChild', childId); }
   getPayload(payloadId: string): Promise<Uint8Array> { return this.call('getPayload', payloadId); }

--- a/src/messaging/telegram-origin/OriginStore.worker.ts
+++ b/src/messaging/telegram-origin/OriginStore.worker.ts
@@ -10,6 +10,7 @@ const methods = new Set([
   'claim', 'markDispatched', 'releaseUndispatchedClaim', 'renewClaim', 'recordOutcome', 'reapAbandoned', 'addMaterialization',
   'recordOperationState', 'reserveNotice', 'recordNoticeOutcome', 'archive', 'cleanupPayloads', 'diagnostics', 'getPayload', 'consumeAuditAssertion',
   'retireNoticeOwner', 'reconcileReceipt',
+  'reserveRecoveryAttempt',
   'healthTransaction', 'recoverableAdmissions', 'takeRecoverableAdmissions', 'registerOwner', 'legacyCandidates', 'importLegacy', 'reserveDiagnostic', 'completeDiagnostic', 'browserRecovery', 'getFederatedMetrics', 'getBrowserRecoveryStates', 'undiagnosedOrigins',
 ]);
 try { if (data.mode !== 'spool') backend = new OriginStoreBackend(data.options); parentPort!.postMessage({ ready: true }); }

--- a/src/messaging/telegram-origin/OriginStoreBackend.ts
+++ b/src/messaging/telegram-origin/OriginStoreBackend.ts
@@ -19,6 +19,7 @@ import type {
 } from './StoreTypes.js';
 
 const SIX_HOURS = 6 * 60 * 60_000;
+const RECOVERY_REVIEW_INTERVAL_MS = 15 * 60_000;
 const MAX_LEASE_MS = 60_000;
 const MAX_ARCHIVE_BYTES = 32 * 1024 * 1024;
 const MAX_ARCHIVE_READ_BYTES = 64 * 1024 * 1024;
@@ -113,6 +114,8 @@ export class OriginStoreBackend {
       CREATE TABLE IF NOT EXISTS telegram_origin_metrics (metric TEXT PRIMARY KEY, count INTEGER NOT NULL);
       CREATE TABLE IF NOT EXISTS telegram_origin_health (id INTEGER PRIMARY KEY CHECK(id=1), ticked_at INTEGER NOT NULL);
       CREATE TABLE IF NOT EXISTS telegram_origin_recovery_cursor (id INTEGER PRIMARY KEY CHECK(id=1), after_rowid INTEGER NOT NULL);
+      CREATE TABLE IF NOT EXISTS telegram_origin_recovery_schedule (
+        operation_id TEXT PRIMARY KEY, attempts INTEGER NOT NULL, next_attempt_at INTEGER NOT NULL);
       CREATE TABLE IF NOT EXISTS telegram_origin_owners (owner_boot_id TEXT PRIMARY KEY, machine_id TEXT NOT NULL);
       CREATE TABLE IF NOT EXISTS telegram_origin_platform_receipts (
         child_id TEXT NOT NULL, origin_id TEXT NOT NULL, transport TEXT NOT NULL, account_id TEXT NOT NULL,
@@ -410,6 +413,35 @@ export class OriginStoreBackend {
   takeRecoverableAdmissions(input: { limit?: number; now?: number } = {}): OriginAdmission[] {
     return this.readRecoverableAdmissions(input, true);
   }
+  /** Charge a recovery start BEFORE policy review or transport preparation.
+   * The canonical outbox serializes main/lifeline contenders and retains this
+   * brake through worker/process restarts. This is scheduling, not permission
+   * to send, and never consumes or resets the child's transport attempt budget.
+   * A crash consumes the interval; an uncertain write must never start review.
+   */
+  reserveRecoveryAttempt(input: { operationId: string; now?: number }): boolean {
+    id(input.operationId);
+    const now = input.now ?? Date.now();
+    integer(now, 0, Number.MAX_SAFE_INTEGER - RECOVERY_REVIEW_INTERVAL_MS);
+    return this.db.transaction(() => {
+      const eligible = this.db.prepare(`SELECT 1 FROM telegram_origin_operations o
+        WHERE o.operation_id=? AND o.kind='ordinary' AND o.state IN ('admitted','held','partial')
+        AND o.prepared_at<=? AND o.deadline_at>?
+        AND NOT EXISTS (SELECT 1 FROM telegram_origin_recovery_schedule r
+          WHERE r.operation_id=o.operation_id AND r.next_attempt_at>?)
+        AND EXISTS (SELECT 1 FROM telegram_origin_children c JOIN entries e ON e.delivery_id=c.delivery_id
+          WHERE c.operation_id=o.operation_id AND c.state='queued' AND e.state='queued'
+          AND e.attempts<o.max_attempts AND (e.next_attempt_at IS NULL OR e.next_attempt_at<=?))
+        AND NOT EXISTS (SELECT 1 FROM telegram_origin_children c WHERE c.operation_id=o.operation_id
+          AND c.state NOT IN ('queued','accepted'))`)
+        .get(input.operationId, now, now, now, new Date(now).toISOString());
+      if (!eligible) return false;
+      this.db.prepare(`INSERT INTO telegram_origin_recovery_schedule VALUES (?,1,?)
+        ON CONFLICT(operation_id) DO UPDATE SET attempts=attempts+1,next_attempt_at=excluded.next_attempt_at`)
+        .run(input.operationId, now + RECOVERY_REVIEW_INTERVAL_MS);
+      return true;
+    }).immediate();
+  }
   private readRecoverableAdmissions(input: { limit?: number; now?: number }, advance: boolean): OriginAdmission[] {
     const limit = input.limit ?? 10, now = input.now ?? Date.now();
     integer(limit, 1, 100);
@@ -417,12 +449,14 @@ export class OriginStoreBackend {
       const after = advance ? (this.db.prepare('SELECT after_rowid FROM telegram_origin_recovery_cursor WHERE id=1').get() as { after_rowid: number } | undefined)?.after_rowid ?? 0 : 0;
       const operations = this.db.prepare(`SELECT o.*,o.rowid recovery_rowid FROM telegram_origin_operations o
         WHERE o.kind='ordinary' AND o.state IN ('admitted','held','partial') AND o.deadline_at>?
+        AND NOT EXISTS (SELECT 1 FROM telegram_origin_recovery_schedule r
+          WHERE r.operation_id=o.operation_id AND r.next_attempt_at>?)
         AND EXISTS (SELECT 1 FROM telegram_origin_children c JOIN entries e ON e.delivery_id=c.delivery_id
           WHERE c.operation_id=o.operation_id AND c.state='queued' AND e.state='queued'
           AND e.attempts<o.max_attempts AND (e.next_attempt_at IS NULL OR e.next_attempt_at<=?))
         AND NOT EXISTS (SELECT 1 FROM telegram_origin_children c WHERE c.operation_id=o.operation_id
           AND c.state NOT IN ('queued','accepted'))
-        ORDER BY CASE WHEN o.rowid>? THEN 0 ELSE 1 END,o.rowid LIMIT ?`).all(now, new Date(now).toISOString(), after, limit) as Array<DbOperation & { recovery_rowid: number }>;
+        ORDER BY CASE WHEN o.rowid>? THEN 0 ELSE 1 END,o.rowid LIMIT ?`).all(now, now, new Date(now).toISOString(), after, limit) as Array<DbOperation & { recovery_rowid: number }>;
       const admissions = operations.map(op => {
         const audit = this.getOrigin(op.origin_id);
         if (!audit) return fail('recovery-origin-missing');
@@ -705,7 +739,8 @@ export class OriginStoreBackend {
     const children = op ? this.db.prepare('SELECT * FROM telegram_origin_children WHERE operation_id=? ORDER BY rowid').all(op.operation_id) as DbChild[] : [];
     const attempts = op ? this.db.prepare('SELECT a.* FROM telegram_origin_attempts a JOIN telegram_origin_children c ON c.child_id=a.child_id WHERE c.operation_id=? ORDER BY a.created_at,a.attempt_id').all(op.operation_id) as DbAttempt[] : [];
     const verification = this.db.prepare('SELECT evidence_json FROM telegram_origin_verifications WHERE origin_id=?').get(originId) as { evidence_json: string } | undefined;
-    return { sequence: row.sequence, record: storedRecord, ...(verification ? { acceptanceVerification: JSON.parse(verification.evidence_json) } : {}), ...(diagnostic ? { diagnostic: {
+    const recovery = op ? this.db.prepare('SELECT attempts,next_attempt_at nextAttemptAt FROM telegram_origin_recovery_schedule WHERE operation_id=?').get(op.operation_id) as OriginAuditRecord['recovery'] : undefined;
+    return { sequence: row.sequence, record: storedRecord, ...(recovery ? { recovery } : {}), ...(verification ? { acceptanceVerification: JSON.parse(verification.evidence_json) } : {}), ...(diagnostic ? { diagnostic: {
       ...diagnostic, state: diagnostic.state === 'pending' && diagnostic.createdAt + 30_000 < Date.now() ? 'unavailable' : diagnostic.state,
     } } : {}), operation: op ? { operationId: op.operation_id, preparedAt: op.prepared_at, deadlineAt: op.deadline_at, maxAttempts: op.max_attempts, state: op.state } : null,
       children: children.map(child => ({ childId: child.child_id, deliveryId: child.delivery_id, destinationJson: child.destination_json, generation: child.generation, state: child.state, attempts: this.entry(child.delivery_id)?.attempts ?? 0 })),

--- a/src/messaging/telegram-origin/StoreTypes.ts
+++ b/src/messaging/telegram-origin/StoreTypes.ts
@@ -126,6 +126,8 @@ export interface OriginAcceptanceVerification {
   keyStatusAtAcceptance: 'active';
 }
 export interface OriginAuditRecord {
+  /** Automatic recovery starts, separate from actual transport attempts. */
+  recovery?: { attempts: number; nextAttemptAt: number };
   acceptanceVerification?: OriginAcceptanceVerification;
   diagnostic?: { state: string; reason: string; createdAt: number; resolvedAt: number | null; diagnosis: string | null };
   sequence: number;

--- a/src/messaging/telegram-origin/TelegramOriginRuntime.ts
+++ b/src/messaging/telegram-origin/TelegramOriginRuntime.ts
@@ -324,9 +324,10 @@ export class TelegramOriginRuntime {
             browser.executor.options.accountId === operation.record.destination.accountId &&
             browser.executor.options.transport === operation.record.destination.transport);
           if (candidates.length !== 1) continue; // Missing/ambiguous enrollment is a hold, never a profile guess.
-          processed++;
           try {
             if (!candidate.admitted) await this.service.admit(operation);
+            if (!await this.store.reserveRecoveryAttempt({ operationId: operation.record.operationId })) continue;
+            processed++;
             await candidates[0].executor.execute(operation); recovered++;
           } catch (error) {
             console.warn('[telegram-origin] browser recovery retained operation', operation.record.operationId,
@@ -337,9 +338,14 @@ export class TelegramOriginRuntime {
         const owners = [this.options.bot, ...(this.options.additionalBots ?? [])].filter(bot =>
           bot.token && bot.accountId === operation.record.destination.accountId);
         if (owners.length !== 1) continue;
-        processed++;
         try {
         if (!candidate.admitted) await this.service.admit(operation);
+        // Pre-claim holds used to re-run paid review on every recovery tick.
+        // Reserve in the same durable owner before entering either review or
+        // transport. Memory-held candidates pass this gate too; a missing or
+        // timed-out reservation leaves the payload queued and spends no review.
+        if (!await this.store.reserveRecoveryAttempt({ operationId: operation.record.operationId })) continue;
+        processed++;
         const request = JSON.parse(operation.admission.children[0].materializations[0].requestJson);
         await telegramFetch(`https://api.telegram.org/bot${owners[0].token}/${request.method}`,
           { method: 'POST', headers: { 'Content-Type': request.contentType }, body: request.body,

--- a/tests/e2e/telegram-origin-production-boot.test.ts
+++ b/tests/e2e/telegram-origin-production-boot.test.ts
@@ -19,6 +19,40 @@ beforeAll(async () => { worker = await compileOriginWorker(); });
 const cleanup: Array<() => Promise<void>> = [];
 afterEach(async () => { for (const close of cleanup.splice(0).reverse()) await close(); vi.unstubAllGlobals(); });
 describe('Telegram origin production bootstrap', () => {
+  it('retains the recovery review brake through a real production shutdown and restart', async () => {
+    const root = await mkdtemp('/tmp/origin-review-boot-');
+    cleanup.push(async () => { await SafeFsExecutor.safeRm(root, { recursive: true, force: true, operation: 'test:origin-review-boot:cleanup' }); });
+    const stateDir = path.join(root, '.instar'); await mkdir(path.join(stateDir, 'state'), { recursive: true });
+    const config = { projectDir: root, stateDir, projectName: 'echo', port: 0, authToken: 'fixture-auth',
+      messaging: [{ type: 'telegram', enabled: true, config: { token: '123:review-fixture', chatId: '-100123', lifelineTopicId: 7848 } }] };
+    await writeFile(path.join(stateDir, 'config.json'), JSON.stringify(config));
+    let lifecycle: OriginSessionLifecycle | undefined;
+    const review = vi.fn(async () => { throw new Error('review service temporarily unavailable'); });
+    const start = async () => {
+      const boot = await bootTelegramOrigin({ config: config as never, token: '123:review-fixture', noticeOwner: true,
+        workerUrl: worker, holdsLease: () => true, isSessionLive: () => true,
+        attachSessionLifecycle: value => { lifecycle = value; }, diagnoseUnknown: vi.fn(async () => undefined), onNoticeState: vi.fn() });
+      cleanup.push(() => boot.close());
+      boot.runtime.attachSendPolicy({ review, authorizeDispatch: () => ({ ok: true }) });
+      return boot;
+    };
+    let boot = await start();
+    const token = await lifecycle!.issue({ sessionId: 'queued-session', harnessId: 'codex-cli', projectDir: root, configuredModel: 'selected-model' });
+    const operation = await boot.runtime.service.runWithSessionToken(token, () => boot.runtime.service.prepareBot({
+      method: 'sendMessage', accountId: '123', params: { chat_id: '-100123', message_thread_id: 42, text: 'Here is the requested client report.' } }));
+    await boot.runtime.service.admit(operation);
+    expect(await boot.runtime.recoverHeld()).toEqual({ processed: 1, recovered: 0 });
+    expect(review).toHaveBeenCalledOnce();
+    await boot.close();
+    boot = await start();
+    for (let n = 0; n < 12; n++) expect(await boot.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+    expect(review).toHaveBeenCalledOnce();
+    const audit = await boot.runtime.store.getOperation(operation.record.operationId);
+    expect(audit?.recovery).toMatchObject({ attempts: 1 });
+    expect(audit?.operation).toMatchObject({ deadlineAt: operation.admission.deadlineAt, state: 'admitted' });
+    expect(audit?.attempts).toEqual([]);
+  });
+
   it('loads real config/identity authorities, attaches session lifecycle, and records a hidden internal reply through HTTP', async () => {
     const root = await mkdtemp('/tmp/origin-boot-');
     cleanup.push(async () => { await SafeFsExecutor.safeRm(root, { recursive: true, force: true, operation: 'test:origin-production-boot:cleanup' }); });

--- a/tests/integration/telegram-origin-routes.test.ts
+++ b/tests/integration/telegram-origin-routes.test.ts
@@ -76,6 +76,45 @@ async function browserHarness(extra: Record<string, unknown> = {}) {
   return { ...h, invoke, executor, send };
 }
 describe('Telegram origin through the complete reply HTTP pipeline', () => {
+  it('paces repeated recovery reviews and exposes the durable delay through authenticated audit HTTP', async () => {
+    const review = vi.fn(async (_text: string) => ({ pass: true, latencyMs: 1 }));
+    const h = await appHarness({ messagingToneGate: { review } });
+    h.runtime.service.options.authorize = () => false;
+    const sent = await request(h.app).post('/telegram/reply/42')
+      .set('Authorization', 'Bearer agent-test').set('X-Instar-Origin-Session', h.sessionToken)
+      .send({ text: 'The client report is ready for your review.' });
+    expect(sent.status).toBe(409); expect(review).toHaveBeenCalledOnce();
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 1, recovered: 0 });
+    expect(review).toHaveBeenCalledTimes(2);
+    for (let n = 0; n < 12; n++) expect(await h.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+    expect(review).toHaveBeenCalledTimes(2); expect(h.network).not.toHaveBeenCalled();
+    const audit = await request(h.app).get('/telegram/origins').set('Authorization', 'Bearer agent-test')
+      .set('X-Instar-AgentId', 'echo').set('X-Instar-Operator-Session', 'operator-test');
+    expect(audit.status).toBe(200);
+    expect(audit.body.records[0].recovery).toMatchObject({ attempts: 1 });
+    expect(audit.body.records[0].recovery.nextAttemptAt).toBeGreaterThan(Date.now() + 14 * 60_000);
+    expect(audit.body.records[0].attempts).toEqual([]);
+    // Advance only the real worker scheduler's explicit test clock. Network,
+    // policy, original custody and request bytes continue through production.
+    let due = audit.body.records[0].recovery.nextAttemptAt;
+    const take = h.runtime.store.takeRecoverableAdmissions.bind(h.runtime.store);
+    const reserve = h.runtime.store.reserveRecoveryAttempt.bind(h.runtime.store);
+    vi.spyOn(h.runtime.store, 'takeRecoverableAdmissions').mockImplementation(input => take({ ...input, now: due }));
+    vi.spyOn(h.runtime.store, 'reserveRecoveryAttempt').mockImplementation(input => reserve({ ...input, now: due }));
+    h.runtime.service.options.authorize = () => true;
+    review.mockImplementation(async () => ({ pass: false, advisory: true, rule: 'B21_USER_TASK_SUBSTITUTION',
+      issue: 'Current policy requires a revised response', suggestion: 'Revise', decisionRef: 'current-review', latencyMs: 1 }));
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 1, recovered: 0 });
+    expect(review).toHaveBeenCalledTimes(3); expect(h.network).not.toHaveBeenCalled();
+    due += 15 * 60_000;
+    review.mockImplementation(async () => ({ pass: true, latencyMs: 1 }));
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 1, recovered: 1 });
+    expect(review).toHaveBeenCalledTimes(4); expect(h.network).toHaveBeenCalledOnce();
+    const delivered = await h.runtime.store.getOperation(audit.body.records[0].operation.operationId);
+    expect(delivered?.operation?.state).toBe('accepted');
+    expect(delivered?.record.envelopeJson).toBe(audit.body.records[0].record.envelopeJson);
+  });
+
   it('records the fixed AutoUpdater notice through the authenticated apply route without accepting caller author claims', async () => {
     let updater: AutoUpdater;
     const proxy = { applyPendingUpdate: (options: never) => updater.applyPendingUpdate(options), getStatus: () => updater.getStatus() };

--- a/tests/integration/telegram-reply-origin-migration.test.ts
+++ b/tests/integration/telegram-reply-origin-migration.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
-import { telegramOriginCertificationAwareness, telegramOriginLeaseAwareness } from '../../src/messaging/telegram-origin/OriginAwareness.js';
+import { telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginRecoveryAwareness } from '../../src/messaging/telegram-origin/OriginAwareness.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const prior = fs.readFileSync('tests/fixtures/relay-history/telegram-reply-pre-origin.sh', 'utf8');
@@ -83,16 +83,20 @@ describe('origin relay installed-upgrade parity', () => {
     const first = migrate();
     expect(first).toContain(telegramOriginCertificationAwareness());
     expect(first).toContain(telegramOriginLeaseAwareness());
+    expect(first).toContain(telegramOriginRecoveryAwareness());
     expect(first).toContain('messageOrigin.outageNotice.enabled');
     expect(first).toContain('Operator note: preserve this workflow.');
     const second = migrate();
     expect(second.split('Origin rollout certification:')).toHaveLength(2);
     expect(second.split('Origin lease renewal dependency:')).toHaveLength(2);
     expect(second.split('Message origins on your phone:')).toHaveLength(2);
+    expect(second.split('Queued-message review pacing:')).toHaveLength(2);
     expect(second).toBe(first);
     for (const shadow of shadows) {
       const content = fs.readFileSync(shadow, 'utf8');
       expect(content).toContain('Operator shadow note.');
+      expect(content).toContain(telegramOriginRecoveryAwareness());
+      expect(content.split('Queued-message review pacing:')).toHaveLength(2);
       expect(content).toContain('messageOrigin.outageNotice.enabled');
       expect(content.split('Origin rollout certification:')).toHaveLength(2);
       expect(content.split('Origin lease renewal dependency:')).toHaveLength(2);

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -244,6 +244,7 @@ describe('Feature Delivery Completeness', () => {
       ['Origin lease renewal dependency:', 'telegramOriginLeaseAwareness'],
       ['Message origins on your phone:', 'telegramOriginDashboardAwareness'],
       ['Origin detector health:', 'telegramOriginDetectorAwareness'],
+      ['Queued-message review pacing:', 'telegramOriginRecoveryAwareness'],
     ];
     for (const [phrase, builder] of featureAddenda) {
       it(`origin addendum "${phrase}" reaches new and existing framework instructions`, () => {

--- a/tests/unit/telegram-origin/detector-canary.test.ts
+++ b/tests/unit/telegram-origin/detector-canary.test.ts
@@ -23,9 +23,14 @@ describe('owned detector known-state canary', () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
     const canary = new OriginDetectorCanary({ workerUrl, configWorkerUrl, intervalMs: 60_000 }); cleanups.push(() => canary.close());
     const run = vi.spyOn(canary, 'run');
-    const settle = async () => { const deadline = performance.now() + 5000;
-      while (canary.getHealth().state === 'running' && performance.now() < deadline) await new Promise(resolve => setImmediate(resolve));
-      expect(canary.getHealth().state).toBe('pass'); };
+    const settle = async () => {
+      // The scheduling clock is frozen; await the actual worker and its cleanup
+      // instead of imposing an unrelated wall-clock deadline on the fixture.
+      const result = run.mock.results.at(-1);
+      expect(result?.type).toBe('return');
+      await result!.value;
+      expect(canary.getHealth().state).toBe('pass');
+    };
     canary.start();
     await vi.advanceTimersByTimeAsync(59_999); expect(run).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1); await settle(); expect(run).toHaveBeenCalledOnce();
@@ -46,6 +51,9 @@ describe('owned detector known-state canary', () => {
     } finally { read.mockRestore(); write.mockRestore(); }
   });
   it('uses real encrypted fixtures and checks positive and negative source authority without native claims', async () => {
+    // This case verifies the source contract. Freeze the parent's deadline while
+    // real fixture workers run; bounded timeout behavior has its own case below.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
     let now = Date.now();
     const canary = new OriginDetectorCanary({ workerUrl, configWorkerUrl, intervalMs: 60_000, now: () => now }); cleanups.push(() => canary.close());
     await canary.run();

--- a/tests/unit/telegram-origin/recovery-review-budget.test.ts
+++ b/tests/unit/telegram-origin/recovery-review-budget.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { OriginStore } from '../../../src/messaging/telegram-origin/OriginStore.js';
+import { admission, compileOriginWorker, temporaryState } from '../../helpers/telegramOriginStore.js';
+
+let worker: URL;
+const stores: OriginStore[] = [];
+beforeAll(async () => { worker = await compileOriginWorker(); });
+afterEach(async () => { await Promise.all(stores.splice(0).map(store => store.close())); });
+const interval = 15 * 60_000;
+async function open(stateDir = temporaryState()) {
+  const store = await OriginStore.open({ stateDir, agentId: 'echo' }, worker); stores.push(store); return store;
+}
+
+describe('durable recovery review pacing', () => {
+  it('reserves once across owners and restart, with an exact due boundary and unchanged transport budget', async () => {
+    const stateDir = temporaryState(), first = await open(stateDir), second = await open(stateDir);
+    const now = Date.now(), op = admission('paced', now);
+    await first.admit(op);
+    const results = await Promise.all([first, second].map(store => store.reserveRecoveryAttempt({ operationId: op.operationId, now })));
+    expect(results.sort()).toEqual([false, true]);
+    await first.close(); await second.close();
+    const reopened = await open(stateDir);
+    await reopened.admit(op); // Repeated admission must not reset the spending clock.
+    expect(await reopened.reserveRecoveryAttempt({ operationId: op.operationId, now: now + interval - 1 })).toBe(false);
+    expect(await reopened.takeRecoverableAdmissions({ now: now + interval - 1 })).toEqual([]);
+    expect((await reopened.takeRecoverableAdmissions({ now: now + interval })).map(row => row.operationId)).toEqual([op.operationId]);
+    expect(await reopened.reserveRecoveryAttempt({ operationId: op.operationId, now: now + interval })).toBe(true);
+    const audit = await reopened.getOperation(op.operationId);
+    expect(audit?.recovery).toEqual({ attempts: 2, nextAttemptAt: now + 2 * interval });
+    expect(audit?.operation).toMatchObject({ deadlineAt: op.deadlineAt, maxAttempts: 9, state: 'admitted' });
+    expect(audit?.attempts).toEqual([]);
+    expect(audit?.children[0]).toMatchObject({ state: 'queued', attempts: 0 });
+    expect((await reopened.recoverableAdmissions({ now: now + 2 * interval }))[0]).toEqual(op);
+  });
+
+  it('leaves another operation eligible and bounds recovery over the original lifetime', async () => {
+    const store = await open(), now = Date.now(), a = admission('a', now), b = admission('b', now);
+    await store.admit(a); await store.admit(b);
+    for (let n = 0; n < 24; n++) {
+      expect(await store.reserveRecoveryAttempt({ operationId: a.operationId, now: now + n * interval })).toBe(true);
+      expect(await store.reserveRecoveryAttempt({ operationId: a.operationId, now: now + n * interval + 1 })).toBe(false);
+    }
+    for (const extra of [0, 24 * 60 * 60_000, 7 * 24 * 60 * 60_000]) {
+      expect(await store.reserveRecoveryAttempt({ operationId: a.operationId, now: a.deadlineAt + extra })).toBe(false);
+    }
+    expect((await store.takeRecoverableAdmissions({ now })).map(row => row.operationId)).toEqual([b.operationId]);
+    expect(await store.reserveRecoveryAttempt({ operationId: b.operationId, now })).toBe(true);
+  });
+
+  it('cannot reserve missing, suppressed, uncertain or not-yet-due work', async () => {
+    const store = await open(), now = Date.now();
+    expect(await store.reserveRecoveryAttempt({ operationId: 'missing', now })).toBe(false);
+    for (const outcome of ['outcome-unknown', 'known-failed'] as const) {
+      const op = admission(outcome, now); await store.admit(op);
+      const child = op.children[0];
+      const claim = await store.claim({ childId: child.childId, materializationId: child.materializations[0].materializationId, ownerBootId: 'owner', leaseMs: 60_000 });
+      if (claim.status !== 'claimed') throw new Error('fixture claim unavailable');
+      await store.markDispatched(claim.child);
+      await store.recordOutcome({ ...claim.child, outcome, ...(outcome === 'known-failed' ? { nextAttemptAt: now + 60_000 } : {}) });
+      expect(await store.reserveRecoveryAttempt({ operationId: op.operationId, now })).toBe(false);
+      if (outcome === 'known-failed') expect(await store.reserveRecoveryAttempt({ operationId: op.operationId, now: now + 60_000 })).toBe(true);
+    }
+    const suppressed = admission('suppressed', now); await store.admit(suppressed);
+    await store.recordOperationState({ operationId: suppressed.operationId, state: 'suppressed' });
+    expect(await store.reserveRecoveryAttempt({ operationId: suppressed.operationId, now })).toBe(false);
+  });
+});

--- a/upgrades/next/telegram-recovery-review-budget.md
+++ b/upgrades/next/telegram-recovery-review-budget.md
@@ -1,0 +1,39 @@
+# Bound queued Telegram review costs
+
+<!-- bump: patch -->
+
+## What Changed
+
+Automatic Telegram recovery now records a 15-minute interval per original queued
+operation before entering outbound review or delivery. Failed reviews and
+pre-dispatch refusals previously left the operation immediately recoverable,
+causing another paid review on each recovery pass without consuming a transport
+attempt. Upgraded recovery processes using the same canonical outbox share the
+durable interval, which survives process and worker restarts. Current policy is
+still evaluated when due. The recovery-owner server must restart onto the patch;
+installing package files alone does not change a running process.
+
+The existing origin audit exposes recovery starts and the next eligible time.
+Original payloads, delivery deadlines, child attempt limits and uncertain-result
+fences are preserved. Existing agents receive the behavior and awareness on update.
+
+## What to Tell Your User
+
+Queued Telegram messages now wait at least 15 minutes between automatic recovery
+attempts, instead of repeatedly spending review tokens while sending is broken.
+Restarting an agent does not restart this spending loop. This mitigates repeated
+review costs; a queued message is still not a guarantee of delivery.
+
+## Summary of New Capabilities
+
+- The existing origin audit shows `recovery.attempts` and `recovery.nextAttemptAt`.
+- No configuration change or queue clearing is required.
+
+## Evidence
+
+Real worker tests cover concurrent owners, restart, re-admission, exact interval
+boundaries, original deadline and transport budgets, uncertain results and fair
+selection. HTTP tests count reviews through the actual outbound evaluator and
+verify current-policy refusal and eventual delivery on a due attempt. Production
+boot tests exercise the persisted interval through shutdown and restart.
+Final validation results are recorded in the side-effects artifact.

--- a/upgrades/side-effects/telegram-recovery-review-budget.md
+++ b/upgrades/side-effects/telegram-recovery-review-budget.md
@@ -1,0 +1,156 @@
+# Side-Effects Review — Bound automatic Telegram recovery review spending
+
+**Date:** 2026-09-09
+**Author:** Echo
+**Second-pass reviewer:** review_retry_mitigation
+**Spec:** docs/specs/telegram-message-origin.md (approved bounded custody/recovery contract)
+
+## Summary of the change
+
+Current-main baseline 5ebfcedda, version 1.3.1231, remote
+https://github.com/JKHeadley/instar.git, fresh instar-created worktree
+fix/telegram-recovery-review-budget. Justin explicitly requested an urgent cost
+mitigation and deployment in topic 69507. OriginStoreBackend owns an additive
+operation recovery schedule in the existing canonical outbox. Runtime reserves
+an interval before bot or browser recovery, including newly admitted memory-held
+candidates. Origin audit returns count and next time. Shared scaffold awareness
+and idempotent CLAUDE/AGENTS/GEMINI migration explain the behavior.
+
+## Decision-point inventory
+
+- Recovery selection/reservation: modified deterministic scheduling; 15-minute
+  spacing before potentially paid work, transactionally shared across processes.
+- Review, ownership, capacity, child claims, receipt classification: passed through
+  without granting new authority or caching review approval.
+- Original deadline, actual attempt ceilings and uncertainty fences: preserved.
+
+## 1. Over-block
+
+A queued message whose underlying fault resolves just after a failed recovery
+may wait up to 15 minutes for the next attempt. This is an intentional cost
+mitigation, not a claim of prompt delivery. Fresh authored operations are not
+delayed by another operation's cooldown. A crash after reservation consumes the
+interval even if review never ran. Lost reservation responses also spend no review.
+
+## 2. Under-block
+
+This bounds recovery invocations, not token counts or total currency. One review
+may invoke multiple existing reviewers. A fixed operation has at most 24 automatic
+recovery starts during its default six-hour original lifetime; actual transport
+attempts retain their existing ceiling. Newly authored operations incur normal
+review costs. The store already refuses deadlines beyond six hours; shorter
+original deadlines permit fewer spaced recovery starts.
+Broader startup, relay, network-deadline and stale-message delivery defects remain
+tracked in topic 69507. <!-- tracked: topic-69507 -->
+
+## 3. Level-of-abstraction fit
+
+The canonical transactional outbox owns pacing; an in-memory timer would reset on
+restarts and fail across main/Lifeline contenders. Both execution paths reserve
+through the real worker. Evidence mirrors and spools cannot grant recovery.
+
+## 4. Signal vs authority compliance
+
+Reference: [signal vs authority](../../docs/signal-vs-authority.md).
+Deterministic scheduling of an existing bounded controller does not judge message
+meaning. Existing live outbound policy remains the sole content/tone authority.
+No approval cache, bypass flag, inferred permission, or new semantic blocker.
+
+## 4b. Judgment-point check
+
+No new competing-signals judgment. The 15-minute minimum is an explicit engineering
+spending bound requested by the operator; it is not a classifier of urgency or
+message validity. No pattern detector acquires authority.
+
+## 5. Interactions
+
+Atomic reservation handles simultaneous workers. Re-admission and process reopen
+preserve the row. Cooldown filters maintain fair traversal, while a second check
+on reservation covers memory-held candidates and concurrent scans. Existing child
+claim checks still execute after review; reservation grants no send entitlement.
+Unknown or terminal children cannot reserve. Timing state never updates child
+attempt counts, next transport retry times, payloads or original deadlines.
+
+## 6. External surfaces
+
+Existing authenticated origin audit adds optional recovery count/next time.
+No credentials, message text or new endpoint is exposed. Read-only audit does not
+move recovery clocks. No operator form or destructive action is added. Existing
+agents receive an additive SQLite table automatically when the store opens and
+shared awareness through the normal migrator; custom prose is preserved.
+
+## 7. Multi-machine posture
+
+Machine-local BY DESIGN: execution and pacing belong to the transport credential
+owner's canonical outbox. Upgraded processes using that outbox share the interval.
+Today the scheduled recovery caller is AgentServer; Lifeline boots the runtime
+but does not schedule recoverHeld. Mitigation takes effect when the recovery-owner
+server runs the patched version. Installing files alone does not hot-swap a
+process; the existing Lifeline upgrade/restart mechanism is unchanged. Source evidence
+on another machine cannot grant execution or reset the owner's clock. Existing
+pool origin audit carries the added fields. This does not introduce queue transfer
+or new ownership authority. No new user-facing notices or URLs are generated.
+
+## 8. Rollback cost
+
+Revert runtime code and publish a patch. The additive scheduling table can remain
+unused by the previous release; no payloads or receipts need repair. Rolling back
+restores the repeated-review risk. Queue cleanup is not part of this change.
+
+## Conclusion
+
+The design provides a persisted spacing bound with the existing finite deadline,
+preserving live review and delivery safety. Implementation and independent review are complete. All required local
+validation is green; normal repository merge and publication checks remain.
+
+## Second-pass review
+
+Reviewer independently inspected the final runtime/store diff, all-tier tests,
+and this artifact. No code safety blocker was identified. A wording concern
+about Lifeline recovery/instant package uptake was resolved by naming the actual
+AgentServer recovery caller and requiring a running patched owner before claiming
+activation. Due-retry tests exercise current-policy refusal and accepted delivery
+under the original operation. After independently verifying the correction,
+review_retry_mitigation stated: "Concur with the review." The reviewer also
+verified the live class-closure grader resolves the worker ratchet.
+
+## Evidence pointers
+
+- Red reproduction: all three new worker tests failed because no durable recovery
+  reservation existed, before implementing it.
+- Worker pacing and fairness: 5 tests passed.
+- Initial HTTP/runtime/boot run: 55 passed; a new boot test omitted awaiting its
+  asynchronous preparation result, corrected before final validation.
+- Migration and fresh-template checks: 18 passed.
+- Build and full lint completed successfully. Final HTTP and production boot:
+  27 tests passed. The first full run detected the required awareness addendum
+  missing from the feature-delivery registry test; added it with the existing
+  shared-builder pairing. The next full run found a canary test using an arbitrary
+  five-second real-time poll while its scheduling timers were frozen. Replaced
+  that poll with awaiting the actual worker completion Promise; all 12 canary
+  tests passed, and the independent reviewer concurred that real worker, timing,
+  timeout, cleanup and close coverage remains intact. The completed aggregate
+  subsequently recorded 51,779 passing tests and one failed source-contract
+  canary case whose real worker exceeded the parent six-second deadline under
+  load. That source-contract test now freezes only the parent deadline timers;
+  nested workers still execute real crypto/filesystem/permission checks, and
+  the dedicated timeout case remains unchanged. All 12 canary tests passed
+  under the same load and independent review concurred. A clean full run on
+  the corrected tree passed: 3,344 files and 51,780 tests, zero failures. The
+  containing command was interrupted during its later integration stage without
+  a failed test. Resuming the unchanged standard stage commands completed with
+  exit zero: integration 518 files / 4,181 tests; E2E 368 files / 3,231 tests.
+  Final lint passed. Skipped cases and TODO cases retain their existing status.
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`.
+`guardEvidence.enforcementType: ratchet`.
+`guardEvidence.citation: tests/unit/telegram-origin/recovery-review-budget.test.ts`.
+`guardEvidence.howCaught`: recovery tick → paid review → pre-claim refusal formerly
+returned to immediate eligibility without a debit. The transactional 15-minute
+reservation precedes review, survives re-admission/restart/concurrent owners, and
+settles at the immutable deadline. The ratchet asserts exactly 24 starts during
+the default six-hour lifetime, zero further starts after expiry even at a week,
+and independent progress for other original operations. See also the controller
+inventory ratchet `tests/unit/self-action-convergence.test.ts`.


### PR DESCRIPTION
## ELI16 — Stop repeated paid reviews while Telegram delivery is blocked

A queued Telegram message could pay for another outbound review on every recovery pass even though a later refusal prevented sending. Those refusals did not consume a delivery attempt, so the same message kept spending review tokens.

This patch records a 15-minute wait for each original queued message before automatic recovery starts. The wait survives restarts and concurrent processes. When the next attempt is due, current policy is checked again. The original message and delivery deadline stay intact. This reduces repeated spending; it does not guarantee delivery or fix every delivery defect. Once the underlying problem clears, a queued message may wait up to 15 minutes for another attempt.

## Implementation and validation

The canonical outbox reserves the recovery interval atomically before bot or browser review. Existing audit responses expose recovery starts and the next eligible time. The normal update migrator refreshes the shared agent guidance. Activation requires the recovery-owner server to run the patched version.

Build and final lint passed. Clean aggregate: 51,780 tests passed with zero failures. Dedicated integration: 4,181 tests passed. Dedicated end-to-end: 3,231 tests passed. All stages have zero failures; after a command interruption during integration, the unchanged integration and end-to-end commands completed separately. Two diagnostic test-clock corrections retain real encrypted workers and dedicated timeout coverage. Independent messaging review concurred.

Contract: [Telegram message origin](https://github.com/JKHeadley/instar/blob/main/docs/specs/telegram-message-origin.md). Side-effects artifact: `upgrades/side-effects/telegram-recovery-review-budget.md`.

The automatic pre-push affected-test selector timed out and reported its smoke tier skipped; the complete local test stages above passed, and CI remains the merge authority.

CI: the first Node 20 shard 3 run hit a 25 ms SQLite lock refusal in the unchanged two-worker claim test. All 18 focused storage tests passed locally; independent review supported one bounded rerun. That shard passed on the identical commit. All eight Node 20/22 shards and the downstream build, integration and end-to-end checks passed.

Released as v1.3.1232; npm gitHead matches merge commit cc5ce5a49f22b98dcb89c7ac4c7df66b4d3a2f40. Publication and clean-install smoke checks passed.
