### PR TITLE
fix(telegram): acquire send capacity after durable dispatch recording

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-10T12-32-45-978Z-telegram-late-capacity.json
+++ b/.instar/instar-dev-decisions/2026-09-10T12-32-45-978Z-telegram-late-capacity.json
@@ -1,0 +1,31 @@
+{
+  "ts": "2026-09-10T12:32:45.978Z",
+  "slug": "telegram-late-capacity",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 28,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts",
+      "src/messaging/telegram-origin/OriginAwareness.ts",
+      "src/messaging/telegram-origin/OriginBotEgress.ts"
+    ],
+    "addedLines": 23,
+    "deletedLines": 5
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "Moves existing one-use capacity reservation within an already-authorized send; no new automatic retry or autonomous controller. Original operation recovery pacing, charged attempts, deadline and unknown-outcome fences remain unchanged."
+  },
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -22,7 +22,7 @@ import { originToolGuardHook } from '../messaging/telegram-origin/OriginToolGuar
  */
 
 import fs from 'node:fs';
-import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, telegramOriginTransportAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
+import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, telegramOriginTransportAwareness, telegramOriginCapacityAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
 import { migrateTelegramOriginDisplay } from '../messaging/telegram-origin/OriginConfig.js';
 import path from 'node:path';
 import os from 'node:os';
@@ -6256,6 +6256,12 @@ setTimeout(() => process.exit(0), 2000);
       result.upgraded.push('CLAUDE.md: added Telegram network deadline awareness');
     }
 
+    if (!content.includes('Telegram capacity checks:')) {
+      content += '\n' + telegramOriginCapacityAwareness();
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Telegram late capacity awareness');
+    }
+
     const refreshedOriginCanary = refreshOriginCanaryStartupAwareness(content);
     if (refreshedOriginCanary !== content) {
       content = refreshedOriginCanary;
@@ -10653,6 +10659,7 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
         ['Origin detector health:', telegramOriginDetectorAwareness],
         ['Queued-message review pacing:', telegramOriginRecoveryAwareness],
         ['Telegram send deadlines:', telegramOriginTransportAwareness],
+        ['Telegram capacity checks:', telegramOriginCapacityAwareness],
       ] as const) {
         if (claudeMd.includes(marker) && !appended.includes(marker)) {
           appended = appended.trimEnd() + '\n\n' + render();

--- a/src/messaging/telegram-origin/OriginAwareness.ts
+++ b/src/messaging/telegram-origin/OriginAwareness.ts
@@ -26,6 +26,10 @@ export function telegramOriginTransportAwareness(): string {
   return 'Telegram send deadlines: each network request gets its full timeout after origin review, recording and capacity preparation. A caller cancellation proven before network invocation leaves the original operation eligible for bounded recovery; it does not cancel durable message intent. Failure after network invocation remains uncertain and must not be replayed merely because it reports an abort or timeout. Slow review can still hold a message, and queued custody is not delivery confirmation.\n';
 }
 
+export function telegramOriginCapacityAwareness(): string {
+  return 'Telegram capacity checks: ordinary replies acquire the credential owner\'s short-lived capacity only after durable dispatch intent, immediately before network invocation. Storage preparation cannot use up that grant. An unavailable or expired grant still holds the original message and consumes a charged attempt, even if no network call started; sustained capacity refusal can exhaust its original attempt limit. The existing recovery pacing, deadline, ownership and shared rate limit remain in force. Never recreate a held message to obtain a new budget.\n';
+}
+
 export function telegramOriginAwareness(port: number): string {
   return `
 ### Telegram message origin
@@ -43,6 +47,7 @@ ${telegramOriginDashboardAwareness()}
 ${telegramOriginDetectorAwareness()}
 ${telegramOriginRecoveryAwareness()}
 ${telegramOriginTransportAwareness()}
+${telegramOriginCapacityAwareness()}
 Ordinary bot messages and fixed outage notices share the credential owner's bounded send capacity across server and Lifeline processes. A \`credential-capacity-unavailable\` result retains the original operation for recovery; never replace it with a new message. An unavailable or stale capacity owner holds sends. Recording-worker failure does not disable the independent notice queue or its current permission checks.
 
 Claude and Codex tool hooks direct raw Telegram writes to the recorded relay or typed browser broker. Managed Telegram profiles belong to the broker; generic browser tools cannot use them. This cooperative hook is not an operating-system sandbox. Other enabled harnesses must prove equivalent enrollment before activation; a hook being installed is not proof of complete sender coverage.

--- a/src/messaging/telegram-origin/OriginBotEgress.ts
+++ b/src/messaging/telegram-origin/OriginBotEgress.ts
@@ -78,13 +78,19 @@ export async function dispatchOriginBotEgress(input: {
   wire.prepare = async request => {
     const send = await prepareWire(request);
     const authority = owner.service.options.capacity;
-    const grant = await authority?.reserve(request.accountId);
-    if (!grant || !authority) throw new OriginCapacityUnavailable();
+    if (!authority) throw new OriginCapacityUnavailable();
     let available = true;
-    const valid = () => available && Date.now() < grant.expiresAt;
+    const valid = () => available;
     return { valid, cancel: () => { available = false; }, send: async () => {
       if (!valid()) { available = false; throw new OriginCapacityUnavailable(); }
-      available = false; // Never let a delayed/repeated closure use this grant.
+      // Latch before any await: even concurrent invocations get only one grant.
+      available = false;
+      // Durable claim/dispatch and policy checks have finished. Their latency
+      // must not consume this short-lived permission to start network work.
+      // Refusal here is a charged, provably pre-network failure; never erase
+      // the already-recorded dispatch intent or renew/refund a capacity debit.
+      const grant = await authority.reserve(request.accountId);
+      if (!grant || Date.now() >= grant.expiresAt) throw new OriginCapacityUnavailable();
       if (!await authority.consume(grant) || Date.now() >= grant.expiresAt) throw new OriginCapacityUnavailable();
       return send();
     } };

--- a/tests/e2e/telegram-origin-late-capacity-lifecycle.test.ts
+++ b/tests/e2e/telegram-origin-late-capacity-lifecycle.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { setTimeout as delay } from 'node:timers/promises';
+import request from 'supertest';
+import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { lateCapacityHttpHarness } from '../helpers/telegramLateCapacityHttp.js';
+
+let worker: URL;
+const closes: Array<() => Promise<void>> = [];
+beforeAll(async () => { worker = await compileOriginWorker(); });
+afterEach(async () => { for (const close of closes.splice(0).reverse()) await close(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+describe('late ordinary capacity is alive across production Boot restart', () => {
+  it('records concrete receipts after slow durable dispatch before and after restart', async () => {
+    const h = await lateCapacityHttpHarness(worker, false); closes.push(h.close);
+    let firstOperation: string | undefined;
+    for (const phase of ['before', 'after']) {
+      if (phase === 'after') await h.restart();
+      const mark = h.runtime.store.markDispatched.bind(h.runtime.store);
+      vi.spyOn(h.runtime.store, 'markDispatched').mockImplementation(async input => {
+        const result = await mark(input); await delay(300); return result;
+      });
+      const response = await request(h.app).post('/telegram/reply/42')
+        .set('Authorization', 'Bearer agent-test').set('X-Instar-Origin-Session', h.sessionToken)
+        .send({ text: `The requested report ${phase} the server restart is ready.` });
+      expect(response.status).toBe(200);
+      const rows = (await h.runtime.store.listOrigins()).records;
+      expect(rows.every(row => row.operation?.state === 'accepted')).toBe(true);
+      expect(rows.every(row => row.attempts.length === 1 && row.attempts[0].outcome === 'accepted')).toBe(true);
+      if (phase === 'before') { expect(rows).toHaveLength(1); firstOperation = rows[0].operation?.operationId; }
+      else {
+        expect(rows).toHaveLength(2);
+        expect(rows.some(row => row.operation?.operationId === firstOperation)).toBe(true);
+      }
+    }
+    expect(h.network).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/e2e/telegram-origin-notice-policy.test.ts
+++ b/tests/e2e/telegram-origin-notice-policy.test.ts
@@ -87,7 +87,7 @@ describe('production bootstrap outage authority separation', () => {
       notificationOutcome: 'suppressed', notificationAttempted: false, reason: 'destination-policy' }));
     expect(h.wire).not.toHaveBeenCalled();
   });
-  it.each(['before', 'after'] as const)('never invokes a late wire closure when capacity expires %s durable dispatch intent', async phase => {
+  it.each(['before-consume', 'after-consume'] as const)('never invokes a late wire closure when capacity expires %s', async phase => {
     const h = await boot(true, true);
     let prepared: Awaited<ReturnType<NonNullable<OriginBotTransport['prepare']>>> | undefined;
     const execute = h.runtime.service.executePreparedBot.bind(h.runtime.service);
@@ -98,13 +98,18 @@ describe('production bootstrap outage authority separation', () => {
     });
     const actualNow = Date.now.bind(Date); let offset = 0;
     const clock = vi.spyOn(Date, 'now').mockImplementation(() => actualNow() + offset);
-    if (phase === 'before') {
-      const claim = h.runtime.store.claim.bind(h.runtime.store);
-      vi.spyOn(h.runtime.store, 'claim').mockImplementation(async input => { const result = await claim(input); offset = 500; return result; });
-    } else {
-      const mark = h.runtime.store.markDispatched.bind(h.runtime.store);
-      vi.spyOn(h.runtime.store, 'markDispatched').mockImplementation(async input => { const result = await mark(input); offset = 500; return result; });
-    }
+    const capacity = h.runtime.service.options.capacity!;
+    const reserve = capacity.reserve.bind(capacity), consume = capacity.consume.bind(capacity);
+    const reserveSpy = vi.spyOn(capacity, 'reserve').mockImplementation(async accountId => {
+      const grant = await reserve(accountId);
+      if (phase === 'before-consume') offset = 500;
+      return grant;
+    });
+    const consumeSpy = vi.spyOn(capacity, 'consume').mockImplementation(async grant => {
+      const result = await consume(grant);
+      if (phase === 'after-consume') offset = 500;
+      return result;
+    });
     try {
       await expect(telegramFetch('https://api.telegram.org/bot123:notice-fixture/sendMessage', { method: 'POST',
         headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ chat_id: '-100123', message_thread_id: 42, text: 'Expires before network' }) }))
@@ -112,8 +117,11 @@ describe('production bootstrap outage authority separation', () => {
       expect(prepared).toBeDefined(); await expect(prepared!.send()).rejects.toThrow('credential-capacity-unavailable');
       expect(h.wire).not.toHaveBeenCalled();
       const row = (await h.runtime.store.listOrigins()).records.find(row => row.attempts.length > 0)!;
-      expect(row.attempts[0]).toMatchObject({ phase: phase === 'before' ? 'claimed' : 'dispatched', outcome: 'known-failed' });
-    } finally { clock.mockRestore(); }
+      expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'known-failed' });
+      expect(row.attempts).toHaveLength(1);
+      expect(reserveSpy).toHaveBeenCalledTimes(1);
+      expect(consumeSpy).toHaveBeenCalledTimes(phase === 'before-consume' ? 0 : 1);
+    } finally { clock.mockRestore(); reserveSpy.mockRestore(); consumeSpy.mockRestore(); }
   });
   it('retains one notice while ordinary sends spend shared capacity, then drains without either recording worker', async () => {
     const h = await boot(true, true);

--- a/tests/helpers/telegramLateCapacity.ts
+++ b/tests/helpers/telegramLateCapacity.ts
@@ -1,0 +1,44 @@
+import { generateKeyPairSync, randomUUID } from 'node:crypto';
+import { vi } from 'vitest';
+import { TelegramOriginRuntime } from '../../src/messaging/telegram-origin/TelegramOriginRuntime.js';
+import type { OriginSessionLifecycle } from '../../src/messaging/telegram-origin/OriginSessionRegistry.js';
+import { telegramFetch } from '../../src/messaging/telegram-egress.js';
+import { fixtureOriginContentDedup } from './originContentDedup.js';
+import { temporaryState } from './telegramOriginStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const privateKey = generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+/** Real runtime, durable worker and owner authority; only the remote Bot API is
+ * a fixture. Callers own runtime.close and restoring the fetch stub/spies. */
+export async function lateCapacityHarness(workerUrl: URL) {
+  const stateDir = temporaryState(), token = `123:${randomUUID()}`;
+  let lifecycle: OriginSessionLifecycle | undefined;
+  const runtime = await TelegramOriginRuntime.open({ storage: { stateDir, agentId: 'echo' }, workerUrl,
+    identity: { agentId: 'echo', agentName: 'Echo', originMachineId: 'studio', originMachineName: 'Studio' },
+    signingKey: { privateKey, keyId: 'studio-1', keyEpoch: 1 },
+    bot: { token, accountId: '123', chatId: '-100123' },
+    isSessionLive: () => true, attachSessionLifecycle: value => { lifecycle = value; },
+    display: () => ({}), authorize: () => true, diagnoseUnknown: async () => undefined,
+    alertDestinations: () => [], getAlertPolicy: () => null, onNoticeState: () => undefined });
+  const sessionToken = await lifecycle!.issue({ sessionId: 'capacity-session', harnessId: 'codex-cli',
+    projectDir: process.cwd(), configuredModel: 'fixture-model' });
+  runtime.attachSendPolicy({ review: async () => ({ ok: true }), authorizeDispatch: () => ({ ok: true }),
+    ...fixtureOriginContentDedup(stateDir) });
+  const network = vi.fn(async (_url: string, init: RequestInit) => {
+    init.signal?.throwIfAborted();
+    const body = JSON.parse(init.body as string);
+    return new Response(JSON.stringify({ ok: true, result: { message_id: 91,
+      chat: { id: -100123 }, message_thread_id: body.message_thread_id } }));
+  });
+  vi.stubGlobal('fetch', network);
+  const send = () => runtime.service.runWithSessionToken(sessionToken,
+    () => telegramFetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST', body: JSON.stringify({ chat_id: '-100123', message_thread_id: 42,
+        text: 'The requested capacity report.' }), networkTimeoutMs: 15_000 }));
+  const close = async () => {
+    await runtime.close();
+    await SafeFsExecutor.safeRm(stateDir, { recursive: true, force: true, operation: 'test:late-capacity:cleanup' });
+  };
+  return { runtime, network, send, stateDir, token, sessionToken, close };
+}

--- a/tests/helpers/telegramLateCapacityHttp.ts
+++ b/tests/helpers/telegramLateCapacityHttp.ts
@@ -1,0 +1,64 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import express from 'express';
+import { vi } from 'vitest';
+import { bootTelegramOrigin } from '../../src/messaging/telegram-origin/TelegramOriginBoot.js';
+import type { OriginSessionLifecycle } from '../../src/messaging/telegram-origin/OriginSessionRegistry.js';
+import { originCapacityClient } from '../../src/messaging/telegram-origin/OriginNoticeIpc.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { createRoutes } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { waitForOriginDisplayReady } from './telegramOriginReady.js';
+
+/** Production Boot + real adapter/reply HTTP route. IPC mode uses the actual
+ * socket/client against Boot's owner; it does not claim a second process boot. */
+export async function lateCapacityHttpHarness(workerUrl: URL, useIpc: boolean) {
+  const root = await mkdtemp('/tmp/lcap-'), stateDir = path.join(root, '.instar');
+  await mkdir(path.join(stateDir, 'state'), { recursive: true });
+  const token = '123:late-capacity-fixture';
+  const config = { projectDir: root, stateDir, projectName: 'echo', port: 0, authToken: 'agent-test',
+    messaging: [{ type: 'telegram', enabled: true, config: { token, chatId: '-100123', lifelineTopicId: 7848 } }] };
+  await writeFile(path.join(stateDir, 'config.json'), JSON.stringify(config));
+  let boot: Awaited<ReturnType<typeof bootTelegramOrigin>>;
+  let adapter: TelegramAdapter, app: express.Express, sessionToken: string;
+  let ownsLease = true, generation = 0, messageId = 120;
+  const nativeFetch = globalThis.fetch;
+  const network = vi.fn(async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string);
+    return new Response(JSON.stringify({ ok: true, result: { message_id: ++messageId,
+      chat: { id: -100123 }, message_thread_id: body.message_thread_id } }));
+  });
+  vi.stubGlobal('fetch', (url: string, init: RequestInit) => String(url).startsWith('https://api.telegram.org/')
+    ? network(url, init) : nativeFetch(url, init));
+  const start = async () => {
+    let lifecycle: OriginSessionLifecycle | undefined;
+    boot = await bootTelegramOrigin({ config: config as never, token, noticeOwner: true,
+      workerUrl, holdsLease: () => ownsLease, isSessionLive: () => true,
+      attachSessionLifecycle: value => { lifecycle = value; },
+      diagnoseUnknown: async () => undefined, onNoticeState: () => undefined });
+    if (useIpc) {
+      const socketPath = boot.runtime.options.noticeProcess?.socketPath;
+      if (!socketPath) throw new Error('actual Boot capacity socket was not wired');
+      boot.runtime.service.options.capacity = originCapacityClient(socketPath);
+    }
+    adapter = new TelegramAdapter({ token, chatId: '-100123' }, stateDir, { suppressLifelineAutoCreate: true });
+    app = express(); app.use(express.json());
+    app.use((req, res, next) => { if (req.get('Authorization') !== 'Bearer agent-test') { res.sendStatus(401); return; } next(); });
+    app.use(createRoutes({ config, telegramOrigin: boot.runtime, telegram: adapter,
+      messagingToneGate: { review: async () => ({ pass: true, latencyMs: 0 }) },
+      sessionManager: { clearInjectionTracker: () => undefined } } as never));
+    await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
+    sessionToken = await lifecycle!.issue({ sessionId: `http-capacity-${++generation}`, harnessId: 'codex-cli',
+      projectDir: root, configuredModel: 'fixture-model' });
+  };
+  const close = async () => {
+    await adapter?.stop(); await boot?.close();
+    await SafeFsExecutor.safeRm(root, { recursive: true, force: true, operation: 'test:late-capacity-http:cleanup' });
+  };
+  try { await start(); } catch (error) { await close(); throw error; }
+  return {
+    get app() { return app; }, get runtime() { return boot.runtime; }, get sessionToken() { return sessionToken; },
+    network, close, revokeLease: () => { ownsLease = false; },
+    restart: async () => { await adapter.stop(); await boot.close(); await start(); },
+  };
+}

--- a/tests/integration/telegram-origin-late-capacity.test.ts
+++ b/tests/integration/telegram-origin-late-capacity.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { setTimeout as delay } from 'node:timers/promises';
+import request from 'supertest';
+import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { lateCapacityHttpHarness } from '../helpers/telegramLateCapacityHttp.js';
+
+let worker: URL;
+const closes: Array<() => Promise<void>> = [];
+beforeAll(async () => { worker = await compileOriginWorker(); });
+afterEach(async () => { for (const close of closes.splice(0).reverse()) await close(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+describe('late capacity through authenticated reply HTTP and owner IPC', () => {
+  it.each(['claim', 'markDispatched'] as const)('accepts after delayed %s using a fresh real IPC grant', async method => {
+    const h = await lateCapacityHttpHarness(worker, true); closes.push(h.close);
+    const capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve'), consume = vi.spyOn(capacity, 'consume');
+    if (method === 'claim') {
+      const original = h.runtime.store.claim.bind(h.runtime.store);
+      vi.spyOn(h.runtime.store, 'claim').mockImplementation(async input => {
+        const result = await original(input); await delay(300); return result;
+      });
+    } else {
+      const original = h.runtime.store.markDispatched.bind(h.runtime.store);
+      vi.spyOn(h.runtime.store, 'markDispatched').mockImplementation(async input => {
+        const result = await original(input); await delay(300); return result;
+      });
+    }
+    const response = await request(h.app).post('/telegram/reply/42')
+      .set('Authorization', 'Bearer agent-test').set('X-Instar-Origin-Session', h.sessionToken)
+      .send({ text: 'The requested report is ready after storage completed.' });
+    expect(response.status).toBe(200);
+    expect(reserve).toHaveBeenCalledTimes(1); expect(consume).toHaveBeenCalledTimes(1);
+    expect(h.network).toHaveBeenCalledTimes(1);
+    const row = (await h.runtime.store.listOrigins()).records[0];
+    expect(row.operation?.state).toBe('accepted'); expect(row.attempts).toHaveLength(1);
+    expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'accepted' });
+  });
+
+  it('keeps the real lease refusal ahead of capacity and network', async () => {
+    const h = await lateCapacityHttpHarness(worker, true); closes.push(h.close);
+    const reserve = vi.spyOn(h.runtime.service.options.capacity!, 'reserve'); h.revokeLease();
+    const response = await request(h.app).post('/telegram/reply/42')
+      .set('Authorization', 'Bearer agent-test').set('X-Instar-Origin-Session', h.sessionToken)
+      .send({ text: 'The report must wait for its current owner.' });
+    expect(response.status).toBe(409); expect(reserve).not.toHaveBeenCalled();
+    expect(h.network).not.toHaveBeenCalled();
+  });
+
+  it('refuses a lease revoked after durable dispatch without consuming capacity or calling the network', async () => {
+    const h = await lateCapacityHttpHarness(worker, true); closes.push(h.close);
+    const capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve'), consume = vi.spyOn(capacity, 'consume');
+    const mark = h.runtime.store.markDispatched.bind(h.runtime.store);
+    vi.spyOn(h.runtime.store, 'markDispatched').mockImplementation(async input => {
+      const result = await mark(input); h.revokeLease(); return result;
+    });
+    const response = await request(h.app).post('/telegram/reply/42')
+      .set('Authorization', 'Bearer agent-test').set('X-Instar-Origin-Session', h.sessionToken)
+      .send({ text: 'The report must wait because ownership changed during dispatch.' });
+    expect(response.status).toBe(409);
+    expect(reserve).toHaveBeenCalledTimes(1); expect(consume).not.toHaveBeenCalled();
+    expect(h.network).not.toHaveBeenCalled();
+    const row = (await h.runtime.store.listOrigins()).records[0];
+    expect(row.attempts).toHaveLength(1);
+    expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'known-failed' });
+  });
+
+});

--- a/tests/integration/telegram-origin-routes.test.ts
+++ b/tests/integration/telegram-origin-routes.test.ts
@@ -350,7 +350,8 @@ describe('Telegram origin through the complete reply HTTP pipeline', () => {
     expect(recovered[0].attempts[1]).toMatchObject({ phase: 'dispatched', outcome: 'accepted' });
     expect(recovered[0].children[0].state).toBe('accepted');
     } finally { await close(); }
-  });
+  // This exercises the real 30-second retry backoff; test:push defaults to 10 seconds.
+  }, 45_000);
   it('reuses an actual local review once and never treats caller proxy flags as a prepared-send exemption', async () => {
     const review = vi.fn(async (_text: string) => ({ pass: true, latencyMs: 1 }));
     const h = await appHarness({ messagingToneGate: { review } });

--- a/tests/integration/telegram-origin-routes.test.ts
+++ b/tests/integration/telegram-origin-routes.test.ts
@@ -310,7 +310,7 @@ describe('Telegram origin through the complete reply HTTP pipeline', () => {
       .set('X-Instar-Origin-Session', h.sessionToken)).status).toBe(403);
     expect(h.network).not.toHaveBeenCalled();
   });
-  it('holds before claiming when the credential owner has spent its shared capacity, then recovers the same operation', async () => {
+  it('charges a capacity refusal after dispatch, then recovers the same operation within its original bounds', async () => {
     const h = await appHarness();
     const socketPath = path.join(h.runtime.options.storage.stateDir, 'test-capacity.sock');
     const close = await listenOriginNotices(socketPath, h.runtime.notifier, () => [], h.runtime.capacity);
@@ -319,13 +319,35 @@ describe('Telegram origin through the complete reply HTTP pipeline', () => {
     for (let i = 0; i < 10; i++) expect(await h.runtime.capacity.reserve('bot-1')).not.toBeNull();
     const response = await request(h.app).post('/telegram/reply/42').set('Authorization', 'Bearer agent-test')
       .set('X-Instar-Origin-Session', h.sessionToken).send({ text: 'Here is the result you requested.' });
-    expect(response.status).toBeGreaterThanOrEqual(400); expect(h.network).not.toHaveBeenCalled();
+    expect(response.status).toBe(409); expect(h.network).not.toHaveBeenCalled();
     const rows = (await h.runtime.store.listOrigins()).records;
-    expect(rows).toHaveLength(1); expect(rows[0].attempts).toHaveLength(0); expect(rows[0].children[0].state).toBe('queued');
+    expect(rows).toHaveLength(1); expect(rows[0].attempts).toHaveLength(1);
+    expect(rows[0].attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'known-failed', reason: 'credential-capacity-unavailable' });
+    expect(rows[0].children[0].state).toBe('queued');
+    expect(rows[0].operation?.operationId).toEqual(expect.any(String));
+    expect(rows[0].operation?.operationId).not.toBe('');
+    expect(rows[0].operation?.maxAttempts).toBe(9);
+    expect(rows[0].children[0].attempts).toBe(1);
+    const retryAt = rows[0].attempts[0].nextAttemptAt!;
+    expect(retryAt).toEqual(expect.any(Number));
+    expect(retryAt).toBeGreaterThan(rows[0].attempts[0].resolvedAt!);
     await new Promise(resolve => setTimeout(resolve, 1251));
+    // Free capacity does not erase the charged failure's existing retry backoff.
+    expect(await h.runtime.recoverHeld()).toEqual({ processed: 0, recovered: 0 });
+    expect(h.network).not.toHaveBeenCalled();
+    expect(await h.runtime.store.reserveRecoveryAttempt({ operationId: rows[0].operation!.operationId, now: retryAt - 1 })).toBe(false);
+    await new Promise(resolve => setTimeout(resolve, Math.max(0, retryAt - Date.now()) + 10));
     expect((await h.runtime.recoverHeld()).recovered).toBe(1); expect(h.network).toHaveBeenCalledOnce();
     const recovered = (await h.runtime.store.listOrigins()).records;
-    expect(recovered).toHaveLength(1); expect(recovered[0].record.operationId).toBe(rows[0].record.operationId);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].operation?.operationId).toBe(rows[0].operation!.operationId);
+    expect(recovered[0].record.originId).toBe(rows[0].record.originId);
+    expect(recovered[0].operation?.deadlineAt).toBe(rows[0].operation!.deadlineAt);
+    expect(recovered[0].operation?.maxAttempts).toBe(rows[0].operation!.maxAttempts);
+    expect(recovered[0].attempts).toHaveLength(2);
+    expect(recovered[0].children[0].attempts).toBe(2);
+    expect(recovered[0].attempts[0]).toEqual(rows[0].attempts[0]);
+    expect(recovered[0].attempts[1]).toMatchObject({ phase: 'dispatched', outcome: 'accepted' });
     expect(recovered[0].children[0].state).toBe('accepted');
     } finally { await close(); }
   });

--- a/tests/integration/telegram-reply-origin-migration.test.ts
+++ b/tests/integration/telegram-reply-origin-migration.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
-import { telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginRecoveryAwareness } from '../../src/messaging/telegram-origin/OriginAwareness.js';
+import { telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginRecoveryAwareness, telegramOriginCapacityAwareness } from '../../src/messaging/telegram-origin/OriginAwareness.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const prior = fs.readFileSync('tests/fixtures/relay-history/telegram-reply-pre-origin.sh', 'utf8');
@@ -84,6 +84,7 @@ describe('origin relay installed-upgrade parity', () => {
     expect(first).toContain(telegramOriginCertificationAwareness());
     expect(first).toContain(telegramOriginLeaseAwareness());
     expect(first).toContain(telegramOriginRecoveryAwareness());
+    expect(first).toContain(telegramOriginCapacityAwareness());
     expect(first).toContain('messageOrigin.outageNotice.enabled');
     expect(first).toContain('Operator note: preserve this workflow.');
     const second = migrate();
@@ -92,13 +93,16 @@ describe('origin relay installed-upgrade parity', () => {
     expect(second.split('Message origins on your phone:')).toHaveLength(2);
     expect(second.split('Queued-message review pacing:')).toHaveLength(2);
     expect(second.split('Telegram send deadlines:')).toHaveLength(2);
+    expect(second.split('Telegram capacity checks:')).toHaveLength(2);
     expect(second).toBe(first);
     for (const shadow of shadows) {
       const content = fs.readFileSync(shadow, 'utf8');
       expect(content).toContain('Operator shadow note.');
       expect(content).toContain(telegramOriginRecoveryAwareness());
+      expect(content).toContain(telegramOriginCapacityAwareness());
       expect(content.split('Queued-message review pacing:')).toHaveLength(2);
       expect(content.split('Telegram send deadlines:')).toHaveLength(2);
+      expect(content.split('Telegram capacity checks:')).toHaveLength(2);
       expect(content).toContain('messageOrigin.outageNotice.enabled');
       expect(content.split('Origin rollout certification:')).toHaveLength(2);
       expect(content.split('Origin lease renewal dependency:')).toHaveLength(2);

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -246,6 +246,7 @@ describe('Feature Delivery Completeness', () => {
       ['Origin detector health:', 'telegramOriginDetectorAwareness'],
       ['Queued-message review pacing:', 'telegramOriginRecoveryAwareness'],
       ['Telegram send deadlines:', 'telegramOriginTransportAwareness'],
+      ['Telegram capacity checks:', 'telegramOriginCapacityAwareness'],
     ];
     for (const [phrase, builder] of featureAddenda) {
       it(`origin addendum "${phrase}" reaches new and existing framework instructions`, () => {

--- a/tests/unit/telegram-origin/late-capacity.test.ts
+++ b/tests/unit/telegram-origin/late-capacity.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { setTimeout as delay } from 'node:timers/promises';
+import type { OriginBotTransport } from '../../../src/messaging/telegram-origin/TelegramOriginService.js';
+import { OriginCapacityUnavailable } from '../../../src/messaging/telegram-origin/OriginEgressCapacity.js';
+import { compileOriginWorker } from '../../helpers/telegramOriginStore.js';
+import { lateCapacityHarness } from '../../helpers/telegramLateCapacity.js';
+
+let worker: URL;
+const closes: Array<() => Promise<void>> = [];
+beforeAll(async () => { worker = await compileOriginWorker(); });
+afterEach(async () => {
+  for (const close of closes.splice(0)) await close();
+  vi.restoreAllMocks(); vi.unstubAllGlobals();
+});
+async function harness() {
+  const h = await lateCapacityHarness(worker); closes.push(h.close); return h;
+}
+
+describe('ordinary capacity acquired at the network boundary', () => {
+  it.each(['claim', 'markDispatched'] as const)('excludes delayed durable %s response from the short grant lifetime', async method => {
+    const h = await harness(), capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve'), consume = vi.spyOn(capacity, 'consume');
+    if (method === 'claim') {
+      const original = h.runtime.store.claim.bind(h.runtime.store);
+      vi.spyOn(h.runtime.store, 'claim').mockImplementation(async input => {
+        const claimed = await original(input); await delay(300); return claimed;
+      });
+    } else {
+      const original = h.runtime.store.markDispatched.bind(h.runtime.store);
+      vi.spyOn(h.runtime.store, 'markDispatched').mockImplementation(async input => {
+        const marked = await original(input); await delay(300); return marked;
+      });
+    }
+    expect((await h.send()).ok).toBe(true);
+    expect(reserve).toHaveBeenCalledTimes(1); expect(consume).toHaveBeenCalledTimes(1);
+    expect(h.network).toHaveBeenCalledTimes(1);
+    const row = (await h.runtime.store.listOrigins()).records[0];
+    expect(row.operation?.state).toBe('accepted');
+    expect(row.attempts).toHaveLength(1);
+    expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'accepted' });
+    expect(row.operation?.operationId).toBe(JSON.parse(row.record.envelopeJson).operationId);
+  });
+
+  it('does not acquire capacity when durable dispatch marking refuses', async () => {
+    const h = await harness(), capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve'), consume = vi.spyOn(capacity, 'consume');
+    vi.spyOn(h.runtime.store, 'markDispatched').mockResolvedValue(false);
+    await expect(h.send()).rejects.toMatchObject({ reason: 'stale-dispatch-fence' });
+    expect(reserve).not.toHaveBeenCalled(); expect(consume).not.toHaveBeenCalled();
+    expect(h.network).not.toHaveBeenCalled();
+  });
+
+  it('charges unavailable capacity after durable intent without invoking network', async () => {
+    const h = await harness(), capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve').mockResolvedValue(null);
+    const consume = vi.spyOn(capacity, 'consume');
+    await expect(h.send()).rejects.toMatchObject({ reason: 'credential-capacity-unavailable' });
+    expect(reserve).toHaveBeenCalledTimes(1); expect(consume).not.toHaveBeenCalled();
+    expect(h.network).not.toHaveBeenCalled();
+    const row = (await h.runtime.store.listOrigins()).records[0];
+    expect(row.attempts).toHaveLength(1);
+    expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'known-failed',
+      reason: 'credential-capacity-unavailable' });
+    expect(row.children[0].state).toBe('queued');
+    expect(row.operation?.maxAttempts).toBe(9);
+  });
+
+  it('reserves only after the real store confirms dispatch intent', async () => {
+    const h = await harness(), capacity = h.runtime.service.options.capacity!;
+    const original = capacity.reserve.bind(capacity);
+    vi.spyOn(capacity, 'reserve').mockImplementation(async account => {
+      const row = (await h.runtime.store.listOrigins()).records[0];
+      expect(row.attempts).toHaveLength(1);
+      expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: null });
+      return original(account);
+    });
+    expect((await h.send()).ok).toBe(true);
+  });
+
+  it('holds a missing capacity dependency before taking a durable claim', async () => {
+    const h = await harness(); h.runtime.service.options.capacity = undefined;
+    const claim = vi.spyOn(h.runtime.store, 'claim');
+    await expect(h.send()).rejects.toMatchObject({ reason: 'credential-capacity-unavailable' });
+    expect(claim).not.toHaveBeenCalled(); expect(h.network).not.toHaveBeenCalled();
+    expect((await h.runtime.store.listOrigins()).records[0].attempts).toEqual([]);
+  });
+
+  it.each(['refused', 'expired-response'] as const)('keeps %s consumption provably unsent and charged, without renewal', async mode => {
+    const h = await harness(), capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve');
+    const original = capacity.consume.bind(capacity);
+    const consume = vi.spyOn(capacity, 'consume').mockImplementation(async grant => {
+      if (mode === 'refused') return false;
+      const consumed = await original(grant); await delay(300); return consumed;
+    });
+    await expect(h.send()).rejects.toMatchObject({ reason: 'credential-capacity-unavailable' });
+    expect(reserve).toHaveBeenCalledTimes(1); expect(consume).toHaveBeenCalledTimes(1);
+    expect(h.network).not.toHaveBeenCalled();
+    const row = (await h.runtime.store.listOrigins()).records[0];
+    expect(row.attempts).toHaveLength(1);
+    expect(row.attempts[0]).toMatchObject({ phase: 'dispatched', outcome: 'known-failed',
+      reason: 'credential-capacity-unavailable' });
+    expect(row.children[0].state).toBe('queued');
+  });
+
+  it('latches before reserve so concurrent and repeated closure calls cannot acquire another grant', async () => {
+    const h = await harness(), capacity = h.runtime.service.options.capacity!;
+    const reserve = vi.spyOn(capacity, 'reserve'), consume = vi.spyOn(capacity, 'consume');
+    type Prepared = Awaited<ReturnType<NonNullable<OriginBotTransport['prepare']>>>;
+    let prepared: Prepared | undefined;
+    const execute = h.runtime.service.executePreparedBot.bind(h.runtime.service);
+    vi.spyOn(h.runtime.service, 'executePreparedBot').mockImplementation(async (operation, network) => {
+      const prepare = network.prepare!;
+      network.prepare = async request => {
+        prepared = await prepare(request);
+        const original = prepared;
+        return { ...original, send: async () => {
+          const outcomes = await Promise.allSettled([original.send(), original.send()]);
+          expect(outcomes[0].status).toBe('fulfilled');
+          expect(outcomes[1]).toMatchObject({ status: 'rejected', reason: expect.any(OriginCapacityUnavailable) });
+          if (outcomes[0].status === 'rejected') throw outcomes[0].reason;
+          return outcomes[0].value;
+        } };
+      };
+      return execute(operation, network);
+    });
+    expect((await h.send()).ok).toBe(true);
+    await expect(prepared!.send()).rejects.toBeInstanceOf(OriginCapacityUnavailable);
+    expect(reserve).toHaveBeenCalledTimes(1); expect(consume).toHaveBeenCalledTimes(1);
+    expect(h.network).toHaveBeenCalledTimes(1);
+  });
+});

--- a/upgrades/next/telegram-late-capacity.md
+++ b/upgrades/next/telegram-late-capacity.md
@@ -3,7 +3,7 @@
 
 Ordinary Telegram sends now acquire the credential owner's short-lived capacity after durable dispatch recording, immediately before the network call. Previously, slow recording could use up the grant's lifetime before the request reached Telegram.
 
-The shared rate limit, lease checks, single-use grants and original recovery bounds remain in force. A capacity refusal at this later point counts as a known failed attempt on the existing message. Persistent saturation can exhaust that message's attempt budget without a network call.
+The shared rate limit, lease checks, single-use grants and original recovery bounds remain in force. A capacity refusal at this later point counts as a known failed attempt on the existing message and retains the existing retry delay. Persistent saturation can exhaust that message's attempt budget without a network call.
 
 ## What to Tell Your User
 

--- a/upgrades/next/telegram-late-capacity.md
+++ b/upgrades/next/telegram-late-capacity.md
@@ -1,0 +1,14 @@
+<!-- bump: patch -->
+## What Changed
+
+Ordinary Telegram sends now acquire the credential owner's short-lived capacity after durable dispatch recording, immediately before the network call. Previously, slow recording could use up the grant's lifetime before the request reached Telegram.
+
+The shared rate limit, lease checks, single-use grants and original recovery bounds remain in force. A capacity refusal at this later point counts as a known failed attempt on the existing message. Persistent saturation can exhaust that message's attempt budget without a network call.
+
+## What to Tell Your User
+
+Slow message recording could make a send permission expire before Instar used it. This patch requests that permission after recording finishes. A held message still needs capacity from its current owner; queued custody does not guarantee delivery.
+
+## Summary of New Capabilities
+
+This repairs existing delivery timing and needs no new setting. Existing agents receive the updated explanation during migration. Do not recreate held messages to bypass their recovery limits.

--- a/upgrades/side-effects/telegram-late-capacity.md
+++ b/upgrades/side-effects/telegram-late-capacity.md
@@ -115,3 +115,22 @@ Boot restart. Build and lint passed. Full test:all and CI remain required
 before this repair's separate release. Class closure unbounded-self-action is n/a:
 this repair adds no automatic retry or autonomous actuation controller and claims
 no generic convergence coverage.
+
+### Existing HTTP capacity compatibility
+
+A later compatibility audit found the pre-existing reply-route test still expected
+zero attempts when shared capacity was exhausted. A focused run failed exactly on
+that obsolete expectation (one attempt was recorded). The updated test preserves
+the actual HTTP/IPC path and requires409, no wire call, one dispatched known-failed
+attempt, and subsequent acceptance on the same nonempty canonical operation ID.
+It also preserves the original deadline and maximum attempts, retains the first
+attempt unchanged and requires a second accepted attempt. The generic service
+contract for other transports that invalidate before dispatch remains unchanged
+and keeps its existing tests. A five-file compatibility run passed87 cases and
+failed this case because its earlier1251ms wait ignored the existing30-second
+known-failure backoff. The corrected case passed separately (one passed,25 skipped):
+free capacity alone cannot trigger recovery, a reservation before the persisted
+retry time is refused, and recovery succeeds after a real wait until that time.
+The charged child count advances from one to two. This is not a claim that a fresh
+combined88-case run passed. No production source change, delay reduction, or
+additional recovery permission is introduced; full validation remains pending.

--- a/upgrades/side-effects/telegram-late-capacity.md
+++ b/upgrades/side-effects/telegram-late-capacity.md
@@ -1,0 +1,117 @@
+# Side-effects review: late ordinary Telegram capacity
+
+**Author:** Echo
+**Independent reviewer:** Hooke; design, implementation, corrected coverage and artifact concurred.
+
+## Scope and governing contract
+
+Justin authorized remaining delivery repairs in topic69507. This independent
+repair starts at deadline candidate7e2eb5900, which includes releasedv1.3.1233's
+permanent model correction. The deadline repair must ship separately first.
+Governing approved contract: [Telegram message origin](../../docs/specs/telegram-message-origin.md),
+particularly N10 shared capacity and the original admission, charged-attempt,
+deadline and uncertain-outcome rules.
+
+A real claim or markDispatched call whose response takes more than250ms reproduced
+the old pre-network capacity expiry. Live operation50b9019b-fb9c-41e1-b51a-478b9381a47e
+also recorded a capacity refusal, then was accepted by its original recovery.
+Its224ms claim-to-result interval does not include reservation time and does not
+prove the live refusal was expiry. IPC, ownership and capacity refusals still share
+the existing reason; better stage diagnostics remain separate work.
+<!-- tracked: topic-69507 -->
+
+## Decision points
+
+- Grant acquisition moves after durable dispatch intent and final origin/policy checks.
+- Prepared closure availability remains single-use and latches before any await.
+- Actual owner reservation, consumption, expiry and lease checks remain authoritative.
+- Known pre-network refusal remains charged; native-fetch uncertainty remains held.
+
+## 1. Over-block
+
+The new grant can still expire during reserve/consume IPC. It refuses rather than
+renewing or refunding capacity. Saturation, which previously held before a claim,
+now produces a charged known-failed attempt after dispatch intent. Sustained
+saturation can exhaust the existing nine transport attempts without a wire call.
+This tradeoff is explicit: never erase durable dispatch intent or reset the
+original operation to make the refusal look uncharged. Missing capacity DI still
+holds before claim. The original six-hour default deadline and fifteen-minute
+review pacing remain unchanged.
+
+## 2. Under-block
+
+Only one reserve and consume can occur per prepared closure, including concurrent
+calls. A failed durable mark never reserves; rejected or expired consumption never
+calls the network. The parent deadline change demotes proof-shaped errors emitted
+after native fetch, so a recycled capacity or cancellation error cannot authorize
+replay. No authorization predicate, rate constant or IPC method is changed.
+
+## 3. Abstraction fit
+
+The existing prepared transport owns the last synchronous callback before network
+invocation. Acquiring there avoids spending the short grant on unrelated durable
+storage latency. No second capacity owner, renewed grant or recovery controller is
+introduced. The actual owner retains the1250ms debit window and startup quiet
+period that account for the250ms grant lifetime.
+
+## 4. Signal versus authority
+
+A delayed real durable response demonstrates the source ordering defect; it does
+not establish fleet frequency. Tests delegate to the actual SQLite worker,
+credential owner, HTTP route and Boot initialization. The IPC fixture connects to
+the actual Boot socket in the same process; it is not a claim of a second-process
+Lifeline lifecycle. Fixture Telegram receipts are the only substituted network
+service. See [signal versus authority](../../docs/signal-vs-authority.md).
+
+## 4b. Judgment points
+
+No new model call, heuristic or policy decision is introduced. Existing policy
+and owner checks retain their meaning and can hold a send.
+
+## 5. Interactions
+
+Fixed outage notices keep their separate reserved-notice lifecycle and share the
+unchanged owner with ordinary sends. Existing grant/debit-window tests cover
+ordinary/notice sharing and replacement-owner quiet time; this repair does not
+claim a new mixed native-wire timestamp proof. Compatibility includes notice
+expiry, outage queue drain, cancellation, recovery pacing and uncertain receipts.
+
+## 6. External surfaces and migration
+
+No endpoint, config or IPC schema change. The agent awareness builder feeds
+scaffold generation; idempotent migration adds the new paragraph to existing
+CLAUDE.md, AGENTS.md and GEMINI.md even when older origin text is already present.
+No custom text is replaced. Source changes reach existing server and Lifeline
+processes through normal update and process activation; merely installing a
+package does not prove an older running Lifeline loaded it.
+
+## 6b. Operator surface
+
+No new approval or control. The upgrade guide explains the timing repair and
+charged-attempt tradeoff. Retained operations must not be copied or replayed as
+new messages to work around a hold.
+
+## 7. Multi-machine posture
+
+The current lease owner remains the only capacity authority. Standby, revoked
+lease and replacement-owner checks continue to fence sends. No session token is
+forwarded to a peer, and no direct standby bypass is added.
+
+## 8. Rollback
+
+Revert this repair and publish a patch; no durable data migration or queue clearing
+is needed. Reverting restores the reproduced early-grant expiry behavior.
+
+## Evidence and review
+
+Four real-path regression cases failed against unchanged production source.
+The minimal fix passed26 targeted tests across four files. Expanded unit, real
+HTTP/IPC, Boot restart lifecycle and migration/completeness checks passed170 tests
+across five files. Review required moving older expiry fixtures to the new
+reserve/consume boundary and adding lease revocation after dispatch; that
+compatibility run passed all72 tests across ten files, including both expiry
+cases, late lease revocation, uncertain outcomes, recovery pacing and the real
+Boot restart. Build and lint passed. Full test:all and CI remain required
+before this repair's separate release. Class closure unbounded-self-action is n/a:
+this repair adds no automatic retry or autonomous actuation controller and claims
+no generic convergence coverage.


### PR DESCRIPTION
Ordinary Telegram sends could spend a 250ms capacity grant while awaiting durable claim or dispatch recording. Acquire and consume the existing owner's single-use grant after those steps, immediately before network invocation. The prepared closure latches before awaiting capacity, so concurrent calls cannot obtain extra grants.

## ELI16

Instar records a message before sending it. Previously, a short-lived permission to send could expire while that recording was still finishing. This change asks for permission after recording is complete. If capacity is unavailable then, the failed attempt counts against the original message's limit. Instar still refuses to send without its current owner's permission.

## Validation

- The prior candidate `6853576f` passed the full local suite: 51,840 aggregate tests, 4,188 integration tests and 3,233 end-to-end tests, with zero failures. All 5,380 frozen fingerprints were verified.
- Both capacity commits were replayed unchanged onto released main `91ac6278` (v1.3.1234). Production source is unchanged; inherited deadline diagnostics affect two test files. The build regenerates its manifest and version-stamped standards metadata; reversing only the version/digest fields reproduces the prior standards asset hashes exactly.
- Rebased candidate `3a9cf6e21` passed build and all 239 focused tests across eight files through `npm test`, including both changed diagnostic files, real capacity IPC, authenticated HTTP, restart, original recovery backoff and migration. Its CI exposed a test configuration mismatch on both Node versions: the real 30-second backoff case inherited the push suite's 10-second timeout.
- Current head `1471148d8` changes only that case's explicit timeout to 45 seconds, retaining every assertion and all production code. It passes under the actual `test:push` configuration (31.48 seconds for the case). Independent review concurs; all 5,380 source fingerprints differ only in that test file. CI on this head is required before release.
- Independent implementation and portability reviews concurred. Earlier focused runs and complete full-run evidence remain recorded; their results are not relabeled as a full run on the rebased head.

## Tradeoff and scope

Sustained capacity refusal can exhaust the original attempt limit without a network call. No grant renewal, refund, TTL, shared rate window, IPC method or retry controller changes. Existing grant/debit-window tests support the rate claim; this is not a new mixed native-wire timestamp proof. The socket fixture runs both ends in one process. Running Lifeline must load the new package during activation.

This repair is stacked on the separately released deadline repair; it must retain its own release. Artifacts: upgrades/next/telegram-late-capacity.md and upgrades/side-effects/telegram-late-capacity.md.
