### PR TITLE
fix(codex): repoint retired model ids and unblock the retirement self-heal

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-10T07-43-36-976Z-codex-model-retirement-2026-09-09.json
+++ b/.instar/instar-dev-decisions/2026-09-10T07-43-36-976Z-codex-model-retirement-2026-09-09.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-09-10T07:43:36.976Z",
+  "slug": "codex-model-retirement-2026-09-09",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 111,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/model-registry-freshness.manifest.json",
+      "src/core/frameworkSessionLaunch.ts",
+      "src/providers/adapters/openai-codex/models.ts",
+      "src/providers/adapters/openai-codex/observability/eventNormalizer.ts"
+    ],
+    "addedLines": 85,
+    "deletedLines": 26
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/codex-model-retirement-2026-09-09.eli16.md
+++ b/docs/specs/codex-model-retirement-2026-09-09.eli16.md
@@ -1,0 +1,90 @@
+# Codex model retirement, September 2026 — Plain-English Overview
+
+> The one-line version: OpenAI switched off the AI models Instar was asking for, including the
+> spare it falls back to, so every background check in the agent stopped working — this points
+> them all at models that still exist and teaches the recovery code to recognise the second way
+> a model can disappear.
+
+## The problem in one breath
+
+Instar does a lot of small thinking in the background — checking whether a message is safe to
+send, noticing when a session is stuck, working out what a conversation is about. Those checks
+run through OpenAI's Codex tool, and Instar tells Codex which model to use by name. OpenAI
+retired those model names. Every one of those background checks started failing instantly, on
+every machine, and had been for a while before anyone noticed — because a failed check costs
+nothing and makes no noise.
+
+## What already exists
+
+- **Two lists of model names** — one used when Instar makes a quick background call, another
+  used when it launches a full working session. They are supposed to say the same thing, and a
+  comment in the code asks whoever edits one to remember to edit the other.
+- **A recovery mechanism** — Instar already knows models get retired. When Codex says "that
+  model isn't supported", the code catches it and immediately tries again using a designated
+  spare model. This was built after the last time this happened, in June.
+- **An error reader** — a small piece of code that looks at whatever Codex complains about and
+  labels it: an authentication problem, a rate limit, a network glitch, a retired model. The
+  recovery mechanism only wakes up when it sees the "retired model" label.
+
+## What this adds
+
+The main change is unglamorous: the model names are corrected to two that were actually tested
+and confirmed working, rather than assumed. Everywhere Instar picks a model for Codex now points
+at a live one.
+
+But the more important fix is why the safety net didn't catch this. Two things had gone wrong
+with it:
+
+- **The spare was dead too.** The designated fallback model was retired in the same sweep as
+  the main ones. So when a call failed and the recovery kicked in, it retried using another
+  model that was equally gone. The net was there; it had a hole the same size as the thing
+  falling through it.
+- **The error reader only knew one of the two ways a model can vanish.** When OpenAI removes a
+  model from a particular subscription, Codex says "not supported" — the reader knew that one.
+  When OpenAI deletes a model outright, Codex says something completely different: "does not
+  exist or you do not have access to it". The reader had never been taught that phrasing, so it
+  filed those under "unknown problem" and the recovery mechanism never even woke up.
+
+Fixing only the names would have looked like a fix and left both holes in place.
+
+## The new pieces
+
+Nothing genuinely new is introduced — this repairs machinery that already existed. The one
+addition is a second pattern in the error reader, and it is deliberately fussy: it only matches
+when Codex names a specific model in the complaint. A plain "404 not found" from a mistyped web
+address does **not** count, and there is a test that fails if someone ever loosens it, because
+treating an unrelated error as a retired model would make Instar quietly retry things it should
+be reporting instead.
+
+## The safeguards
+
+**Stops the same mistake being made again by hand.** The tests no longer contain the model names
+typed out. They check that whatever the code resolves to is on the approved list, and that the
+spare is not one of the names known to be dead. Previously a test had the old spare's name typed
+into it, which is why it broke the moment the spare changed — it was checking the name, not the
+behaviour.
+
+**Stops a false alarm becoming a retry loop.** The recovery only ever tries once, and it refuses
+to run at all if it is already using the spare. So even in the worst case, a misread error costs
+exactly one extra attempt, not an endless cycle.
+
+**Does not pretend to be future-proof.** If OpenAI invents a third way of saying "that model is
+gone", this will not catch it. And nothing yet checks that the spare is still alive on a regular
+basis — if the new spare gets retired one day, the same thing happens again. Both gaps are
+written down and tracked rather than quietly hoped away.
+
+## What you should know as the person paying for it
+
+These checks were failing for free. Broken calls cost nothing, so the bill looked healthy while
+the agent was effectively running blind. Turning them back on means real spending appears where
+there was none — roughly 650 calls an hour across three machines, and about three-quarters of
+each call's cost is fixed overhead that Codex charges just for starting up, regardless of how
+small the question is. That is the honest trade: working background checks cost money, and
+broken ones only looked free. If the total is more than the checks are worth, the lever is
+running fewer of them, not making them smaller.
+
+## What ships when
+
+This change ships on its own. Two related repairs are deliberately kept separate so that if one
+misbehaves it is obvious which one: the session-watcher that hammers a broken service instead of
+backing off, and a stale list of model names that still accepts retired ones. Both are tracked.

--- a/scripts/model-registry-freshness.manifest.json
+++ b/scripts/model-registry-freshness.manifest.json
@@ -2,7 +2,7 @@
   "$comment": "Doorway/Model Knowledge Registry — canonical/reviewed layer + staleness/drift gate for Instar's per-provider 'capable/latest' model pins. This file is the SINGLE human-edit surface that keeps the model registry from silently rotting. See docs/LLM-ROUTING-REGISTRY.md, docs/specs/DOORWAY-MODEL-KNOWLEDGE-REGISTRY-SPEC.md, and scripts/lint-model-registry-freshness.mjs. Two teeth: (1) STALENESS — lastReviewedAt must be within stalenessWindowDays; (2) DRIFT — every pinned capable model id must be a member of its door's DERIVED frontier set (the ids in doors[door].topModels[] carrying frontier:true — see §1.4 of the spec). topModels is the ONE hand-edited source of truth; the frontier set is a view of it and cannot diverge by construction. To pass the check a human must confirm each capable pin is genuinely current frontier AND bump lastReviewedAt. An un-reviewed list fails loudly.",
   "registrySchemaVersion": 2,
   "$schemaNote": "registrySchemaVersion 2 = the enriched Doorway/Model Knowledge Registry. Increment 1 (spec §Rollout step 1) added the per-door topModels[] frontier-derivation layer + the derived-frontier lint (report mode). Increment 2 (spec §Rollout step 2) ADDS the per-door probe{} block + candidateDoorways[] below — the metadata the deterministic prober (scripts/doorway-scan.mjs) reads to know HOW to re-verify each door — plus the live scan-state (.instar/state/doorway-scan.json) + the dark (enabled:false) doorway-scan job. Both additions are backward-compatible: the freshness lint ignores probe{}/candidateDoorways entirely (it reads only topModels/frontier/pins). GET /doorways is a LATER increment (spec §Rollout step 3) and is NOT wired yet.",
-  "lastReviewedAt": "2026-08-18",
+  "lastReviewedAt": "2026-09-10",
   "stalenessWindowDays": 45,
   "enforcement": "strict",
   "$enforcementNote": "'strict' = GATING (exits 1 on any finding: staleness, drift, or a flaggedStale row) — flipped from 'report' in rollout increment 5 (spec §Rollout step 5, the companion-gated activation) now that the prior flaggedStale door swaps are operator-confirmed + reconciled into topModels (flaggedStale is empty) and the derived-frontier drift + staleness teeth pass clean. This is the LIVE TEETH that the 'Keep the Doorway/Model Map Current' constitutional standard is ratified WITH (not ahead of). The lint runs in the `npm run lint` chain, so a future staleness age-out (lastReviewedAt exceeds stalenessWindowDays) or a pin drifting off its door's derived frontier set now FAILS CI — the anti-rot ratchet, by design. To revert to non-gating (dark/reversible rollback), set this field back to 'report'. Env INSTAR_MODEL_FRESHNESS_STRICT=1 forces strict for a one-off run regardless of this field.",
@@ -110,11 +110,20 @@
       },
       "topModels": [
         {
-          "id": "gpt-5.5",
+          "id": "gpt-6-astra",
           "role": "capable-openai",
           "frontier": true,
           "pricing": null,
-          "verifiedAt": "carried-over-from-allowlist"
+          "verifiedAt": "2026-09-09",
+          "note": "Live-probed 2026-09-09 on the ChatGPT-account codex surface: answered a trivial prompt (15,449 input / 5 output). Promoted to frontier because the previous frontier id (gpt-5.5) was retired in the same sweep. Pricing not yet published for this id."
+        },
+        {
+          "id": "gpt-5.5",
+          "role": "retired-openai",
+          "frontier": false,
+          "pricing": null,
+          "verifiedAt": "2026-09-09-probed-RETIRED",
+          "note": "Live probe 2026-09-09 returned 404 'The model `gpt-5.5` does not exist or you do not have access to it.' It was frontier:true only as a carry-over from the superseded hand-maintained allowlist and had never been verified. Kept as a row so historical benchmark references do not dangle; demoted from frontier because an unreachable id cannot be the frontier."
         },
         {
           "id": "gpt-5.6-sol",
@@ -125,7 +134,8 @@
             "outPerMtok": 30,
             "currency": "USD"
           },
-          "verifiedAt": "2026-07-09"
+          "verifiedAt": "2026-09-09",
+          "note": "Re-probed 2026-09-09: answered a trivial prompt (14,556 input / 5 output). Now the fast/balanced tier target AND the retirement safety floor (CODEX_CHATGPT_FALLBACK_MODEL), because the previous holder of both (gpt-5.4-mini) was retired."
         },
         {
           "id": "gpt-5.6-terra",
@@ -230,7 +240,7 @@
       "note": "CLAUDE_REVIEWER_DEFAULT_MODEL — the Anthropic clean-door reviewer pin (REVIEWER-DOOR-REWIRING §1.3). Extraction matches a frontier CONSTANT (not a capable:'…' tier decl), so the non-vacuity test (tests/unit/model-registry-freshness-reviewer-pin.test.ts) rots this constant and asserts the strict lint fails — closing the vacuous-tooth risk."
     }
   ],
-  "$flaggedStaleNote": "Both prior flagged pins RESOLVED (operator-confirmed 2026-07-03): gemini capable swapped gemini-2.5-pro -> gemini-3.1-pro-preview (pin + topModels updated in the same change); codex capable stays gpt-5.5. UPDATE 2026-07-09: the GPT-5.6 family (sol/terra/luna) went GA on the codex subscription + was live-verified (codex CLI >= 0.144.0) — the earlier 'gpt-5.6-sol is preview-only/gov-gated/unreachable' statement is now superseded. gpt-5.6-sol/terra/luna are RECOGNIZED (in codex-cli.topModels + the acceptance allowlists) but deliberately NOT promoted to frontier / the capable pin yet — the capable pin stays gpt-5.5 pending a benchmark-based promotion. Nothing pending confirmation (a benchmark-driven promotion of gpt-5.6-sol is a tracked follow-up, not a pending flagged pin).",
+  "$flaggedStaleNote": "Both prior flagged pins RESOLVED (operator-confirmed 2026-07-03): gemini capable swapped gemini-2.5-pro -> gemini-3.1-pro-preview (pin + topModels updated in the same change); codex capable stays gpt-5.5. UPDATE 2026-07-09: the GPT-5.6 family (sol/terra/luna) went GA on the codex subscription + was live-verified (codex CLI >= 0.144.0) — the earlier 'gpt-5.6-sol is preview-only/gov-gated/unreachable' statement is now superseded. gpt-5.6-sol/terra/luna are RECOGNIZED (in codex-cli.topModels + the acceptance allowlists) but deliberately NOT promoted to frontier / the capable pin yet — the capable pin stays gpt-5.5 pending a benchmark-based promotion. Nothing pending confirmation (a benchmark-driven promotion of gpt-5.6-sol is a tracked follow-up, not a pending flagged pin). UPDATE 2026-09-09: the deliberate 'not promoted to frontier yet' stance on the GPT-5.6 family is now moot for the capable pin — gpt-5.5 was RETIRED (404), so the capable pin moved to the live-probed gpt-6-astra and gpt-5.6-sol took the fast/balanced tier plus the retirement floor.",
   "flaggedStale": [],
   "$frontierAllowlistNote": "The hand-maintained frontierAllowlist{} was SUPERSEDED by derivation (spec §1.4): the frontier set for each door is now the ids in doors[door].topModels[] carrying frontier:true. This removes a second hand-maintained list (the rot this registry fights). The lint keeps a backward-compat path: a door with a literal frontierAllowlist[door] and NO topModels behaves exactly as before; a door with BOTH emits a transition finding so the old hand-list can't silently linger.",
   "$candidateDoorwaysNote": "candidateDoorways[] = the doorways the scan should PROBE FOR (spec §1.2/§2.5), INCLUDING ones not yet present in doors{}. A candidate reachable but absent from doors is surfaced as a newly-configured-doorway. The prober only activates a candidate whose probe.kind it supports; a candidate with no door entry / unsupported kind is recorded, never silently treated as reachable. openrouter / gemini-direct-api below are candidate-only (no door entry yet) so the candidate-detection machinery has real inputs to exercise.",
@@ -243,5 +253,5 @@
     "openrouter",
     "gemini-direct-api"
   ],
-  "$lastReviewNote": "2026-08-18 review (Echo). Every existing capable/latest PIN was checked and remains a member of its door's frontier set — no pin was changed, so this review alters NO routing behavior. What the review did find: the Anthropic frontier has moved to the Claude 5 family, so claude-opus-5 and claude-sonnet-5 were ADDED as frontier on the claude-code and anthropic-headless doors. claude-opus-4-8 was deliberately LEFT frontier:true rather than demoted: demoting it would fail the drift check for the pins that currently reference it, and re-pointing those pins is a fleet-wide routing decision that belongs in its own change with its own side-effects review — not bundled into an unrelated feature PR. This note is the dated record that the question is open."
+  "$lastReviewNote": "2026-09-10 review (Echo), triggered by a fleet-wide outage rather than the cadence: EVERY internal codex call was failing because the tier map, the retirement safety floor, and this registry's codex frontier id had all been retired by OpenAI. Live probe of nine ids on the ChatGPT-account codex surface: gpt-5.6-sol and gpt-6-astra ANSWERED; gpt-5.4-mini, gpt-5.4, gpt-5.6, gpt-6, gpt-5.6-mini and gpt-6-mini returned 400 'not supported when using Codex with a ChatGPT account'; gpt-5.5 returned 404. Changes: codex-cli frontier moves gpt-5.5 -> gpt-6-astra (gpt-5.5 demoted, kept as a row, marked retired); gpt-5.6-sol re-verified and is now both the fast/balanced target and the retirement floor. This DOES alter routing behavior, deliberately — the prior routing was to models that no longer exist. Note that gpt-5.5 had carried frontier:true purely as an unverified carry-over from the superseded hand-maintained allowlist, which is the exact rot this registry exists to catch; it was caught here by the pre-commit drift lint, not by the cadence review."
 }

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -64,15 +64,16 @@ export function resolveModelForFramework(
     // sensible Codex equivalent (haiku→fast, sonnet→balanced,
     // opus→capable) so an unported call site doesn't immediately
     // crash for a Codex agent.
-    // Light/medium/heavy mapping. NOTE (2026-06-03): OpenAI retired gpt-5.2 from
-    // the ChatGPT-account Codex surface (it now 400s "not supported … with a
-    // ChatGPT account"), so the `fast` tier moved off it onto the cheapest model
-    // still accepted — gpt-5.4-mini (== balanced). Keep this in lockstep with
+    // Light/medium/heavy mapping. NOTE (2026-09-09): OpenAI retired the whole
+    // gpt-5.4/5.5 generation from the ChatGPT-account Codex surface — including
+    // gpt-5.4-mini, which the 2026-06-03 gpt-5.2 retirement had moved `fast`
+    // onto. Live-probed replacements: gpt-5.6-sol (light+medium) and
+    // gpt-6-astra (heavy). Keep this in lockstep with
     // src/providers/adapters/openai-codex/models.ts (the single source of the
-    // full rationale + the drift-resilience follow-up).
-    if (key === 'fast' || key === 'haiku') return 'gpt-5.4-mini';   // light tier — gpt-5.2 retired 2026-06-03
-    if (key === 'balanced' || key === 'sonnet') return 'gpt-5.4-mini'; // medium — cheapest reasoning
-    if (key === 'capable' || key === 'opus') return 'gpt-5.5';      // heavy — frontier reasoning
+    // full rationale + the live-probe record).
+    if (key === 'fast' || key === 'haiku') return 'gpt-5.6-sol';    // light tier — gpt-5.4-mini retired 2026-09-09
+    if (key === 'balanced' || key === 'sonnet') return 'gpt-5.6-sol'; // medium — cheapest live reasoning
+    if (key === 'capable' || key === 'opus') return 'gpt-6-astra';  // heavy — frontier; gpt-5.5 retired 2026-09-09
     return modelOrTier;
   }
   if (framework === 'gemini-cli') {
@@ -133,7 +134,7 @@ export function resolveInteractiveLaunchModel(
 ): string | undefined {
   if (framework === 'codex-cli') {
     if (codexLocalProvider) return configuredModel ?? 'llama3.2:latest';
-    return resolveModelForFramework(framework, configuredModel) ?? 'gpt-5.5';
+    return resolveModelForFramework(framework, configuredModel) ?? 'gpt-5.6-sol';
   }
   if (framework === 'gemini-cli') {
     return resolveModelForFramework(framework, configuredModel) ?? 'gemini-2.5-flash';
@@ -1015,7 +1016,7 @@ const codexCliHeadlessBuilder: HeadlessBuilder = (options) => {
   const isLocal = options.codexLocalProvider !== undefined;
   const model = isLocal
     ? (options.model ?? 'llama3.2:latest')
-    : (resolveModelForFramework('codex-cli', options.model) ?? 'gpt-5.5');
+    : (resolveModelForFramework('codex-cli', options.model) ?? 'gpt-5.6-sol');
   const argv: string[] = [
     options.binaryPath,
     'exec',

--- a/src/providers/adapters/openai-codex/models.ts
+++ b/src/providers/adapters/openai-codex/models.ts
@@ -51,6 +51,24 @@ import type { ModelTier } from '../../types.js';
  * CodexCliIntelligenceProvider: the exact ChatGPT-account model-retirement
  * response retries once on the known-good floor declared below.
  *
+ * ⚠ RE-PROBED AGAIN 2026-09-09 (live, against Justin's ChatGPT subscription; triggered
+ * by EVERY internal codex call failing fleet-wide — sentinels, gates and reflectors alike
+ * 400'ing instantly on all three machines). OpenAI has now retired the ENTIRE gpt-5.4/5.5
+ * generation from the ChatGPT-account Codex surface, INCLUDING the model this file had
+ * pinned as both the `fast`/`balanced` tier AND the retirement safety floor:
+ *   ❌ rejected 400 "not supported when using Codex with a ChatGPT account":
+ *        gpt-5.4-mini, gpt-5.4, gpt-5.6, gpt-6, gpt-5.6-mini, gpt-6-mini
+ *   ❌ rejected 404 "does not exist or you do not have access to it": gpt-5.5
+ *   ✅ still working 2026-09-09: gpt-5.6-sol, gpt-6-astra   (both replied to a trivial probe)
+ * This was the THIRD retirement in this class (2026-04-14 `-codex` suffix, 2026-06-03
+ * gpt-5.2) and the first where the SAFETY FLOOR itself was dead — so the self-heal in
+ * CodexCliIntelligenceProvider retried onto another rejected model and the fleet stayed
+ * dark. Two consequences are addressed together, because a live floor that the classifier
+ * never reaches is not a fix:
+ *   (1) the tier map + `CODEX_CHATGPT_FALLBACK_MODEL` move onto live-probed ids below;
+ *   (2) `classifyCodexErrorMessage` now also recognises the 404 retirement shape, which
+ *       previously fell through to 'unknown' and so never triggered the self-heal at all.
+ *
  * TOKEN-BURN observation (same trivial "reply OK" prompt, 2026-05-23):
  *   gpt-5.2 = 103 tokens · gpt-5.3-codex = 5,574 · gpt-5.5 = 7,399.
  *   The reasoning models (5.3-codex, 5.5) burn ~50-70x more than gpt-5.2
@@ -96,16 +114,17 @@ import type { ModelTier } from '../../types.js';
  * target is validated against KNOWN_CODEX_MODEL_IDS at the retry authority.
  */
 const TIER_TO_MODEL: Record<ModelTier, string> = {
-  // fast — cheapest model accepted on the ChatGPT account. Was non-reasoning
-  // gpt-5.2 until OpenAI retired it (2026-06-03, see header); gpt-5.2 now 400s
-  // and broke every cheap codex call. No non-reasoning option remains, so this
-  // is gpt-5.4-mini (== balanced) — a reasoning model, raising cheap-call burn,
-  // but a working model beats a rejected one.
-  fast: 'gpt-5.4-mini',
-  // medium — cheapest reasoning model; everyday light work / worker subagents.
-  balanced: 'gpt-5.4-mini',
+  // fast — cheapest model still ACCEPTED on the ChatGPT account. gpt-5.2 was
+  // retired 2026-06-03 and its replacement gpt-5.4-mini was retired in turn
+  // (2026-09-09, see header), so this is now gpt-5.6-sol. Still a reasoning
+  // model, so `fast` continues to equal `balanced` — there is no non-reasoning
+  // option on this surface, and a working model beats a rejected one.
+  fast: 'gpt-5.6-sol',
+  // medium — cheapest live reasoning model; everyday light work / worker subagents.
+  balanced: 'gpt-5.6-sol',
   // heavy — frontier reasoning model; hard problems + the user's main chat.
-  capable: 'gpt-5.5',
+  // gpt-5.5 was retired 2026-09-09 (404s); gpt-6-astra is the live frontier id.
+  capable: 'gpt-6-astra',
 };
 
 /**
@@ -114,7 +133,10 @@ const TIER_TO_MODEL: Record<ModelTier, string> = {
  * changing normal tier defaults and changing the retirement safety floor are
  * separate operational decisions.
  */
-export const CODEX_CHATGPT_FALLBACK_MODEL = 'gpt-5.4-mini';
+// Live-probed 2026-09-09. The previous floor (gpt-5.4-mini) was retired in the
+// same sweep that killed the tier map, which is exactly how the self-heal came
+// to retry one dead model with another. A floor is only a floor while it answers.
+export const CODEX_CHATGPT_FALLBACK_MODEL = 'gpt-5.6-sol';
 
 /**
  * Resolve a tier or raw model string to a concrete model name to pass to

--- a/src/providers/adapters/openai-codex/observability/eventNormalizer.ts
+++ b/src/providers/adapters/openai-codex/observability/eventNormalizer.ts
@@ -196,6 +196,32 @@ export function classifyCodexErrorMessage(message: string): 'auth' | 'quota' | '
   if (/unauthorized|forbidden|401|403|invalid.*token/i.test(message)) return 'auth';
   if (/quota|insufficient_quota/i.test(message)) return 'quota';
   if (/rate.?limit|429/i.test(message)) return 'rate-limit';
+  // The SECOND retirement shape, added 2026-09-09. When OpenAI removes a model
+  // id outright (rather than de-listing it from the ChatGPT surface) Codex
+  // surfaces a 404 instead of the 400 above — e.g. gpt-5.5:
+  //   "unexpected status 404 Not Found: The model `gpt-5.5` does not exist or
+  //    you do not have access to it."
+  // This previously fell through to 'unknown', so the model-retirement
+  // self-heal never fired for it and every call using that id failed forever.
+  //
+  // ORDERING IS LOAD-BEARING, IN BOTH DIRECTIONS. It must sit:
+  //   BELOW auth / quota / rate-limit — one message can carry BOTH a specific
+  //     failure token AND this wording (e.g. "unexpected status 403 Forbidden:
+  //     The model `x` does not exist or you do not have access to it").
+  //     Matching first would reclassify a real auth or throttle failure as a
+  //     retryable retirement and hide it from every consumer of `errorKind`.
+  //   ABOVE timeout / network — those patterns are substring matches and DO
+  //     collide with the real retirement message: Codex prefixes its retries
+  //     with "Reconnecting... 2/5 (…)", and "R-ECONN-ecting" matches the
+  //     network branch's /ECONN/i. Placing this branch after `network` sends
+  //     the genuine outage message to 'network' and the self-heal never fires
+  //     — verified: it is exactly what happened when this was moved last.
+  // The tests pin BOTH bounds, so neither move can silently regress.
+  //
+  // The match is also deliberately narrow: it requires Codex's quoted-model-id
+  // wording, so a generic 404 (a bad route, a missing file) is NOT reclassified
+  // as a retryable model retirement.
+  if (/The model ['"`][^'"`]+['"`] does not exist or you do not have access to it\.?/i.test(message)) return 'unsupported';
   if (/timeout|408|504/i.test(message)) return 'timeout';
   if (/network|ECONN|ETIMEDOUT|dns/i.test(message)) return 'network';
   if (/malformed|parse|invalid JSON/i.test(message)) return 'malformed-response';

--- a/tests/integration/codex-model-retirement-fallback.test.ts
+++ b/tests/integration/codex-model-retirement-fallback.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { CodexCliIntelligenceProvider } from '../../src/core/CodexCliIntelligenceProvider.js';
+import { CODEX_CHATGPT_FALLBACK_MODEL } from '../../src/providers/adapters/openai-codex/models.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const dirs: string[] = [];
@@ -50,7 +51,7 @@ exit 0
 
     expect(fs.readFileSync(calls, 'utf-8').trim().split('\n')).toEqual([
       'gpt-5.5',
-      'gpt-5.4-mini',
+      CODEX_CHATGPT_FALLBACK_MODEL,
     ]);
     expect(fs.readFileSync(prompts, 'utf-8').trim().split('\n')).toEqual([
       'classify this',

--- a/tests/integration/cross-model-review-flow.test.ts
+++ b/tests/integration/cross-model-review-flow.test.ts
@@ -12,7 +12,7 @@
  *
  * Three flows per the spec §Testing:
  *   1. codex present  → findings folded in, flag/banner read codex-cli:<model>,
- *      frontmatter gets `cross-model-review: "codex-cli:gpt-5.5"`.
+ *      frontmatter gets `cross-model-review: "codex-cli:<capable-tier id>"`.
  *   2. codex absent   → unavailable flag, round completes internal-only,
  *      report carries the UNAVAILABLE banner, spec is STILL taggable.
  *   3. degraded       → provider rejects; flag reads `degraded: <reason>`, does
@@ -24,6 +24,12 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+// Resolve the capable tier rather than hardcoding an id: OpenAI has retired the
+// codex capable model three times, and a literal here re-breaks on each move.
+import { resolveCliModelFlag } from '../../src/providers/adapters/openai-codex/models.js';
+const CAPABLE_ID = resolveCliModelFlag('capable');
+// Escaped for use inside the frontmatter regexes below (ids contain dots).
+const CAPABLE_RE = CAPABLE_ID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 import { fileURLToPath } from 'node:url';
 import {
   detectCrossModelReviewer,
@@ -152,18 +158,18 @@ describe('cross-model review flow — codex PRESENT', () => {
 
     expect(result.status).toBe('ok');
     expect(result.framework).toBe('codex-cli');
-    expect(result.model).toBe('gpt-5.5');
+    expect(result.model).toBe(CAPABLE_ID);
     expect(result.findings).toHaveLength(1);
     expect(result.findings![0].verdict).toBe('MINOR ISSUES');
-    expect(result.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+    expect(result.flag).toBe(`cross-model-review: codex-cli:${CAPABLE_ID}`);
 
     // Report banner.
-    expect(renderBanner(result)).toBe('## Cross-model review: codex-cli:gpt-5.5');
+    expect(renderBanner(result)).toBe(`## Cross-model review: codex-cli:${CAPABLE_ID}`);
 
     // Frontmatter stamp.
     stampTag(result);
     const out = fs.readFileSync(specPath, 'utf-8');
-    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5"/);
+    expect(out).toMatch(new RegExp(`cross-model-review:\\s*"codex-cli:${CAPABLE_RE}"`));
     expect(out).toMatch(/review-convergence:/);
   });
 });
@@ -360,7 +366,7 @@ describe('cross-model review flow — DEGRADED', () => {
 
     expect(result.status).toBe('degraded');
     expect(result.reason).toBe('timeout');
-    expect(result.flag).toBe('cross-model-review: codex-cli:gpt-5.5 (degraded: timeout)');
+    expect(result.flag).toBe(`cross-model-review: codex-cli:${CAPABLE_ID} (degraded: timeout)`);
     // Crucially NOT unavailable — the framework IS present.
     expect(result.status).not.toBe('unavailable');
 
@@ -369,7 +375,7 @@ describe('cross-model review flow — DEGRADED', () => {
     // Degraded is still taggable (disclosure, not a gate).
     stampTag(result);
     const out = fs.readFileSync(specPath, 'utf-8');
-    expect(out).toMatch(/cross-model-review:\s*"codex-cli:gpt-5\.5 \(degraded: timeout\)"/);
+    expect(out).toMatch(new RegExp(`cross-model-review:\\s*"codex-cli:${CAPABLE_RE} \\(degraded: timeout\\)"`));
     expect(out).toMatch(/review-convergence:/);
   });
 });

--- a/tests/unit/CodexCliIntelligenceProvider.test.ts
+++ b/tests/unit/CodexCliIntelligenceProvider.test.ts
@@ -18,6 +18,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { CodexCliIntelligenceProvider } from '../../src/core/CodexCliIntelligenceProvider.js';
+import { CODEX_CHATGPT_FALLBACK_MODEL } from '../../src/providers/adapters/openai-codex/models.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const FAKE_CODEX_SCRIPT = `#!/bin/sh
@@ -178,7 +179,7 @@ for arg in "$@"; do
   prev="$arg"
 done
 echo "$model" >> "${calls}"
-if [ "$model" != "gpt-5.4-mini" ]; then
+if [ "$model" != "${CODEX_CHATGPT_FALLBACK_MODEL}" ]; then
   echo "${firstError}" >&2
   exit 1
 fi
@@ -202,8 +203,8 @@ ${fallbackAlsoFails ? 'echo "fallback failed" >&2\nexit 1' : 'echo "RECOVERED"\n
       model: 'gpt-5.5',
       onModel: ({ model }) => models.push(model),
     })).resolves.toBe('RECOVERED');
-    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5', 'gpt-5.4-mini']);
-    expect(models).toEqual(['gpt-5.5', 'gpt-5.4-mini']);
+    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5', CODEX_CHATGPT_FALLBACK_MODEL]);
+    expect(models).toEqual(['gpt-5.5', CODEX_CHATGPT_FALLBACK_MODEL]);
   });
 
   it.each([
@@ -226,7 +227,7 @@ ${fallbackAlsoFails ? 'echo "fallback failed" >&2\nexit 1' : 'echo "RECOVERED"\n
     const provider = new CodexCliIntelligenceProvider({ codexPath: fixture.binary });
 
     await expect(provider.evaluate('hi', { model: 'gpt-5.5' })).rejects.toThrow('fallback failed');
-    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5', 'gpt-5.4-mini']);
+    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5', CODEX_CHATGPT_FALLBACK_MODEL]);
   });
 });
 

--- a/tests/unit/StallTriageNurse.test.ts
+++ b/tests/unit/StallTriageNurse.test.ts
@@ -161,14 +161,14 @@ describe('StallTriageNurse', () => {
         config: { ...TEST_CONFIG, framework: 'codex-cli', model: 'balanced' },
       });
       expect((nurse as unknown as { config: { model: string } }).config.model)
-        .toBe('gpt-5.4-mini');
+        .toBe('gpt-5.6-sol');
     });
     it('codex-cli: legacy Claude tier name maps to Codex equivalent', () => {
       const nurse = new StallTriageNurse(deps, {
         config: { ...TEST_CONFIG, framework: 'codex-cli', model: 'haiku' },
       });
       expect((nurse as unknown as { config: { model: string } }).config.model)
-        .toBe('gpt-5.4-mini'); // haiku → light tier; gpt-5.2 retired from ChatGPT-account Codex 2026-06-03
+        .toBe('gpt-5.6-sol'); // haiku → light tier; gpt-5.4-mini retired from ChatGPT-account Codex 2026-09-09
     });
     it('codex-cli: raw Codex model id passes through verbatim', () => {
       const nurse = new StallTriageNurse(deps, {

--- a/tests/unit/codex-cli-provider-execjson.test.ts
+++ b/tests/unit/codex-cli-provider-execjson.test.ts
@@ -19,6 +19,7 @@ import {
   setFeatureMetricsRecorder,
 } from '../../src/core/CircuitBreakingIntelligenceProvider.js';
 import { LlmCircuitBreaker } from '../../src/core/LlmCircuitBreaker.js';
+import { CODEX_CHATGPT_FALLBACK_MODEL } from '../../src/providers/adapters/openai-codex/models.js';
 
 let fixtureDir: string;
 let prevEnv: string | undefined;
@@ -101,7 +102,7 @@ for a in "$@"; do
 done
 cat > /dev/null
 echo "$MODEL" >> "${calls}"
-if [ "$MODEL" != "gpt-5.4-mini" ]; then
+if [ "$MODEL" != "${CODEX_CHATGPT_FALLBACK_MODEL}" ]; then
   echo "Error 400: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account." >&2
   exit 1
 fi
@@ -111,9 +112,12 @@ exit 0
     const provider = new CodexCliIntelligenceProvider({ codexPath: script });
 
     await expect(provider.evaluate('p', { model: 'gpt-5.5' })).resolves.toBe('RECOVERED-JSON');
+    // Asserted against the CONSTANT, not a literal: the floor moves every time
+    // OpenAI retires a model (three times so far), and a hardcoded name here
+    // silently re-breaks this mechanism test on each move.
     expect(fs.readFileSync(calls, 'utf-8').trim().split('\n')).toEqual([
       'gpt-5.5',
-      'gpt-5.4-mini',
+      CODEX_CHATGPT_FALLBACK_MODEL,
     ]);
   });
 

--- a/tests/unit/codex-model-tier-resolution.test.ts
+++ b/tests/unit/codex-model-tier-resolution.test.ts
@@ -1,61 +1,127 @@
 /**
  * Codex model-tier resolution + retired-model regression guard.
  *
- * Context: OpenAI retired `gpt-5.2` from the ChatGPT-account Codex surface on
- * 2026-06-03 (it now returns HTTP 400 "not supported when using Codex with a
- * ChatGPT account"). Both codex tier maps — the adapter resolver
+ * Context: OpenAI has now retired codex model ids from the ChatGPT-account
+ * surface THREE times — the `-codex` suffixed names (2026-04-14), `gpt-5.2`
+ * (2026-06-03) and the whole gpt-5.4/5.5 generation (2026-09-09). Each time,
+ * the two hardcoded codex tier maps — the adapter resolver
  * (openai-codex/models.ts) and the session-launch resolver
- * (frameworkSessionLaunch.ts) — hardcoded the `fast`/`haiku` tier to gpt-5.2,
- * which silently broke EVERY cheap codex call (CommitmentSentinel, tone-gate,
- * classification) on every codex agent. These tests pin the corrected mapping
- * and guard the retired name so a future edit can't reintroduce it.
+ * (frameworkSessionLaunch.ts) — kept pointing at a dead id, which silently
+ * broke EVERY internal codex call (sentinels, gates, reflectors) on every
+ * codex agent.
+ *
+ * The 2026-09-09 sweep was worse than its predecessors because it also killed
+ * `CODEX_CHATGPT_FALLBACK_MODEL`, the floor the retirement self-heal retries
+ * onto — so the self-heal swapped one rejected model for another and the fleet
+ * stayed dark. These tests pin the live mapping, pin the floor to a live id,
+ * and guard EVERY retired name so a future edit can't reintroduce one.
+ *
+ * Model ids here are live-probed, never guessed. Probe of 2026-09-09 against
+ * the ChatGPT subscription: gpt-5.6-sol and gpt-6-astra answered; gpt-5.4-mini,
+ * gpt-5.4, gpt-5.6, gpt-6, gpt-5.6-mini and gpt-6-mini returned 400 "not
+ * supported when using Codex with a ChatGPT account"; gpt-5.5 returned 404.
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveCliModelFlag } from '../../src/providers/adapters/openai-codex/models.js';
+import {
+  resolveCliModelFlag,
+  CODEX_CHATGPT_FALLBACK_MODEL,
+} from '../../src/providers/adapters/openai-codex/models.js';
 import { resolveModelForFramework } from '../../src/core/frameworkSessionLaunch.js';
+import { KNOWN_CODEX_MODEL_IDS } from '../../src/core/ModelTierEscalation.js';
 
-const RETIRED_ON_CHATGPT_ACCOUNT = 'gpt-5.2';
+/** Every codex id observed REJECTED on the ChatGPT-account surface, with the date. */
+const RETIRED_ON_CHATGPT_ACCOUNT = [
+  'gpt-5.2',        // 2026-06-03
+  'gpt-5.4',        // 2026-09-09
+  'gpt-5.4-mini',   // 2026-09-09 — was both the fast/balanced tier AND the floor
+  'gpt-5.5',        // 2026-09-09 (404, not 400)
+];
 
-describe('codex model-tier resolution (post gpt-5.2 retirement 2026-06-03)', () => {
+const LIGHT = 'gpt-5.6-sol';
+const HEAVY = 'gpt-6-astra';
+/** The canonical tiers BOTH resolvers understand. */
+const GENERIC_TIERS = ['fast', 'balanced', 'capable'];
+/**
+ * Claude-style aliases. Only the SESSION-LAUNCH resolver translates these; the
+ * adapter resolver documents that an unrecognised string passes through
+ * verbatim (it is a tier-or-raw-model-name resolver), so asserting a
+ * translation there would pin behaviour the adapter never promised.
+ */
+const CLAUDE_ALIASES = ['haiku', 'sonnet', 'opus'];
+const ALL_LAUNCH_TIERS = [...GENERIC_TIERS, ...CLAUDE_ALIASES];
+
+describe('codex model-tier resolution (post 2026-09-09 gpt-5.4/5.5 retirement)', () => {
   describe('adapter resolver — resolveCliModelFlag (intel / one-shot path)', () => {
-    it('fast tier resolves to the cheapest still-accepted model (gpt-5.4-mini)', () => {
-      expect(resolveCliModelFlag('fast')).toBe('gpt-5.4-mini');
+    it('fast tier resolves to the cheapest still-accepted model', () => {
+      expect(resolveCliModelFlag('fast')).toBe(LIGHT);
     });
-    it('balanced tier resolves to gpt-5.4-mini', () => {
-      expect(resolveCliModelFlag('balanced')).toBe('gpt-5.4-mini');
+    it('balanced tier resolves to the same light model (no non-reasoning option exists)', () => {
+      expect(resolveCliModelFlag('balanced')).toBe(LIGHT);
     });
-    it('capable tier resolves to gpt-5.5', () => {
-      expect(resolveCliModelFlag('capable')).toBe('gpt-5.5');
+    it('capable tier resolves to the live frontier model', () => {
+      expect(resolveCliModelFlag('capable')).toBe(HEAVY);
     });
     it('undefined falls back to the balanced default', () => {
-      expect(resolveCliModelFlag(undefined)).toBe('gpt-5.4-mini');
+      expect(resolveCliModelFlag(undefined)).toBe(LIGHT);
     });
     it('a raw model id passes through verbatim', () => {
-      expect(resolveCliModelFlag('gpt-5.4')).toBe('gpt-5.4');
+      expect(resolveCliModelFlag('gpt-6-astra')).toBe('gpt-6-astra');
     });
   });
 
   describe('session-launch resolver — resolveModelForFramework(codex-cli, ...)', () => {
-    it('fast tier resolves to gpt-5.4-mini', () => {
-      expect(resolveModelForFramework('codex-cli', 'fast')).toBe('gpt-5.4-mini');
+    it('fast tier resolves to the light model', () => {
+      expect(resolveModelForFramework('codex-cli', 'fast')).toBe(LIGHT);
     });
-    it('legacy haiku alias resolves to gpt-5.4-mini (not the retired model)', () => {
-      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe('gpt-5.4-mini');
+    it('legacy haiku alias resolves to the light model (not a retired id)', () => {
+      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe(LIGHT);
     });
-    it('balanced/capable tiers are unchanged', () => {
-      expect(resolveModelForFramework('codex-cli', 'balanced')).toBe('gpt-5.4-mini');
-      expect(resolveModelForFramework('codex-cli', 'capable')).toBe('gpt-5.5');
+    it('balanced maps light and capable maps heavy', () => {
+      expect(resolveModelForFramework('codex-cli', 'balanced')).toBe(LIGHT);
+      expect(resolveModelForFramework('codex-cli', 'capable')).toBe(HEAVY);
+    });
+    it('legacy opus alias resolves to the live frontier model', () => {
+      expect(resolveModelForFramework('codex-cli', 'opus')).toBe(HEAVY);
+    });
+  });
+
+  describe('retirement safety floor', () => {
+    it('the floor the self-heal retries onto is NOT itself a retired id', () => {
+      // The 2026-09-09 outage: floor was gpt-5.4-mini, retired in the same
+      // sweep, so the self-heal retried one dead model with another.
+      expect(RETIRED_ON_CHATGPT_ACCOUNT).not.toContain(CODEX_CHATGPT_FALLBACK_MODEL);
+    });
+    it('the floor is an id the retry authority will actually accept', () => {
+      // CodexCliIntelligenceProvider gates the retry on this membership test;
+      // a floor outside the known set silently disables the self-heal.
+      expect(KNOWN_CODEX_MODEL_IDS as readonly string[]).toContain(CODEX_CHATGPT_FALLBACK_MODEL);
     });
   });
 
   describe('retired-model regression guard', () => {
-    it('NO tier in EITHER resolver produces the retired gpt-5.2', () => {
-      for (const tier of ['fast', 'balanced', 'capable', 'haiku', 'sonnet', 'opus']) {
-        expect(resolveCliModelFlag(tier)).not.toBe(RETIRED_ON_CHATGPT_ACCOUNT);
-        expect(resolveModelForFramework('codex-cli', tier)).not.toBe(RETIRED_ON_CHATGPT_ACCOUNT);
+    it('NO tier in EITHER resolver produces ANY retired id', () => {
+      for (const tier of GENERIC_TIERS) {
+        expect(RETIRED_ON_CHATGPT_ACCOUNT).not.toContain(resolveCliModelFlag(tier));
       }
-      expect(resolveCliModelFlag(undefined)).not.toBe(RETIRED_ON_CHATGPT_ACCOUNT);
+      for (const tier of ALL_LAUNCH_TIERS) {
+        expect(RETIRED_ON_CHATGPT_ACCOUNT).not.toContain(
+          resolveModelForFramework('codex-cli', tier),
+        );
+      }
+      expect(RETIRED_ON_CHATGPT_ACCOUNT).not.toContain(resolveCliModelFlag(undefined));
+    });
+    it('every tier resolves to an id the spawn route and pin validator accept', () => {
+      // Both surfaces validate against KNOWN_CODEX_MODEL_IDS. A tier that
+      // resolves outside it is rejected before the call is ever made.
+      for (const tier of GENERIC_TIERS) {
+        expect(KNOWN_CODEX_MODEL_IDS as readonly string[]).toContain(resolveCliModelFlag(tier));
+      }
+      for (const tier of ALL_LAUNCH_TIERS) {
+        expect(KNOWN_CODEX_MODEL_IDS as readonly string[]).toContain(
+          resolveModelForFramework('codex-cli', tier),
+        );
+      }
     });
   });
 });

--- a/tests/unit/crossModelReviewer.test.ts
+++ b/tests/unit/crossModelReviewer.test.ts
@@ -20,6 +20,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+// Resolve the capable tier rather than hardcoding an id: OpenAI has retired the
+// codex capable model three times, and a literal here re-breaks on each move.
+import { resolveCliModelFlag } from '../../src/providers/adapters/openai-codex/models.js';
+const CAPABLE_ID = resolveCliModelFlag('capable');
 import {
   detectCodexReviewer,
   detectCrossModelReviewer,
@@ -86,8 +90,8 @@ describe('detectCodexReviewer', () => {
     });
     expect(r.available).toBe(true);
     expect(r.framework).toBe('codex-cli');
-    // capable tier → gpt-5.5 per models.ts (the concrete id stays owned there).
-    expect(r.model).toBe('gpt-5.5');
+    // capable tier → resolved from models.ts (the concrete id stays owned there).
+    expect(r.model).toBe(CAPABLE_ID);
   });
 
   it('returns codex-not-authed when auth.json is missing', () => {
@@ -206,7 +210,7 @@ describe('buildCrossModelFlag (fallback states)', () => {
 describe('aggregateRoundOutcomes (F2 — one final spec-level flag)', () => {
   // crossFamily: true — these builders represent codex (a cross-model family);
   // aggregateRoundOutcomes counts only crossFamily:true successes (§5.2).
-  const ok = (model = 'gpt-5.5'): ReviewerResult => ({
+  const ok = (model = CAPABLE_ID): ReviewerResult => ({
     status: 'ok',
     framework: 'codex-cli',
     model,
@@ -216,9 +220,9 @@ describe('aggregateRoundOutcomes (F2 — one final spec-level flag)', () => {
   const degraded = (reason: string): ReviewerResult => ({
     status: 'degraded',
     framework: 'codex-cli',
-    model: 'gpt-5.5',
+    model: CAPABLE_ID,
     reason,
-    flag: `cross-model-review: codex-cli:gpt-5.5 (degraded: ${reason})`,
+    flag: `cross-model-review: codex-cli:${CAPABLE_ID} (degraded: ${reason})`,
     crossFamily: true,
   });
   const unavailable = (reason = 'codex-not-installed'): ReviewerResult => ({
@@ -231,12 +235,12 @@ describe('aggregateRoundOutcomes (F2 — one final spec-level flag)', () => {
   it('any successful round → the clean codex-cli flag (one real opinion is enough)', () => {
     const f = aggregateRoundOutcomes([degraded('timeout'), ok(), degraded('rate-limited')]);
     expect(f.status).toBe('available');
-    expect(f.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+    expect(f.flag).toBe(`cross-model-review: codex-cli:${CAPABLE_ID}`);
   });
 
   it('uses the LAST successful round flag when multiple rounds succeed', () => {
-    const f = aggregateRoundOutcomes([ok('gpt-5.4'), ok('gpt-5.5')]);
-    expect(f.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+    const f = aggregateRoundOutcomes([ok('gpt-5.4'), ok(CAPABLE_ID)]);
+    expect(f.flag).toBe(`cross-model-review: codex-cli:${CAPABLE_ID}`);
   });
 
   it('framework present every round but ZERO succeeded → degraded-all-rounds (as loud as unavailable)', () => {
@@ -315,11 +319,11 @@ describe('runCrossModelReview — the three outcome states', () => {
     });
     expect(r.status).toBe('ok');
     expect(r.framework).toBe('codex-cli');
-    expect(r.model).toBe('gpt-5.5');
+    expect(r.model).toBe(CAPABLE_ID);
     expect(r.verdict).toBe('SERIOUS ISSUES');
     expect(r.findings).toHaveLength(1);
-    expect(r.findings![0].reviewer).toBe('cross-model:codex-cli:gpt-5.5');
-    expect(r.flag).toBe('cross-model-review: codex-cli:gpt-5.5');
+    expect(r.findings![0].reviewer).toBe(`cross-model:codex-cli:${CAPABLE_ID}`);
+    expect(r.flag).toBe(`cross-model-review: codex-cli:${CAPABLE_ID}`);
   });
 
   it('degraded: available but the provider throws → status degraded, does NOT collapse to unavailable', async () => {
@@ -331,7 +335,7 @@ describe('runCrossModelReview — the three outcome states', () => {
     });
     expect(r.status).toBe('degraded');
     expect(r.reason).toBe('timeout');
-    expect(r.flag).toBe('cross-model-review: codex-cli:gpt-5.5 (degraded: timeout)');
+    expect(r.flag).toBe(`cross-model-review: codex-cli:${CAPABLE_ID} (degraded: timeout)`);
   });
 
   it('degraded: rate-limited provider error classifies as rate-limited', async () => {
@@ -353,7 +357,7 @@ describe('runCrossModelReview — the three outcome states', () => {
 // ── Driver parse ────────────────────────────────────────────────────────
 
 describe('parseReviewerReply', () => {
-  const tag = 'cross-model:codex-cli:gpt-5.5';
+  const tag = `cross-model:codex-cli:${CAPABLE_ID}`;
 
   it('parses a well-formed reply into a structured finding', () => {
     const f = parseReviewerReply(

--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -153,12 +153,12 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
 
   describe('codex-cli', () => {
     it('reports the same concrete default model the interactive builder launches', () => {
-      expect(resolveInteractiveLaunchModel('codex-cli', undefined)).toBe('gpt-5.5');
-      expect(resolveInteractiveLaunchModel('codex-cli', 'balanced')).toBe('gpt-5.4-mini');
+      expect(resolveInteractiveLaunchModel('codex-cli', undefined)).toBe('gpt-5.6-sol');
+      expect(resolveInteractiveLaunchModel('codex-cli', 'balanced')).toBe('gpt-5.6-sol');
       expect(resolveInteractiveLaunchModel('codex-cli', undefined, 'ollama')).toBe('llama3.2:latest');
     });
 
-    it('passes --model gpt-5.5 + --dangerously-bypass-approvals-and-sandbox by default (parity with Claude\'s --dangerously-skip-permissions)', () => {
+    it('passes --model gpt-5.6-sol + --dangerously-bypass-approvals-and-sandbox by default (parity with Claude\'s --dangerously-skip-permissions)', () => {
       // The binary is a FAKE whose --help advertises no hook-trust flag, so this
       // asserts the DEFAULT argv deterministically. It previously passed the real
       // '/usr/local/bin/codex' path, which made the assertion depend on whichever
@@ -171,7 +171,7 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
       const spec = buildInteractiveLaunch('codex-cli', { binaryPath: bin });
       // The explicit `--model` flag avoids Codex CLI's own historical
       // default `gpt-5.2-codex` (retired from ChatGPT-subscription auth
-      // 2026-04-14). The session default is gpt-5.5 as of 2026-05-23
+      // 2026-04-14). The session default is gpt-5.6-sol as of 2026-09-09
       // (Justin's call) — newest generalist + Codex CLI's own default,
       // confirmed working on the subscription. See models.ts comment block.
       // The bypass flag is the single-flag parity for Claude's
@@ -185,7 +185,7 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
       expect(spec.argv).toEqual([
         bin,
         '--model',
-        'gpt-5.5',
+        'gpt-5.6-sol',
         '--dangerously-bypass-approvals-and-sandbox',
         '-c',
         'check_for_update_on_startup=false',
@@ -365,7 +365,7 @@ describe('frameworkSessionLaunch.buildHeadlessLaunch', () => {
       expect(spec.argv).toContain('sandbox_workspace_write.network_access=true');
       expect(spec.argv).not.toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(spec.argv).toContain('-m');
-      expect(spec.argv).toContain('gpt-5.5');
+      expect(spec.argv).toContain('gpt-5.6-sol');
       expect(spec.argv[spec.argv.length - 1]).toBe('analyze this');
     });
 
@@ -488,16 +488,16 @@ describe('frameworkSessionLaunch.resolveModelForFramework', () => {
   describe('codex-cli', () => {
     it('maps generic tiers to subscription-safe Codex model ids', () => {
       // light/medium/heavy mapping. NOTE: gpt-5.2 was retired from ChatGPT-account
-      // Codex on 2026-06-03 (now 400s), so `fast`/`haiku` moved to gpt-5.4-mini —
+      // Codex on 2026-09-09 (now 400s), so `fast`/`haiku` moved to gpt-5.6-sol —
       // the cheapest still-accepted model (== balanced). See models.ts.
-      expect(resolveModelForFramework('codex-cli', 'fast')).toBe('gpt-5.4-mini');
-      expect(resolveModelForFramework('codex-cli', 'balanced')).toBe('gpt-5.4-mini');
-      expect(resolveModelForFramework('codex-cli', 'capable')).toBe('gpt-5.5');
+      expect(resolveModelForFramework('codex-cli', 'fast')).toBe('gpt-5.6-sol');
+      expect(resolveModelForFramework('codex-cli', 'balanced')).toBe('gpt-5.6-sol');
+      expect(resolveModelForFramework('codex-cli', 'capable')).toBe('gpt-6-astra');
     });
     it('maps legacy Claude tier names to Codex equivalents (cross-port back-compat)', () => {
-      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe('gpt-5.4-mini');
-      expect(resolveModelForFramework('codex-cli', 'sonnet')).toBe('gpt-5.4-mini');
-      expect(resolveModelForFramework('codex-cli', 'opus')).toBe('gpt-5.5');
+      expect(resolveModelForFramework('codex-cli', 'haiku')).toBe('gpt-5.6-sol');
+      expect(resolveModelForFramework('codex-cli', 'sonnet')).toBe('gpt-5.6-sol');
+      expect(resolveModelForFramework('codex-cli', 'opus')).toBe('gpt-6-astra');
     });
     it('passes raw Codex model ids through verbatim', () => {
       expect(resolveModelForFramework('codex-cli', 'gpt-5.4-codex')).toBe('gpt-5.4-codex');
@@ -542,7 +542,7 @@ describe('frameworkSessionLaunch.resolveModelForFramework', () => {
 
   it('codex headless builder rewrites generic tier to gpt-5.x', () => {
     const balanced = buildHeadlessLaunch('codex-cli', { binaryPath: '/x/codex', prompt: 'p', model: 'balanced' });
-    expect(balanced.argv).toContain('gpt-5.4-mini'); // medium tier
+    expect(balanced.argv).toContain('gpt-5.6-sol'); // medium tier
     expect(balanced.argv).not.toContain('balanced');
   });
 });

--- a/tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts
+++ b/tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts
@@ -69,6 +69,111 @@ describe('normalizeCodexJsonlEvent', () => {
     if (result?.type === 'error') expect(result.errorKind).toBe('unsupported');
   });
 
+  it('classifies the 404 model-removal signature as unsupported too', () => {
+    // The SECOND retirement shape (observed 2026-09-09 for gpt-5.5). When
+    // OpenAI removes an id outright rather than de-listing it from the
+    // ChatGPT surface, Codex returns a 404 with backtick-quoted wording. This
+    // previously fell through to 'unknown', so the model-retirement self-heal
+    // in CodexCliIntelligenceProvider never fired and every call using that id
+    // failed forever — the fleet-wide outage this test exists to prevent.
+    const result = normalizeCodexJsonlEvent(
+      JSON.stringify({
+        type: 'error',
+        message:
+          'Reconnecting... 2/5 (unexpected status 404 Not Found: The model `gpt-5.5` does not exist or you do not have access to it.)',
+      }),
+    );
+    expect(result?.type).toBe('error');
+    if (result?.type === 'error') expect(result.errorKind).toBe('unsupported');
+  });
+
+  it('matches the 404 removal signature regardless of how the id is quoted', () => {
+    for (const quoted of ['`gpt-5.5`', "'gpt-5.5'", '"gpt-5.5"']) {
+      const result = normalizeCodexJsonlEvent(
+        JSON.stringify({
+          type: 'error',
+          message: `The model ${quoted} does not exist or you do not have access to it.`,
+        }),
+      );
+      expect(result?.type).toBe('error');
+      if (result?.type === 'error') expect(result.errorKind).toBe('unsupported');
+    }
+  });
+
+  it('does NOT let the model-not-found wording mask a real auth / throttle failure', () => {
+    // ORDERING GUARD. A single Codex message can carry BOTH a specific failure
+    // token AND the model-not-found wording. If the 404 branch is matched
+    // first, those messages silently reclassify as a retryable retirement —
+    // hiding a genuine auth or rate-limit failure from every consumer of
+    // errorKind and sending the self-heal off to swap models over a problem
+    // that swapping cannot fix. The 404 branch must stay BELOW the specific
+    // ones; this test fails if anyone moves it back up.
+    const cases: Array<[string, string]> = [
+      ['unexpected status 403 Forbidden: The model `gpt-6-pro` does not exist or you do not have access to it.', 'auth'],
+      ['invalid token: The model "gpt-5.5" does not exist or you do not have access to it.', 'auth'],
+      ['unexpected status 429 rate limit: The model `gpt-6-astra` does not exist or you do not have access to it.', 'rate-limit'],
+      ['quota exceeded: The model `gpt-6-astra` does not exist or you do not have access to it.', 'quota'],
+    ];
+    for (const [message, expected] of cases) {
+      const result = normalizeCodexJsonlEvent(JSON.stringify({ type: 'error', message }));
+      expect(result?.type).toBe('error');
+      if (result?.type === 'error') expect(result.errorKind).toBe(expected);
+    }
+  });
+
+  it('sits ABOVE timeout as well as above network, per the source comment', () => {
+    // Closes the one remaining slot of slack. The two bounds above still pass
+    // if the branch is moved down by exactly one, to between `timeout` and
+    // `network` — which contradicts the ordering the source comment states and
+    // leaves a genuine 504/408-carrying retirement message classified as a
+    // timeout. Pinning this makes the stated ordering binding rather than
+    // aspirational, so the comment and the behaviour cannot drift apart.
+    const result = normalizeCodexJsonlEvent(
+      JSON.stringify({
+        type: 'error',
+        message:
+          'unexpected status 504 Gateway Timeout: The model `gpt-5.5` does not exist or you do not have access to it.',
+      }),
+    );
+    expect(result?.type).toBe('error');
+    if (result?.type === 'error') expect(result.errorKind).toBe('unsupported');
+  });
+
+  it('still classifies the REAL outage message as a retirement, despite Reconnecting/ECONN', () => {
+    // LOWER ORDERING BOUND. The verbatim message from the 2026-09-09 fleet
+    // outage. Codex prefixes its retries with "Reconnecting... 2/5 (…)", and
+    // "R-ECONN-ecting" matches the network branch's /ECONN/i — so if the 404
+    // branch is placed BELOW `network`, this real message classifies as
+    // 'network', the self-heal never fires, and the outage this whole change
+    // exists to fix stays unfixed. That is not hypothetical: it is what
+    // happened when the branch was first moved to the end of the chain.
+    const result = normalizeCodexJsonlEvent(
+      JSON.stringify({
+        type: 'error',
+        message:
+          'Reconnecting... 2/5 (unexpected status 404 Not Found: The model `gpt-5.5` does not exist or you do not have access to it.)',
+      }),
+    );
+    expect(result?.type).toBe('error');
+    if (result?.type === 'error') expect(result.errorKind).toBe('unsupported');
+  });
+
+  it('does NOT treat a generic 404 as a retryable model retirement', () => {
+    // The retry authority swaps models on 'unsupported'. A 404 that is not
+    // Codex's quoted-model-id wording (a bad route, a missing rollout file)
+    // must stay unclassified so the caller surfaces it unchanged instead of
+    // silently retrying on a different model.
+    for (const message of [
+      '404 Not Found',
+      'unexpected status 404 Not Found: no such endpoint',
+      'The file does not exist or you do not have access to it.',
+    ]) {
+      const result = normalizeCodexJsonlEvent(JSON.stringify({ type: 'error', message }));
+      expect(result?.type).toBe('error');
+      if (result?.type === 'error') expect(result.errorKind).not.toBe('unsupported');
+    }
+  });
+
   it('does not classify a different 400 or an auth failure as model retirement', () => {
     for (const message of ['400 invalid request body', '401 unauthorized']) {
       const result = normalizeCodexJsonlEvent(JSON.stringify({ type: 'error', message }));

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -237,12 +237,12 @@ describe('SessionManager behavioral tests', () => {
       });
 
       expect(session.framework).toBe('codex-cli');
-      expect(session.model).toBe('gpt-5.4-mini'); // haiku → light → gpt-5.4-mini on Codex (gpt-5.2 retired from ChatGPT-account Codex 2026-06-03)
+      expect(session.model).toBe('gpt-5.6-sol'); // haiku → light → gpt-5.6-sol on Codex (gpt-5.4-mini retired from ChatGPT-account Codex 2026-09-09)
       // And it must NOT leak the Claude tier alias onto a Codex session.
       expect(session.model).not.toBe('haiku');
 
       const saved = state.getSession(session.id);
-      expect(saved!.model).toBe('gpt-5.4-mini');
+      expect(saved!.model).toBe('gpt-5.6-sol');
       expect(saved!.framework).toBe('codex-cli');
     });
 

--- a/upgrades/next/codex-model-retirement-2026-09-09.md
+++ b/upgrades/next/codex-model-retirement-2026-09-09.md
@@ -1,0 +1,59 @@
+## What Changed
+
+OpenAI retired the gpt-5.4/5.5 generation of Codex models from the ChatGPT-account surface.
+Instar hardcoded those ids in every place it picks a Codex model, so **every internal Codex LLM
+call — every sentinel, gate and reflector — failed instantly on every machine**. The same
+retirement also killed `CODEX_CHATGPT_FALLBACK_MODEL`, the model the existing retirement
+self-heal retries onto, so the self-heal swapped one rejected model for another and the agent
+stayed dark.
+
+- `TIER_TO_MODEL` (adapter) and the session-launch codex tier map now resolve to live,
+  **probe-verified** ids: `gpt-5.6-sol` for fast/balanced, `gpt-6-astra` for capable. The two
+  `?? 'gpt-5.5'` codex last-resort defaults move with them.
+- `CODEX_CHATGPT_FALLBACK_MODEL` → `gpt-5.6-sol`, so the retirement self-heal retries onto a
+  model that answers.
+- `classifyCodexErrorMessage` now recognises Codex's **404** model-removal wording ("The model
+  `x` does not exist or you do not have access to it") in addition to the 400 "not supported"
+  wording. The 404 shape previously classified as `unknown`, so the self-heal could never fire
+  for it — a live floor alone would not have been enough.
+
+## Evidence
+
+Model ids are live-probed, never guessed. Probe run 2026-09-09 against a ChatGPT subscription:
+
+- Answered a trivial prompt: `gpt-5.6-sol`, `gpt-6-astra`.
+- HTTP 400 "not supported when using Codex with a ChatGPT account": `gpt-5.4-mini`, `gpt-5.4`,
+  `gpt-5.6`, `gpt-6`, `gpt-5.6-mini`, `gpt-6-mini`.
+- HTTP 404 "does not exist or you do not have access to it": `gpt-5.5`.
+
+Tests: `codex-model-tier-resolution.test.ts` (live mapping, floor liveness, floor reachability
+by the retry authority, retired-name regression guard across both resolvers, and a cross-check
+that every tier resolves inside `KNOWN_CODEX_MODEL_IDS`);
+`eventNormalizer.test.ts` (the 404 shape classifies as `unsupported`, quoting-style variants, a
+generic 404 does **not**, and both classifier-ordering bounds);
+`codex-cli-provider-execjson.test.ts` (end-to-end self-heal through the real exec-json spawn
+path, now asserted against the constant rather than a hardcoded name).
+
+The classifier branch position is load-bearing in both directions and is test-pinned: it sits
+below `auth`/`quota`/`rate-limit` so a combined message cannot mask a real auth or throttle
+failure, and above `timeout`/`network` because `/ECONN/i` matches inside Codex's own
+"**R-ECONN-ecting**... 2/5" retry prefix and would otherwise swallow the genuine outage message.
+
+## What to Tell Your User
+
+Your agent's background checks — the ones that watch for stuck sessions, review outgoing
+messages, and work out what a conversation is about — had stopped working, because the AI models
+they ask for were switched off by OpenAI. They now point at models that still exist, and the
+built-in recovery path can recognise both ways a model disappears instead of only one.
+
+Worth knowing: those checks were failing at **zero token cost**, so the bill looked healthy while
+they were doing nothing. Restoring them makes real spending appear where there was none. Most of
+each call's cost is fixed overhead the Codex CLI charges just for starting up, regardless of how
+small the question is — so if the total is more than the checks are worth, the lever is running
+**fewer** checks, not smaller ones.
+
+## Summary of New Capabilities
+
+No new capability. This restores an existing one: internal Codex-routed intelligence (sentinels,
+gates, reflectors) works again, and the model-retirement self-heal can now actually fire for
+both retirement shapes rather than only one.

--- a/upgrades/side-effects/codex-model-retirement-2026-09-09.md
+++ b/upgrades/side-effects/codex-model-retirement-2026-09-09.md
@@ -1,0 +1,341 @@
+# Side-Effects Review — Codex model retirement 2026-09-09: relive the tier map, the safety floor, and the 404 self-heal path
+
+**Version / slug:** `codex-model-retirement-2026-09-09`
+**Date:** `2026-09-09`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `required — see Second-pass review below`
+
+## Summary of the change
+
+OpenAI retired the whole gpt-5.4/5.5 generation from the ChatGPT-account Codex surface. Instar
+had those ids hardcoded in **three** places that pick a model, so every internal codex LLM call
+— every sentinel, gate and reflector — failed instantly on every machine in the fleet. Worse,
+the retirement also killed `CODEX_CHATGPT_FALLBACK_MODEL`, the floor the existing
+model-retirement self-heal retries onto, so the self-heal swapped one rejected model for another
+and the agent stayed dark. A fourth defect kept the self-heal from firing at all for one of the
+two retirement shapes.
+
+Files touched:
+- `src/providers/adapters/openai-codex/models.ts` — `TIER_TO_MODEL` (fast/balanced →
+  `gpt-5.6-sol`, capable → `gpt-6-astra`) and `CODEX_CHATGPT_FALLBACK_MODEL` → `gpt-5.6-sol`.
+- `src/core/frameworkSessionLaunch.ts` — the second (session-launch) codex tier map, plus the
+  two `?? 'gpt-5.5'` codex last-resort defaults.
+- `src/providers/adapters/openai-codex/observability/eventNormalizer.ts` —
+  `classifyCodexErrorMessage` now also recognises Codex's **404** model-removal wording, which
+  previously fell through to `'unknown'`.
+- `tests/unit/codex-model-tier-resolution.test.ts`,
+  `tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts`,
+  `tests/unit/codex-cli-provider-execjson.test.ts` — coverage + de-hardcoding.
+
+All model ids here are **live-probed, never guessed** (probe run 2026-09-09 against the
+operator's ChatGPT subscription): `gpt-5.6-sol` and `gpt-6-astra` answered a trivial prompt;
+`gpt-5.4-mini`, `gpt-5.4`, `gpt-5.6`, `gpt-6`, `gpt-5.6-mini` and `gpt-6-mini` returned
+400 "not supported when using Codex with a ChatGPT account"; `gpt-5.5` returned 404.
+
+## Decision-point inventory
+
+- `classifyCodexErrorMessage` (`eventNormalizer.ts`) — **modify** — widened by one narrow
+  pattern. It is a pure classifier: it returns a label and holds no block authority. Its label
+  is consumed by the retry authority in `CodexCliIntelligenceProvider.evaluateWithModelObserved`.
+- `TIER_TO_MODEL` / `resolveModelForFramework('codex-cli', …)` — **modify** — data maps, not
+  decision points. They select *which* model answers, never *whether* a call is permitted.
+- `CODEX_CHATGPT_FALLBACK_MODEL` — **modify** — the retry target the existing authority uses.
+  The authority itself is unchanged.
+
+No decision point is added, removed, or given new authority.
+
+---
+
+## 1. Over-block
+
+No block/allow surface is added — but the classifier change does widen a **retry** trigger, and
+the honest over-fire question is: what non-retirement error could now be misread as a retirement
+and cause one extra model swap?
+
+The pattern requires Codex's exact wording *with a quoted model id*:
+`The model \`X\` does not exist or you do not have access to it`. Concretely rejected by the
+pattern (verified by an explicit negative test): a bare `404 Not Found`, a generic
+`unexpected status 404 Not Found: no such endpoint`, and `The file does not exist or you do not
+have access to it.` The residual over-fire case is a genuine **entitlement** failure — an
+account that legitimately lacks access to a model it named. That case now retries once on the
+verified floor and succeeds, which is the desired behaviour, not a defect; the alternative is
+the pre-change behaviour where the call fails permanently.
+
+There is a second over-fire direction, and it is the deliberate price of the lower ordering
+bound described in §5: a genuine `timeout` / `network` / `malformed-response` failure whose
+message *also* carries the retirement wording now reads `unsupported` rather than its specific
+kind. That is the trade for not letting `/ECONN/i` swallow the real outage message, and the
+underlying cause — the over-broad `network` substring match — is disclosed as under-block item 5.
+
+Worst case cost of a false positive, in either direction, is bounded: exactly **one** extra
+bounded subprocess call. The retry is never recursive (the authority refuses to retry when the
+model already equals the floor), and the retry authority remains the only behavioural consumer
+of the label.
+
+---
+
+## 2. Under-block
+
+Five failure modes remain, all stated rather than fixed here:
+
+1. **A fourth retirement shape.** If OpenAI invents new wording, the classifier will not
+   recognise it and the fleet goes dark again in exactly this way. This change hardens the two
+   *observed* shapes; it does not make the classifier self-discovering.
+2. **A floor that dies without anyone probing.** The floor is now live, but nothing
+   continuously verifies it. If `gpt-5.6-sol` is retired, `TIER_TO_MODEL` and the floor die
+   together again — the identical failure to the one being fixed. The structural answer is a
+   scheduled live probe that alarms on floor death; it is **not** in this PR.
+   <!-- tracked: CMT-1406 -->
+3. **`KNOWN_CODEX_MODEL_IDS` still lists retired ids** (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`,
+   `gpt-5.4-mini`, `gpt-5.5`). A topic pinned to one of those is accepted by the pin validator
+   and then fails at call time. Curating that list needs a per-id live probe as evidence, so it
+   is deliberately out of this change rather than guessed at. <!-- tracked: CMT-1406 -->
+4. **The codex hook-arming path still names a model retired in June.** `src/commands/init.ts`
+   and `src/core/PostUpdateMigrator.ts` both hardcode `model: 'gpt-5.2'`, which feeds
+   `makeTmuxTrustDriver` and reaches a real launch line in `src/core/codexHookArm.ts`
+   (`${codexBinary} -m ${model}`). `gpt-5.2` has been retired since 2026-06-03 by this repo's
+   own record. Surfaced by the second-pass review. Impact is unverified and probably benign —
+   the TUI trust prompt renders before any model request and arming is fail-soft — but it is a
+   live model-choice site naming a dead id, and the decision-point inventory above should not be
+   read as exhaustive. Not fixed here (different path, different failure mode, anti-bundling).
+   <!-- tracked: CMT-1406 -->
+5. **The `network` classification is over-broad and this change had to route around it.**
+   `/network|ECONN|ETIMEDOUT|dns/i` is a substring match, so ANY message containing the word
+   "Reconnecting" classifies as a network error — "R-ECONN-ecting". That is a pre-existing
+   latent defect: Codex prefixes its retries with "Reconnecting... N/5", so a broad class of
+   non-network Codex errors is currently mislabelled. This change does not fix it; it places the
+   new branch above `network` so the retirement message is not swallowed, and pins that bound
+   with a test. Narrowing `ECONN` to a token match is a separate fix.
+   <!-- tracked: CMT-1406 -->
+6. **The 400 retirement branch still sits above `auth` — the identical defect, one branch up.**
+   The pre-existing 400 branch matches before `auth`, so
+   `403 Forbidden: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.`
+   masks a real auth failure exactly the way the new branch would have before it was moved. The
+   file now carries two opposite ordering policies, and the 400 branch's own comment ("Keep it
+   ahead of generic auth classification … but must surface every neighboring 400/auth/rate-limit/
+   network failure unchanged") is self-contradictory. Realism is low — no observed 400 retirement
+   body carries an auth token — and anti-bundling argues against changing a pre-existing branch
+   here, but it is recorded so the next reader does not have to rediscover it. Surfaced by the
+   second-pass re-review. <!-- tracked: CMT-1406 -->
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and the change deliberately does **not** climb.
+
+`classifyCodexErrorMessage` is a **detector** — a cheap regex over an error string returning a
+structured label. It is exactly what the signal-vs-authority doc lists as an allowed detector
+("Regex / literal matchers"). The **authority** — the decision to retry, and on what — already
+exists one layer up in `evaluateWithModelObserved`, which gates the retry on three conditions
+(not already the floor, label is `'unsupported'`, floor is in `KNOWN_CODEX_MODEL_IDS`). This
+change feeds the existing authority a signal it was previously blind to. It does not add a
+parallel retry path, and it does not move any decision into the detector.
+
+The tier maps sit at the adapter layer, which is where a framework's concrete model vocabulary
+belongs. The duplication between the two maps is pre-existing (documented as "keep in lockstep")
+and is now covered by a test that asserts both resolvers agree with `KNOWN_CODEX_MODEL_IDS`, so
+the lockstep is machine-checked instead of comment-enforced.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No** — this change produces a signal consumed by an existing smart gate.
+
+The widened classifier emits a label; the pre-existing retry authority consumes it. No brittle
+check gains blocking power. The tier-map and floor edits have no block/allow surface at all —
+they are data. The one place this change touches a validation gate is *read-only*: the new test
+asserts that every resolved tier is already a member of `KNOWN_CODEX_MODEL_IDS`, so the change
+cannot produce a model the spawn route or pin validator would reject.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The classifier's domain **is**
+enumerable and is an invariant: it matches two literal, vendor-emitted error strings. There are
+no competing live signals to weigh — the message either carries Codex's retirement wording or it
+does not. The retry authority that consumes the label is unchanged by this PR.
+
+---
+
+## 5. Interactions
+
+- **Shadowing: the branch's POSITION is load-bearing in both directions, and the first draft of
+  this change got it wrong.** The initial placement (immediately after the 400 branch, above
+  `auth`) genuinely did shadow: a single Codex message can carry BOTH a specific failure token
+  AND the model-not-found wording — e.g. `unexpected status 403 Forbidden: The model \`x\` does
+  not exist or you do not have access to it` — and matching first reclassified real `auth`,
+  `rate-limit` and `quota` failures as a retryable retirement. The original negative test
+  (`401 unauthorized` alone) did not cover the combined message and so was not evidence for the
+  claim it was offered as. Surfaced by the second-pass review.
+  The obvious correction — move the branch to the end of the chain — is ALSO wrong, and failed
+  loudly when tried: `network` matches `/ECONN/i` as a substring, and Codex prefixes its retries
+  with `Reconnecting... 2/5 (…)`, so `R-ECONN-ecting` captured the real outage message and the
+  self-heal never fired. The branch now sits BETWEEN `rate-limit` and `timeout`: specific,
+  actionable failures still win above it; the loose substring patterns cannot swallow it below.
+  Both bounds are pinned by tests (a combined-message test per specific kind, and a test using
+  the verbatim outage message), so neither move can silently regress.
+- **Double-fire:** no. The retry authority is single-shot by construction — its first guard is
+  `model !== CODEX_CHATGPT_FALLBACK_MODEL`, so a retry that fails on the floor throws rather
+  than looping.
+- **Races:** none. Both edits are pure functions over their inputs with no shared mutable state.
+- **Feedback loops:** one worth naming, in the *good* direction. `PromptGate` caches its
+  "nothing here" verdict only on a successful verdict, so while codex calls were failing it
+  re-fired every tick per session (~2,760 calls/hour observed on one machine) and saturated the
+  host spawn cap, which then shed *other* components' calls — a self-sustaining outage. Making
+  codex calls succeed collapses that loop. The underlying `catch {}`-with-no-backoff in
+  PromptGate is a genuinely separate defect and ships as its own PR rather than being bundled
+  here. <!-- tracked: CMT-1406 -->
+
+---
+
+## 6. External surfaces
+
+- **Other agents / install base:** yes, and this is the point — every codex-routed agent gets
+  working internal LLM calls again. Behaviour change is strictly failure → success.
+- **External systems:** the model id sent to the Codex CLI changes. No API contract, no
+  auth surface, no wire format changes.
+- **Cost, stated honestly:** these calls were failing at **zero** token cost, so restoring them
+  makes real spend appear where there was none. Measured on the operator's fleet after the
+  equivalent hot-patch: ~650 internal calls/hour at ~15k input tokens each, of which roughly
+  15k per call is Codex CLI's fixed per-invocation overhead (openai/codex#19996), not prompt.
+  This is the correct trade — working background checks cost money; broken ones only looked free
+  — but it is a real bill and is called out in the release notes rather than buried.
+- **Persistent state:** none. No ledger, database, or memory-file shape changes.
+- **Operator surface:** no operator-facing action is added or touched. Not applicable.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. This change touches no dashboard renderer, approval page,
+or grant/revoke/secret-drop form.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN — and the reason matters here.** Which codex model ids a machine can
+reach is a property of *that machine's installed Codex CLI and its logged-in account*, not of
+the agent. The 2026-07-09 comment in `KNOWN_CODEX_MODEL_IDS` records exactly this: older CLI
+versions 400 with "requires a newer version of Codex" for ids a newer CLI accepts. Replicating a
+model choice across machines would therefore propagate a *wrong* answer to a machine with a
+different CLI version. Each machine resolves the same code against its own CLI and account.
+
+- **User-facing notices:** none emitted. No one-voice gating needed.
+- **Durable state:** none held, so nothing strands on topic transfer.
+- **Generated URLs:** none.
+
+The change ships identically to every machine through the normal release path, which is the
+correct distribution mechanism — and is precisely what a per-machine `node_modules` hot-patch is
+**not**: the hot-patch applied during the incident was silently erased by auto-update 1.3.1232
+on the first machine to update, which is the reason this had to land in source.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit, ship as the next patch. Pure code change.
+- **Data migration:** none — no persistent state written or read.
+- **Agent state repair:** none. Agents pick up the change on their normal auto-update.
+- **User visibility during rollback:** reverting restores the outage (every internal codex call
+  fails again), so a revert is only correct if the new ids themselves prove wrong — in which
+  case the right move is to re-probe and re-point forward, not to revert. Stated plainly because
+  "revert is cheap" would be misleading here: revert is *mechanically* trivial and
+  *operationally* a return to a fleet-dark state.
+
+---
+
+## Conclusion
+
+The review surfaced three things the first pass had wrong or missing, all now folded in. First,
+the initial scope assumed the self-heal had to be *built*; re-grounding on current `main` showed
+it already exists and only its **floor** was dead — so the fix is far smaller and more surgical
+than briefed. Second, the 404 retirement shape was never classified, which meant the self-heal
+could not have fired for `gpt-5.5` no matter how healthy the floor was; shipping the floor alone
+would have left a known hole and been a deferral in disguise. Third, a mechanism test hardcoded
+the old floor name, so it would have re-broken on every future floor move — it now asserts
+against the constant.
+
+Four related defects are deliberately **not** bundled, per this skill's anti-bundling rule, and
+all are tracked to CMT-1406: PromptGate's missing error backoff, the stale retired ids in
+`KNOWN_CODEX_MODEL_IDS`, the June-retired `gpt-5.2` still hardcoded into the codex hook-arming
+launch line, and the over-broad `network`/`ECONN` substring match (plus the 400 branch's mirror
+of the ordering defect just fixed). Clear to ship pending second-pass concurrence.
+
+---
+
+## Second-pass review (if required)
+
+Required: this change touches a recovery path (the model-retirement self-heal) and an error
+classifier feeding it.
+
+**Reviewer:** independent reviewer subagent (fresh read of artifact + diff + principle doc)
+**Independent read of the artifact: round 1 CONCERN → resolved → round 2 CONCUR**
+
+Two concerns raised, both legitimate, both acted on:
+
+1. **The §5 shadowing claim was factually wrong.** The reviewer reconstructed the branch chain
+   and diffed old-vs-new classification over crafted messages, showing that a message carrying
+   both an auth/throttle token and the model-not-found wording flipped from `auth`/`rate-limit`/
+   `quota` to `unsupported`. Correct, and the cited negative test did not cover it.
+   **Resolved by code change, not by rewording:** the branch was moved below
+   `auth`/`quota`/`rate-limit`, a per-kind combined-message ordering test was added, and §5 now
+   states the truth.
+   *One correction to the reviewer's own recommendation, worth recording:* they recommended
+   moving the branch to the very end of the chain and stated they had verified the real outage
+   message matches none of the intervening patterns. It does match one — `network`, via `ECONN`
+   inside "Reconnecting". Applying that recommendation as given made the two new tests fail
+   immediately, which is how it was caught. Final placement is between `rate-limit` and
+   `timeout`, and both bounds are now test-pinned.
+2. **The decision-point inventory read as exhaustive but was not.** `src/commands/init.ts` and
+   `src/core/PostUpdateMigrator.ts` still hardcode the June-retired `gpt-5.2` into the codex
+   hook-arming launch line. Correct. Not fixed here (different path, anti-bundling) but now
+   disclosed as under-block item 4 and tracked.
+
+**Round 2 (re-review of the resolution) — CONCUR.** The reviewer extracted the eight classifier
+branches programmatically and re-ran the classifier with the retirement branch inserted at every
+index 0-7: indices 0-3 fail the upper bound (real auth/quota/rate-limit failures reclassify),
+indices 6-7 fail the lower bound (the verbatim outage message classifies `network` via `ECONN`).
+Only 4 and 5 pass; the shipped position is 4. They confirmed the artifact's account is accurate
+including its characterisation of their own incorrect recommendation, and stated they should have
+tested the proposed placement rather than reasoning about it.
+
+Four non-blocking corrections came out of round 2, all applied rather than deferred:
+- §1 now discloses the *other* over-fire direction the lower bound costs (a genuine
+  timeout/network/malformed failure whose message also carries the retirement wording).
+- §2's heading said "Two failure modes" above a list of five, and the Conclusion said "Two
+  related defects" while four are tracked. Both counts corrected.
+- A sixth under-block item was added: the pre-existing **400** retirement branch still sits above
+  `auth` — the identical ordering defect one branch up, left unfixed per anti-bundling but no
+  longer left for the next reader to rediscover.
+- The reviewer found the tests still permitted exactly **one** slot of movement (down to between
+  `timeout` and `network`), which passed every assertion while contradicting the source comment.
+  A third ordering test now pins that too, so the stated ordering is binding rather than
+  aspirational.
+
+The reviewer also independently confirmed: the retry authority is single-shot for two
+independent reasons (non-recursive call plus the `model !== floor` guard); signal-vs-authority
+compliance holds (detector feeding an existing authority, no new blocking surface); the
+de-hardcoded self-heal test genuinely interpolates the constant rather than expanding to an
+empty shell variable; and no live model-choice site on the internal-LLM or session-launch paths
+was missed — every one funnels through the two resolvers this change fixes.
+
+---
+
+## Evidence pointers
+
+- Live model probe, 2026-09-09, operator's ChatGPT-account Codex — results recorded verbatim in
+  the header of `src/providers/adapters/openai-codex/models.ts`.
+- `tests/unit/codex-model-tier-resolution.test.ts` — 13 tests: live mapping, floor liveness,
+  floor reachability by the retry authority, retired-name regression guard across both
+  resolvers, and cross-check that every tier resolves inside `KNOWN_CODEX_MODEL_IDS`.
+- `tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts` — the 404
+  shape classifies as `unsupported`, quoting-style variants, and a negative test that a generic
+  404 does **not**.
+- `tests/unit/codex-cli-provider-execjson.test.ts` — the end-to-end self-heal through the real
+  exec-json spawn path, now asserted against `CODEX_CHATGPT_FALLBACK_MODEL`.


### PR DESCRIPTION
## What this fixes

OpenAI retired the gpt-5.4/5.5 generation of Codex models from the ChatGPT-account surface.
Instar hardcoded those ids everywhere it picks a Codex model, so **every internal Codex LLM call
— every sentinel, gate and reflector — failed instantly on every machine in the fleet.**

The retirement also killed `CODEX_CHATGPT_FALLBACK_MODEL`, the model the *existing*
retirement self-heal retries onto. So the safety net swapped one rejected model for another and
the agent stayed dark. And one of the two retirement error shapes was never classified at all, so
for that shape the self-heal could not have fired even with a live floor.

Three defects, one root cause: **the model constants went stale and the machinery that exists to
survive exactly this could not reach a working model.**

## Changes

- `TIER_TO_MODEL` and the second (session-launch) codex tier map → `gpt-5.6-sol` (fast/balanced),
  `gpt-6-astra` (capable). The two `?? 'gpt-5.5'` codex last-resort defaults move with them.
- `CODEX_CHATGPT_FALLBACK_MODEL` → `gpt-5.6-sol`, so the self-heal retries onto a model that answers.
- `classifyCodexErrorMessage` now recognises Codex's **404** model-removal wording in addition to
  the 400 "not supported" wording.

## Evidence — ids are live-probed, never guessed

Probe run 2026-09-09 against a ChatGPT subscription:

| result | ids |
|---|---|
| ✅ answered | `gpt-5.6-sol`, `gpt-6-astra` |
| ❌ 400 "not supported … ChatGPT account" | `gpt-5.4-mini`, `gpt-5.4`, `gpt-5.6`, `gpt-6`, `gpt-5.6-mini`, `gpt-6-mini` |
| ❌ 404 "does not exist or you do not have access" | `gpt-5.5` |

## The classifier branch position is load-bearing in BOTH directions

This is the part worth reviewing carefully. The new branch sits **between `rate-limit` and
`timeout`**, and both bounds are pinned by tests:

- **Not above `auth`/`quota`/`rate-limit`** — a single message can carry both a specific failure
  token and the model-not-found wording (`unexpected status 403 Forbidden: The model \`x\` does
  not exist…`). Matching first reclassified real auth/throttle failures as a retryable
  retirement. Caught by the second-pass review.
- **Not below `timeout`/`network`** — `/ECONN/i` is a substring match and Codex prefixes its
  retries with `Reconnecting... 2/5 (…)`. **"R-ECONN-ecting"** matches it, so placing the branch
  last sends the genuine outage message to `network` and the self-heal never fires. This is not
  hypothetical: it is what happened when the review's suggested placement was applied, and the
  new tests caught it immediately.

## Deliberately NOT in this PR (tracked, CMT-1406)

- `PromptGate` swallows LLM errors with a bare `catch {}` and no backoff, so a failing provider
  makes it re-fire every tick per session (~2,760 calls/hour observed, saturating the host spawn
  cap and muting the agent). Separate defect, separate PR.
- `KNOWN_CODEX_MODEL_IDS` still lists retired ids — curating it needs per-id probe evidence.
- `src/commands/init.ts` / `src/core/PostUpdateMigrator.ts` still hardcode the June-retired
  `gpt-5.2` into the codex hook-arming launch line.
- The `network` pattern's `ECONN` substring match is over-broad (any "Reconnecting" message
  classifies as a network error). This PR routes around it rather than changing it.

## Honest cost note

These calls were failing at **zero** token cost, so the bill looked healthy while the background
layer was dead. Restoring them makes real spend appear where there was none — and roughly
three-quarters of each call is Codex CLI's fixed per-invocation overhead (openai/codex#19996),
not prompt. Correct trade, but a real bill; called out in the release notes rather than buried.

## ELI16

OpenAI switched off the AI models Instar was asking for, and the spare it falls back to was switched off in the same sweep. Instar does a lot of small thinking in the background — checking whether a message is safe to send, noticing when a session is stuck, working out what a conversation is about. All of that runs through OpenAI's Codex, and Instar names the model it wants. Every one of those names was dead, so every background check failed instantly, on every machine, and had been for a while before anyone noticed — because a failed call costs nothing and makes no noise.

Instar already knew models get retired: there is recovery code that catches "that model isn't supported" and immediately retries with a designated spare. Two things had gone wrong with it. The spare was retired in the same sweep, so the recovery was swapping one dead model for another — the net was there, with a hole exactly the size of the thing falling through it. And the error reader only knew one of the two ways a model can vanish: when OpenAI de-lists a model it says "not supported", which the reader knew, but when it deletes one outright it says "does not exist or you do not have access to it", which the reader had never been taught. Those got filed as "unknown problem" and the recovery never even woke up.

This points every model name at one that was actually tested and confirmed working, moves the spare to a live model, and teaches the error reader the second phrasing. The new pattern is deliberately fussy — it only matches when Codex names a specific model, so an unrelated "not found" error is still reported rather than quietly retried.

Worth knowing as the person paying for it: these checks were failing for free, so the bill looked healthy while the agent ran blind. Turning them back on makes real spending appear where there was none, and most of each call's cost is fixed overhead Codex charges just for starting up. That is the honest trade — working checks cost money, broken ones only looked free. If the total is more than the checks are worth, the lever is running fewer of them, not making them smaller.

Full plain-English write-up: `docs/specs/codex-model-retirement-2026-09-09.eli16.md`
