### PR TITLE
fix(telegram): start network deadlines after origin preparation

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-10T09-04-30-955Z-telegram-transport-deadlines.json
+++ b/.instar/instar-dev-decisions/2026-09-10T09-04-30-955Z-telegram-transport-deadlines.json
@@ -1,0 +1,44 @@
+{
+  "ts": "2026-09-10T09:04:30.955Z",
+  "slug": "telegram-transport-deadlines",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 119,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts",
+      "src/lifeline/TelegramLifeline.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/telegram-egress.ts",
+      "src/messaging/telegram-origin/OriginAwareness.ts",
+      "src/messaging/telegram-origin/OriginMesh.ts",
+      "src/messaging/telegram-origin/OriginTestProbe.ts",
+      "src/messaging/telegram-origin/OriginTransportCancellation.ts",
+      "src/messaging/telegram-origin/TelegramOriginRuntime.ts",
+      "src/messaging/telegram-origin/TelegramOriginService.ts"
+    ],
+    "addedLines": 77,
+    "deletedLines": 42
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "The ratchet and transport regressions preserve original identity, durable 15-minute pacing, six-hour deadline and attempt ceiling; cancellation cannot reset the loop and post-invocation uncertainty excludes resend."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-09-10T09-04-30-955Z-telegram-transport-deadlines.json
+++ b/.instar/instar-dev-decisions/2026-09-10T09-04-30-955Z-telegram-transport-deadlines.json
@@ -36,8 +36,8 @@
     "closure": "guard",
     "guardEvidence": {
       "enforcementType": "ratchet",
-      "citation": "tests/unit/self-action-convergence.test.ts",
-      "howCaught": "The ratchet and transport regressions preserve original identity, durable 15-minute pacing, six-hour deadline and attempt ceiling; cancellation cannot reset the loop and post-invocation uncertainty excludes resend."
+      "citation": "tests/unit/telegram-origin/recovery-review-budget.test.ts",
+      "howCaught": "The real durable reservation ratchet bounds each original admitted operation to 24 recovery starts over its default six-hour lifetime, with exact due/deadline boundaries, owner/restart persistence and unknown suppression. Production restart tests connect the brake to paid review; transport tests preserve attempt charging and ambiguity."
     }
   },
   "verdict": "pass"

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -22,7 +22,7 @@ import { originToolGuardHook } from '../messaging/telegram-origin/OriginToolGuar
  */
 
 import fs from 'node:fs';
-import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
+import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, telegramOriginTransportAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
 import { migrateTelegramOriginDisplay } from '../messaging/telegram-origin/OriginConfig.js';
 import path from 'node:path';
 import os from 'node:os';
@@ -6250,6 +6250,12 @@ setTimeout(() => process.exit(0), 2000);
       result.upgraded.push('CLAUDE.md: added queued-message review pacing awareness');
     }
 
+    if (!content.includes('Telegram send deadlines:')) {
+      content += '\n' + telegramOriginTransportAwareness();
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Telegram network deadline awareness');
+    }
+
     const refreshedOriginCanary = refreshOriginCanaryStartupAwareness(content);
     if (refreshedOriginCanary !== content) {
       content = refreshedOriginCanary;
@@ -10646,6 +10652,7 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
         ['Message origins on your phone:', telegramOriginDashboardAwareness],
         ['Origin detector health:', telegramOriginDetectorAwareness],
         ['Queued-message review pacing:', telegramOriginRecoveryAwareness],
+        ['Telegram send deadlines:', telegramOriginTransportAwareness],
       ] as const) {
         if (claudeMd.includes(marker) && !appended.includes(marker)) {
           appended = appended.trimEnd() + '\n\n' + render();

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -2971,22 +2971,13 @@ export class TelegramLifeline {
     // pass 36 finding 6.
     const url = `https://api.telegram.org/bot${this.config.token}/${method}`;
     const timeoutMs = method === 'getUpdates' ? 60_000 : 15_000;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-    let response: Response;
-    try {
-      // EGRESS. Goes through the shared door so the visibility check runs on the SERIALISED body —
-      // the exact bytes Telegram receives, after every transform. See src/messaging/telegram-egress.ts.
-      response = await telegramFetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(sendParams.outgoingParams),
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timer);
-    }
+    // Origin review/storage/capacity must finish before this request's clock starts.
+    const response = await telegramFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(sendParams.outgoingParams),
+      networkTimeoutMs: timeoutMs,
+    });
 
     if (!response.ok) {
       // Handle 429 Too Many Requests — respect Telegram's retry_after

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -5817,22 +5817,13 @@ export class TelegramAdapter implements MessagingAdapter {
 
     // Long polling uses 30s timeout in params — give extra headroom
     const timeoutMs = method === 'getUpdates' ? 60_000 : 15_000;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-    let response: Response;
-    try {
-      // EGRESS. Goes through the shared door so the visibility check runs on the SERIALISED body —
-      // the exact bytes Telegram receives, after every transform. See src/messaging/telegram-egress.ts.
-      response = await telegramFetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(sendParams.outgoingParams),
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timer);
-    }
+    // Origin review/storage/capacity must finish before this request's clock starts.
+    const response = await telegramFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(sendParams.outgoingParams),
+      networkTimeoutMs: timeoutMs,
+    });
 
     if (!response.ok) {
       // Handle 429 Too Many Requests — respect Telegram's retry_after

--- a/src/messaging/telegram-egress.ts
+++ b/src/messaging/telegram-egress.ts
@@ -45,6 +45,8 @@
  * discover the gap.
  */
 import { dispatchOriginBotEgress } from './telegram-origin/OriginBotEgress.js';
+import { OriginTransportCancelledBeforeNetwork } from './telegram-origin/OriginTransportCancellation.js';
+import { OriginCapacityUnavailable } from './telegram-origin/OriginEgressCapacity.js';
 import type { OriginPreparedBotOperation } from './telegram-origin/TelegramOriginService.js';
 import {
   assertOutgoingPayloadVisible,
@@ -329,12 +331,22 @@ function collectParams(url: string, body: RequestInit['body']): {
  * reader-visible content is unknown, so "no field" cannot be told apart from "not checked"), an
  * unparseable body, and a body shape that cannot be read without consuming it.
  */
+export interface TelegramRequestInit extends RequestInit {
+  /** Per native request, starting after origin review/storage/capacity. Caller
+   * cancellation remains independent. The deadline also covers receipt reading. */
+  networkTimeoutMs?: number;
+}
 export async function telegramFetch(
   url: string | URL,
-  init: RequestInit = {},
+  init: TelegramRequestInit = {},
   originNoticeCapability?: object,
   originPreparedOperation?: OriginPreparedBotOperation,
 ): Promise<Response> {
+  const networkTimeoutMs = init.networkTimeoutMs;
+  if (networkTimeoutMs !== undefined && (!Number.isSafeInteger(networkTimeoutMs) ||
+    networkTimeoutMs <= 0 || networkTimeoutMs > 2_147_483_647)) {
+    throw new TelegramEgressError('telegram-network-timeout-invalid');
+  }
   // The TYPE said `string`; the RUNTIME is what ships. Native `fetch` also accepts `URL` and `Request`
   // objects, and JavaScript callers are not bound by the signature — review pass 38 finding 3. A `URL`
   // is normalised to its string form and checked exactly like any other. A `Request` is REFUSED: its
@@ -495,15 +507,34 @@ export async function telegramFetch(
   // next person to write `outgoing.body = x ?? init.body` inherits a hole the comment promised was shut.
   const outgoing: RequestInit = {};
   for (const key of Object.keys(init)) {
-    if (key === 'body') continue;
+    if (key === 'body' || key === 'networkTimeoutMs') continue;
     (outgoing as Record<string, unknown>)[key] = (init as Record<string, unknown>)[key];
   }
   outgoing.body = checkedBody ?? null;
+  const network = async (networkUrl: string, networkInit: RequestInit, originManaged = false): Promise<Response> => {
+    // The proof is about invocation, not whether an arbitrary transport error
+    // says "aborted". No await separates this check from the native fetch call.
+    if (originManaged && networkInit.signal?.aborted) throw new OriginTransportCancelledBeforeNetwork();
+    if (networkTimeoutMs !== undefined) {
+      const deadline = AbortSignal.timeout(networkTimeoutMs);
+      networkInit = { ...networkInit, signal: networkInit.signal
+        ? AbortSignal.any([networkInit.signal, deadline]) : deadline };
+    }
+    try { return await fetch(networkUrl, networkInit); }
+    catch (error) {
+      // A caller can reuse an earlier known-unsent error as abort(reason).
+      // Once fetch was invoked even that same object is no longer proof.
+      if (error instanceof OriginTransportCancelledBeforeNetwork || error instanceof OriginCapacityUnavailable) {
+        throw new Error('telegram-network-invocation-failed', { cause: error });
+      }
+      throw error;
+    }
+  };
   if (method !== null) {
     const { params } = collectParams(href, checkedBody);
     const recorded = await dispatchOriginBotEgress({ method, url: href, init: outgoing, params,
-      noticeCapability: originNoticeCapability, preparedOperation: originPreparedOperation }, (sealedUrl, sealedInit) => fetch(sealedUrl, sealedInit));
+      noticeCapability: originNoticeCapability, preparedOperation: originPreparedOperation }, (sealedUrl, sealedInit) => network(sealedUrl, sealedInit, true));
     if (recorded) return recorded;
   }
-  return fetch(href, outgoing);
+  return network(href, outgoing);
 }

--- a/src/messaging/telegram-origin/OriginAwareness.ts
+++ b/src/messaging/telegram-origin/OriginAwareness.ts
@@ -22,6 +22,10 @@ export function telegramOriginRecoveryAwareness(): string {
   return 'Queued-message review pacing: automatic origin recovery reserves a durable 15-minute interval per original operation before reviewing or attempting delivery. Failed reviews, send refusals and process restarts cannot reset that interval. Existing origin audit records expose `recovery.attempts` and `recovery.nextAttemptAt`; these count recovery starts, not Telegram sends or tokens. A due retry still checks current policy. The original deadline and transport attempt limit remain in force, and retained messages are not guaranteed delivered. New replies are independent; never rewrite or resend a held message merely to bypass this interval.\n';
 }
 
+export function telegramOriginTransportAwareness(): string {
+  return 'Telegram send deadlines: each network request gets its full timeout after origin review, recording and capacity preparation. A caller cancellation proven before network invocation leaves the original operation eligible for bounded recovery; it does not cancel durable message intent. Failure after network invocation remains uncertain and must not be replayed merely because it reports an abort or timeout. Slow review can still hold a message, and queued custody is not delivery confirmation.\n';
+}
+
 export function telegramOriginAwareness(port: number): string {
   return `
 ### Telegram message origin
@@ -38,6 +42,7 @@ ${telegramOriginLeaseAwareness()}
 ${telegramOriginDashboardAwareness()}
 ${telegramOriginDetectorAwareness()}
 ${telegramOriginRecoveryAwareness()}
+${telegramOriginTransportAwareness()}
 Ordinary bot messages and fixed outage notices share the credential owner's bounded send capacity across server and Lifeline processes. A \`credential-capacity-unavailable\` result retains the original operation for recovery; never replace it with a new message. An unavailable or stale capacity owner holds sends. Recording-worker failure does not disable the independent notice queue or its current permission checks.
 
 Claude and Codex tool hooks direct raw Telegram writes to the recorded relay or typed browser broker. Managed Telegram profiles belong to the broker; generic browser tools cannot use them. This cooperative hook is not an operating-system sandbox. Other enabled harnesses must prove equivalent enrollment before activation; a hook being installed is not proof of complete sender coverage.

--- a/src/messaging/telegram-origin/OriginMesh.ts
+++ b/src/messaging/telegram-origin/OriginMesh.ts
@@ -123,7 +123,7 @@ export async function handleOriginMesh(options: {
     const request = JSON.parse(operation.admission.children[0].materializations[0].requestJson);
     const response = await telegramFetch(`https://api.telegram.org/bot${runtime.options.bot.token}/${request.method}`,
       { method: 'POST', headers: { 'Content-Type': request.contentType }, body: request.body,
-        signal: AbortSignal.timeout(10_000) }, undefined, operation);
+        networkTimeoutMs: 10_000 }, undefined, operation);
     const body = await response.json() as { result?: { message_id?: number } };
     return { ok: true, originId: record.originId, messageId: body.result?.message_id, originReceiptConfirmed: true };
   } catch (error) {

--- a/src/messaging/telegram-origin/OriginTestProbe.ts
+++ b/src/messaging/telegram-origin/OriginTestProbe.ts
@@ -39,7 +39,7 @@ export async function sendRecordedTestProbe(input: { projectDir: string; botToke
     await runtime.service.runAsAutomation('test-as-self', async () => {
       await telegramFetch(`https://api.telegram.org/bot${input.botToken}/sendMessage`, { method: 'POST',
         headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ chat_id: input.chatId, text: `test-as-self ${input.nonce}` }),
-        signal: AbortSignal.timeout(Math.max(1, Math.min(30_000, input.timeoutMs))) });
+        networkTimeoutMs: Math.max(1, Math.min(30_000, input.timeoutMs)) });
     });
   } finally { await runtime.close(); }
 }

--- a/src/messaging/telegram-origin/OriginTransportCancellation.ts
+++ b/src/messaging/telegram-origin/OriginTransportCancellation.ts
@@ -1,0 +1,9 @@
+/** In-process evidence only: minted immediately before the native fetch call,
+ * with no intervening await. Never infer this from an AbortError or a signal's
+ * reason after invoking fetch; that request might already have reached Telegram. */
+export class OriginTransportCancelledBeforeNetwork extends Error {
+  constructor() {
+    super('telegram-request-cancelled-before-network');
+    this.name = 'OriginTransportCancelledBeforeNetwork';
+  }
+}

--- a/src/messaging/telegram-origin/TelegramOriginRuntime.ts
+++ b/src/messaging/telegram-origin/TelegramOriginRuntime.ts
@@ -164,7 +164,7 @@ export class TelegramOriginRuntime {
         if (!options.bot.token) throw new Error('origin-source-has-no-transport-credential');
         return telegramFetch(`https://api.telegram.org/bot${options.bot.token}/${request.method}`,
         { method: 'POST', headers: { 'Content-Type': request.contentType }, body: request.body,
-          signal: AbortSignal.timeout(10_000) }, capability);
+          networkTimeoutMs: 10_000 }, capability);
       },
     });
     // A tokenless source prepares and records evidence but owns no Bot API door.
@@ -349,7 +349,7 @@ export class TelegramOriginRuntime {
         const request = JSON.parse(operation.admission.children[0].materializations[0].requestJson);
         await telegramFetch(`https://api.telegram.org/bot${owners[0].token}/${request.method}`,
           { method: 'POST', headers: { 'Content-Type': request.contentType }, body: request.body,
-            signal: AbortSignal.timeout(10_000) }, undefined, operation);
+            networkTimeoutMs: 10_000 }, undefined, operation);
         recovered++;
         } catch (error) {
           // One held operation must not starve unrelated queued destinations.

--- a/src/messaging/telegram-origin/TelegramOriginService.ts
+++ b/src/messaging/telegram-origin/TelegramOriginService.ts
@@ -14,6 +14,7 @@ import type { OriginLegacySnapshot } from './OriginLegacy.js';
 import type { OriginAutomationAuthor } from './OriginAutomationAuthor.js';
 import { bindBotCompanion } from './OriginBotCompanion.js';
 import { nextOriginKnownFailure } from './OriginRetry.js';
+import { OriginTransportCancelledBeforeNetwork } from './OriginTransportCancellation.js';
 import { correlateBotReceipt, correlatePartialBotReceipt, replayBotReceipt } from './OriginBotReceipt.js';
 import type { OriginBotReceipt } from './OriginBotReceipt.js';
 import type { DerivedMaterializationInput, StoredChild } from './StoreTypes.js';
@@ -549,7 +550,7 @@ export class TelegramOriginService {
       let response: Response;
       try { response = prepared ? await prepared.send() : await network(Object.freeze(request)); }
       catch (error) {
-        if (error instanceof OriginCapacityUnavailable) {
+        if (error instanceof OriginCapacityUnavailable || error instanceof OriginTransportCancelledBeforeNetwork) {
           // This in-process closure was invalidated before invoking network.
           // Retain the charged attempt once dispatch intent was durable. A
           // crash without this proof remains outcome-unknown on recovery.

--- a/tests/e2e/job-scheduler-origin-custody.test.ts
+++ b/tests/e2e/job-scheduler-origin-custody.test.ts
@@ -7,6 +7,7 @@ import { JobScheduler } from '../../src/scheduler/JobScheduler.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 
 let worker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); });
@@ -51,6 +52,7 @@ describe('scheduled completion through the production Telegram origin boundary',
     });
     vi.stubGlobal('fetch', wire);
 
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
     await scheduler.notifyJobComplete('session', 'fixture');
 
     expect(wire).toHaveBeenCalledOnce();

--- a/tests/e2e/telegram-deterministic-notice-origin.test.ts
+++ b/tests/e2e/telegram-deterministic-notice-origin.test.ts
@@ -9,6 +9,7 @@ import { sendDeterministicTelegramNotice, sendUnknownProducerTelegramNotice, wit
 import { QuotaNotifier } from '../../src/monitoring/QuotaNotifier.js';
 import { OriginAuthorCall } from '../../src/messaging/telegram-origin/OriginAutomationAuthor.js';
 import { compileOriginWorker, compileOriginConfigWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 let worker: URL, configWorker: URL;
@@ -38,6 +39,7 @@ async function boot(mode: 'send-only' | 'server-polling') {
   const adapter = new TelegramAdapter(telegramConfig as never, stateDir);
   const batcher = new NotificationBatcher(); batcher.configureBounds({ stateDir });
   wireTelegramSendSide({ mode, telegram: adapter, notificationBatcher: batcher, originService: runtime.service }); batcher.stop();
+  await waitForOriginDisplayReady(runtime, { chatId: '-100123', topicId: '42' });
   return { runtime, adapter, batcher, stateDir, wire };
 }
 

--- a/tests/e2e/telegram-origin-enrollment.test.ts
+++ b/tests/e2e/telegram-origin-enrollment.test.ts
@@ -11,6 +11,7 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
 import { originCertificationFixture } from '../helpers/originCertification.js';
 import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 
 let worker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); });
@@ -54,6 +55,7 @@ describe('production origin enrollment factory', () => {
     ]) });
     const wire = vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 7, chat: { id: -100123 }, message_thread_id: 43 } })));
     vi.stubGlobal('fetch', wire);
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '43' });
     await telegram.sendToTopic(43, 'Metadata remains recorded while release certification is missing.');
     expect(wire).toHaveBeenCalledTimes(1);
     const sent = (await boot.runtime.store.listOrigins()).records.filter(row => JSON.parse(row.record.envelopeJson).destination.topicId === '43');

--- a/tests/e2e/telegram-origin-enrollment.test.ts
+++ b/tests/e2e/telegram-origin-enrollment.test.ts
@@ -12,6 +12,7 @@ import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
 import { originCertificationFixture } from '../helpers/originCertification.js';
 import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
 import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
+import { setTimeout as delay } from 'node:timers/promises';
 
 let worker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); });
@@ -38,7 +39,20 @@ describe('production origin enrollment factory', () => {
       workerUrl: worker, enrollmentPackageRoot: packageRoot, noticeOwner: true, holdsLease: () => true,
       listLiveSessions: () => [], diagnoseUnknown: async () => undefined, onNoticeState: () => undefined });
     let boot = await start(f.root); cleanups.push(() => boot.close());
-    const first = await boot.runtime.status();
+    // Completion is attainable after the independently refreshed destination
+    // observer becomes ready. Boot's inventory can precede that observation.
+    // Only this exact startup gap is retryable; other missing obligations
+    // still fail immediately, and no policy or permission is manufactured.
+    const readinessDeadline = performance.now() + 12_500;
+    let first = await boot.runtime.status();
+    while (performance.now() < readinessDeadline) {
+      const missing = first.activation.observations.filter(item => !['ready', 'not-applicable'].includes(item.state));
+      if (missing.length !== 1 || missing[0].obligation !== 'notice-policy' ||
+        missing[0].state !== 'unknown' || missing[0].subject !== 'operator-alert-destinations' ||
+        missing[0].reason !== 'notice-destination-or-policy-unavailable') break;
+      await delay(50);
+      first = await boot.runtime.status();
+    }
     expect(first.activation.observations.filter(item => !['ready', 'not-applicable'].includes(item.state))).toEqual([]);
     expect(first.activation.complete).toBe(true);
     await boot.close(); boot = await start(path.join(f.root, 'missing-release'));

--- a/tests/e2e/telegram-origin-notice-policy.test.ts
+++ b/tests/e2e/telegram-origin-notice-policy.test.ts
@@ -10,6 +10,8 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { migrateSecrets } from '../../src/core/SecretMigrator.js';
 import { SecretStore } from '../../src/core/SecretStore.js';
 import type { OriginBotTransport } from '../../src/messaging/telegram-origin/TelegramOriginService.js';
+import type { OriginSourceHealth } from '../../src/messaging/telegram-origin/OriginDetectorHealth.js';
+import type { OutageNoticeState } from '../../src/messaging/telegram-origin/TelegramOriginOutageNotifier.js';
 
 let worker: URL, configWorker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); configWorker = await compileOriginConfigWorker(); });
@@ -29,9 +31,12 @@ async function boot(withAuthority: boolean, allowOrdinary = false, vault = false
     authorized: true, clientPreferences: 'telegram-managed', optedOut: false,
     observerHealthy: true, observedAt: now, validUntil: now + 30_000, version: 'fixture-observation' };
   let ownsLease = true;
+  const noticeStates: OutageNoticeState[] = [];
   const current = await bootTelegramOrigin({ config: config as never, token: '123:notice-fixture', noticeOwner: true,
-    workerUrl: worker, configWorkerUrl: configWorker, holdsLease: () => ownsLease, diagnoseUnknown: async () => undefined, onNoticeState: () => undefined,
+    workerUrl: worker, configWorkerUrl: configWorker, holdsLease: () => ownsLease, diagnoseUnknown: async () => undefined,
+    onNoticeState: state => { noticeStates.push(state); if (noticeStates.length > 16) noticeStates.shift(); },
     ...(withAuthority ? { readAlertDestinationPolicy: () => policy } : {}) });
+  const bootReturnedAt = Date.now();
   let storageFailed = false;
   cleanups.push(async () => {
     // The deliberate permanent worker loss also prevents durable owner
@@ -45,11 +50,15 @@ async function boot(withAuthority: boolean, allowOrdinary = false, vault = false
     return new Response(JSON.stringify({ ok: true, result: { message_id: 99, chat: { id: -100123 }, message_thread_id: body.message_thread_id } }));
   });
   vi.stubGlobal('fetch', wire);
-  // Boot starts independent observers; a config revision can invalidate its
-  // first snapshot before the five-second refresh. Establish real readiness
-  // before a test advances time, rotates secrets or destroys recording workers.
-  // Notice reservation may follow on the subsequent independent health tick.
+  // These are outages after the observer is operating, not startup tests.
+  // A first healthy snapshot can precede delayed startup watch events. Require
+  // one successful real post-boot read, then validate the actual authorities.
+  // This does not promise that later config invalidations cannot occur.
+  expect(typeof current.runtime.options.readDetectorHealth).toBe('function');
   await vi.waitFor(() => {
+    const sources = current.runtime.options.readDetectorHealth!().sources as { config: OriginSourceHealth };
+    expect(sources.config).toMatchObject({ state: 'healthy', busy: false });
+    expect(sources.config.succeededAt).toBeGreaterThan(bootReturnedAt);
     expect(current.runtime.options.display({ version: 1, transport: 'bot-api', accountId: '123', chatId: '-100123',
       topicId: '42', messageId: null, inlineMessageId: null, scheduledMessageId: null })).toBeDefined();
     expect(current.runtime.options.getAlertPolicy('operator-attention-hub')).toMatchObject({ authorized: true, optedOut: false });
@@ -62,7 +71,9 @@ async function boot(withAuthority: boolean, allowOrdinary = false, vault = false
       headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ chat_id: '-100123', message_thread_id: 42, text: 'Held ordinary message' }) }))
       .rejects.toMatchObject({ reason: 'all-durable-recording-sinks-unavailable' });
   };
-  return { ...current, wire, failRecording, stateDir, config, loseOwnership: () => { ownsLease = false; }, revoke: () => { policy = null; }, optOut: () => { policy = { ...policy!, optedOut: true }; } };
+  const diagnostics = () => JSON.stringify({ noticeStates, sources: current.runtime.options.readDetectorHealth!().sources,
+    policy: current.runtime.options.getAlertPolicy('operator-attention-hub') });
+  return { ...current, wire, failRecording, stateDir, config, diagnostics, loseOwnership: () => { ownsLease = false; }, revoke: () => { policy = null; }, optOut: () => { policy = { ...policy!, optedOut: true }; } };
 }
 describe('production bootstrap outage authority separation', () => {
   it('rechecks notice permission after a capacity grant without consuming a revoked notice', async () => {
@@ -113,7 +124,8 @@ describe('production bootstrap outage authority separation', () => {
     await vi.waitFor(() => expect(h.runtime.notifier.getState('operator-attention-hub')).toMatchObject({
       notificationAttempted: false, notificationOutcome: 'queued', reason: 'credential-capacity-unavailable' }));
     expect(h.wire).toHaveBeenCalledOnce();
-    await vi.waitFor(() => expect(h.runtime.notifier.getState('operator-attention-hub').notificationOutcome).toBe('accepted'), { timeout: 3000 });
+    await vi.waitFor(() => expect(h.runtime.notifier.getState('operator-attention-hub').notificationOutcome,
+      h.diagnostics()).toBe('accepted'), { timeout: 3000 });
     expect(h.wire).toHaveBeenCalledTimes(2);
     h.runtime.notifier.requestHoldNotice('operator-attention-hub');
     await new Promise(resolve => setTimeout(resolve, 150)); expect(h.wire).toHaveBeenCalledTimes(2);

--- a/tests/e2e/telegram-origin-notice-policy.test.ts
+++ b/tests/e2e/telegram-origin-notice-policy.test.ts
@@ -45,6 +45,16 @@ async function boot(withAuthority: boolean, allowOrdinary = false, vault = false
     return new Response(JSON.stringify({ ok: true, result: { message_id: 99, chat: { id: -100123 }, message_thread_id: body.message_thread_id } }));
   });
   vi.stubGlobal('fetch', wire);
+  // Boot starts independent observers; a config revision can invalidate its
+  // first snapshot before the five-second refresh. Establish real readiness
+  // before a test advances time, rotates secrets or destroys recording workers.
+  // Notice reservation may follow on the subsequent independent health tick.
+  await vi.waitFor(() => {
+    expect(current.runtime.options.display({ version: 1, transport: 'bot-api', accountId: '123', chatId: '-100123',
+      topicId: '42', messageId: null, inlineMessageId: null, scheduledMessageId: null })).toBeDefined();
+    expect(current.runtime.options.getAlertPolicy('operator-attention-hub')).toMatchObject({ authorized: true, optedOut: false });
+    expect(current.runtime.notifier.getState('operator-attention-hub').notificationOutcome).toBe('reserved');
+  }, { timeout: 12_500, interval: 50 });
   const failRecording = async () => {
     await current.runtime.store.close(); await current.runtime.spool.close();
     storageFailed = true;

--- a/tests/e2e/telegram-origin-production-boot.test.ts
+++ b/tests/e2e/telegram-origin-production-boot.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { fixtureOriginContentDedup } from '../helpers/originContentDedup.js';
 import { bootTelegramOrigin } from '../../src/messaging/telegram-origin/TelegramOriginBoot.js';
 import { telegramFetch } from '../../src/messaging/telegram-egress.js';
 import { postOriginAutomationReply } from '../../src/messaging/telegram-origin/OriginAutomationReply.js';
@@ -9,6 +10,7 @@ import { createRoutes } from '../../src/server/routes.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
 import { admission, compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 import type { OriginSessionLifecycle } from '../../src/messaging/telegram-origin/OriginSessionRegistry.js';
 import express from 'express';
 import { PendingRelayStore } from '../../src/messaging/pending-relay-store.js';
@@ -19,6 +21,62 @@ beforeAll(async () => { worker = await compileOriginWorker(); });
 const cleanup: Array<() => Promise<void>> = [];
 afterEach(async () => { for (const close of cleanup.splice(0).reverse()) await close(); vi.unstubAllGlobals(); });
 describe('Telegram origin production bootstrap', () => {
+  it('gives recovery after production restart a fresh network deadline after durable preparation', async () => {
+    const root = await mkdtemp('/tmp/origin-deadline-boot-');
+    cleanup.push(async () => { await SafeFsExecutor.safeRm(root, { recursive: true, force: true, operation: 'test:origin-deadline-boot:cleanup' }); });
+    const stateDir = path.join(root, '.instar'); await mkdir(path.join(stateDir, 'state'), { recursive: true });
+    const config = { projectDir: root, stateDir, projectName: 'echo', port: 0, authToken: 'fixture-auth',
+      messaging: [{ type: 'telegram', enabled: true, config: { token: '123:deadline-fixture', chatId: '-100123', lifelineTopicId: 7848 } }] };
+    await writeFile(path.join(stateDir, 'config.json'), JSON.stringify(config));
+    let lifecycle: OriginSessionLifecycle | undefined;
+    const start = async () => {
+      const boot = await bootTelegramOrigin({ config: config as never, token: '123:deadline-fixture', noticeOwner: true,
+        workerUrl: worker, holdsLease: () => true, isSessionLive: () => true,
+        attachSessionLifecycle: value => { lifecycle = value; }, diagnoseUnknown: vi.fn(async () => undefined), onNoticeState: vi.fn() });
+      cleanup.push(() => boot.close());
+      boot.runtime.attachSendPolicy({ review: async () => ({ ok: true }), authorizeDispatch: () => ({ ok: true }),
+        ...fixtureOriginContentDedup(stateDir) });
+      // A config revision can invalidate boot's initial snapshot. Wait for
+      // real authority readiness before testing transport recovery.
+      await vi.waitFor(async () => expect(await boot.runtime.service.options.authorize({
+        accountId: '123', destination: { chatId: '-100123' },
+      } as never)).toBe(true), { timeout: 7000, interval: 100 });
+      return boot;
+    };
+    let boot = await start();
+    const token = await lifecycle!.issue({ sessionId: 'queued-deadline-session', harnessId: 'codex-cli', projectDir: root, configuredModel: 'selected-model' });
+    const operation = await boot.runtime.service.runWithSessionToken(token, () => boot.runtime.service.prepareBot({
+      method: 'sendMessage', accountId: '123', params: { chat_id: '-100123', message_thread_id: 42, text: 'The report prepared before restart.' } }));
+    await boot.runtime.service.admit(operation);
+    await boot.close(); boot = await start();
+    const deadline = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    const network = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(init.signal).toBe(deadline.signal); init.signal!.throwIfAborted();
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 81, chat: { id: -100123 }, message_thread_id: 42 } }));
+    });
+    vi.stubGlobal('fetch', network);
+    const claim = boot.runtime.store.claim.bind(boot.runtime.store);
+    vi.spyOn(boot.runtime.store, 'claim').mockImplementation(async input => { expect(timeout).not.toHaveBeenCalled(); return claim(input); });
+    const failures: string[] = [];
+    const execute = boot.runtime.service.executePreparedBot.bind(boot.runtime.service);
+    vi.spyOn(boot.runtime.service, 'executePreparedBot').mockImplementation(async (...args) => {
+      try { return await execute(...args); }
+      catch (error) { failures.push(error instanceof Error ? error.message : String(error)); throw error; }
+    });
+    try {
+      const result = await boot.runtime.recoverHeld();
+      expect(failures).toEqual([]);
+      expect(result).toEqual({ processed: 1, recovered: 1 });
+      expect(timeout).toHaveBeenCalledOnce(); expect(timeout).toHaveBeenCalledWith(10_000);
+      const audit = await boot.runtime.store.getOperation(operation.record.operationId);
+      expect(audit?.record.originId).toBe(operation.record.originId);
+      expect(audit?.operation).toMatchObject({ state: 'accepted', deadlineAt: operation.admission.deadlineAt });
+      expect(audit?.recovery).toMatchObject({ attempts: 1 });
+      expect(network).toHaveBeenCalledOnce();
+    } finally { timeout.mockRestore(); }
+  });
+
   it('retains the recovery review brake through a real production shutdown and restart', async () => {
     const root = await mkdtemp('/tmp/origin-review-boot-');
     cleanup.push(async () => { await SafeFsExecutor.safeRm(root, { recursive: true, force: true, operation: 'test:origin-review-boot:cleanup' }); });
@@ -34,6 +92,11 @@ describe('Telegram origin production bootstrap', () => {
         attachSessionLifecycle: value => { lifecycle = value; }, diagnoseUnknown: vi.fn(async () => undefined), onNoticeState: vi.fn() });
       cleanup.push(() => boot.close());
       boot.runtime.attachSendPolicy({ review, authorizeDispatch: () => ({ ok: true }) });
+      // Review-budget assertions begin only after the real configuration
+      // observer permits preparation; boot's initial snapshot may be invalidated.
+      await vi.waitFor(async () => expect(await boot.runtime.service.options.authorize({
+        accountId: '123', destination: { chatId: '-100123' },
+      } as never)).toBe(true), { timeout: 7000, interval: 100 });
       return boot;
     };
     let boot = await start();
@@ -102,6 +165,7 @@ describe('Telegram origin production bootstrap', () => {
     await vi.waitFor(async () => expect((await boot.runtime.status()).activation.observations).toEqual(expect.arrayContaining([
       expect.objectContaining({ obligation: 'send-policy', state: 'ready', reason: 'send-policy-authority-attached' }),
     ])), { timeout: 7000, interval: 100 });
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '77' });
     const server = await new Promise<import('node:http').Server>(resolve => { const s = app.listen(0, '127.0.0.1', () => resolve(s)); });
     cleanup.push(() => new Promise<void>(resolve => server.close(() => resolve())));
     const updateText = 'The generated update includes the completed work and the detailed verification results.';

--- a/tests/e2e/telegram-origin-runtime-lifecycle.test.ts
+++ b/tests/e2e/telegram-origin-runtime-lifecycle.test.ts
@@ -71,10 +71,18 @@ describe('Telegram origin initialization and outage lifecycle', () => {
     const h = await boot();
     h.network.mockRejectedValue(new Error('response connection lost after dispatch'));
     const stateDir = h.runtime.options.storage.stateDir;
+    const sendFailures: unknown[] = [];
     const create = () => {
       const batcher = new NotificationBatcher();
       batcher.configureBounds({ stateDir });
-      batcher.setSendFunction(async () => { await h.send(); return { messageId: 0 }; });
+      batcher.setSendFunction(async () => {
+        try { await h.send(); return { messageId: 0 }; }
+        catch (error) {
+          sendFailures.push(error instanceof Error ? { name: error.name, message: error.message,
+            ...error } : error);
+          throw error;
+        }
+      });
       batcher.setOriginDeliveryResolver(id => originDeliveryConfirmed(h.runtime.store, id));
       return batcher;
     };
@@ -84,7 +92,7 @@ describe('Telegram origin initialization and outage lifecycle', () => {
     batcher = create();
     expect(await batcher.flush('SUMMARY')).toBe(0);
     expect(await batcher.flush('SUMMARY')).toBe(0);
-    expect(h.network).toHaveBeenCalledOnce();
+    expect(h.network, JSON.stringify(sendFailures)).toHaveBeenCalledOnce();
     const page = await h.runtime.store.listOrigins({ topicId: '42' });
     expect(page.records).toHaveLength(1);
     expect(page.records[0].operation?.state).toBe('outcome-unknown');

--- a/tests/e2e/threadline-telegram-origin-authors.test.ts
+++ b/tests/e2e/threadline-telegram-origin-authors.test.ts
@@ -14,6 +14,7 @@ import { ThreadResumeMap } from '../../src/threadline/ThreadResumeMap.js';
 import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
 import { SalienceGate } from '../../src/threadline/SalienceGate.js';
 import { temporaryState, compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 
 let worker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); });
@@ -32,6 +33,7 @@ describe('Threadline Telegram authors using production origin initialization', (
     const boot = await bootTelegramOrigin({ config: config as never, token: '123:fixture', noticeOwner: false, workerUrl: worker,
       holdsLease: () => true, diagnoseUnknown: async () => undefined, onNoticeState: () => undefined });
     close.push(boot.close);
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
     const service = boot.runtime.service;
     const sink = async (topicId: number, text: string) => {
       const operation = service.prepareBot({ method: 'sendMessage', accountId: '123', params: { chat_id: '-100123', message_thread_id: topicId, text } });

--- a/tests/e2e/triage-origin-authors.test.ts
+++ b/tests/e2e/triage-origin-authors.test.ts
@@ -7,6 +7,7 @@ import { triageOriginSender, readTriageSessionAuthor } from '../../src/monitorin
 import { StallTriageNurse } from '../../src/monitoring/StallTriageNurse.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 import type { OriginSessionLifecycle } from '../../src/messaging/telegram-origin/OriginSessionRegistry.js';
 
 let worker: URL;
@@ -47,6 +48,7 @@ describe('production triage author binding', () => {
     boot.runtime.observer.track(boot.runtime.sessions.getBinding('triage-session')!, { path: source, nativeSessionId: 'native-triage' });
     const nativeAuthor = await readTriageSessionAuthor(boot.runtime, 'triage-session');
     const surfaceTriage = triageOriginSender(boot.runtime.service, 'triage-orchestrator', (topicId, text) => telegram.sendToTopic(topicId, text));
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
     await surfaceTriage(42, 'The scoped triage session found the cause.', nativeAuthor);
 
     const nurse = new StallTriageNurse({} as never, { intelligence: { evaluate: async (_prompt: string, options: any) => {

--- a/tests/helpers/telegramOriginReady.ts
+++ b/tests/helpers/telegramOriginReady.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { setTimeout as delay } from 'node:timers/promises';
+import type { TelegramOriginRuntime } from '../../src/messaging/telegram-origin/TelegramOriginRuntime.js';
+
+/** Opt-in setup for tests of behavior after configuration readiness. Boot can
+ * return while a newer config revision invalidates its initial snapshot. This
+ * observes the actual display authority; it does not approve dispatch, retry a
+ * send, or apply to tests of unavailable startup authorities.
+ */
+export async function waitForOriginDisplayReady(runtime: TelegramOriginRuntime,
+  destination: { chatId: string | null; topicId: string | null }) {
+  assert.equal(typeof runtime.options.display, 'function', 'production display authority must be wired');
+  const deadline = performance.now() + 12_500;
+  for (;;) {
+    let projection;
+    try {
+      projection = runtime.options.display({ accountId: runtime.options.bot.accountId, ...destination });
+    } catch (error) {
+      if (!(error instanceof Error) || error.message !== 'origin-display-authority-unavailable' || performance.now() >= deadline) throw error;
+      // Real timers preserve lease tests that fake only interval callbacks.
+      // vi.waitFor would also advance those unrelated fake timers.
+      await delay(50);
+      continue;
+    }
+    assert.ok(projection && typeof projection === 'object', 'display authority must return its projection');
+    assert.ok(projection.agent && typeof projection.agent === 'object', 'production agent display settings must be present');
+    return projection;
+  }
+}

--- a/tests/integration/telegram-origin-lease-renewal.test.ts
+++ b/tests/integration/telegram-origin-lease-renewal.test.ts
@@ -9,6 +9,7 @@ import { createRoutes } from '../../src/server/routes.js';
 import type { OriginSessionLifecycle } from '../../src/messaging/telegram-origin/OriginSessionRegistry.js';
 import { originLeaseDependencyFixture } from '../helpers/originLeaseDependency.js';
 import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 
 let worker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); });
@@ -33,11 +34,9 @@ describe('HTTP origin sends depend on the real renewed lease', () => {
     const app = express(); app.use(express.json());
     app.use((req, res, next) => { if (req.get('Authorization') !== 'Bearer fixture-auth') { res.sendStatus(401); return; } next(); });
     app.use(createRoutes({ config, telegramOrigin: boot.runtime, telegram, sessionManager: { clearInjectionTracker: () => undefined } } as never));
-    // Boot/session setup writes machine evidence watched by the independent
-    // config authority. Let its real refresh settle before advancing only the
-    // lease clock; otherwise that unrelated startup invalidation masks the
-    // decision boundary this HTTP test is exercising.
-    await new Promise(resolve => setTimeout(resolve, 5500));
+    // Observe actual configuration readiness before advancing the lease clock;
+    // a startup invalidation must not mask the lease boundary under test.
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
     expect(boot.runtime.options.display({ chatId: '-100123', topicId: '42' } as never).agent?.enabled).toBe(false);
     const wire = vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { message_id: 10, chat: { id: -100123 }, message_thread_id: 42 } })));
     vi.stubGlobal('fetch', wire);

--- a/tests/integration/telegram-origin-mesh.test.ts
+++ b/tests/integration/telegram-origin-mesh.test.ts
@@ -70,6 +70,26 @@ async function boot(extra: { source?: Record<string, unknown>; owner?: Record<st
   return { owner, source, credential, send, sendOther, botNetwork, auditAssertion, revoke: () => { attestationRevoked = true; } };
 }
 describe('Telegram origin signed mesh HTTP pipeline', () => {
+  it('starts the holder network clock only after signed mesh admission and current policy', async () => {
+    const h = await boot();
+    const deadline = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    const claim = h.owner.store.claim.bind(h.owner.store);
+    vi.spyOn(h.owner.store, 'claim').mockImplementation(async input => {
+      expect(timeout).not.toHaveBeenCalledWith(10_000);
+      return claim(input);
+    });
+    try {
+      await expect(h.source.service.runWithSessionToken(h.credential, () => relayOriginBot({ runtime: h.source,
+        topicId: 42, chatId: '-100123', text: 'The requested report from the source machine.', send: h.send })))
+        .resolves.toMatchObject({ messageId: 321 });
+      expect(timeout).toHaveBeenCalledWith(10_000);
+      expect(h.botNetwork).toHaveBeenCalledOnce();
+      expect(h.botNetwork.mock.calls[0][1].signal).toBe(deadline.signal);
+      expect((await h.owner.store.listOrigins()).records[0].children[0].state).toBe('accepted');
+    } finally { timeout.mockRestore(); }
+  });
+
   it('resolves a lost holder response from durable source evidence after a worker restart without resending', async () => {
     const h = await boot();
     let heldOperation = '';

--- a/tests/integration/telegram-origin-notice-policy.test.ts
+++ b/tests/integration/telegram-origin-notice-policy.test.ts
@@ -10,6 +10,7 @@ import type { OriginSessionLifecycle } from '../../src/messaging/telegram-origin
 import { telegramFetch } from '../../src/messaging/telegram-egress.js';
 import { migrateSecrets } from '../../src/core/SecretMigrator.js';
 import { compileOriginWorker, compileOriginConfigWorker, temporaryState } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
 
 let worker: URL, configWorker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); configWorker = await compileOriginConfigWorker(); });
@@ -44,6 +45,11 @@ async function harness(enabled: boolean) {
         headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ chat_id: '-100123', message_thread_id: topic, text }) });
       return { messageId: ((await response.json()) as any).result.message_id, timestamp: new Date().toISOString() };
     } } } as never));
+  await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
+  await vi.waitFor(() => {
+    expect(boot.runtime.options.getAlertPolicy('operator-attention-hub')).toMatchObject({ authorized: true, optedOut: !enabled });
+    if (enabled) expect(boot.runtime.notifier.getState('operator-attention-hub').notificationOutcome).toBe('reserved');
+  }, { timeout: 12_500, interval: 50 });
   const failRecording = async () => { await boot.runtime.store.close(); await boot.runtime.spool.close(); stopped = true; };
   const send = () => request(app).post('/telegram/reply/42').set('Authorization', 'Bearer fixture-auth')
     .set('X-Instar-Origin-Session', token).send({ text: 'This ordinary answer must remain held while recording is unavailable.',

--- a/tests/integration/telegram-origin-notice-policy.test.ts
+++ b/tests/integration/telegram-origin-notice-policy.test.ts
@@ -11,6 +11,7 @@ import { telegramFetch } from '../../src/messaging/telegram-egress.js';
 import { migrateSecrets } from '../../src/core/SecretMigrator.js';
 import { compileOriginWorker, compileOriginConfigWorker, temporaryState } from '../helpers/telegramOriginStore.js';
 import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
+import type { OriginSourceHealth } from '../../src/messaging/telegram-origin/OriginDetectorHealth.js';
 
 let worker: URL, configWorker: URL;
 beforeAll(async () => { worker = await compileOriginWorker(); configWorker = await compileOriginConfigWorker(); });
@@ -28,6 +29,7 @@ async function harness(enabled: boolean) {
   const boot = await bootTelegramOrigin({ config: config as never, token: '123:notice-http', noticeOwner: true,
     workerUrl: worker, configWorkerUrl: configWorker, holdsLease: () => true, isSessionLive: () => true, attachSessionLifecycle: value => { lifecycle = value; },
     diagnoseUnknown: async () => undefined, onNoticeState: () => undefined });
+  const bootReturnedAt = Date.now();
   let stopped = false;
   cleanup.push(async () => { if (stopped) await expect(boot.close()).rejects.toMatchObject({ code: 'origin-store-unavailable' }); else await boot.close(); });
   const token = await lifecycle!.issue({ sessionId: 'fixture-session', harnessId: 'codex-cli', projectDir: stateDir, configuredModel: 'configured-model' });
@@ -46,7 +48,13 @@ async function harness(enabled: boolean) {
       return { messageId: ((await response.json()) as any).result.message_id, timestamp: new Date().toISOString() };
     } } } as never));
   await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
+  expect(typeof boot.runtime.options.readDetectorHealth).toBe('function');
   await vi.waitFor(() => {
+    // Inject the outage only after an actual post-boot observation. Preserve
+    // the configured opt-out and the production fire-time permission checks.
+    const sources = boot.runtime.options.readDetectorHealth!().sources as { config: OriginSourceHealth };
+    expect(sources.config).toMatchObject({ state: 'healthy', busy: false });
+    expect(sources.config.succeededAt).toBeGreaterThan(bootReturnedAt);
     expect(boot.runtime.options.getAlertPolicy('operator-attention-hub')).toMatchObject({ authorized: true, optedOut: !enabled });
     if (enabled) expect(boot.runtime.notifier.getState('operator-attention-hub').notificationOutcome).toBe('reserved');
   }, { timeout: 12_500, interval: 50 });

--- a/tests/integration/telegram-origin-routes.test.ts
+++ b/tests/integration/telegram-origin-routes.test.ts
@@ -1,3 +1,4 @@
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
 import { AutoUpdater } from '../../src/core/AutoUpdater.js';
 import { NotificationBatcher } from '../../src/messaging/NotificationBatcher.js';
 import { wireTelegramSendSide } from '../../src/messaging/telegramSendSideComposition.js';
@@ -76,6 +77,29 @@ async function browserHarness(extra: Record<string, unknown> = {}) {
   return { ...h, invoke, executor, send };
 }
 describe('Telegram origin through the complete reply HTTP pipeline', () => {
+  it('starts the real adapter network deadline after the HTTP policy and origin claim', async () => {
+    let adapter: TelegramAdapter;
+    const h = await appHarness({ telegram: { sendToTopic: (...args: Parameters<TelegramAdapter['sendToTopic']>) => adapter.sendToTopic(...args) } });
+    adapter = new TelegramAdapter({ token: h.botToken, chatId: '-100123' }, h.stateDir, { suppressLifelineAutoCreate: true });
+    const deadline = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    const claim = h.runtime.store.claim.bind(h.runtime.store);
+    vi.spyOn(h.runtime.store, 'claim').mockImplementation(async input => {
+      expect(timeout).not.toHaveBeenCalled();
+      return claim(input);
+    });
+    try {
+      const response = await request(h.app).post('/telegram/reply/42')
+        .set('Authorization', 'Bearer agent-test').set('X-Instar-Origin-Session', h.sessionToken)
+        .send({ text: 'The requested delivery report is ready.' });
+      expect(response.status).toBe(200);
+      expect(timeout).toHaveBeenCalledWith(15_000);
+      expect(h.network).toHaveBeenCalledOnce();
+      expect(h.network.mock.calls[0][1].signal).toBe(deadline.signal);
+      expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('accepted');
+    } finally { timeout.mockRestore(); await adapter.stop(); }
+  });
+
   it('paces repeated recovery reviews and exposes the durable delay through authenticated audit HTTP', async () => {
     const review = vi.fn(async (_text: string) => ({ pass: true, latencyMs: 1 }));
     const h = await appHarness({ messagingToneGate: { review } });

--- a/tests/integration/telegram-origin-routes.test.ts
+++ b/tests/integration/telegram-origin-routes.test.ts
@@ -457,7 +457,7 @@ describe('Telegram origin through the complete reply HTTP pipeline', () => {
     const token = h.runtime.service.issueAutomationReply('fixed-notice', 77, body, deterministicAutomationAuthor());
     const response = await request(h.app).post('/telegram/reply/77').set('Authorization', 'Bearer agent-test')
       .set('X-Instar-Origin-Automation', token).send(body);
-    expect(response.status).toBe(200);
+    expect(response.status, JSON.stringify(response.body)).toBe(200);
     const page = await h.runtime.store.listOrigins();
     expect(JSON.parse(page.records[0].record.envelopeJson).model).toMatchObject({ status: 'not-applicable', reason: 'deterministic-automation' });
   });

--- a/tests/integration/telegram-reply-origin-migration.test.ts
+++ b/tests/integration/telegram-reply-origin-migration.test.ts
@@ -91,12 +91,14 @@ describe('origin relay installed-upgrade parity', () => {
     expect(second.split('Origin lease renewal dependency:')).toHaveLength(2);
     expect(second.split('Message origins on your phone:')).toHaveLength(2);
     expect(second.split('Queued-message review pacing:')).toHaveLength(2);
+    expect(second.split('Telegram send deadlines:')).toHaveLength(2);
     expect(second).toBe(first);
     for (const shadow of shadows) {
       const content = fs.readFileSync(shadow, 'utf8');
       expect(content).toContain('Operator shadow note.');
       expect(content).toContain(telegramOriginRecoveryAwareness());
       expect(content.split('Queued-message review pacing:')).toHaveLength(2);
+      expect(content.split('Telegram send deadlines:')).toHaveLength(2);
       expect(content).toContain('messageOrigin.outageNotice.enabled');
       expect(content.split('Origin rollout certification:')).toHaveLength(2);
       expect(content.split('Origin lease renewal dependency:')).toHaveLength(2);

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -245,6 +245,7 @@ describe('Feature Delivery Completeness', () => {
       ['Message origins on your phone:', 'telegramOriginDashboardAwareness'],
       ['Origin detector health:', 'telegramOriginDetectorAwareness'],
       ['Queued-message review pacing:', 'telegramOriginRecoveryAwareness'],
+      ['Telegram send deadlines:', 'telegramOriginTransportAwareness'],
     ];
     for (const [phrase, builder] of featureAddenda) {
       it(`origin addendum "${phrase}" reaches new and existing framework instructions`, () => {

--- a/tests/unit/telegram-origin/transport-deadlines.test.ts
+++ b/tests/unit/telegram-origin/transport-deadlines.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { generateKeyPairSync, randomUUID } from 'node:crypto';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { TelegramLifeline } from '../../../src/lifeline/TelegramLifeline.js';
 import type { OriginSessionLifecycle } from '../../../src/messaging/telegram-origin/OriginSessionRegistry.js';
@@ -44,14 +44,26 @@ describe('Telegram network deadlines after origin preparation', () => {
   it('wires the Lifeline sender to a late network duration and preserves long-poll headroom', async () => {
     const h = await harness(), projectDir = temporaryState();
     mkdirSync(path.join(projectDir, '.instar'));
+    // This constructor-only fixture never starts a provider or tmux. Private
+    // fail-on-use executables remove unrelated host CLI prerequisites.
+    const codexPath = path.join(projectDir, 'fixture-codex'), tmuxPath = path.join(projectDir, 'fixture-tmux');
+    for (const binary of [codexPath, tmuxPath]) {
+      writeFileSync(binary, '#!/bin/sh\nprintf invoked > \"$0.invoked\"\nexit 91\n', { mode: 0o700 });
+    }
     writeFileSync(path.join(projectDir, '.instar/config.json'), JSON.stringify({
-      projectName: 'deadline-fixture', port: 4042, messaging: [{ type: 'telegram', enabled: true,
+      projectName: 'deadline-fixture', port: 4042,
+      sessions: { framework: 'codex-cli', frameworkBinaryPaths: { 'codex-cli': codexPath }, tmuxPath },
+      messaging: [{ type: 'telegram', enabled: true,
         config: { token: h.token, chatId: '-100123' } }],
     }));
     // Construct the actual class without starting polling or process supervision.
     const lifeline = new TelegramLifeline(projectDir) as unknown as {
       apiCall(method: string, params: Record<string, unknown>): Promise<unknown>;
+      projectConfig: { sessions: { framework: string; frameworkBinaryPaths: Record<string, string>; tmuxPath: string } };
     };
+    expect(lifeline.projectConfig.sessions.framework).toBe('codex-cli');
+    expect(lifeline.projectConfig.sessions.frameworkBinaryPaths['codex-cli']).toBe(codexPath);
+    expect(lifeline.projectConfig.sessions.tmuxPath).toBe(tmuxPath);
     const deadline = new AbortController();
     const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
     h.review.mockImplementation(async () => { expect(timeout).not.toHaveBeenCalled(); return { ok: true }; });
@@ -62,6 +74,8 @@ describe('Telegram network deadlines after origin preparation', () => {
     expect(h.network.mock.calls[0][1].signal).toBe(deadline.signal);
     await lifeline.apiCall('getUpdates', { timeout: 30 });
     expect(timeout).toHaveBeenLastCalledWith(60_000);
+    expect(existsSync(`${codexPath}.invoked`)).toBe(false);
+    expect(existsSync(`${tmuxPath}.invoked`)).toBe(false);
   });
   it('starts the deadline only after policy, durable claim and capacity consumption', async () => {
     const h = await harness();

--- a/tests/unit/telegram-origin/transport-deadlines.test.ts
+++ b/tests/unit/telegram-origin/transport-deadlines.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateKeyPairSync, randomUUID } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { TelegramLifeline } from '../../../src/lifeline/TelegramLifeline.js';
+import type { OriginSessionLifecycle } from '../../../src/messaging/telegram-origin/OriginSessionRegistry.js';
+import { OriginTransportCancelledBeforeNetwork } from '../../../src/messaging/telegram-origin/OriginTransportCancellation.js';
+import { OriginCapacityUnavailable } from '../../../src/messaging/telegram-origin/OriginEgressCapacity.js';
+import { TelegramOriginRuntime } from '../../../src/messaging/telegram-origin/TelegramOriginRuntime.js';
+import { telegramFetch } from '../../../src/messaging/telegram-egress.js';
+import { compileOriginWorker, temporaryState } from '../../helpers/telegramOriginStore.js';
+import { fixtureOriginContentDedup } from '../../helpers/originContentDedup.js';
+
+let worker: URL;
+const runtimes: TelegramOriginRuntime[] = [];
+const privateKey = generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+beforeAll(async () => { worker = await compileOriginWorker(); });
+afterEach(async () => { for (const runtime of runtimes.splice(0)) await runtime.close(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+async function harness() {
+  const stateDir = temporaryState(), token = `123:${randomUUID()}`;
+  let lifecycle: OriginSessionLifecycle | undefined;
+  const runtime = await TelegramOriginRuntime.open({ storage: { stateDir, agentId: 'echo' }, workerUrl: worker,
+    identity: { agentId: 'echo', agentName: 'Echo', originMachineId: 'studio', originMachineName: 'Studio' },
+    signingKey: { privateKey, keyId: 'studio-1', keyEpoch: 1 }, bot: { token, accountId: 'bot-1', chatId: '-100123' },
+    isSessionLive: () => true, attachSessionLifecycle: value => { lifecycle = value; },
+    display: () => ({}), authorize: () => true, diagnoseUnknown: async () => undefined,
+    alertDestinations: () => [], getAlertPolicy: () => null, onNoticeState: () => undefined });
+  runtimes.push(runtime);
+  const sessionToken = await lifecycle!.issue({ sessionId: 'deadline-session', harnessId: 'codex-cli', projectDir: process.cwd(), configuredModel: 'fixture-model' });
+  const review = vi.fn(async () => ({ ok: true as const }));
+  runtime.attachSendPolicy({ review, authorizeDispatch: () => ({ ok: true }), ...fixtureOriginContentDedup(stateDir) });
+  const network = vi.fn(async (_url: string, init: RequestInit) => {
+    init.signal?.throwIfAborted();
+    const body = JSON.parse(init.body as string);
+    return new Response(JSON.stringify({ ok: true, result: { message_id: 27, chat: { id: -100123 }, message_thread_id: body.message_thread_id } }));
+  });
+  vi.stubGlobal('fetch', network);
+  const send = (options: RequestInit & { networkTimeoutMs?: number } = {}, text = 'Requested report') =>
+    runtime.service.runWithSessionToken(sessionToken, () => telegramFetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST', body: JSON.stringify({ chat_id: '-100123', message_thread_id: 42, text }), ...options }));
+  return { runtime, review, network, send, token, sessionToken };
+}
+describe('Telegram network deadlines after origin preparation', () => {
+  it('wires the Lifeline sender to a late network duration and preserves long-poll headroom', async () => {
+    const h = await harness(), projectDir = temporaryState();
+    mkdirSync(path.join(projectDir, '.instar'));
+    writeFileSync(path.join(projectDir, '.instar/config.json'), JSON.stringify({
+      projectName: 'deadline-fixture', port: 4042, messaging: [{ type: 'telegram', enabled: true,
+        config: { token: h.token, chatId: '-100123' } }],
+    }));
+    // Construct the actual class without starting polling or process supervision.
+    const lifeline = new TelegramLifeline(projectDir) as unknown as {
+      apiCall(method: string, params: Record<string, unknown>): Promise<unknown>;
+    };
+    const deadline = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    h.review.mockImplementation(async () => { expect(timeout).not.toHaveBeenCalled(); return { ok: true }; });
+    await expect(h.runtime.service.runWithSessionToken(h.sessionToken, () => lifeline.apiCall('sendMessage', {
+      chat_id: '-100123', message_thread_id: 42, text: 'Requested Lifeline status',
+    }))).resolves.toMatchObject({ message_id: 27 });
+    expect(h.review).toHaveBeenCalledOnce(); expect(timeout).toHaveBeenCalledWith(15_000);
+    expect(h.network.mock.calls[0][1].signal).toBe(deadline.signal);
+    await lifeline.apiCall('getUpdates', { timeout: 30 });
+    expect(timeout).toHaveBeenLastCalledWith(60_000);
+  });
+  it('starts the deadline only after policy, durable claim and capacity consumption', async () => {
+    const h = await harness();
+    const clocks: AbortController[] = [];
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation(() => { const c = new AbortController(); clocks.push(c); return c.signal; });
+    h.review.mockImplementation(async () => { expect(timeout).not.toHaveBeenCalled(); return { ok: true }; });
+    const claim = h.runtime.store.claim.bind(h.runtime.store);
+    vi.spyOn(h.runtime.store, 'claim').mockImplementation(async input => { expect(timeout).not.toHaveBeenCalled(); return claim(input); });
+    const consume = h.runtime.service.options.capacity!.consume.bind(h.runtime.service.options.capacity!);
+    vi.spyOn(h.runtime.service.options.capacity!, 'consume').mockImplementation(async grant => { expect(timeout).not.toHaveBeenCalled(); return consume(grant); });
+    expect((await h.send({ networkTimeoutMs: 15_000 })).ok).toBe(true);
+    expect(timeout).toHaveBeenCalledOnce(); expect(timeout).toHaveBeenCalledWith(15_000);
+    expect(h.review).toHaveBeenCalledOnce();
+    expect(h.network.mock.calls[0][1].signal).toBe(clocks[0].signal);
+    expect(h.network.mock.calls[0][1]).not.toHaveProperty('networkTimeoutMs');
+    expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('accepted');
+  });
+  it.each(['already', 'during-review'] as const)('records %s caller cancellation as known unsent without a network invocation', async when => {
+    const h = await harness(), caller = new AbortController();
+    if (when === 'already') caller.abort();
+    else h.review.mockImplementation(async () => { caller.abort(); return { ok: true }; });
+    await expect(h.send({ signal: caller.signal, networkTimeoutMs: 15_000 }))
+      .rejects.toMatchObject({ reason: 'telegram-request-cancelled-before-network' });
+    expect(h.network).not.toHaveBeenCalled();
+    const row = (await h.runtime.store.listOrigins()).records[0];
+    expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'known-failed', reason: 'telegram-request-cancelled-before-network' });
+    expect(row.children[0].state).toBe('queued');
+    expect(row.operation?.operationId).toBe(JSON.parse(row.record.envelopeJson).operationId);
+  });
+  it('retains caller cancellation after invocation as unknown and never automatically replays it', async () => {
+    const h = await harness(), caller = new AbortController();
+    h.network.mockImplementation(async (_url, init) => { caller.abort(); init.signal!.throwIfAborted(); throw new Error('unreachable'); });
+    await expect(h.send({ signal: caller.signal, networkTimeoutMs: 15_000 })).rejects.toMatchObject({ outcome: 'outcome-unknown' });
+    expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('outcome-unknown');
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+    expect(h.network).toHaveBeenCalledOnce();
+  });
+  it('keeps the deadline live after headers while the receipt body is read', async () => {
+    const h = await harness(), deadline = new AbortController();
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    h.network.mockImplementation(async (_url, init) => new Response(new ReadableStream({ start(controller) {
+      expect(init.signal).toBe(deadline.signal);
+      init.signal!.addEventListener('abort', () => controller.error(init.signal!.reason), { once: true });
+      queueMicrotask(() => deadline.abort(new DOMException('Network deadline', 'TimeoutError')));
+    } })));
+    await expect(h.send({ networkTimeoutMs: 15_000 })).rejects.toMatchObject({ outcome: 'outcome-unknown' });
+    expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('outcome-unknown');
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+  });
+  it.each([0, -1, NaN, Infinity, 1.5])('rejects invalid network duration %s before origin mutation', async networkTimeoutMs => {
+    const h = await harness();
+    await expect(h.send({ networkTimeoutMs })).rejects.toThrow('telegram-network-timeout-invalid');
+    expect(h.network).not.toHaveBeenCalled(); expect((await h.runtime.store.listOrigins()).records).toEqual([]);
+  });
+  it('starts a fresh deadline for every split child', async () => {
+    const h = await harness(), clocks: AbortController[] = [];
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation(() => {
+      const c = new AbortController(); clocks.push(c); return c.signal;
+    });
+    const mark = h.runtime.store.markDispatched.bind(h.runtime.store);
+    vi.spyOn(h.runtime.store, 'markDispatched').mockImplementation(async fence => {
+      // Earlier child deadlines may expire while storing the next child's intent.
+      for (const clock of clocks) clock.abort();
+      return mark(fence);
+    });
+    expect((await h.send({ networkTimeoutMs: 15_000 }, 'This is the requested detailed report. '.repeat(260))).ok).toBe(true);
+    expect(h.network.mock.calls.length).toBeGreaterThan(1);
+    expect(timeout).toHaveBeenCalledTimes(h.network.mock.calls.length);
+    h.network.mock.calls.forEach((call, index) => expect(call[1].signal).toBe(clocks[index].signal));
+    expect((await h.runtime.store.listOrigins()).records[0].children.every(child => child.state === 'accepted')).toBe(true);
+  });
+  it('loads and verifies durable multipart bytes before starting the network deadline', async () => {
+    const h = await harness(), deadline = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    const getPayload = h.runtime.store.getPayload.bind(h.runtime.store);
+    const payloadReads = vi.spyOn(h.runtime.store, 'getPayload').mockImplementation(async id => {
+      expect(timeout).not.toHaveBeenCalled(); return getPayload(id);
+    });
+    h.network.mockImplementation(async (_url, init) => {
+      expect(init.signal).toBe(deadline.signal);
+      expect(Buffer.from(init.body as Uint8Array).toString()).toContain('Requested attachment bytes');
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 27, chat: { id: -100123 }, message_thread_id: 42 } }));
+    });
+    const body = new FormData(); body.append('chat_id', '-100123'); body.append('message_thread_id', '42');
+    body.append('caption', 'The requested attachment'); body.append('document', new Blob(['Requested attachment bytes']), 'report.txt');
+    expect((await h.runtime.service.runWithSessionToken(h.sessionToken, () => telegramFetch(`https://api.telegram.org/bot${h.token}/sendDocument`,
+      { method: 'POST', body, networkTimeoutMs: 60_000 }))).ok).toBe(true);
+    expect(payloadReads).toHaveBeenCalled(); expect(timeout).toHaveBeenCalledOnce(); expect(timeout).toHaveBeenCalledWith(60_000);
+    expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('accepted');
+  });
+  it('fences a network deadline after invocation and does not classify it as caller cancellation', async () => {
+    const h = await harness(), deadline = new AbortController();
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
+    h.network.mockImplementation(async (_url, init) => {
+      deadline.abort(new DOMException('Network deadline', 'TimeoutError'));
+      init.signal!.throwIfAborted(); throw new Error('unreachable');
+    });
+    await expect(h.send({ networkTimeoutMs: 15_000 })).rejects.toMatchObject({ outcome: 'outcome-unknown' });
+    expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('outcome-unknown');
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+  });
+  it.each([OriginTransportCancelledBeforeNetwork, OriginCapacityUnavailable])('does not reuse %s as proof when native fetch rejects with that abort reason', async (ErrorType) => {
+    const h = await harness(), caller = new AbortController();
+    const recycled = new ErrorType();
+    h.network.mockImplementation(async (_url, init) => { caller.abort(recycled); init.signal!.throwIfAborted(); throw new Error('unreachable'); });
+    await expect(h.send({ signal: caller.signal, networkTimeoutMs: 15_000 })).rejects.toMatchObject({ outcome: 'outcome-unknown' });
+    expect((await h.runtime.store.listOrigins()).records[0].children[0].state).toBe('outcome-unknown');
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+  });
+  it('preserves the original caller signal when no network duration was requested', async () => {
+    const h = await harness(), caller = new AbortController();
+    expect((await h.send({ signal: caller.signal })).ok).toBe(true);
+    expect(h.network.mock.calls[0][1].signal).toBe(caller.signal);
+  });
+});

--- a/tests/unit/update-checker-apply.test.ts
+++ b/tests/unit/update-checker-apply.test.ts
@@ -5,12 +5,14 @@
  * error handling, and edge cases.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { UpdateChecker } from '../../src/core/UpdateChecker.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type ExecSeam = { execAsync(cmd: string, args: string[], timeoutMs: number): Promise<string> };
 
 describe('UpdateChecker.applyUpdate()', () => {
   let tmpDir: string;
@@ -212,14 +214,19 @@ describe('UpdateChecker.fetchChangelog()', () => {
 describe('UpdateChecker.rollback()', () => {
   let tmpDir: string;
   let checker: UpdateChecker;
+  let exec: MockInstance<ExecSeam['execAsync']>;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-rollback-'));
     fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
     checker = new UpdateChecker(tmpDir);
+    vi.spyOn(checker, 'getInstalledVersion').mockReturnValue('0.1.12');
+    exec = vi.spyOn(checker as unknown as ExecSeam, 'execAsync')
+      .mockRejectedValue(new Error('fixture install unavailable'));
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/update-checker-apply.test.ts:218' });
   });
 
@@ -229,6 +236,7 @@ describe('UpdateChecker.rollback()', () => {
     const result = await checker.rollback();
     expect(result.success).toBe(false);
     expect(result.message).toContain('No rollback info');
+    expect(exec).not.toHaveBeenCalled();
   });
 
   it('canRollback returns true after saving rollback info', () => {
@@ -275,15 +283,21 @@ describe('UpdateChecker.rollback()', () => {
       updatedAt: new Date().toISOString(),
     }));
 
-    // npm install will fail in test environment, but we verify the structure
+    // Exercise real rollback handling without launching npm or using the network.
     const result = await checker.rollback();
-    expect(result).toHaveProperty('success');
-    expect(result).toHaveProperty('previousVersion');
-    expect(result).toHaveProperty('restoredVersion');
-    expect(result).toHaveProperty('message');
-    expect(typeof result.message).toBe('string');
-    expect(result.message.length).toBeGreaterThan(0);
-  }, 30000);
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith('npm', [
+      'install', 'instar@0.1.11', '--ignore-scripts',
+      '--prefix', path.join(tmpDir, 'shadow-install'),
+    ], 120000);
+    expect(result).toEqual({
+      success: false, previousVersion: '0.1.12', restoredVersion: '0.1.12',
+      message: 'Rollback failed: fixture install unavailable',
+    });
+    expect(checker.getRollbackInfo()).toMatchObject({
+      previousVersion: '0.1.11', updatedVersion: '0.1.12',
+    });
+  });
 
   it('refuses rollback below the delivery compatibility floor while evidence is live', async () => {
     fs.writeFileSync(path.join(tmpDir, 'state', 'update-rollback.json'), JSON.stringify({
@@ -293,52 +307,83 @@ describe('UpdateChecker.rollback()', () => {
     const result = await checker.rollback();
     expect(result.success).toBe(false);
     expect(result.message).toContain('compatibility-projector floor');
+    expect(exec).not.toHaveBeenCalled();
   });
 });
 
 describe('UpdateChecker.check() with changeSummary', () => {
   let tmpDir: string;
   let checker: UpdateChecker;
-  let originalFetch: typeof global.fetch;
+  let exec: MockInstance<ExecSeam['execAsync']>;
+  let changelog: MockInstance<UpdateChecker['fetchChangelog']>;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-check-summary-'));
     fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
     checker = new UpdateChecker(tmpDir);
-    originalFetch = global.fetch;
+    vi.spyOn(checker, 'getInstalledVersion').mockReturnValue('0.1.11');
+    exec = vi.spyOn(checker as unknown as ExecSeam, 'execAsync').mockResolvedValue('0.1.12');
+    changelog = vi.spyOn(checker, 'fetchChangelog').mockResolvedValue('Fixed important bugs');
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
+    vi.restoreAllMocks();
     SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/update-checker-apply.test.ts:299' });
   });
 
   it('includes changeSummary in UpdateInfo when update available', async () => {
-    // Mock fetchChangelog to return a summary
-    vi.spyOn(checker, 'fetchChangelog').mockResolvedValue('Fixed important bugs');
-
     const info = await checker.check();
-
-    // If update is available (depends on npm state), changeSummary should be populated
-    if (info.updateAvailable) {
-      expect(info.changeSummary).toBe('Fixed important bugs');
-    }
-    // Always has these fields
-    expect(info).toHaveProperty('currentVersion');
-    expect(info).toHaveProperty('latestVersion');
-    expect(info).toHaveProperty('checkedAt');
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledWith('npm', ['view', 'instar', 'version'], 15000);
+    expect(changelog).toHaveBeenCalledTimes(1);
+    expect(changelog).toHaveBeenCalledWith('0.1.12');
+    expect(info).toMatchObject({
+      currentVersion: '0.1.11', latestVersion: '0.1.12', updateAvailable: true,
+      changeSummary: 'Fixed important bugs', checkedAt: expect.any(String),
+    });
   });
 
   it('persists changeSummary to state file', async () => {
-    vi.spyOn(checker, 'fetchChangelog').mockResolvedValue('Big improvements');
+    changelog.mockResolvedValue('Big improvements');
+    const info = await checker.check();
+    expect(info.updateAvailable).toBe(true);
+    expect(info.changeSummary).toBe('Big improvements');
+    expect(checker.getLastCheck()).toEqual(info);
+    expect(JSON.parse(fs.readFileSync(path.join(tmpDir, 'state', 'update-check.json'), 'utf8'))).toEqual(info);
+  });
 
-    await checker.check();
+  it('persists a same-version check without fetching a changelog', async () => {
+    exec.mockResolvedValue('0.1.11');
+    const info = await checker.check();
+    expect(info).toMatchObject({ currentVersion: '0.1.11', latestVersion: '0.1.11', updateAvailable: false });
+    expect(info.changeSummary).toBeUndefined();
+    expect(changelog).not.toHaveBeenCalled();
+    expect(checker.getLastCheck()).toEqual(info);
+  });
 
-    const lastCheck = checker.getLastCheck();
-    expect(lastCheck).not.toBeNull();
-    // changeSummary only present if updateAvailable is true
-    if (lastCheck!.updateAvailable) {
-      expect(lastCheck!.changeSummary).toBe('Big improvements');
-    }
+  it('returns a current-version fallback offline without inventing saved state', async () => {
+    exec.mockRejectedValue(new Error('fixture registry unavailable'));
+    const info = await checker.check();
+    expect(info).toEqual({
+      currentVersion: '0.1.11', latestVersion: '0.1.11', updateAvailable: false,
+      checkedAt: expect.any(String),
+    });
+    expect(changelog).not.toHaveBeenCalled();
+    expect(checker.getLastCheck()).toBeNull();
+    expect(fs.existsSync(path.join(tmpDir, 'state', 'update-check.json'))).toBe(false);
+  });
+
+  it('returns the unchanged saved result offline without overwriting it', async () => {
+    const saved = await checker.check();
+    const stateFile = path.join(tmpDir, 'state', 'update-check.json');
+    const bytes = fs.readFileSync(stateFile, 'utf8');
+    exec.mockRejectedValue(new Error('fixture registry unavailable'));
+    changelog.mockClear();
+    vi.mocked(checker.getInstalledVersion).mockReturnValue('0.1.13');
+
+    expect(await checker.check()).toEqual(saved);
+    expect(changelog).not.toHaveBeenCalled();
+    expect(checker.getLastCheck()).toEqual(saved);
+    expect(fs.readFileSync(stateFile, 'utf8')).toBe(bytes);
   });
 });

--- a/upgrades/next/telegram-transport-deadlines.md
+++ b/upgrades/next/telegram-transport-deadlines.md
@@ -1,0 +1,32 @@
+<!-- bump: patch -->
+## What Changed
+
+Telegram network deadlines now begin when each actual request starts, after
+origin review, durable recording, attachment loading and credential preparation.
+Adapter and Lifeline sends, signed holder relays, recovery and fixed notices use
+the shared duration contract. Each message part receives a fresh deadline, which
+continues through reading the response body.
+
+Caller cancellation proven before the network call remains a known unsent
+attempt in the original outbox. It retains the original recovery limits. A timeout
+or cancellation after the call starts remains uncertain and cannot justify a
+second send. Even a reused cancellation error cannot change that distinction.
+
+## What to Tell Your User
+
+A slow review no longer uses up the time reserved for actually sending a Telegram
+message. This repairs one cause of held replies. Other failures can still hold
+messages, and an uncertain send is still protected against accidental duplicates.
+
+## Summary of New Capabilities
+
+- Message parts each receive a full network timeout after preparation.
+- Cancellation of one attempt does not discard the original queued message.
+- Existing agents receive the repair and explanation through normal updates.
+
+## Evidence
+
+Validation results and independent review are recorded in the side-effects
+artifact. Tests cover the real outbox, caller cancellation, split requests,
+attachments, receipt-body failures, HTTP adapter, signed mesh and production
+restart recovery. No live Telegram traffic is used by these tests.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -300,3 +300,28 @@ Audit erratum: the earlier enrollment-test trace mistakenly cited the nonexisten
 spec read and used is `docs/specs/telegram-message-origin.md`. A fresh trace records
 the correct path; the original audit record is retained rather than rewritten.
 This corrects the citation, not the approved production contract or test behavior.
+
+### Complete local validation and CI portability correction
+
+Candidate7e2eb5900 completed the full local test:all with exit0: aggregate3345
+passing files/51825 passing tests (4files/29tests skipped,3todo); dedicated
+integration518files/4184tests (2files/12tests skipped); dedicated E2E368files/3232tests
+(1file/7tests skipped,3todo). All5375 frozen source/test hashes remained unchanged.
+This is separate candidate evidence; the original exhausted build stays escalated.
+
+PR2018 CI run34479109543 then failed three unit shards. Both Node20 and22 exposed
+a dependency in the new Lifeline constructor fixture: omitted framework settings
+made real loadConfig require an installed Claude CLI. A bounded test-only correction
+supplies explicit codex-cli configuration and private fail-on-use provider/tmux
+executables, asserts the resolved fixture paths, and proves neither is launched.
+Actual configuration loading, Lifeline construction, policy timing and15s/60s
+network assertions remain intact. No production prerequisite or live config changes.
+
+Another shard reported pre-network capacity holds in the triage-author and
+attachment/companion lifecycle cases, plus source-lock contention and cleanup
+ENOTEMPTY in the feedback150k performance case. The annotations establish those
+outcomes, not their incidence or one shared cause. Those three files remain
+unchanged. All45 cases across them and the corrected deadline unit file passed
+locally. That does not count as a clean CI run or a correction of the independent
+contention mechanisms; the next candidate still requires clean full validation
+and CI. No attempt-limit, capacity TTL, lock bound or failed assertion was relaxed.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -185,11 +185,21 @@ cancellation case remains intact and renewed concurrence. Further full-run resul
 ## Class-Closure Declaration (display-only mirror)
 
 `defectClass: unbounded-self-action`, `closure: guard`.
-`guardEvidence`: ratchet, tests/unit/self-action-convergence.test.ts plus
-real-worker transport-deadlines.test.ts and recovery-review-budget.test.ts.
+`guardEvidence`: ratchet, tests/unit/telegram-origin/recovery-review-budget.test.ts,
+supplemented by real-worker transport-deadlines.test.ts and production-boot tests.
+The generic self-action registry does not register ordinary recoverHeld; its test
+is not the evidence for this claim. Independent audit corrected that citation.
 Recovery still reserves 15 minutes before review, preserves the original maximum
 six-hour deadline and existing child-attempt ceiling. Pre-network cancellation
 charges the original attempt and cannot reset identity, deadline or pacing. The
 control edge is original queued operation -> due recovery -> reviewed send;
 the durable interval settles repeated failure and the deadline/attempt limit
 terminates it. Unknown outcomes remain excluded from recovery.
+
+The actual recovery-budget test proves at most24 automatic recovery starts per
+original admitted operation over its default six-hour lifetime, exact due and
+expiry boundaries, competing owners, restart/re-admission persistence and unknown
+suppression. The production restart test connects that reservation to paid review;
+transport cases retain charged cancellation attempts and uncertainty fences.
+This is not a fleet-wide spending cap or a bound on newly created operations.
+Hooke independently re-read these concrete tests and concurred with the correction.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -240,3 +240,18 @@ reviewed the actual two-file diff and concurred with the bounded observer
 precondition and preserved terminal semantics. A fresh full run is required.
 This test-only amendment creates no production autonomous action; the overall
 transport repair retains the recovery guard evidence declared above.
+
+## Enrollment startup observation
+
+The sixth aggregate ended with SIGTERM/exit143 before a summary; its initiator is
+unproven. It had 3089 passing-file lines and one reported enrollment failure.
+A separate exact reproduction failed with only notice-policy/unknown for
+operator-alert-destinations: notice-destination-or-policy-unavailable at the
+first Boot status. The completion-attainable test now polls real status for at
+most12.5 seconds, only for that exact startup observation. Any different or
+additional missing obligation fails immediately. No policy is renewed, no
+production permission is changed, and missing release evidence still fails
+certification. Enrollment plus HTTP/E2E notice tests passed21 cases. Hooke
+reviewed the actual amendment and concurred; its suggested state/subject pins
+were added. This test-only amendment adds no autonomous production action.
+Full combined release validation remains required; no incomplete run is green.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -1,0 +1,195 @@
+# Side-effects review: Telegram transport deadlines
+
+**Author:** Echo
+**Second-pass reviewer:** Hooke
+
+## Summary of the change
+
+Fresh Instar worktree fix/telegram-transport-deadlines at origin/main4180b00b2,
+version1.3.1232, remoteJKHeadley/instar. Justin authorized remaining delivery
+repairs in topic69507. The existing approved/converged Telegram message-origin
+contract governs this fix. telegramFetch accepts a validated networkTimeoutMs
+and creates the signal at its single native fetch boundary. Internal senders
+pass durations instead of arming clocks before review. A dedicated local error
+identifies cancellation checked synchronously before native invocation; the
+service records known-failed using existing budgets. The callback strips that
+proof from any rejection raised after invocation, including reused abort reasons.
+
+## Decision-point inventory
+
+- Network deadline start: modified transport lifecycle invariant.
+- Known-unsent versus ambiguous outcome: exact invocation evidence, modified.
+- Outbound review, content dedup, origin, ownership and capacity: passed through.
+- Recovery pacing, original deadlines and attempt counts: passed through.
+- Awareness installation: additive, idempotent existing-agent migration.
+
+## 1. Over-block
+
+An explicit caller cancellation prevents that attempt even when its original
+queued intent is still valid. This preserves cancellation and leaves bounded
+recovery to the existing outbox. Post-invocation failures deliberately remain
+uncertain even if the network might not have transmitted bytes: the local process
+cannot prove that. No new content judgment or ownership refusal is added.
+
+## 2. Under-block
+
+The duration covers network invocation through body consumption, not total review
+latency or an entire multipart logical operation. Review and recording retain
+existing stage limits. Each child receives its own budget. This does not repair
+standby relay selection, startup readiness, dead-pane supervisor detection or
+installed model retirement; those remain authorized work in topic69507, with the
+model/PromptGate source work owned by the coordinated session in topic74958.
+<!-- tracked: topic-69507 -->
+
+## 3. Level-of-abstraction fit
+
+The shared egress boundary owns the clock because only it knows when fetch starts.
+The durable service owns outcome classification and retry state. Callers supply a
+duration, not a pre-expiring signal. Independent caller signals and HTTP/mesh RPC
+budgets remain independent. Attachment integrity is checked before the boundary.
+
+## 4. Signal vs authority compliance
+
+Reference: [signal vs authority](../../docs/signal-vs-authority.md).
+No message-meaning classifier is added. Invocation, caller-signal state and exact
+error provenance are transport invariants. Existing policy retains sole content
+judgment. Cancellation is not a new operation-cancellation permission.
+
+## 4b. Judgment-point check
+
+No new heuristic at a competing-signals decision point. The synchronous
+pre-invocation boundary provides exact local evidence; every later ambiguous
+exception preserves the conservative fence.
+
+## 5. Interactions
+
+No approval caching or duplicate recovery controller. The original operation and
+child identity, payload, deadlines and attempt counters remain unchanged. Known
+pre-network cancellation after durable dispatch intent retains its charged
+attempt, like invalidated credential capacity. A crash before outcome persistence
+still recovers as uncertain. Each child combines its new network deadline with
+the unchanged caller signal. The deadline remains attached through receipt reading;
+clearing a timer at headers would create another unbounded wait. Non-managed
+requests without a duration preserve their original signal. Invalid durations are
+refused before any origin mutation. The local proof error is wrapped if fetch
+itself rejects with either that cancellation error or OriginCapacityUnavailable,
+preventing recycled abort(reason) from granting a resend. Actual capacity refusals
+before invocation remain outside this catch and retain known-unsent accounting.
+
+## 6. External surfaces
+
+Users can receive replies whose reviews exceeded the old network duration.
+No new API endpoint, credential exposure or operator action. Internal TypeScript
+callers may pass networkTimeoutMs; it never enters the sealed payload or native
+RequestInit. Shared scaffold awareness and PostUpdateMigrator update existing
+CLAUDE/AGENTS/GEMINI content once. No config default or durable schema migration.
+
+## 6b. Operator-surface quality
+
+No operator form, dashboard renderer or grant/revoke surface is changed.
+
+## 7. Multi-machine posture
+
+Machine-local by design: the actual sending machine owns each network deadline.
+Signed mesh submissions retain source origin and execution-owner authority;
+receiver-side preparation completes before the receiver's network clock starts.
+No new notices, URLs or replicated state. Existing operation routing and audit
+remain authoritative. A token-bearing standby's selection defect is separate.
+
+## 8. Rollback cost
+
+Revert these source changes and publish a new patch; no data cleanup. Rollback
+restores premature-expiry behavior, so a correction forward is preferable. Never
+clear queued messages or uncertain outcomes as part of rollback.
+
+## Conclusion
+
+The fix belongs at the shared transport boundary and preserves custody and
+uncertainty protections. Independent implementation review found no blocker.
+At this review checkpoint, full-suite validation remains required before release;
+the PR validation record will carry its final outcome.
+
+## Second-pass review
+
+Hooke reviewed the design independently, requiring a fresh clock per child,
+response-body coverage, explicit caller cancellation, and demotion of recycled
+proof errors after invocation. Implementation review concurs: deadline placement, body coverage, preserved caller
+signal, recycled-error demotion and durable outcome accounting match the design.
+Hooke independently reviewed the Lifeline case after its 16-case suite passed.
+A subsequent provenance audit found the sibling capacity-proof error could also
+be recycled as a post-invocation abort reason. The first aggregate run was stopped
+deliberately to correct it. A parameterized regression reproduced that defect;
+the boundary now demotes both proof types after native invocation. Hooke reviewed
+the correction and renewed code concurrence. The corrected transport suite passed
+17 cases. A subsequent aggregate found four existing notice-fixture startup races;
+it was stopped before editing. Those fixtures now await real display/policy and
+reserved-notice readiness before fault injection, including the initial boot in
+the recovery-budget test. Hooke verified that every existing fault assertion and
+cancellation case remains intact and renewed concurrence. Further full-run results and corrections are recorded below.
+
+## Evidence pointers
+
+- Initial regression run: 8 failures, 3 passes against unchanged source.
+- Corrected real-session fixture: 13 focused tests passed; expanded 16-case
+  transport suite subsequently passed, including multipart, network timeout, and the actual Lifeline sender.
+- HTTP adapter, signed mesh, migration and awareness tests passed (200 cases
+  across pipeline run excluding the new production recovery case).
+- Production restart recovery passed after waiting for the real configuration
+  observer to become ready (a later revision can invalidate the boot snapshot).
+  The test does not replace configuration/ownership authority or force a retry.
+- The new capacity-abort regression failed with held instead of outcome-unknown
+  before correction (one failure, one pass, fifteen cases skipped).
+- Corrected build and lint passed. Five-file transport/service/HTTP/mesh/boot
+  checks passed 94 cases. Final boot/notice readiness checks passed 19 cases,
+  including all 16 notice-policy cases. Counts overlap on the three boot cases.
+- The second aggregate reported four failures caused by fixture readiness
+  assumptions and was deliberately interrupted. The intermediate readiness run
+  exposed the same assumption in the existing recovery-budget boot case; that
+  precondition was corrected too. Both interrupted aggregates remain incomplete;
+  the fresh final full run is pending, not reported as a pass.
+- The third run passed 1,323 files, including all 19 boot/notice cases, before
+  Tinypool exited because its process.js disappeared from the shared agent-home
+  node_modules tree. That dependency tree changed during the run and the file
+  subsequently reappeared. Exit 1 is an incomplete run, not a test-suite pass.
+  The worktree now has private dependencies installed from its unchanged lockfile;
+  both other delivery worktrees have independent copies from the identical lockfile.
+  The private-dependency build and native SQLite smoke passed. All 5,369 frozen
+  source/test hashes remained unchanged. A fourth full run started with the private
+  dependency tree (echo-transport-deadlines-test-all-isolated.log).
+- That fourth run completed its aggregate with exactly two failures, 3,343 files
+  and 51,804 tests passed. Triage-author and scheduler-custody fixtures sent before
+  display authority was ready. Dedicated integration/E2E stages did not start.
+  The correction adds an opt-in real-display readiness helper to the remaining
+  positive boot fixtures; it retries only the exact unavailable-authority error
+  for at most 12.5 seconds and asserts required wiring/projection. Real timer
+  waits do not advance the lease tests' fake interval clock. Integration notice
+  setup also verifies the actual opt-out value and reservation before storage
+  destruction. Startup-unavailability, tokenless enrollment, failed authority,
+  lease loss and uncertain-delivery assertions remain intact.
+- These waits isolate the behavior those tests exercise. They do not fix the
+  production gap where a snapshot can be invalidated before boot returns and
+  display failure can precede durable admission. The precise watcher/source
+  event causing these two failures remains unproven; the initial resolved digest
+  assignment itself does not increment the revision. Production readiness and
+  retention are tracked separately in the authorized topic-69507 delivery work.
+  <!-- tracked: topic-69507 -->
+- Corrected ten-file readiness/negative-boundary validation passed all 35 cases
+  (echo-origin-readiness-class-targeted.log), including both failed fixtures,
+  real lease-loss boundaries, opted-out notices, tokenless enrollment and canary
+  startup failures. Hooke independently inspected the helper and every call site,
+  and concurred that required DI, exact-error retry, monotonic bounded waiting,
+  fake-clock isolation and intentional fault assertions are preserved. Source
+  build/lint passed before this test-only correction; normal commit lint runs
+  again. The next complete full run is required; no full-suite pass is claimed.
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`.
+`guardEvidence`: ratchet, tests/unit/self-action-convergence.test.ts plus
+real-worker transport-deadlines.test.ts and recovery-review-budget.test.ts.
+Recovery still reserves 15 minutes before review, preserves the original maximum
+six-hour deadline and existing child-attempt ceiling. Pre-network cancellation
+charges the original attempt and cannot reset identity, deadline or pacing. The
+control edge is original queued operation -> due recovery -> reviewed send;
+the durable interval settles repeated failure and the deadline/attempt limit
+terminates it. Unknown outcomes remain excluded from recovery.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -255,3 +255,48 @@ certification. Enrollment plus HTTP/E2E notice tests passed21 cases. Hooke
 reviewed the actual amendment and concurred; its suggested state/subject pins
 were added. This test-only amendment adds no autonomous production action.
 Full combined release validation remains required; no incomplete run is green.
+
+## Seventh aggregate and separate updater fixture correction
+
+The seventh aggregate, at candidate ebfba9244 on released v1.3.1233, completed
+with exit1: 3344 passed files, one failed file, four skipped files; 51821 passed
+tests, one failed test, 29 skipped tests and three todo. Duration was3191.33s.
+All5375 frozen source/test files were unchanged. The dedicated integration/E2E
+commands did not start because the aggregate failed. The initial progress counter
+included individual passing tests; only these final summary counts are authoritative.
+
+The only failure was `update-checker-apply.test.ts`'s persistence assertion. It
+called real `npm view instar version`, then assumed a non-null saved result.
+Production correctly returns an unsaved current-version fallback on registry
+failure when there is no cache. The precise registry error was swallowed by that
+existing fallback; the15006ms duration alone does not establish its cause.
+The same file also launched a real rollback install and asserted only result shape.
+
+The original build exhausted its three fix cycles and was terminally escalated
+through the normal CLI. Its state, plan and audit were preserved in a read-only
+snapshot; counters were not reset and it was not marked complete. Hooke reviewed
+the escalation disposition: the independently diagnosed single-file updater
+fixture repair is a separate bounded task under existing authorization, not a new
+transport fix budget. The build skill excludes single-file edits and does not
+explicitly require operator permission for this correction. Further unexplained
+or production failures require new reassessment.
+
+Only the updater unit fixture changes: fixed installed/registry versions and
+mocked instance exec calls retain real check, persistence and rollback handling.
+Assertions now require actual update/changelog persistence, same-version behavior,
+offline fallback without invented state, unchanged offline cache, exact failed
+rollback invocation and retained metadata, plus no install on refusal paths.
+No production updater behavior, timeout or delivery implementation changed.
+The first focused run had43 passes and two failures because the new combined
+call-count/argument matcher is unavailable in the repository's Vitest version.
+Three matcher calls were replaced with equivalent separate count and argument
+assertions. The same three updater files then passed all45 tests. Hooke reviewed
+the actual correction and the compatibility amendment and concurred. A new full
+candidate run remains required. Later green validation will be recorded separately
+and cannot retroactively pass an earlier failed run.
+
+Audit erratum: the earlier enrollment-test trace mistakenly cited the nonexistent
+`docs/specs/TELEGRAM-MESSAGE-ORIGIN-SPEC.md`. The actual approved/converged transport
+spec read and used is `docs/specs/telegram-message-origin.md`. A fresh trace records
+the correct path; the original audit record is retained rather than rewritten.
+This corrects the citation, not the approved production contract or test behavior.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -325,3 +325,12 @@ unchanged. All45 cases across them and the corrected deadline unit file passed
 locally. That does not count as a clean CI run or a correction of the independent
 contention mechanisms; the next candidate still requires clean full validation
 and CI. No attempt-limit, capacity TTL, lock bound or failed assertion was relaxed.
+
+
+### CI hold diagnostics after complete candidate validation
+
+Candidate704b3e65b passed complete local test:all with the same aggregate, integration and E2E counts above; all5375 fingerprints matched. CI34489858714 passed all eight unit shards and Build, then failed one integration and one E2E case. The deterministic-notice HTTP case returned409; the ambiguous batcher-send lifecycle observed zero native calls. Neither assertion retained the underlying reason. The exact HTTP case and all26 HTTP cases passed unchanged locally. This is nonreproduction, not proof of grant expiry or a repaired flake.
+
+The bounded diagnostic change adds the HTTP response body to its existing200 assertion and captures/rethrows the same fixture send error for the existing exactlyone native-call assertion. No timing, grant, recovery bound, send authority or production code changes. Per docs/signal-vs-authority.md, this only surfaces test evidence and has no blocking authority. No over-block, under-block, or new decision interaction is introduced; the existing assertions stay strict. It is test-local on each machine, with no external or migration surface. Rollback removes diagnostic messages. Full candidate validation and clean CI remain required. The original exhausted build ledger remains escalated and unchanged.
+
+Both diagnostic files passed all52 tests in77.19s (`echo-deadline-ci-hold-diagnostics-targeted.log`). This targeted pass does not replace new full or CI validation.

--- a/upgrades/side-effects/telegram-transport-deadlines.md
+++ b/upgrades/side-effects/telegram-transport-deadlines.md
@@ -203,3 +203,40 @@ suppression. The production restart test connects that reservation to paid revie
 transport cases retain charged cancellation attempts and uncertainty fences.
 This is not a fleet-wide spending cap or a bound on newly created operations.
 Hooke independently re-read these concrete tests and concurred with the correction.
+
+
+## Post-boot outage-fixture verification
+
+The fifth complete aggregate run finished with 3344 passed files and one failed
+file: 51805 passed tests and one failed test. The capacity-drain outage case
+became suppressed rather than accepted after its initial readiness check. The
+original assertion did not include the suppression reason, so its precise cause
+is unproven. The dedicated integration/E2E commands did not start after that
+aggregate failure. This is not a full-suite pass.
+
+A real compiled bootstrap probe, an instrumented execution of the existing test
+file, a predetermined four-run diagnostic batch, and one filename-instrumented
+execution all passed. These diagnostics do not replace release validation. The
+third fixed diagnostic run captured actual FSWatcher invalidation during an
+unchanged positive bot-only fixture before its observer recovered; no exact
+filename was captured for that event. The later filename diagnostic did not
+reproduce it. This establishes a reachable startup invalidation, not proof of the
+original failed capacity case's trigger.
+
+The E2E and HTTP outage fixtures now require one successful, idle, healthy config
+observation after Boot returned, within their existing bounded setup wait, before
+failing the recording workers once. Real display, policy, notice reservation and
+explicit opt-out checks remain. The external fixture policy retains its original
+observation/expiry; it is not renewed to pass the test. This establishes an
+operating observer, not a guarantee that all future filesystem events have drained.
+Startup-negative tests and runtime N6 terminal suppression remain unchanged.
+A bounded sixteen-state history plus current source health/policy appears in the
+capacity-drain assertion failure so another suppression provides its actual reason.
+No production runtime source changed in this correction. Both actual E2E/HTTP
+files passed all18 cases (echo-origin-notice-post-boot-targeted.log), including
+capacity drain, grant expiry before/after dispatch intent, failed recording workers,
+credential rotation, policy revocation and explicit opt-out. Hooke independently
+reviewed the actual two-file diff and concurred with the bounded observer
+precondition and preserved terminal semantics. A fresh full run is required.
+This test-only amendment creates no production autonomous action; the overall
+transport repair retains the recovery guard evidence declared above.


### PR DESCRIPTION
A reply's network timer could expire during origin review, leaving no time for the eventual Telegram request. Start each network deadline at the native fetch boundary, preserve explicit caller cancellation, and keep uncertain outcomes fenced against duplicate delivery. Existing agents receive the updated awareness paragraph during migration.

## ELI16

A reply needs time to be checked before it is sent. Previously, the timer for contacting Telegram could run out during those checks. The network now gets its own time allowance when sending actually begins. An explicit cancellation still works, and a reply whose delivery is uncertain is never blindly repeated.

## Validation

- Candidate `300805dba` passed the complete local `npm run test:all`: aggregate51,825 tests/3,345 files; dedicated integration4,184 tests/518 files; dedicated E2E3,232 tests/368 files, with zero failures. All5,375 frozen source/test fingerprints were verified unchanged after completion.
- CI run `34496616313` passed all eight unit shards, Type Check, Build, integration and E2E on this same head. Both diagnostic test files also passed all52 cases through `npm test`; lint passed.
- Prior CI `34489858714` passed all eight unit shards and Build, but integration and E2E each failed one origin-send assertion. The HTTP case received 409; the batcher lifecycle observed zero native network calls. The diagnostic-only commit retains both strict assertions and captures the response/error reason without changing timing, retries or authority. Those prior causes remain unestablished.
- Build, lint and focused transport, HTTP, signed relay, Boot, migration and cancellation checks passed. The Lifeline fixture explicitly configures private executable paths and verifies neither runs, preserving real configuration and API coverage without requiring a provider CLI installation.
- Normal push guards completed; the bounded smoke selector timed out and reported skipped with zero tests. This is not counted as a pass.

## Review and limits

Independent review concurred. The change preserves original operation identity, charged attempts, recovery bounds, capacity ownership and the v1.3.1232 recovery-review brake. Earlier failed and interrupted runs are recorded in the side-effects review and local validation evidence. Other delivery repairs have separate releases.

[Upgrade guide](upgrades/next/telegram-transport-deadlines.md) · [Side-effects review](upgrades/side-effects/telegram-transport-deadlines.md)
