### PR TITLE
fix(telegram): preserve dashboard posts when edits are held

### DIFF
--- a/.instar/instar-dev-decisions/2026-09-10T20-25-10-696Z-telegram-dashboard-edit-rejection.json
+++ b/.instar/instar-dev-decisions/2026-09-10T20-25-10-696Z-telegram-dashboard-edit-rejection.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-09-10T20:25:10.696Z",
+  "slug": "telegram-dashboard-edit-rejection",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter",
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 96,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/TelegramEditRejection.ts",
+      "src/messaging/telegram-origin/OriginAwareness.ts",
+      "src/messaging/telegram-origin/TelegramOriginService.ts",
+      "src/scaffold/templates.ts"
+    ],
+    "addedLines": 84,
+    "deletedLines": 12
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "Removes an exception-driven extra send from one invocation; introduces no autonomous retry controller and claims no broader wake-loop or cross-invocation replacement-custody closure."
+  },
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -22,7 +22,7 @@ import { originToolGuardHook } from '../messaging/telegram-origin/OriginToolGuar
  */
 
 import fs from 'node:fs';
-import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, telegramOriginTransportAwareness, telegramOriginCapacityAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
+import { telegramOriginAwareness, telegramOriginNoticeAwareness, telegramOriginCertificationAwareness, telegramOriginLeaseAwareness, telegramOriginDashboardAwareness, telegramOriginDetectorAwareness, telegramOriginRecoveryAwareness, telegramOriginTransportAwareness, telegramOriginCapacityAwareness, telegramDashboardEditAwareness, refreshOriginCanaryStartupAwareness } from '../messaging/telegram-origin/OriginAwareness.js';
 import { migrateTelegramOriginDisplay } from '../messaging/telegram-origin/OriginConfig.js';
 import path from 'node:path';
 import os from 'node:os';
@@ -6262,6 +6262,12 @@ setTimeout(() => process.exit(0), 2000);
       result.upgraded.push('CLAUDE.md: added Telegram late capacity awareness');
     }
 
+    if (!content.includes('Dashboard edit rejection:')) {
+      content += '\n' + telegramDashboardEditAwareness();
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added dashboard edit rejection awareness');
+    }
+
     const refreshedOriginCanary = refreshOriginCanaryStartupAwareness(content);
     if (refreshedOriginCanary !== content) {
       content = refreshedOriginCanary;
@@ -10660,6 +10666,7 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
         ['Queued-message review pacing:', telegramOriginRecoveryAwareness],
         ['Telegram send deadlines:', telegramOriginTransportAwareness],
         ['Telegram capacity checks:', telegramOriginCapacityAwareness],
+        ['Dashboard edit rejection:', telegramDashboardEditAwareness],
       ] as const) {
         if (claudeMd.includes(marker) && !appended.includes(marker)) {
           appended = appended.trimEnd() + '\n\n' + render();

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -1,4 +1,5 @@
 import { TelegramOriginHoldError } from './telegram-origin/types.js';
+import { recordTelegramEditRejection, takeTelegramEditRejection } from './TelegramEditRejection.js';
 /**
  * Telegram Messaging Adapter — send/receive messages via Telegram Bot API.
  *
@@ -2020,14 +2021,18 @@ export class TelegramAdapter implements MessagingAdapter {
         console.log(`[telegram] Edited dashboard message ${existingMessageId} in-place`);
         return { edited: true, messageId: existingMessageId, warnings }; // Success — no new message, no unread badge
       } catch (err) {
-        // Edit failed — message was deleted, or content unchanged. Fall through to send new.
-        const errStr = String(err);
-        if (errStr.includes('message is not modified')) {
+        const rejection = takeTelegramEditRejection(err, { method: 'editMessageText',
+          accountId: typeof this.config.token === 'string' ? this.config.token.split(':')[0] : '',
+          params: { chat_id: this.config.chatId, message_id: existingMessageId } });
+        if (rejection === 'not-modified') {
           console.log(`[telegram] Dashboard message unchanged — skipping`);
           return { edited: true, messageId: existingMessageId, warnings };
         }
-        console.log(`[telegram] Dashboard message ${existingMessageId} edit failed, sending new: ${errStr}`);
-        warnings.push(`existing pinned message edit failed: ${errStr}`);
+        // A hold or uncertain edit cannot authorize another operation. Retain
+        // the original error and saved ID; only concrete deletion permits send.
+        if (rejection !== 'message-missing') throw err;
+        console.log(`[telegram] Dashboard message ${existingMessageId} no longer exists; replacing it`);
+        warnings.push('existing pinned message no longer exists');
       }
     }
 
@@ -2063,7 +2068,7 @@ export class TelegramAdapter implements MessagingAdapter {
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       console.error(`[telegram] Failed to broadcast dashboard URL: ${detail}`);
-      throw new Error(`Telegram dashboard broadcast failed: ${detail}`);
+      throw err;
     }
   }
 
@@ -5838,6 +5843,7 @@ export class TelegramAdapter implements MessagingAdapter {
           await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
           return this.apiCall(method, params, retryCount + 1);
         } catch (retryErr) {
+          if (retryErr instanceof TelegramOriginHoldError) throw retryErr;
           if (retryErr instanceof Error && retryErr.message.includes('after')) throw retryErr;
           throw new Error(`Telegram API rate limited ${safeUrl} (429)`);
         }
@@ -5866,7 +5872,13 @@ export class TelegramAdapter implements MessagingAdapter {
         delete retryParams.parse_mode;
         return this.apiCall(method, retryParams, retryCount);
       }
-      throw new Error(`Telegram API error ${safeUrl} (${response.status}): ${text}`);
+      const error = new Error(`Telegram API error ${safeUrl} (${response.status}): ${text}`);
+      let body: unknown;
+      try { body = JSON.parse(text); }
+      catch { throw error; } // Malformed platform responses grant no replacement evidence.
+      throw recordTelegramEditRejection(error, response.status, body, {
+        method, accountId: typeof this.config.token === 'string' ? this.config.token.split(':')[0] : '', params: sendParams.outgoingParams,
+      });
     }
 
     const data = await response.json() as { ok: boolean; result: unknown };

--- a/src/messaging/TelegramEditRejection.ts
+++ b/src/messaging/TelegramEditRejection.ts
@@ -1,0 +1,43 @@
+/** Narrow evidence from the Telegram response boundary, never from error text. */
+type EditRejection = 'message-missing' | 'not-modified';
+interface EditTarget { method: string; accountId: string; params: Record<string, unknown>; }
+interface Evidence { accountId: string; chatId: string; messageId: number; kind: EditRejection; }
+const evidence = new WeakMap<Error, Readonly<Evidence>>();
+
+function target(input: EditTarget): Omit<Evidence, 'kind'> | null {
+  const { chat_id: chatId, message_id: messageId } = input.params;
+  if (input.method !== 'editMessageText' || !/^\d+$/.test(input.accountId) ||
+    !((typeof chatId === 'string' && /^-?\d+$/.test(chatId)) ||
+      (typeof chatId === 'number' && Number.isSafeInteger(chatId))) ||
+    typeof messageId !== 'number' || !Number.isSafeInteger(messageId) || messageId <= 0) return null;
+  return { accountId: input.accountId, chatId: String(chatId), messageId };
+}
+
+/**
+ * Only call with an actual Telegram response. Managed sends must first persist
+ * the known-failed outcome. Keep the SAME error, including its origin operation.
+ * Evidence stays local to this error object; serialization grants no authority.
+ */
+export function recordTelegramEditRejection<T extends Error>(error: T, status: number,
+  body: unknown, input: EditTarget): T {
+  const bound = target(input);
+  if (!bound || status !== 400 || !body || typeof body !== 'object') return error;
+  const reply = body as Record<string, unknown>;
+  if (reply.ok !== false || reply.error_code !== 400) return error;
+  let kind: EditRejection;
+  if (reply.description === 'Bad Request: message to edit not found') kind = 'message-missing';
+  else if (reply.description === 'Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message') kind = 'not-modified';
+  else return error;
+  evidence.set(error, Object.freeze({ ...bound, kind }));
+  return error;
+}
+
+/** Consume once, only for the account/chat/message whose edit was rejected. */
+export function takeTelegramEditRejection(error: unknown, input: EditTarget): EditRejection | null {
+  if (!(error instanceof Error)) return null;
+  const proof = evidence.get(error), expected = target(input);
+  if (!proof || !expected || proof.accountId !== expected.accountId ||
+    proof.chatId !== expected.chatId || proof.messageId !== expected.messageId) return null;
+  evidence.delete(error);
+  return proof.kind;
+}

--- a/src/messaging/telegram-origin/OriginAwareness.ts
+++ b/src/messaging/telegram-origin/OriginAwareness.ts
@@ -30,6 +30,10 @@ export function telegramOriginCapacityAwareness(): string {
   return 'Telegram capacity checks: ordinary replies acquire the credential owner\'s short-lived capacity only after durable dispatch intent, immediately before network invocation. Storage preparation cannot use up that grant. An unavailable or expired grant still holds the original message and consumes a charged attempt, even if no network call started; sustained capacity refusal can exhaust its original attempt limit. The existing recovery pacing, deadline, ownership and shared rate limit remain in force. Never recreate a held message to obtain a new budget.\n';
 }
 
+export function telegramDashboardEditAwareness(): string {
+  return 'Dashboard edit rejection: a held or uncertain pinned-link edit preserves its original operation and saved message ID; it never escalates into a fresh dashboard post. Only Telegram\'s concrete missing-message rejection for that same target permits replacement, after durable outcome recording for managed sends. An authoritative unchanged response is a no-op. `POST /telegram/dashboard-refresh` still reports failed refreshes; inspect the original origin record rather than deleting the saved ID or manually reposting to evade a hold. This guard limits dashboard send amplification; it does not repair false wake classification or guarantee that a held edit is delivered.\n';
+}
+
 export function telegramOriginAwareness(port: number): string {
   return `
 ### Telegram message origin

--- a/src/messaging/telegram-origin/TelegramOriginService.ts
+++ b/src/messaging/telegram-origin/TelegramOriginService.ts
@@ -2,6 +2,7 @@
 // (docs/STANDARDS-REGISTRY.md). Recording and presentation are independent.
 import { sealOriginAdmission, validOriginAdmission } from './OriginAdmissionSeal.js';
 import { OriginCapacityUnavailable } from './OriginEgressCapacity.js';
+import { recordTelegramEditRejection } from '../TelegramEditRejection.js';
 import type { OriginCapacityAuthority } from './OriginEgressCapacity.js';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { originSendPolicyInput, validOriginSendPolicyInput, OriginSendPolicyRefusal } from './OriginSendPolicy.js';
@@ -563,7 +564,7 @@ export class TelegramOriginService {
         await this.#outcomeUnknown(operation, claim.child, 'transport-acceptance-unknown');
         throw new TelegramOriginHoldError('transport-acceptance-unknown', operation.record.operationId, 'outcome-unknown');
       }
-      type BotResponse = { ok?: boolean; result?: unknown; parameters?: { retry_after?: unknown } };
+      type BotResponse = { ok?: boolean; result?: unknown; error_code?: unknown; description?: unknown; parameters?: { retry_after?: unknown } };
       let parsed: BotResponse | null = null;
       try { parsed = JSON.parse(await response.clone().text()) as BotResponse; } catch { /* No concrete receipt; never infer success from HTTP alone. */ }
       const receipt = correlateBotReceipt(request, parsed?.result, this.#now());
@@ -578,9 +579,13 @@ export class TelegramOriginService {
         const nextAttemptAt = response.status === 429 ? nextOriginKnownFailure({ attempt: claim.child.attemptNumber,
           maxAttempts: operation.admission.maxAttempts, deadlineAt: operation.admission.deadlineAt, now: this.#now(),
           minimumDelayMs: Number.isSafeInteger(retryAfter) && Number(retryAfter) > 0 ? Number(retryAfter) * 1000 : 0 }) : undefined;
-        await this.options.store.recordOutcome({ ...claim.child, outcome: 'known-failed', reason: `telegram-${response.status}`,
+        const saved = await this.options.store.recordOutcome({ ...claim.child, outcome: 'known-failed', reason: `telegram-${response.status}`,
           ...(nextAttemptAt === undefined ? {} : { nextAttemptAt }) });
-        throw new TelegramOriginHoldError(`telegram-${response.status}`, operation.record.operationId, 'known-failed');
+        const error = new TelegramOriginHoldError(`telegram-${response.status}`, operation.record.operationId, 'known-failed');
+        if (saved.recorded) recordTelegramEditRejection(error, response.status, parsed, {
+          method: request.method, accountId: request.accountId, params: JSON.parse(request.body),
+        });
+        throw error;
       } else {
         const partial = response.ok && parsed?.ok === true ? correlatePartialBotReceipt(request, parsed.result, this.#now()) : null;
         const reason = partial ? 'partial-platform-receipt' : 'response-without-correlated-receipt';

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -9,7 +9,7 @@
  * When augmenting an existing project, only missing files are created.
  */
 
-import { telegramOriginAwareness } from "../messaging/telegram-origin/OriginAwareness.js";
+import { telegramOriginAwareness, telegramDashboardEditAwareness } from "../messaging/telegram-origin/OriginAwareness.js";
 
 // The "Playwright Profile Registry" CLAUDE.md awareness section is authored ONCE in
 // PostUpdateMigrator (the single source of truth shared by new installs here and the
@@ -1754,6 +1754,7 @@ The AutonomousLivenessReconciler also covers a second dead-work shape: an autono
 
   if (hasTelegram) {
     content += telegramOriginAwareness(port);
+    content += '\n' + telegramDashboardEditAwareness();
     content += `
 ## Telegram Relay
 

--- a/tests/e2e/telegram-dashboard-edit-rejection.test.ts
+++ b/tests/e2e/telegram-dashboard-edit-rejection.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { bootTelegramOrigin } from '../../src/messaging/telegram-origin/TelegramOriginBoot.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { TelegramOriginHoldError } from '../../src/messaging/telegram-origin/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { compileOriginWorker } from '../helpers/telegramOriginStore.js';
+import { waitForOriginDisplayReady } from '../helpers/telegramOriginReady.js';
+import { fixtureOriginContentDedup } from '../helpers/originContentDedup.js';
+
+let worker: URL;
+beforeAll(async () => { worker = await compileOriginWorker(); });
+const cleanup: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const close of cleanup.splice(0).reverse()) await close();
+  vi.restoreAllMocks(); vi.unstubAllGlobals();
+});
+
+async function fixture() {
+  // macOS's long os.tmpdir() exceeds the Unix-domain socket path limit.
+  const root = fs.mkdtempSync('/tmp/dashboard-rejection-boot-');
+  cleanup.push(() => SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'test:dashboard-rejection-boot:cleanup' }));
+  const stateDir = path.join(root, '.instar'); fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  const savedPath = path.join(stateDir, 'state', 'dashboard-message.json');
+  const saved = JSON.stringify({ messageId: 88, savedAt: '2026-09-10T00:00:00.000Z' }); fs.writeFileSync(savedPath, saved);
+  const telegramConfig = { token: '123:dashboard-boot-fixture', chatId: '-100123', dashboardTopicId: 5, dashboardPin: '123456',
+    messageOrigin: { display: { enabled: false } } };
+  const config = { projectDir: root, stateDir, projectName: 'echo', port: 0, authToken: 'fixture-auth',
+    messaging: [{ type: 'telegram', enabled: true, config: telegramConfig }] };
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify(config));
+  let ownsLease = true;
+  const boot = await bootTelegramOrigin({ config: config as never, token: telegramConfig.token, workerUrl: worker,
+    noticeOwner: true, holdsLease: () => ownsLease, isSessionLive: () => false,
+    diagnoseUnknown: async () => undefined, onNoticeState: () => undefined });
+  cleanup.push(() => boot.close());
+  boot.runtime.attachSendPolicy({ review: async () => ({ ok: true }), authorizeDispatch: () => ({ ok: true }),
+    ...fixtureOriginContentDedup(stateDir) });
+  await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: null });
+  await vi.waitFor(async () => expect(await boot.runtime.service.options.authorize({
+    accountId: '123', destination: { chatId: '-100123' },
+  } as never)).toBe(true), { timeout: 7000 });
+  const telegram = new TelegramAdapter(telegramConfig, stateDir, { suppressLifelineAutoCreate: true });
+  cleanup.push(() => telegram.stop());
+  return { ...boot, telegram, saved, savedPath, loseLease: () => { ownsLease = false; } };
+}
+
+describe('dashboard edits through production origin startup', () => {
+  it.each([true, false])('requires durable evidence for a managed unchanged no-op (recorded: %s)', async recorded => {
+    const f = await fixture();
+    if (!recorded) vi.spyOn(f.runtime.store, 'recordOutcome').mockResolvedValue({ recorded: false } as never);
+    const wire = vi.fn(async () => new Response(JSON.stringify({ ok: false, error_code: 400,
+      description: 'Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message',
+    }), { status: 400 })); vi.stubGlobal('fetch', wire);
+    const send = vi.spyOn(f.telegram, 'sendToTopic');
+    const result = await f.telegram.broadcastDashboardUrl('https://fixture.example.test', 'quick').catch(error => error);
+    if (recorded) expect(result).toMatchObject({ edited: true, messageId: 88 });
+    else expect(result).toBeInstanceOf(TelegramOriginHoldError);
+    expect(wire).toHaveBeenCalledOnce(); expect(send).not.toHaveBeenCalled();
+    expect(fs.readFileSync(f.savedPath, 'utf8')).toBe(f.saved);
+    const rows = (await f.runtime.store.listOrigins()).records;
+    expect(rows).toHaveLength(1); expect(rows[0].attempts).toHaveLength(1);
+    if (recorded) expect(rows[0].attempts[0].outcome).toBe('known-failed');
+  });
+
+  it.each(['before-wire', 'after-wire'] as const)('preserves one original operation when held %s', async boundary => {
+    const f = await fixture();
+    if (boundary === 'before-wire') f.loseLease();
+    const wire = vi.fn(async () => { throw new Error('connection closed without a receipt'); }); vi.stubGlobal('fetch', wire);
+    const send = vi.spyOn(f.telegram, 'sendToTopic');
+    const error = await f.telegram.broadcastDashboardUrl('https://fixture.example.test', 'quick').catch(error => error);
+    expect(error).toBeInstanceOf(TelegramOriginHoldError);
+    expect(error.outcome).toBe(boundary === 'before-wire' ? 'held' : 'outcome-unknown');
+    expect(wire).toHaveBeenCalledTimes(boundary === 'before-wire' ? 0 : 1);
+    expect(send).not.toHaveBeenCalled(); expect(fs.readFileSync(f.savedPath, 'utf8')).toBe(f.saved);
+    const rows = (await f.runtime.store.listOrigins()).records;
+    expect(rows).toHaveLength(1); expect(rows[0].operation?.operationId).toBe(error.operationId);
+    expect(rows[0].attempts).toHaveLength(boundary === 'before-wire' ? 0 : 1);
+  });
+
+  it.each(['recorded', 'refused', 'throws'] as const)('permits replacement only after durable missing-message outcome is %s', async persistence => {
+    const f = await fixture(), methods: string[] = [];
+    const originalRecordOutcome = f.runtime.store.recordOutcome.bind(f.runtime.store);
+    const persistenceFailure = new Error('fixture outcome recording unavailable');
+    let originalSendError: unknown;
+    const sendBot = f.runtime.service.sendBot.bind(f.runtime.service);
+    vi.spyOn(f.runtime.service, 'sendBot').mockImplementation(async (...args) => {
+      try { return await sendBot(...args); }
+      catch (error) { originalSendError = error; throw error; }
+    });
+    vi.spyOn(f.runtime.store, 'recordOutcome').mockImplementation(async input => {
+      if (input.outcome === 'known-failed') {
+        if (persistence === 'throws') throw persistenceFailure;
+        if (persistence === 'refused') return { recorded: false } as never;
+      }
+      return originalRecordOutcome(input);
+    });
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const method = new URL(url).pathname.split('/').pop()!; methods.push(method);
+      if (method === 'editMessageText') return new Response(JSON.stringify({ ok: false, error_code: 400, description: 'Bad Request: message to edit not found' }), { status: 400 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 99, chat: { id: -100123 }, message_thread_id: 5 } }));
+    }));
+    const send = vi.spyOn(f.telegram, 'sendToTopic');
+    const result = await f.telegram.broadcastDashboardUrl('https://fixture.example.test', 'quick').catch(error => error);
+    if (persistence === 'recorded') {
+      expect(result).toMatchObject({ edited: false, messageId: 99 }); expect(send).toHaveBeenCalledOnce();
+      expect(methods).toEqual(['editMessageText', 'sendMessage', 'unpinAllForumTopicMessages', 'pinChatMessage']);
+      expect(JSON.parse(fs.readFileSync(f.savedPath, 'utf8')).messageId).toBe(99);
+      const rows = (await f.runtime.store.listOrigins()).records;
+      expect(rows).toHaveLength(2);
+      expect(rows.flatMap(row => row.attempts).map(attempt => attempt.outcome).sort()).toEqual(['accepted', 'known-failed']);
+    } else {
+      expect(result).toBe(originalSendError);
+      expect(result).toBeInstanceOf(TelegramOriginHoldError);
+      if (persistence === 'throws') expect(result.reason).toBe('origin-execution-state-unavailable');
+      expect(send).not.toHaveBeenCalled(); expect(methods).toEqual(['editMessageText']);
+      expect(fs.readFileSync(f.savedPath, 'utf8')).toBe(f.saved);
+    }
+  });
+});

--- a/tests/e2e/telegram-origin-production-boot.test.ts
+++ b/tests/e2e/telegram-origin-production-boot.test.ts
@@ -45,8 +45,13 @@ describe('Telegram origin production bootstrap', () => {
     };
     let boot = await start();
     const token = await lifecycle!.issue({ sessionId: 'queued-deadline-session', harnessId: 'codex-cli', projectDir: root, configuredModel: 'selected-model' });
-    const operation = await boot.runtime.service.runWithSessionToken(token, () => boot.runtime.service.prepareBot({
-      method: 'sendMessage', accountId: '123', params: { chat_id: '-100123', message_thread_id: 42, text: 'The report prepared before restart.' } }));
+    const operation = await boot.runtime.service.runWithSessionToken(token, async () => {
+      // Session observation is asynchronous; observe display readiness after it,
+      // immediately before the first preparation (never retry the send).
+      await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
+      return boot.runtime.service.prepareBot({ method: 'sendMessage', accountId: '123',
+        params: { chat_id: '-100123', message_thread_id: 42, text: 'The report prepared before restart.' } });
+    });
     await boot.runtime.service.admit(operation);
     await boot.close(); boot = await start();
     const deadline = new AbortController();
@@ -101,8 +106,11 @@ describe('Telegram origin production bootstrap', () => {
     };
     let boot = await start();
     const token = await lifecycle!.issue({ sessionId: 'queued-session', harnessId: 'codex-cli', projectDir: root, configuredModel: 'selected-model' });
-    const operation = await boot.runtime.service.runWithSessionToken(token, () => boot.runtime.service.prepareBot({
-      method: 'sendMessage', accountId: '123', params: { chat_id: '-100123', message_thread_id: 42, text: 'Here is the requested client report.' } }));
+    const operation = await boot.runtime.service.runWithSessionToken(token, async () => {
+      await waitForOriginDisplayReady(boot.runtime, { chatId: '-100123', topicId: '42' });
+      return boot.runtime.service.prepareBot({ method: 'sendMessage', accountId: '123',
+        params: { chat_id: '-100123', message_thread_id: 42, text: 'Here is the requested client report.' } });
+    });
     await boot.runtime.service.admit(operation);
     expect(await boot.runtime.recoverHeld()).toEqual({ processed: 1, recovered: 0 });
     expect(review).toHaveBeenCalledOnce();

--- a/tests/integration/guards-route.test.ts
+++ b/tests/integration/guards-route.test.ts
@@ -325,7 +325,9 @@ describe('heartbeat posture ingestion (MachinePoolRegistry + GuardPostureStore)'
   };
 
   it('stamps RECEIVER-side receipt time, persists durably, and reloads across a restart', () => {
-    let now = 1_781_300_000_000;
+    // Match the durable store's real clock; a fixed sample eventually expires
+    // under its 90-day retention policy and stops testing restart persistence.
+    let now = Date.now();
     const store = new GuardPostureStore(stateDir);
     const pool = new MachinePoolRegistry({
       listMachines: () => [{ machineId: 'm-peer', nickname: 'mini' }],
@@ -363,7 +365,7 @@ describe('heartbeat posture ingestion (MachinePoolRegistry + GuardPostureStore)'
   });
 
   it('persists a changed uninspectable key list even when every existing posture count stays equal', () => {
-    let now = 1_781_300_000_000;
+    let now = Date.now();
     const store = new GuardPostureStore(stateDir);
     const pool = new MachinePoolRegistry({
       listMachines: () => [{ machineId: 'm-peer', nickname: 'mini' }],
@@ -394,7 +396,7 @@ describe('heartbeat posture ingestion (MachinePoolRegistry + GuardPostureStore)'
   });
 
   it('a posture-less beat carries the previous block forward WITHOUT refreshing its age', () => {
-    let now = 1_781_300_000_000;
+    let now = Date.now();
     const pool = new MachinePoolRegistry({
       listMachines: () => [{ machineId: 'm-peer' }],
       clockSkewToleranceMs: 300_000,

--- a/tests/integration/telegram-dashboard-edit-rejection.test.ts
+++ b/tests/integration/telegram-dashboard-edit-rejection.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { TelegramOriginHoldError } from '../../src/messaging/telegram-origin/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const cleanup: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const close of cleanup.splice(0).reverse()) await close();
+  vi.restoreAllMocks(); vi.unstubAllGlobals();
+});
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-rejection-http-'));
+  cleanup.push(() => SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'test:dashboard-rejection-http:cleanup' }));
+  const stateDir = path.join(root, '.instar'); fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  const savedPath = path.join(stateDir, 'state', 'dashboard-message.json');
+  const saved = JSON.stringify({ messageId: 88, savedAt: '2026-09-10T00:00:00.000Z' }); fs.writeFileSync(savedPath, saved);
+  const telegram = new TelegramAdapter({ token: '123:dashboard-http-fixture', chatId: '-100123', dashboardTopicId: 5, dashboardPin: '123456' }, stateDir);
+  cleanup.push(() => telegram.stop());
+  const config = { projectName: 'dashboard-http-fixture', projectDir: root, stateDir, port: 0, authToken: 'fixture-auth',
+    sessions: {}, tunnel: { enabled: true, type: 'quick' } };
+  const app = express(); app.use(express.json());
+  app.use((req, res, next) => { if (req.get('Authorization') !== 'Bearer fixture-auth') { res.sendStatus(401); return; } next(); });
+  app.use(createRoutes({ config, telegram, tunnel: { url: 'https://fixture.example.test' }, sessionManager: {} } as never));
+  return { app, telegram, savedPath, saved };
+}
+
+describe('dashboard refresh HTTP edit rejection', () => {
+  it.each(['held', 'outcome-unknown'] as const)('returns the existing failure response for %s without creating another send', async outcome => {
+    const f = fixture();
+    const held = new TelegramOriginHoldError('credential-capacity-unavailable', 'original-operation', outcome);
+    const wire = vi.fn().mockRejectedValue(held); vi.stubGlobal('fetch', wire);
+    const send = vi.spyOn(f.telegram, 'sendToTopic');
+    const response = await request(f.app).post('/telegram/dashboard-refresh').set('Authorization', 'Bearer fixture-auth').send({});
+    expect(response.status).toBe(502);
+    expect(JSON.stringify(response.body)).toContain('credential-capacity-unavailable');
+    expect(send).not.toHaveBeenCalled(); expect(wire).toHaveBeenCalledOnce();
+    expect(fs.readFileSync(f.savedPath, 'utf8')).toBe(f.saved);
+  });
+
+  it('refreshes through the real route after Telegram proves the pinned message missing', async () => {
+    const f = fixture(), methods: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      const method = new URL(url).pathname.split('/').pop()!; methods.push(method);
+      if (method === 'editMessageText') return new Response(JSON.stringify({ ok: false, error_code: 400, description: 'Bad Request: message to edit not found' }), { status: 400 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 99, chat: { id: -100123 }, message_thread_id: 5 } }));
+    }));
+    const response = await request(f.app).post('/telegram/dashboard-refresh').set('Authorization', 'Bearer fixture-auth').send({});
+    expect(response.status).toBe(200); expect(response.body.action).toBe('refreshed');
+    expect(methods).toEqual(['editMessageText', 'sendMessage', 'unpinAllForumTopicMessages', 'pinChatMessage']);
+    expect(JSON.parse(fs.readFileSync(f.savedPath, 'utf8')).messageId).toBe(99);
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -247,6 +247,7 @@ describe('Feature Delivery Completeness', () => {
       ['Queued-message review pacing:', 'telegramOriginRecoveryAwareness'],
       ['Telegram send deadlines:', 'telegramOriginTransportAwareness'],
       ['Telegram capacity checks:', 'telegramOriginCapacityAwareness'],
+      ['Dashboard edit rejection:', 'telegramDashboardEditAwareness'],
     ];
     for (const [phrase, builder] of featureAddenda) {
       it(`origin addendum "${phrase}" reaches new and existing framework instructions`, () => {

--- a/tests/unit/telegram-api-edge.test.ts
+++ b/tests/unit/telegram-api-edge.test.ts
@@ -5,9 +5,11 @@
  * and apiCall timeout configuration.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { createTempProject } from '../helpers/setup.js';
 
 describe('TelegramAdapter — API edge cases', () => {
   const sourcePath = path.join(process.cwd(), 'src/messaging/TelegramAdapter.ts');
@@ -23,14 +25,23 @@ describe('TelegramAdapter — API edge cases', () => {
       expect(source).toContain('safeUrl');
     });
 
-    it('uses safeUrl in HTTP error messages (not raw URL)', () => {
-      // HTTP error messages (status code errors) should use safeUrl
-      const httpErrorLines = source.split('\n').filter(line =>
-        line.includes('throw new Error') && line.includes('Telegram API error')
-      );
-      expect(httpErrorLines.length).toBeGreaterThan(0);
-      for (const line of httpErrorLines) {
-        expect(line).toContain('safeUrl');
+    it.each([403, 500])('redacts the request URL in HTTP %s errors with a non-JSON body', async status => {
+      const project = createTempProject();
+      const token = '123456:edge-redaction-fixture';
+      const adapter = new TelegramAdapter({ token, chatId: '-100123' }, project.stateDir);
+      const wire = vi.fn(async (_url: string) => new Response('Gateway refused the request', { status }));
+      vi.stubGlobal('fetch', wire);
+      try {
+        // Exercise the real API boundary, including its malformed-body branch.
+        const api = adapter as unknown as { apiCall(method: string, params: Record<string, unknown>): Promise<unknown> };
+        const request = api.apiCall('getMe', {});
+        await expect(request).rejects.toThrow(`Telegram API error https://api.telegram.org/bot[REDACTED]/getMe (${status}): Gateway refused the request`);
+        await expect(request).rejects.not.toThrow(token);
+        expect(wire).toHaveBeenCalledOnce();
+        expect(wire.mock.calls[0]?.[0]).toBe(`https://api.telegram.org/bot${token}/getMe`);
+      } finally {
+        try { await adapter.stop(); }
+        finally { vi.unstubAllGlobals(); project.cleanup(); }
       }
     });
   });

--- a/tests/unit/telegram-dashboard-edit-migration.test.ts
+++ b/tests/unit/telegram-dashboard-edit-migration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { generateClaudeMd } from '../../src/scaffold/templates.js';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { telegramDashboardEditAwareness } from '../../src/messaging/telegram-origin/OriginAwareness.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('dashboard edit rejection installation parity', () => {
+  it('informs newly generated agents of the failure response and original-operation custody', () => {
+    expect(generateClaudeMd('echo', 'Echo', 4042, true)).toContain(telegramDashboardEditAwareness());
+  });
+  it.each([false, true])('updates an existing agent idempotently (already present: %s)', alreadyPresent => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-edit-migration-'));
+    const stateDir = path.join(projectDir, '.instar'), md = path.join(projectDir, 'CLAUDE.md');
+    fs.mkdirSync(stateDir); fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ projectName: 'echo', port: 4042 }));
+    fs.writeFileSync(md, '# Existing custom instructions\n' + (alreadyPresent ? telegramDashboardEditAwareness() : ''));
+    for (const shadow of ['AGENTS.md', 'GEMINI.md']) fs.writeFileSync(path.join(projectDir, shadow), '# Custom framework instructions\n');
+    try {
+      const migrate = () => new PostUpdateMigrator({ stateDir, projectDir, version: '1.3.1235' }).migrate();
+      migrate(); const first = fs.readFileSync(md, 'utf8');
+      expect(first).toContain('# Existing custom instructions');
+      expect(first).toContain(telegramDashboardEditAwareness());
+      migrate(); const second = fs.readFileSync(md, 'utf8');
+      expect(second.split('Dashboard edit rejection:')).toHaveLength(2);
+      expect(second).toContain(telegramDashboardEditAwareness());
+      for (const shadow of ['AGENTS.md', 'GEMINI.md']) {
+        const text = fs.readFileSync(path.join(projectDir, shadow), 'utf8');
+        expect(text).toContain('# Custom framework instructions');
+        expect(text).toContain(telegramDashboardEditAwareness());
+      }
+    } finally {
+      SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'test:dashboard-edit-migration:cleanup' });
+    }
+  });
+});

--- a/tests/unit/telegram-dashboard-edit-rejection.test.ts
+++ b/tests/unit/telegram-dashboard-edit-rejection.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { TelegramOriginHoldError } from '../../src/messaging/telegram-origin/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { recordTelegramEditRejection, takeTelegramEditRejection } from '../../src/messaging/TelegramEditRejection.js';
+
+const missing = { ok: false, error_code: 400, description: 'Bad Request: message to edit not found' };
+const unchanged = { ok: false, error_code: 400, description: 'Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message' };
+
+describe('dashboard refresh preserves rejected edits', () => {
+  let dir: string;
+  let statePath: string;
+  let adapter: TelegramAdapter;
+  let originalState: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-edit-rejection-'));
+    statePath = path.join(dir, 'state', 'dashboard-message.json');
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    originalState = JSON.stringify({ messageId: 88, savedAt: '2026-09-10T00:00:00.000Z' });
+    fs.writeFileSync(statePath, originalState);
+    adapter = new TelegramAdapter({ token: '123456:fixture-token', chatId: '-100123456',
+      dashboardTopicId: 5, dashboardPin: '123456' }, dir);
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true,
+      operation: 'tests/unit/telegram-dashboard-edit-rejection.test.ts:cleanup' });
+  });
+
+  it.each([
+    new TelegramOriginHoldError('credential-capacity-unavailable', 'original-operation'),
+    new TelegramOriginHoldError('transport-acceptance-unknown', 'original-operation', 'outcome-unknown'),
+    new Error('network unavailable'),
+    new Error('message is not modified'),
+    new Error('Bad Request: message to edit not found'),
+  ])('does not turn an unproven edit rejection into a fresh send: %s', async error => {
+    const fetch = vi.fn().mockRejectedValue(error);
+    vi.stubGlobal('fetch', fetch);
+    const send = vi.spyOn(adapter, 'sendToTopic').mockResolvedValue({ messageId: 99, topicId: 5 });
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).rejects.toBe(error);
+    expect(send).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+
+  it.each([null, undefined])('preserves original custody on a tokenless adapter (%s)', async token => {
+    await adapter.stop();
+    adapter = new TelegramAdapter({ token: token as never, chatId: '-100123456', dashboardTopicId: 5, dashboardPin: '123456' }, dir);
+    const held = new TelegramOriginHoldError('unregistered-credential-owner', 'original-operation');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(held));
+    const send = vi.spyOn(adapter, 'sendToTopic');
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).rejects.toBe(held);
+    expect(send).not.toHaveBeenCalled();
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+
+  it.each([
+    [400, { ok: false, error_code: 400, description: "Bad Request: message can't be edited" }],
+    [403, { ok: false, error_code: 403, description: 'Forbidden: bot was kicked' }],
+    [500, { ok: false, error_code: 500, description: 'Bad Request: message to edit not found' }],
+    [400, { ok: false, error_code: 403, description: 'Bad Request: message to edit not found' }],
+    [400, { ...missing, ok: true }],
+    [400, { ...missing, description: `${missing.description}: try sending again` }],
+    [401, missing],
+    [400, null],
+  ])('refuses replacement for HTTP%s without exact message-gone evidence', async (status, body) => {
+    const fetch = vi.fn().mockImplementation(async () => new Response(JSON.stringify(body), { status }));
+    vi.stubGlobal('fetch', fetch);
+    const send = vi.spyOn(adapter, 'sendToTopic').mockResolvedValue({ messageId: 99, topicId: 5 });
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).rejects.toThrow();
+    expect(send).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+
+  it('treats the exact authoritative unchanged response as a no-op', async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify(unchanged), { status: 400 }));
+    vi.stubGlobal('fetch', fetch);
+    const send = vi.spyOn(adapter, 'sendToTopic');
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).resolves.toMatchObject({ edited: true, messageId: 88 });
+    expect(fetch).toHaveBeenCalledOnce(); expect(send).not.toHaveBeenCalled();
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+
+  it('replaces only the missing message, then edits the saved replacement on the next refresh', async () => {
+    const requests: Array<{ method: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {
+      const method = new URL(url).pathname.split('/').pop()!;
+      const body = JSON.parse(init.body as string); requests.push({ method, body });
+      if (method === 'editMessageText' && body.message_id === 88) return new Response(JSON.stringify(missing), { status: 400 });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 99, chat: { id: -100123456 } } }));
+    }));
+    const send = vi.spyOn(adapter, 'sendToTopic');
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).resolves.toMatchObject({ edited: false, messageId: 99 });
+    expect(JSON.parse(fs.readFileSync(statePath, 'utf8')).messageId).toBe(99);
+    await expect(adapter.broadcastDashboardUrl('https://next.example.test', 'quick')).resolves.toMatchObject({ edited: true, messageId: 99 });
+    expect(send).toHaveBeenCalledOnce();
+    expect(requests.map(r => r.method)).toEqual(['editMessageText', 'sendMessage', 'unpinAllForumTopicMessages', 'pinChatMessage', 'editMessageText']);
+    expect(requests[4].body.message_id).toBe(99);
+  });
+
+  it('preserves the original hold when the authorized replacement itself is held', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(missing), { status: 400 })));
+    const held = new TelegramOriginHoldError('credential-capacity-unavailable', 'replacement-operation');
+    const send = vi.spyOn(adapter, 'sendToTopic').mockRejectedValue(held);
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).rejects.toBe(held);
+    expect(send).toHaveBeenCalledOnce();
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+
+  it('preserves the saved ID on malformed response JSON', async () => {
+    const fetch = vi.fn(async () => new Response('message to edit not found', { status: 400 }));
+    vi.stubGlobal('fetch', fetch);
+    const send = vi.spyOn(adapter, 'sendToTopic');
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).rejects.toThrow('Telegram API error');
+    expect(fetch).toHaveBeenCalledOnce(); expect(send).not.toHaveBeenCalled();
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+
+  it('never replaces a rate-limited edit after the existing retry budget is exhausted', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: false, error_code: 429, parameters: { retry_after: 0 } }), { status: 429 })));
+    const send = vi.spyOn(adapter, 'sendToTopic');
+    await expect(adapter.broadcastDashboardUrl('https://new.example.test', 'quick')).rejects.toThrow('after 3 retries');
+    expect(send).not.toHaveBeenCalled();
+    expect(fs.readFileSync(statePath, 'utf8')).toBe(originalState);
+  });
+});
+
+describe('Telegram edit rejection evidence boundaries', () => {
+  const target = { method: 'editMessageText', accountId: '123', params: { chat_id: '-100123', message_id: 88 } };
+  it('preserves error identity and binds evidence to account, chat, message and method, consumed once', () => {
+    const held = new TelegramOriginHoldError('telegram-400', 'original-operation', 'known-failed');
+    expect(recordTelegramEditRejection(held, 400, missing, target)).toBe(held);
+    for (const foreign of [{ ...target, accountId: '456' }, { ...target, method: 'sendMessage' },
+      { ...target, params: { ...target.params, chat_id: '-100456' } }, { ...target, params: { ...target.params, message_id: 89 } }]) {
+      expect(takeTelegramEditRejection(held, foreign)).toBeNull();
+    }
+    expect(takeTelegramEditRejection(held, target)).toBe('message-missing');
+    expect(takeTelegramEditRejection(held, target)).toBeNull();
+  });
+  it('does not transfer authority through copied error fields or serialization', () => {
+    const error = recordTelegramEditRejection(new Error('platform rejection'), 400, missing, target);
+    expect(takeTelegramEditRejection(Object.assign(new Error(error.message), error), target)).toBeNull();
+    expect(takeTelegramEditRejection(JSON.parse(JSON.stringify(error)), target)).toBeNull();
+  });
+});

--- a/tests/unit/telegram-token-redaction.test.ts
+++ b/tests/unit/telegram-token-redaction.test.ts
@@ -4,25 +4,31 @@
  * Security: Bot tokens in logs/errors could be harvested by log aggregators.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { createTempProject } from '../helpers/setup.js';
 
 describe('TelegramAdapter — token redaction', () => {
-  it('apiCall uses a sanitized URL in error messages', () => {
-    const source = fs.readFileSync(
-      path.join(process.cwd(), 'src/messaging/TelegramAdapter.ts'),
-      'utf-8',
-    );
-
-    // Must define safeUrl with [REDACTED]
-    expect(source).toContain('bot[REDACTED]');
-
-    // Error throw must use safeUrl, not url
-    const errorLine = source.match(/throw new Error\(`Telegram API error .+?\)/);
-    expect(errorLine).toBeTruthy();
-    expect(errorLine![0]).toContain('safeUrl');
-    expect(errorLine![0]).not.toMatch(/\$\{url\}/);
+  it.each(['sendMessage', 'editMessageText'])('redacts the token in an actual %s rejection', async method => {
+    const project = createTempProject();
+    const token = '123456:platform-redaction-fixture';
+    const adapter = new TelegramAdapter({ token, chatId: '-100123' }, project.stateDir);
+    const body = { ok: false, error_code: 403, description: 'Forbidden: bot was kicked' };
+    const wire = vi.fn(async (_url: string) => new Response(JSON.stringify(body), { status: 403 }));
+    vi.stubGlobal('fetch', wire);
+    try {
+      const api = adapter as unknown as { apiCall(method: string, params: Record<string, unknown>): Promise<unknown> };
+      const request = api.apiCall(method, { chat_id: '-100123', message_id: 88, text: 'The client report is ready for review.' });
+      await expect(request).rejects.toThrow(`Telegram API error https://api.telegram.org/bot[REDACTED]/${method} (403): ${JSON.stringify(body)}`);
+      await expect(request).rejects.not.toThrow(token);
+      expect(wire).toHaveBeenCalledOnce();
+      expect(wire.mock.calls[0]?.[0]).toBe(`https://api.telegram.org/bot${token}/${method}`);
+    } finally {
+      try { await adapter.stop(); }
+      finally { vi.unstubAllGlobals(); project.cleanup(); }
+    }
   });
 
   it('send() only retries on 400 errors (parse failures)', () => {

--- a/upgrades/next/telegram-dashboard-edit-rejection.md
+++ b/upgrades/next/telegram-dashboard-edit-rejection.md
@@ -1,0 +1,14 @@
+# Keep a held dashboard refresh from creating another post
+
+When a pinned dashboard-link edit is held or its delivery is uncertain, Instar now
+keeps the original message ID and reports the failed refresh. It no longer turns
+that failure into a brand-new dashboard post. This reduces the extra sends that
+can accumulate during repeated tunnel restarts.
+
+A confirmed missing pinned message can still be replaced, and an unchanged link
+remains a quiet no-op. Origin recording, ownership, capacity limits and recovery
+budgets remain in force. This patch does not fix false wake detection or guarantee
+delivery of a held message.
+
+Existing agents receive the correction through their normal update and server
+restart. No configuration change or queue reset is required.

--- a/upgrades/next/telegram-dashboard-edit-rejection.md
+++ b/upgrades/next/telegram-dashboard-edit-rejection.md
@@ -1,5 +1,7 @@
 # Keep a held dashboard refresh from creating another post
 
+## What Changed
+
 When a pinned dashboard-link edit is held or its delivery is uncertain, Instar now
 keeps the original message ID and reports the failed refresh. It no longer turns
 that failure into a brand-new dashboard post. This reduces the extra sends that
@@ -10,5 +12,21 @@ remains a quiet no-op. Origin recording, ownership, capacity limits and recovery
 budgets remain in force. This patch does not fix false wake detection or guarantee
 delivery of a held message.
 
+## What to Tell Your User
+
+A held or uncertain pinned-link edit no longer falls back to creating a new
+dashboard post. A held refresh can still leave the existing pinned link stale
+until delivery recovers.
+
 Existing agents receive the correction through their normal update and server
 restart. No configuration change or queue reset is required.
+
+## Summary of New Capabilities
+
+- Dashboard edits preserve the existing message on held or uncertain outcomes.
+- A confirmed missing message can still be replaced; unchanged content stays quiet.
+
+## Evidence
+
+The focused unit, HTTP integration, production-Boot lifecycle and migration tests
+pass. Full-suite validation and CI are required before release.

--- a/upgrades/side-effects/telegram-dashboard-edit-rejection.md
+++ b/upgrades/side-effects/telegram-dashboard-edit-rejection.md
@@ -126,6 +126,20 @@ exposed missing standalone guidance on existing framework files; the explicit
 migration tuple corrected it and all three migration cases passed. Final commit
 checks, full test:all and CI remain required before release.
 
+The first full run on 9ffb202636d7 found two release-completeness failures:
+the new awareness marker was absent from the feature-addenda parity registry,
+and the release fragment lacked the required sections. The parent deliberately
+cancelled its own run after confirming these failures; all 5,579 frozen inputs
+were unchanged. That run is incomplete, not passing. The correction adds the
+marker to the existing real parity assertions and organizes the release note
+under the required headings. It changes no production behavior and removes no
+assertion or release requirement. A fresh full run is required on the correction.
+The corrected completeness suite and dashboard unit/migration tests passed all
+179 cases across three files.
+Independent correction review confirmed the added assertions preserve the gate;
+its wording concern narrowed the user-facing claim to held or uncertain pinned
+edits, preserving the documented cross-invocation replacement limitation.
+
 Class closure: unbounded-self-action is n/a for this bounded change. It removes
 an exception-driven extra send from one invocation and adds no autonomous retry
 controller. It does not claim to close the broader wake loop or cross-invocation

--- a/upgrades/side-effects/telegram-dashboard-edit-rejection.md
+++ b/upgrades/side-effects/telegram-dashboard-edit-rejection.md
@@ -144,3 +144,31 @@ Class closure: unbounded-self-action is n/a for this bounded change. It removes
 an exception-driven extra send from one invocation and adds no autonomous retry
 controller. It does not claim to close the broader wake loop or cross-invocation
 replacement-custody class.
+
+The full run on d9d9dfa92a65 completed with exit 1: 3 failed and 51,883 passed tests (3
+failed/3,349 passed files); subsequent standalone integration and E2E stages did not
+run. All 5,579 frozen inputs were unchanged. Two token-redaction tests depended on the
+source spelling `throw new Error`; the runtime now assigns that error before attaching
+private rejection evidence. Replacements exercise actual JSON and non-JSON rejection
+paths, assert the sanitized request URL and absent fixture token, and independently
+verify one wire request carries the correct token URL. This covers request-URL
+redaction, not arbitrary response-body redaction.
+
+The third failure's final stack identifies prepareBot at production-Boot test 104,
+inside runWithSessionToken after its awaited observer refresh. The two recovery fixtures
+previously checked authorization earlier, before issuing the token. They now also
+observe the actual display authority immediately before their first preparation using
+the existing bounded helper. No preparation, admission, review, or delivery is retried;
+no production permission, timeout, or budget changes. The specific source of
+configuration invalidation remains unproved, and the fixture does not claim atomic
+readiness.
+
+Independent Boot reviews concurred with this exact setup correction conditional on the
+final preparation stack, now confirmed. Hooke concurred with both runtime-redaction
+replacements and recommended always restoring global stubs/temp files even if
+adapter.stop throws; that cleanup improvement is included. Focused validation and a
+fresh complete full run remain required on the correction.
+
+The corrected three-file run passed all 24 tests on the dashboard worktree, including
+the real production-Boot restart cases. Runtime source is unchanged from its passing
+build; full-suite validation and CI are still required.

--- a/upgrades/side-effects/telegram-dashboard-edit-rejection.md
+++ b/upgrades/side-effects/telegram-dashboard-edit-rejection.md
@@ -1,0 +1,132 @@
+# Side-effects review: dashboard edit rejection
+
+**Author:** Echo
+**Independent reviewer:** Hooke; design, implementation and corrected boundaries concurred.
+
+## Scope and governing contract
+
+Justin's report from Scout identifies a dashboard amplifier still present in
+v1.3.1235. A rejected pinned-message edit fell through to a new send regardless
+of whether Telegram had received the edit. This repair preserves the approved
+[Telegram message-origin contract](../../docs/specs/telegram-message-origin.md):
+a hold or uncertain outcome does not authorize a new operation.
+
+The report's false-wake and daily-send counts were supplied by Justin, not
+independently verified on b2lead-insights. Echo's own log contains repeated wake,
+tunnel restart and edit-fallback entries; that confirms the path exists locally,
+not that every wake is false or that this explains every capacity refusal.
+
+## Decision-point inventory
+
+- TelegramAdapter.broadcastDashboardUrl: replace catch-all fresh sends and error
+  substring no-ops with narrow evidence from the platform response boundary.
+- TelegramAdapter.apiCall: bind parsed Telegram rejection evidence to the original
+  error and the actual edit target; preserve typed holds through existing catches.
+- TelegramOriginService.executePreparedBot: retain the same known-failed hold and
+  bind edit evidence only after recordOutcome reports recorded:true.
+- TelegramEditRejection: private, one-use error-object evidence for matching bot
+  account, chat, message and method. No serialized error field grants authority.
+
+## 1. Over-block
+
+Only HTTP400 with ok:false, error_code:400 and the exact Telegram missing-edit
+description permits replacement. A future changed description, cannot-edit,
+authorization rejection, malformed response or lost evidence remains an explicit
+refresh failure, preserving the pinned ID. This may leave a stale dashboard link
+until the underlying fault is resolved. It never invents a successful refresh.
+Exact authoritative unchanged content remains a no-op. First-run sends remain.
+
+## 2. Under-block
+
+Corrupt or unreadable saved-ID state is still treated as absent by the existing
+loader. Existing save failures and simultaneous legitimate missing-message
+refreshes are separate adjacent risks, not repaired here. If a genuinely missing
+message's replacement is held or unknown, a later broadcast against the still-saved
+old ID can receive another genuine missing-message rejection and prepare another
+replacement. This repair fences held edits within a broadcast; it does not add
+durable replacement custody across distinct broadcast calls. That boundary is
+tracked for the subsequent delivery work in topic69507. The broader false-wake
+classifier, unconditional tunnel recovery and opaque admission errors remain
+follow-ups in topic69507. No generic class-convergence claim is made.
+<!-- tracked: topic-69507 -->
+
+## 3. Level-of-abstraction fit
+
+The replacement decision belongs inside broadcastDashboardUrl, before sendToTopic,
+so it covers startup, wake and HTTP callers even when an outer caller catches the
+failure. Managed Telegram4xx responses are consumed inside the origin service;
+evidence must therefore be carried through its original typed hold rather than
+reconstructed from adapter error text. Legacy library use classifies the actual
+raw response at apiCall. These are the only production evidence producers.
+
+## 4. Signal versus authority
+
+This is a constrained transport-outcome invariant, not a semantic message filter.
+HTTP status alone and exception substrings cannot choose a new send. The narrowly
+enumerated platform error, actual target and successful durable outcome write
+provide the required evidence. Existing ownership, content and send-policy
+authorities still decide every replacement. See
+[signal versus authority](../../docs/signal-vs-authority.md).
+
+## 4b. Judgment points
+
+No new static heuristic at a competing-signals decision point, LLM call, timer,
+recovery budget or policy bypass. Wake classification is deliberately separate.
+
+## 5. Interactions
+
+Held/unknown edits never reach replacement, unpin or pin calls. Their original
+operation IDs and saved ID bytes remain intact. A successful missing-message
+replacement saves its new ID and the next refresh edits it. Failed replacement
+sends also preserve their original error identity. Managed outcome-write failure
+cannot mint evidence, even when Telegram's raw response says the message is gone.
+Known-failed edit operations retain the existing recovery rules; this repair does
+not reset attempts, deadlines, content reservations or the fifteen-minute brake.
+No additional retry loop is introduced. Existing raw429 retry behavior remains.
+
+## 6. External surfaces and migration
+
+No new API, config or durable schema. The existing dashboard-refresh route returns
+502 when refresh fails. New-install awareness and idempotent PostUpdateMigrator
+guidance explain original-operation custody and the remaining wake limitation.
+The explicit shadow migration updates AGENTS.md and GEMINI.md even when the new
+paragraph already exists in CLAUDE.md; custom framework text remains.
+Normal package update and server activation install the runtime correction.
+
+## 6b. Operator surface
+
+No new control or approval. A held update is a failure to refresh the pinned link;
+it must not be reported as delivered or worked around by deleting the saved ID.
+
+## 7. Multi-machine posture
+
+Evidence is process-local and target-bound. A serialized remote error cannot
+authorize replacement. Standby and revoked lease refusals remain fenced; no
+session credential is forwarded and no peer is granted a new send budget.
+This repair precedes the pending standby-routing release to stop its relay from
+carrying catch-all fallback dashboard posts.
+
+## 8. Rollback
+
+Revert the repair and publish a patch; no queue clearing or data migration needed.
+Rollback restores the reproduced dashboard amplification defect.
+
+## Evidence
+
+Nine regression tests failed against the released code for the intended reasons.
+The correction passed twenty-two unit cases, three actual HTTP route cases, seven
+production-Boot lifecycle cases and three awareness migration cases. E2E fixture
+repairs used a short Unix-socket path and the actual audit record/outer-service
+error contract. They did not change production to accommodate the fixture.
+Initial build and lint passed; the reviewed build passed. Independent review
+required preserving original errors on null/undefined-token adapters, managed
+unchanged-response coverage and explicit documentation of repeated replacement
+custody. These corrections passed their focused tests. Expanded shadow tests
+exposed missing standalone guidance on existing framework files; the explicit
+migration tuple corrected it and all three migration cases passed. Final commit
+checks, full test:all and CI remain required before release.
+
+Class closure: unbounded-self-action is n/a for this bounded change. It removes
+an exception-driven extra send from one invocation and adds no autonomous retry
+controller. It does not claim to close the broader wake loop or cross-invocation
+replacement-custody class.

--- a/upgrades/side-effects/telegram-dashboard-edit-rejection.md
+++ b/upgrades/side-effects/telegram-dashboard-edit-rejection.md
@@ -172,3 +172,21 @@ fresh complete full run remain required on the correction.
 The corrected three-file run passed all 24 tests on the dashboard worktree, including
 the real production-Boot restart cases. Runtime source is unchanged from its passing
 build; full-suite validation and CI are still required.
+
+The fresh full run on 1523f656a99c completed normally with exit 1: exactly two
+failed and 51,886 passed tests (one failed/3,351 passed files). The only failing
+file was guards-route.test.ts. Standalone integration/E2E stages did not run
+after the aggregate failure. All 5,579 frozen source/test/config inputs were
+verified unchanged after completion.
+
+The receiver fixture used 1781300000000 (2026-06-12T21:33:20Z), which crossed the
+durable store's real-clock 90-day retention threshold at 2026-09-10T21:33:20Z.
+The preceding full run exercised that fixture before the threshold. Three
+receiver-clock initializations now start at Date.now(), retaining their existing
+relative advances and every persistence/age assertion. The sender timestamp
+remains fixed, so receiver-versus-sender semantics are still tested. Production
+retention policy and dashboard runtime behavior are unchanged.
+
+Hooke independently concurred with this exact clock correction. All 20 tests
+passed in both the isolated preparation and the dashboard candidate after the
+patch was applied. The next full run must validate the resulting commit.


### PR DESCRIPTION
## ELI16 — Stop a delayed dashboard edit from creating extra messages

When Instar cannot immediately update the pinned dashboard link, it currently tries to post another copy. Repeated reconnects can turn that into a stream of extra messages and consume the capacity needed for your replies. This change leaves the existing post alone while an edit is delayed or uncertain. It posts a replacement only when Telegram confirms that the original message is missing. Existing agents receive the change through their normal update; no new setting is needed.

## Implementation and validation

Replacement requires Telegram’s confirmed missing-message response for the same bot, chat and message. Managed edits must durably record that rejection first. Confirmed unchanged responses remain no-ops. New and existing CLAUDE/AGENTS/GEMINI guidance use the same contract.

Validation: targeted unit, HTTP, production-boot and migration checks passed, as did the build and normal commit checks. Independent reviews concurred. The aggregate repository suite passed on commit `9a3ce23e48b8ec5a8d6236c54fe7762fa4a51b08`: 51,888 passing tests across 3,352 files, zero failures (29 skipped tests and 3 todo; four skipped files). All 5,579 frozen inputs remain unchanged. The dedicated local integration stage passed 4,191 tests across 520 files (12 skipped tests; two skipped files), and the dedicated E2E stage passed 3,240 tests across 370 files (seven skipped tests and three todo; one skipped file). The complete `npm run test:all` command exited normally with code 0, and all 5,579 frozen inputs were verified unchanged again afterward. These stages overlap in coverage; their counts are not unique tests. GitHub CI must finish before merge and publication. The normal pre-push smoke hook ran zero tests after its affected-test listing timed out; that is not counted as a pass.

The full-run corrections are test-only: boot fixtures await display readiness before preparing the bot; credential-redaction cases exercise the runtime error path; guard fixtures use the current receiver time so the real 90-day retention policy does not age them out. Production delivery permissions and retry budgets are unchanged by those fixture corrections.

Wake classification, admission error specificity, corrupt saved-ID state and replacement custody across repeated broadcasts after a genuine deletion remain separately tracked in topic 69507.

Governing spec: [Telegram message origin](docs/specs/telegram-message-origin.md). [Plain-English overview](docs/specs/telegram-message-origin.eli16.md). [Side-effects review](upgrades/side-effects/telegram-dashboard-edit-rejection.md).
